### PR TITLE
fix(uppy): wire browse button click and reset on modal close

### DIFF
--- a/media/com_j2commerce/js/administrator/j2commerceimage.js
+++ b/media/com_j2commerce/js/administrator/j2commerceimage.js
@@ -104,6 +104,12 @@
             this.modalEl.addEventListener('hidden.bs.modal', () => {
                 this.browserSelections.clear();
                 this.uploadedInSession = [];
+                // Reset Uppy so it reinitializes fresh on next modal open
+                if (this.uppy) {
+                    this.uppy.clear();
+                    this.uppy.destroy();
+                    this.uppy = null;
+                }
             });
 
             const doneBtn = this.modalEl.querySelector('.uppymedia-done-btn');
@@ -182,6 +188,15 @@
                 if (inner) {
                     inner.innerHTML = `<span class="uppymedia-uppy-btn"><i class="fa-solid fa-images" aria-hidden="true"></i> ${this.escapeHtml(this.getText('COM_J2COMMERCE_MULTIIMAGEUPLOADER_ADD_PRODUCT_IMAGES'))}</span>`
                         + `<p class="uppymedia-uppy-hint">${this.escapeHtml(this.getText('COM_J2COMMERCE_MULTIIMAGEUPLOADER_DRAG_DROP_NOTE'))}</p>`;
+                }
+                // Wire browse button to Uppy's hidden file input
+                const browseSpan = addFilesEl.querySelector('.uppymedia-uppy-btn');
+                if (browseSpan) {
+                    browseSpan.style.cursor = 'pointer';
+                    browseSpan.addEventListener('click', () => {
+                        const fileInput = dashboardTarget.querySelector('.uppy-Dashboard-input');
+                        if (fileInput) fileInput.click();
+                    });
                 }
             }
 


### PR DESCRIPTION
## Summary
Fixes #59

## Root Cause
The Uppy image picker had two bugs:

1. **Browse button dead:** The code replaced Uppy Dashboard's built-in AddFiles area (which contains a clickable button wired to the hidden file input) with custom HTML. The replacement span looked like a button but had no click handler.

2. **Drag-drop disappears on reopen:** After the first upload, closing and reopening the modal left Uppy in its "complete" state. The guard prevented re-initialization, so the drag-drop area never reappeared.

## Changes
- Added click handler on `.uppymedia-uppy-btn` span that triggers Uppy's hidden file input — browse button now opens file dialog
- On modal close, destroy the Uppy instance (`uppy.destroy()`) and set to null so it reinitializes fresh on next open

## Testing
1. Admin → Options → edit a dropdown-type option
2. Click image icon on an option value row
3. Click "Add Product Images" → file browser dialog opens
4. Select image → uploads → appears in grid
5. Done → close → reopen → drag-drop area reappears
6. Also works on Products → edit → Images tab

## Files Changed
- `media/com_j2commerce/js/administrator/j2commerceimage.js` — 15 lines added