### PR TITLE
MOD_QUICKICONS

### DIFF
--- a/administrator/modules/mod_j2commerce_quickicons/language/en-GB/mod_j2commerce_quickicons.ini
+++ b/administrator/modules/mod_j2commerce_quickicons/language/en-GB/mod_j2commerce_quickicons.ini
@@ -16,7 +16,7 @@ MOD_J2COMMERCE_QUICKICONS_SHOW_SHIPPING="Show Shipping Methods"
 MOD_J2COMMERCE_QUICKICONS_SHOW_STATISTICS="Show Statistics"
 MOD_J2COMMERCE_QUICKICONS_SHOW_REPORTS="Show Reports"
 MOD_J2COMMERCE_QUICKICONS_SHOW_CONFIG="Show Configuration"
-MOD_J2COMMERCE_QUICKICONS_SHOW_PLUGIN_ICONS="Show Plugin Icons"
+MOD_J2COMMERCE_QUICKICONS_SHOW_PLUGIN_ICONS="Show 3rd Party Plugins"
 MOD_J2COMMERCE_QUICKICONS_SHOW_PLUGIN_ICONS_DESC="When enabled, 3rd party J2Commerce plugins that have dashboard integration enabled will also appear as quick icons."
 
 ; Button label strings (copied from com_j2commerce.ini for dashboard context)

--- a/administrator/modules/mod_j2commerce_quickicons/language/en-GB/mod_j2commerce_quickicons.sys.ini
+++ b/administrator/modules/mod_j2commerce_quickicons/language/en-GB/mod_j2commerce_quickicons.sys.ini
@@ -17,7 +17,7 @@ MOD_J2COMMERCE_QUICKICONS_SHOW_SHIPPING="Show Shipping Methods"
 MOD_J2COMMERCE_QUICKICONS_SHOW_STATISTICS="Show Statistics"
 MOD_J2COMMERCE_QUICKICONS_SHOW_REPORTS="Show Reports"
 MOD_J2COMMERCE_QUICKICONS_SHOW_CONFIG="Show Configuration"
-MOD_J2COMMERCE_QUICKICONS_SHOW_PLUGIN_ICONS="Show Plugin Icons"
+MOD_J2COMMERCE_QUICKICONS_SHOW_PLUGIN_ICONS="Show 3rd Party Plugins"
 MOD_J2COMMERCE_QUICKICONS_SHOW_PLUGIN_ICONS_DESC="When enabled, 3rd party J2Commerce plugins that have dashboard integration enabled will also appear as quick icons."
 
 ; Button label strings (copied from com_j2commerce.ini for dashboard context)


### PR DESCRIPTION
Update "Show Plugin Icons" label to "Show 3rd Party Plugins" in English files

This way it makes sense without having to first display the descriptions.

I spent 10 minutes wondering why I only had 10 icons on the dashboard when I hjad set 11 things to yes before I checked the description

## Before
<img width="649" height="193" alt="image" src="https://github.com/user-attachments/assets/8d32ac2c-c37a-4331-bc4a-7762bd03c190" />

## After
<img width="841" height="236" alt="image" src="https://github.com/user-attachments/assets/e36e5942-3af5-4c11-91a6-c6d8e7b8cecf" />
