### PR TITLE
Hide advanced pricing button when there are no items in the product or inventory list

### DIFF
--- a/administrator/components/com_j2commerce/src/View/Inventory/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Inventory/HtmlView.php
@@ -175,11 +175,13 @@ class HtmlView extends BaseHtmlView
                 ->listCheck(true);
         }
 
-        // Advanced Pricing link
-        $toolbar->linkButton('advancedpricing')
-            ->text('COM_J2COMMERCE_TOOLBAR_ADVANCED_PRICING')
-            ->url('index.php?option=com_j2commerce&view=advancedpricing')
-            ->icon('fas fa-tags');
+        if (!$this->isEmptyState) {
+            // Advanced Pricing link
+            $toolbar->linkButton('advancedpricing')
+                ->text('COM_J2COMMERCE_TOOLBAR_ADVANCED_PRICING')
+                ->url('index.php?option=com_j2commerce&view=advancedpricing')
+                ->icon('fas fa-tags');
+        }
 
         if ($canDo->get('core.admin') || $canDo->get('core.options')) {
             $toolbar->preferences('com_j2commerce');

--- a/administrator/components/com_j2commerce/src/View/Products/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Products/HtmlView.php
@@ -74,6 +74,14 @@ class HtmlView extends BaseHtmlView
     public $activeFilters;
 
     /**
+     * Is this view an Empty State?
+     *
+     * @var   boolean
+     * @since 6.0.6
+     */
+    private $isEmptyState = false;
+
+    /**
      * Display the view
      *
      * @param   string  $tpl  The name of the template file to parse
@@ -174,18 +182,18 @@ class HtmlView extends BaseHtmlView
                 ->listCheck(true);
         }
 
-        // Advanced Pricing link
-        $toolbar->linkButton('advancedpricing')
-            ->text('COM_J2COMMERCE_TOOLBAR_ADVANCED_PRICING')
-            ->url('index.php?option=com_j2commerce&view=advancedpricing')
-            ->icon('fa-solid fa-tags');
+        if (!$this->isEmptyState) {
+            // Advanced Pricing link
+            $toolbar->linkButton('advancedpricing')
+                ->text('COM_J2COMMERCE_TOOLBAR_ADVANCED_PRICING')
+                ->url('index.php?option=com_j2commerce&view=advancedpricing')
+                ->icon('fa-solid fa-tags');
+        }
 
         if ($canDo->get('core.admin') || $canDo->get('core.options')) {
             $toolbar->preferences('com_j2commerce');
         }
 
         $toolbar->help('Products');
-
-
     }
 }


### PR DESCRIPTION
For issue #99.