### PR TITLE
Make vendor user and company fields required in vendor.xml form

### DIFF
--- a/administrator/components/com_j2commerce/forms/vendor.xml
+++ b/administrator/components/com_j2commerce/forms/vendor.xml
@@ -22,6 +22,7 @@
             type="user"
             label="COM_J2COMMERCE_FIELD_VENDOR_USER"
             description="COM_J2COMMERCE_FIELD_VENDOR_USER_DESC"
+            required="true"
         />
 
         <!-- Hidden address_id field (internal link to address table) -->
@@ -106,6 +107,7 @@
             type="text"
             label="COM_J2COMMERCE_FIELD_VENDOR_COMPANY"
             maxlength="255"
+            required="true"
         />
 
         <field


### PR DESCRIPTION
Vendor Name obviously should be a required field. Makes no sense to have a vendor without a name

User field is a required field (not sure where thats set) but its not marked as a required field in the form - it is now