### PR TITLE
fix(vendors): restore missing Vendor edit view and template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,6 +157,10 @@ node_modules/
 vendor/
 !libraries/j2commerce/vendor/
 !libraries/j2commerce/vendor/**
+!administrator/components/com_j2commerce/src/View/Vendor/
+!administrator/components/com_j2commerce/src/View/Vendor/**
+!administrator/components/com_j2commerce/tmpl/vendor/
+!administrator/components/com_j2commerce/tmpl/vendor/**
 *.bak
 
 # Ignore SQL dumps but allow J2Commerce schema files

--- a/administrator/components/com_j2commerce/src/View/Vendor/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Vendor/HtmlView.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Administrator\View\Vendor;
+
+\defined('_JEXEC') or die;
+
+use J2Commerce\Component\J2commerce\Administrator\View\AdminAssetsTrait;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Form\Form;
+use Joomla\CMS\Helper\ContentHelper;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\MVC\View\GenericDataException;
+use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
+use Joomla\CMS\Toolbar\Toolbar;
+use Joomla\CMS\Toolbar\ToolbarHelper;
+use Joomla\Registry\Registry;
+
+/**
+ * Vendor edit view class.
+ *
+ * @since  6.0.6
+ */
+class HtmlView extends BaseHtmlView
+{
+    use AdminAssetsTrait;
+    /**
+     * The Form object
+     *
+     * @var    Form|null
+     * @since  6.0.6
+     */
+    protected $form;
+
+    /**
+     * The active item
+     *
+     * @var    object
+     * @since  6.0.6
+     */
+    protected $item;
+
+    /**
+     * The model state
+     *
+     * @var    Registry
+     * @since  6.0.6
+     */
+    protected $state;
+
+    /**
+     * Custom address fields for dynamic rendering
+     *
+     * @var    array
+     * @since  6.0.7
+     */
+    public $addressCustomFields = [];
+
+    /**
+     * Display the view.
+     *
+     * @param   string  $tpl  The name of the template file to parse.
+     *
+     * @return  void
+     *
+     * @since   6.0.6
+     */
+    public function display($tpl = null): void
+    {
+        if (!$this->getCurrentUser()->authorise('j2commerce.viewproducts', 'com_j2commerce')) {
+            throw new \Exception(Text::_('JLIB_APPLICATION_ERROR_ACCESS_FORBIDDEN'), 403);
+        }
+
+        $this->loadAdminAssets();
+
+        $model = $this->getModel();
+        $model->setUseExceptions(true);
+
+        $this->form  = $model->getForm();
+        $this->item  = $model->getItem();
+        $this->state = $model->getState();
+
+        // Load custom address fields for template use
+        $this->addressCustomFields = $model->getAddressCustomFields();
+
+        $this->addToolbar();
+
+        parent::display($tpl);
+    }
+
+    /**
+     * Add the page title and toolbar.
+     *
+     * @return  void
+     *
+     * @since   6.0.6
+     */
+    protected function addToolbar(): void
+    {
+        Factory::getApplication()->getInput()->set('hidemainmenu', true);
+
+        $isNew = ($this->item->j2commerce_vendor_id === 0);
+        $canDo = ContentHelper::getActions('com_j2commerce');
+        $user  = Factory::getApplication()->getIdentity();
+        $toolbar = $this->getDocument()->getToolbar();
+
+        // Title: "New Vendor" or "Edit Vendor"
+        $title = $isNew ? Text::_('COM_J2COMMERCE_TOOLBAR_NEW') . ' ' . Text::_('COM_J2COMMERCE_VENDOR') : Text::_('COM_J2COMMERCE_TOOLBAR_EDIT') . ' ' . Text::_('COM_J2COMMERCE_VENDOR');
+        ToolbarHelper::title($title, 'fas fa-solid fa-user-tag');
+
+        // If not checked out, can save the item.
+        if ($canDo->get('core.edit') || ($canDo->get('core.create'))) {
+            $toolbar->apply('vendor.apply');
+        }
+
+        if ($canDo->get('core.edit.state')) {
+            // Dropdown save group with configure() callback
+            $saveGroup = $toolbar->dropdownButton('save-group');
+            $saveGroup->configure(
+                function (Toolbar $childBar) use ($canDo, $isNew) {
+                    if ($canDo->get('core.edit') || ($canDo->get('core.create'))) {
+                        $childBar->save('vendor.save');
+                    }
+
+                    if ($canDo->get('core.create')) {
+                        $childBar->save2new('vendor.save2new');
+                    }
+
+                    if (!$isNew && $canDo->get('core.create')) {
+                        $childBar->save2copy('vendor.save2copy');
+                    }
+                }
+            );
+        }
+
+        $toolbar->cancel('vendor.cancel', $isNew ? 'JTOOLBAR_CANCEL' : 'JTOOLBAR_CLOSE');
+        $toolbar->divider();
+        ToolbarHelper::help('Vendors', true, 'https://docs.j2commerce.com/catalog/vendors/');
+    }
+}

