### PR TITLE
fix(config): change default weight/length to metric units (fixes #20)

### DIFF
--- a/administrator/components/com_j2commerce/config.xml
+++ b/administrator/components/com_j2commerce/config.xml
@@ -124,14 +124,14 @@
             name="config_weight_class_id"
             type="weight"
             label="COM_J2COMMERCE_CONFIG_DEFAULT_WEIGHT"
-            default="4"
+            default="2"
         />
 
         <field
             name="config_length_class_id"
             type="length"
             label="COM_J2COMMERCE_CONFIG_DEFAULT_LENGTH"
-            default="2"
+            default="1"
         />
 
         <field

--- a/administrator/components/com_j2commerce/src/Helper/ConfigHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/ConfigHelper.php
@@ -198,7 +198,7 @@ class ConfigHelper
      */
     public static function getDefaultWeightClassId(): int
     {
-        return (int) self::get('config_weight_class_id', 4);
+        return (int) self::get('config_weight_class_id', 2);
     }
 
     /**
@@ -210,7 +210,7 @@ class ConfigHelper
      */
     public static function getDefaultLengthClassId(): int
     {
-        return (int) self::get('config_length_class_id', 2);
+        return (int) self::get('config_length_class_id', 1);
     }
 
     /**

--- a/administrator/components/com_j2commerce/tmpl/product/form_shipping.php
+++ b/administrator/components/com_j2commerce/tmpl/product/form_shipping.php
@@ -74,11 +74,11 @@ $weightsList = array_map(
 );
 
 $defaultLengthClassId = empty($this->item->variant->length_class_id)
-    ? J2CommerceHelper::config()->get('config_length_class_id', 2)
+    ? J2CommerceHelper::config()->get('config_length_class_id', 1)
     : $this->item->variant->length_class_id;
 
 $defaultWeightClassId = empty($this->item->variant->weight_class_id)
-    ? J2CommerceHelper::config()->get('config_weight_class_id', 4)
+    ? J2CommerceHelper::config()->get('config_weight_class_id', 2)
     : $this->item->variant->weight_class_id;
 ?>
 <div class="j2commerce-product-shipping">


### PR DESCRIPTION
Change default weight from Pound (ID=4) to Gram (ID=2) and default length from Inch (ID=2) to Centimetre (ID=1). Imperial units are only used in the USA; metric is the global standard. Only affects fresh installs or unsaved configurations.