### PR TITLE
[Vouchers] Fix missing valid dates and save errors

### DIFF
--- a/administrator/components/com_j2commerce/sql/install.mysql.utf8.sql
+++ b/administrator/components/com_j2commerce/sql/install.mysql.utf8.sql
@@ -1162,6 +1162,8 @@ CREATE TABLE IF NOT EXISTS `#__j2commerce_vouchers` (
   `voucher_type` varchar(255) NOT NULL,
   `subject` varchar(255) NOT NULL,
   `email_body` longtext NOT NULL,
+  `valid_from` datetime DEFAULT NULL,
+  `valid_to` datetime DEFAULT NULL,
   `from_order_id` varchar(255) NOT NULL DEFAULT '0',
   `voucher_value` decimal(15,8) NOT NULL,
   `ordering` int NOT NULL DEFAULT 0,

--- a/administrator/components/com_j2commerce/sql/updates/mysql/6.1.3-2026-03-25.sql
+++ b/administrator/components/com_j2commerce/sql/updates/mysql/6.1.3-2026-03-25.sql
@@ -1,0 +1,7 @@
+-- Add valid_to to vouchers table
+ALTER TABLE `#__j2commerce_vouchers`
+    ADD COLUMN `valid_to` datetime DEFAULT NULL AFTER `email_body`/** CAN FAIL **/;
+
+-- Add valid_from to vouchers table
+ALTER TABLE `#__j2commerce_vouchers`
+    ADD COLUMN `valid_from` datetime DEFAULT NULL AFTER `email_body`/** CAN FAIL **/;

--- a/administrator/components/com_j2commerce/src/Model/VoucherModel.php
+++ b/administrator/components/com_j2commerce/src/Model/VoucherModel.php
@@ -66,8 +66,7 @@ class VoucherModel extends AdminModel
     protected array $history = [];
 
     /**
-     * Override populateState to read 'id' from URL (standard Joomla convention),
-     * not 'j2commerce_voucher_id' (the table's column name).
+     * Override populateState to use Joomla's standard 'id' URL parameter.
      *
      * @return  void
      *
@@ -76,8 +75,8 @@ class VoucherModel extends AdminModel
     protected function populateState(): void
     {
         $app = Factory::getApplication();
-
         $pk = $app->getInput()->getInt('id', 0);
+
         $this->setState($this->getName() . '.id', $pk);
 
         $params = ComponentHelper::getParams('com_j2commerce');
@@ -205,6 +204,21 @@ class VoucherModel extends AdminModel
      */
     public function save($data): bool
     {
+        $app = Factory::getApplication();
+
+        // Resolve existing-record identity from id only.
+        $data['id'] = (int) ($data['id'] ?? $app->getInput()->getInt('id', 0));
+
+        // Map Joomla id to table PK for persistence.
+        if (empty($data['j2commerce_voucher_id']) && $data['id'] > 0) {
+            $data['j2commerce_voucher_id'] = $data['id'];
+        }
+
+        // Keep id aligned if only table PK is present in form payload.
+        if (empty($data['id']) && !empty($data['j2commerce_voucher_id'])) {
+            $data['id'] = (int) $data['j2commerce_voucher_id'];
+        }
+
         // Handle published/enabled alias
         if (isset($data['published'])) {
             $data['enabled'] = $data['published'];
@@ -230,12 +244,15 @@ class VoucherModel extends AdminModel
         PluginHelper::importPlugin('content');
 
         // Alter the voucher code for save as copy
-        $app = Factory::getApplication();
         if ($app->getInput()->get('task') == 'save2copy') {
             $origTable = clone $this->getTable();
-            $origTable->load($app->getInput()->getInt('j2commerce_voucher_id'));
+            $originalId = (int) ($data['id'] ?? 0);
 
-            if ($data['voucher_code'] == $origTable->voucher_code) {
+            if ($originalId > 0) {
+                $origTable->load($originalId);
+            }
+
+            if (!empty($origTable->voucher_code) && $data['voucher_code'] == $origTable->voucher_code) {
                 $data['voucher_code'] = $this->generateNewVoucherCode($data['voucher_code']);
             }
 
@@ -243,10 +260,14 @@ class VoucherModel extends AdminModel
         }
 
         if (parent::save($data)) {
-            // Set the ID for redirect after save
-            $table = $this->getTable();
-            if ($table && isset($table->j2commerce_voucher_id)) {
-                $this->setState($this->getName() . '.j2commerce_voucher_id', $table->j2commerce_voucher_id);
+            $savedId = (int) ($data['id'] ?? 0);
+
+            if ($savedId === 0) {
+                $savedId = (int) $this->getState($this->getName() . '.id');
+            }
+
+            if ($savedId > 0) {
+                $this->setState($this->getName() . '.id', $savedId);
             }
 
             return true;
@@ -518,6 +539,7 @@ class VoucherModel extends AdminModel
         $params = $this->getState('params');
         $db     = $this->getDatabase();
         $query  = $db->getQuery(true);
+        $discountType = 'voucher';
 
         $query->select($db->quoteName([
             'o.j2commerce_order_id',
@@ -546,7 +568,7 @@ class VoucherModel extends AdminModel
             ->group($db->quoteName('od.discount_entity_id'))
             ->order($db->quoteName('o.created_on') . ' DESC')
             ->bind(':voucherId', $voucherId, ParameterType::INTEGER)
-            ->bind(':discountType', $discountType = 'voucher');
+            ->bind(':discountType', $discountType);
 
         try {
             $db->setQuery($query);

--- a/administrator/components/com_j2commerce/src/Table/VoucherTable.php
+++ b/administrator/components/com_j2commerce/src/Table/VoucherTable.php
@@ -97,4 +97,28 @@ class VoucherTable extends Table
 
         return true;
     }
+
+    /**
+     * Override store method to ensure NULL values are stored in database
+     * instead of '0000-00-00 00:00:00'
+     *
+     * @param   boolean  $updateNulls  True to update fields even if they are null
+     *
+     * @return  boolean  True on success
+     */
+    public function store($updateNulls = false)
+    {
+        $nullDate = $this->getDatabase()->getNullDate();
+
+        // Convert '0000-00-00 00:00:00' to null before storing
+        if (isset($this->valid_from) && ($this->valid_from === $nullDate || $this->valid_from === '0000-00-00 00:00:00' || empty($this->valid_from))) {
+            $this->valid_from = null;
+        }
+        if (isset($this->valid_to) && ($this->valid_to === $nullDate || $this->valid_to === '0000-00-00 00:00:00' || empty($this->valid_to))) {
+            $this->valid_to = null;
+        }
+
+        // Force update nulls to true so NULL values are actually stored
+        return parent::store(true);
+    }
 }

--- a/administrator/components/com_j2commerce/src/View/Voucher/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Voucher/HtmlView.php
@@ -166,7 +166,7 @@ class HtmlView extends BaseHtmlView
                 // Add "View Voucher History"
                 $toolbar->linkButton('voucher-history')
                     ->text('COM_J2COMMERCE_VOUCHER_VIEW_HISTORY')
-                    ->url('index.php?option=com_j2commerce&view=voucher&layout=history&j2commerce_voucher_id=' . $this->item->j2commerce_voucher_id)
+                    ->url('index.php?option=com_j2commerce&view=voucher&layout=history&id=' . $this->item->j2commerce_voucher_id)
                     ->icon('icon-list');
 
                 // Add "Send Voucher"
@@ -179,7 +179,7 @@ class HtmlView extends BaseHtmlView
             } else {
                 $toolbar->linkButton('voucherback')
                     ->text('JTOOLBAR_BACK')
-                    ->url('index.php?option=com_j2commerce&view=voucher&layout=edit&j2commerce_voucher_id=' . $this->item->j2commerce_voucher_id)
+                    ->url('index.php?option=com_j2commerce&view=voucher&layout=edit&id=' . $this->item->j2commerce_voucher_id)
                     ->icon('icon-arrow-left');
             }
         }

--- a/administrator/components/com_j2commerce/tmpl/voucher/edit.php
+++ b/administrator/components/com_j2commerce/tmpl/voucher/edit.php
@@ -26,9 +26,10 @@ $wa->useScript('keepalive')
 
 $layout  = 'edit';
 $tmpl    = Factory::getApplication()->input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=component' : '';
+$voucherId = (int) ($this->item->j2commerce_voucher_id ?? 0);
 ?>
 
-<form action="<?php echo Route::_('index.php?option=com_j2commerce&layout=' . $layout . $tmpl . '&j2commerce_voucher_id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="voucher-form" aria-label="<?php echo Text::_('COM_J2COMMERCE_VOUCHER_FORM_' . ((int) $this->item->id === 0 ? 'NEW' : 'EDIT'), true); ?>" class="form-validate">
+<form action="<?php echo Route::_('index.php?option=com_j2commerce&layout=' . $layout . $tmpl . '&id=' . $voucherId); ?>" method="post" name="adminForm" id="voucher-form" aria-label="<?php echo Text::_('COM_J2COMMERCE_VOUCHER_FORM_' . ($voucherId === 0 ? 'NEW' : 'EDIT'), true); ?>" class="form-validate">
 
     <div class="main-card">
         <?php echo HTMLHelper::_('uitab.startTabSet', 'myTab', ['active' => 'details', 'recall' => true, 'breakpoint' => 768]); ?>


### PR DESCRIPTION
The columns valid_from and valid_to are missing from the vouchers table on install or update.
After save, the vouchers could not be saved again (duplication of the voucher code error).
The history view did not correctly show the voucher's history.
This PR addresses those 3 issues.

For issue #35 