### PR TITLE
Update author email to support@j2commerce.com in XML metadata

### DIFF
--- a/libraries/j2commerce/j2commerce.xml
+++ b/libraries/j2commerce/j2commerce.xml
@@ -5,7 +5,7 @@
     <version>1.0.0</version>
     <creationDate>2025-09-24</creationDate>
     <author>J2Commerce, LLC</author>
-    <authorEmail>info@j2commerce.com</authorEmail>
+    <authorEmail>support@j2commerce.com</authorEmail>
     <authorUrl>https://www.j2commerce.com</authorUrl>
     <copyright>(C)2024-2025 J2Commerce, LLC</copyright>
     <license>GNU General Public License version 3 or later</license>


### PR DESCRIPTION
maybe it was deliberate in which case it can be closed but its the only xml not using support@