### PR TITLE
Update text_prefix to 'COM_J2COMMERCE' in InvoicetemplatesController

### DIFF
--- a/administrator/components/com_j2commerce/src/Controller/InvoicetemplatesController.php
+++ b/administrator/components/com_j2commerce/src/Controller/InvoicetemplatesController.php
@@ -29,7 +29,7 @@ class InvoicetemplatesController extends AdminController
      * @var    string
      * @since  6.0.0
      */
-    protected $text_prefix = 'COM_J2COMMERCE_INVOICETEMPLATES';
+    protected $text_prefix = 'COM_J2COMMERCE';
 
     /**
      * Method to get a model object, loading it if required.


### PR DESCRIPTION
This ensures that the correct strings are loaded when changing the state of a filter group.

Before it was trying COM_J2COMMERCE_INVOICETEMPLATES_N_ITEMS_UNPUBLISHED which doesnt exist.

With this PR it is correctly using the generic COM_J2COMMERCE_N_ITEMS_UNPUBLISHED