### PR TITLE
fix(localization): fix null message on reinstall buttons

### DIFF
--- a/plugins/j2commerce/app_localization_data/src/Extension/AppLocalizationData.php
+++ b/plugins/j2commerce/app_localization_data/src/Extension/AppLocalizationData.php
@@ -36,11 +36,11 @@ final class AppLocalizationData extends CMSPlugin implements SubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            'onAjaxAppLocalizationData' => 'onAjaxAppLocalizationData',
+            'onAjaxApp_localization_data' => 'handleAjax',
         ];
     }
 
-    public function onAjaxAppLocalizationData(AjaxEvent $event): void
+    public function handleAjax(AjaxEvent $event): void
     {
         $app = $this->getApplication();
 
@@ -81,6 +81,8 @@ final class AppLocalizationData extends CMSPlugin implements SubscriberInterface
     private function insertTableValues(): array
     {
         $tableName = $this->getApplication()->getInput()->getCmd('table', '');
+
+        Log::add('Localization data reset requested for table: ' . $tableName, Log::DEBUG, 'com_j2commerce');
 
         if ($tableName === 'metrics') {
             return $this->resetMetrics();

--- a/plugins/j2commerce/app_localization_data/src/Field/LocalizationDataField.php
+++ b/plugins/j2commerce/app_localization_data/src/Field/LocalizationDataField.php
@@ -156,13 +156,24 @@ document.addEventListener('DOMContentLoaded', () => {
             return response.json();
         })
         .then(data => {
-            if (data.success) {
-                Joomla.renderMessages({'success': [data.message]});
+            // com_ajax wraps plugin result: {success: true, data: ['{"success":true,"message":"..."}'] }
+            let result = data;
+            if (data.data && Array.isArray(data.data) && data.data.length > 0) {
+                try {
+                    result = JSON.parse(data.data[0]);
+                } catch (e) {
+                    // data.data[0] may already be an object
+                    result = typeof data.data[0] === 'object' ? data.data[0] : data;
+                }
+            }
+            if (result.success) {
+                Joomla.renderMessages({'success': [result.message]});
             } else {
-                Joomla.renderMessages({'error': [data.message || '{$errorText}']});
+                Joomla.renderMessages({'error': [result.message || '{$errorText}']});
             }
         })
-        .catch(() => {
+        .catch(err => {
+            console.error('[J2C Localization] Request failed for table:', table, err);
             Joomla.renderMessages({'error': ['{$errorText}']});
         })
         .finally(() => {


### PR DESCRIPTION
## Core Update

### Changes
- Fix event name mismatch: com_ajax dispatches `onAjaxApp_localization_data` but subscriber listened for `onAjaxAppLocalizationData`
- Fix JS response parsing to unwrap com_ajax wrapper (`data.data[0]`)
- Add debug logging for table reset requests

### Files Modified
| Type | Count |
|------|-------|
| PHP files | 2 |

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only (non-core excluded)