### PR TITLE
Reordered product ID and price sorting options in filter dropdown

### DIFF
--- a/administrator/components/com_j2commerce/forms/filter_advancedpricing.xml
+++ b/administrator/components/com_j2commerce/forms/filter_advancedpricing.xml
@@ -32,14 +32,14 @@
             onchange="this.form.submit();"
         >
             <option value="">JGLOBAL_SORT_BY</option>
-            <option value="v.product_id ASC">COM_J2COMMERCE_HEADING_PRODUCT_ID_ASC</option>
-            <option value="v.product_id DESC">COM_J2COMMERCE_HEADING_PRODUCT_ID_DESC</option>
             <option value="product_name ASC">COM_J2COMMERCE_HEADING_PRODUCT_NAME_ASC</option>
             <option value="product_name DESC">COM_J2COMMERCE_HEADING_PRODUCT_NAME_DESC</option>
-            <option value="pp.price ASC">COM_J2COMMERCE_HEADING_PRICE_ASC</option>
-            <option value="pp.price DESC">COM_J2COMMERCE_HEADING_PRICE_DESC</option>
+            <option value="v.product_id ASC">COM_J2COMMERCE_HEADING_PRODUCT_ID_ASC</option>
+            <option value="v.product_id DESC">COM_J2COMMERCE_HEADING_PRODUCT_ID_DESC</option>
             <option value="group_name ASC">COM_J2COMMERCE_HEADING_USER_GROUP_ASC</option>
             <option value="group_name DESC">COM_J2COMMERCE_HEADING_USER_GROUP_DESC</option>
+            <option value="pp.price ASC">COM_J2COMMERCE_HEADING_PRICE_ASC</option>
+            <option value="pp.price DESC">COM_J2COMMERCE_HEADING_PRICE_DESC</option>
         </field>
         <field
             name="limit"


### PR DESCRIPTION
In Core Joomla (and it seems most of j2commerce) we try to set the order of the filters to match the column order

<img width="1570" height="334" alt="image" src="https://github.com/user-attachments/assets/789ace99-1c2e-486a-b9c3-a4ec0c88f086" />
