### PR TITLE
Change tax rate name cell from <td> to <th> for accessibility

### DIFF
--- a/administrator/components/com_j2commerce/tmpl/taxrates/default.php
+++ b/administrator/components/com_j2commerce/tmpl/taxrates/default.php
@@ -77,11 +77,11 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
                                 <td class="text-center">
                                     <?php echo HTMLHelper::_('jgrid.published', $item->enabled, $i, 'taxrates.', true, 'cb'); ?>
                                 </td>
-                                <td>
+                                <th scope="row">
                                     <a href="<?php echo Route::_('index.php?option=com_j2commerce&task=taxrate.edit&id=' . $item->j2commerce_taxrate_id); ?>">
                                         <?php echo $this->escape($item->taxrate_name); ?>
                                     </a>
-                                </td>
+                                </th>
                                 <td class="d-none d-md-table-cell">
                                     <?php echo number_format((float) $item->tax_percent, 3); ?>%
                                 </td>


### PR DESCRIPTION
This also ensures that the column select dropdown doesnt let you disable the tax rate Name Column