### PR TITLE
Update variant option message

### DIFF
--- a/administrator/components/com_j2commerce/language/en-GB/com_j2commerce.ini
+++ b/administrator/components/com_j2commerce/language/en-GB/com_j2commerce.ini
@@ -2793,7 +2793,7 @@ COM_J2COMMERCE_OPTION_SET_VALUES="Set Option Values"
 COM_J2COMMERCE_OPTIONS_ADD="Add Option"
 COM_J2COMMERCE_OPTIONS_CREATE="Create Option"
 COM_J2COMMERCE_OPTIONS_NO_OPTION_MESSAGE="No options have been added to this product."
-COM_J2COMMERCE_SEARCH_AND_ADD_VARIANT_OPTION="Search and add variant options"
+COM_J2COMMERCE_SEARCH_AND_ADD_VARIANT_OPTION="Select options to add"
 COM_J2COMMERCE_SAVE_PRODUCT_FIRST_TO_ADD_OPTIONS="Please save the product first before adding options."
 COM_J2COMMERCE_OPTION_REMOVED="Option removed successfully."
 

--- a/administrator/components/com_j2commerce/language/en-US/com_j2commerce.ini
+++ b/administrator/components/com_j2commerce/language/en-US/com_j2commerce.ini
@@ -2793,7 +2793,7 @@ COM_J2COMMERCE_OPTION_SET_VALUES="Set Option Values"
 COM_J2COMMERCE_OPTIONS_ADD="Add Option"
 COM_J2COMMERCE_OPTIONS_CREATE="Create Option"
 COM_J2COMMERCE_OPTIONS_NO_OPTION_MESSAGE="No options have been added to this product."
-COM_J2COMMERCE_SEARCH_AND_ADD_VARIANT_OPTION="Search and add variant options"
+COM_J2COMMERCE_SEARCH_AND_ADD_VARIANT_OPTION="Select options to add"
 COM_J2COMMERCE_SAVE_PRODUCT_FIRST_TO_ADD_OPTIONS="Please save the product first before adding options."
 COM_J2COMMERCE_OPTION_REMOVED="Option removed successfully."
 

--- a/administrator/language/en-GB/com_j2commerce.ini
+++ b/administrator/language/en-GB/com_j2commerce.ini
@@ -2781,7 +2781,7 @@ COM_J2COMMERCE_OPTION_SET_VALUES="Set Option Values"
 COM_J2COMMERCE_OPTIONS_ADD="Add Option"
 COM_J2COMMERCE_OPTIONS_CREATE="Create Option"
 COM_J2COMMERCE_OPTIONS_NO_OPTION_MESSAGE="No options have been added to this product."
-COM_J2COMMERCE_SEARCH_AND_ADD_VARIANT_OPTION="Search and add variant options"
+COM_J2COMMERCE_SEARCH_AND_ADD_VARIANT_OPTION="Select options to add"
 COM_J2COMMERCE_SAVE_PRODUCT_FIRST_TO_ADD_OPTIONS="Please save the product first before adding options."
 COM_J2COMMERCE_OPTION_REMOVED="Option removed successfully."
 


### PR DESCRIPTION
Change from "Search and add" to "Select options to add"

its not a search and I dont think the word variant is very user friendly and ~I dont see it used on the page where you create options

But maybe thats just my opinion 

## Before
<img width="1150" height="208" alt="image" src="https://github.com/user-attachments/assets/4228bf5e-e6a5-4b46-8317-7db92cca775d" />

## After
<img width="1722" height="396" alt="image" src="https://github.com/user-attachments/assets/910c28e1-c35b-4f44-9ee9-c610a9c032e2" />