--- a/administrator/components/com_j2commerce/tmpl/vendor/edit.php
+++ b/administrator/components/com_j2commerce/tmpl/vendor/edit.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
+use Joomla\CMS\Router\Route;
+
+/** @var \J2Commerce\Component\J2commerce\Administrator\View\Vendor\HtmlView $this */
+
+$wa = $this->getDocument()->getWebAssetManager();
+$wa->useScript('keepalive')
+    ->useScript('form.validate');
+
+?>
+<form action="<?php echo Route::_('index.php?option=com_j2commerce&layout=edit&id=' . (int) $this->item->j2commerce_vendor_id); ?>" method="post" name="adminForm" id="vendor-form" class="form-validate">
+
+    <div class="main-card">
+        <?php echo HTMLHelper::_('uitab.startTabSet', 'myTab', ['active' => 'details', 'recall' => true, 'breakpoint' => 768]); ?>
+
+        <?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'details', Text::_('COM_J2COMMERCE_FIELDSET_BASIC')); ?>
+        <div class="row">
+            <div class="col-lg-9">
+                <div class="row">
+                    <div class="col-lg-6">
+                        <fieldset id="fieldset-basic" class="options-form">
+                            <legend><?php echo Text::_('COM_J2COMMERCE_FIELDSET_ADDRESS_CONTACT'); ?></legend>
+                            <div class="form-grid">
+                                <?php echo $this->form->renderField('company'); ?>
+                                <?php echo $this->form->renderField('first_name'); ?>
+                                <?php echo $this->form->renderField('last_name'); ?>
+                                <?php echo $this->form->renderField('j2commerce_user_id'); ?>
+                                <?php echo $this->form->renderField('email'); ?>
+                                <?php echo $this->form->renderField('phone_1'); ?>
+                                <?php echo $this->form->renderField('phone_2'); ?>
+                                <?php echo $this->form->renderField('fax'); ?>
+                                <?php echo $this->form->renderField('tax_number'); ?>
+                            </div>
+                        </fieldset>
+                    </div>
+                    <div class="col-lg-6">
+                        <fieldset id="fieldset-address-right" class="options-form">
+                            <legend><?php echo Text::_('COM_J2COMMERCE_FIELDSET_ADDRESS_LOCATION'); ?></legend>
+                            <div class="form-grid">
+                                <?php echo $this->form->renderField('address_1'); ?>
+                                <?php echo $this->form->renderField('address_2'); ?>
+                                <?php echo $this->form->renderField('city'); ?>
+                                <?php echo $this->form->renderField('zip'); ?>
+                                <?php echo $this->form->renderField('country_id'); ?>
+                                <?php echo $this->form->renderField('zone_id'); ?>
+
+                                <?php
+                                // Render custom address fields dynamically
+                                foreach ($this->addressCustomFields as $field) {
+                                    // Only render non-core fields (core fields are already rendered above)
+                                    $coreFields = ['first_name', 'last_name', 'email', 'address_1', 'address_2', 'city', 'zip', 'country_id', 'zone_id', 'phone_1', 'phone_2', 'company', 'tax_number'];
+                                    if (!\in_array($field->field_namekey, $coreFields, true) && $this->form->getField($field->field_namekey)) {
+                                        echo $this->form->renderField($field->field_namekey);
+                                    }
+                                }
+                                ?>
+                            </div>
+                        </fieldset>
+                    </div>
+                </div>
+            </div>
+            <div class="col-lg-3">
+                <?php echo LayoutHelper::render('joomla.edit.global', $this); ?>
+            </div>
+        </div>
+        <?php echo HTMLHelper::_('uitab.endTab'); ?>
+
+        <?php echo HTMLHelper::_('uitab.endTabSet'); ?>
+    </div>
+
+    <input type="hidden" name="task" value="">
+    <?php echo $this->form->renderField('j2commerce_vendor_id'); ?>
+    <?php echo $this->form->renderField('j2commerce_address_id'); ?>
+    <?php echo $this->form->renderField('address_id'); ?>
+    <?php echo HTMLHelper::_('form.token'); ?>
+</form>
+
+<script>
+/**
+ * J2Commerce Vendor - Country/Zone AJAX linking
+ * Loads zones dynamically based on the selected country
+ */
+document.addEventListener('DOMContentLoaded', function() {
+    'use strict';
+
+    const countrySelect = document.getElementById('jform_country_id');
+    const zoneSelect = document.getElementById('jform_zone_id');
+
+    if (!countrySelect || !zoneSelect) {
+        return;
+    }
+
+    /**
+     * Load zones for the selected country via AJAX
+     *
+     * @param {number} countryId - The selected country ID
+     * @param {number} selectedZoneId - The zone ID to pre-select (optional)
+     */
+    async function loadZones(countryId, selectedZoneId = 0) {
+        // Show loading state
+        zoneSelect.innerHTML = '<option value=""><?php echo Text::_('COM_J2COMMERCE_LOADING', true); ?></option>';
+        zoneSelect.disabled = true;
+
+        if (!countryId || countryId === '0' || countryId === '') {
+            zoneSelect.innerHTML = '<option value=""><?php echo Text::_('COM_J2COMMERCE_SELECT_ZONE', true); ?></option>';
+            zoneSelect.disabled = false;
+            return;
+        }
+
+        try {
+            const url = 'index.php?option=com_j2commerce&task=vendor.getZones&country_id=' + countryId + '&zone_id=' + selectedZoneId;
+            const response = await fetch(url);
+
+            if (!response.ok) {
+                throw new Error('Network response was not ok');
+            }
+
+            const html = await response.text();
+            zoneSelect.innerHTML = html;
+            zoneSelect.disabled = false;
+        } catch (error) {
+            console.error('Error loading zones:', error);
+            zoneSelect.innerHTML = '<option value=""><?php echo Text::_('COM_J2COMMERCE_SELECT_ZONE', true); ?></option>';
+            zoneSelect.disabled = false;
+        }
+    }
+
+    // Listen for country changes
+    countrySelect.addEventListener('change', function() {
+        loadZones(this.value, 0);
+    });
+
+    // On page load, if the country is already selected, load zones with the current zone value
+    const initialCountryId = countrySelect.value;
+    const initialZoneId = zoneSelect.value || 0;
+
+    if (initialCountryId && initialCountryId !== '0' && initialCountryId !== '') {
+        loadZones(initialCountryId, initialZoneId);
+    }
+});
+</script>


### PR DESCRIPTION
## Core Update

### Changes
- Restored `src/View/Vendor/HtmlView.php` (singular edit view) — was lost when `gh repo sync --force` rewrote fork history
- Restored `tmpl/vendor/edit.php` (vendor edit form template)
- Added `.gitignore` exceptions so `Vendor` view directory isn't caught by the global `vendor/` ignore rule

### Root Cause
The singular Vendor view files existed only on a stale local branch (`language/en-GB-translation-2026-03-23`) that was never merged to `main`. When upstream sync rewrote the fork, these files disappeared from the working tree.

### Files Modified
| Type | Count |
|------|-------|
| PHP files | 2 |
| Config (.gitignore) | 1 |

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only