### PR TITLE
Reordered sort options in filtergroups form for improved clarity

### DIFF
--- a/administrator/components/com_j2commerce/forms/filter_filtergroups.xml
+++ b/administrator/components/com_j2commerce/forms/filter_filtergroups.xml
@@ -29,12 +29,12 @@
             default="a.group_name ASC"
             >
             <option value="">JGLOBAL_SORT_BY</option>
-            <option value="a.group_name ASC">COM_J2COMMERCE_FILTERGROUP_NAME_ASC</option>
-            <option value="a.group_name DESC">COM_J2COMMERCE_FILTERGROUP_NAME_DESC</option>
-            <option value="a.enabled ASC">JSTATUS_ASC</option>
-            <option value="a.enabled DESC">JSTATUS_DESC</option>
             <option value="a.ordering ASC">JGRID_HEADING_ORDERING_ASC</option>
             <option value="a.ordering DESC">JGRID_HEADING_ORDERING_DESC</option>
+            <option value="a.enabled ASC">JSTATUS_ASC</option>
+            <option value="a.enabled DESC">JSTATUS_DESC</option>
+            <option value="a.group_name ASC">COM_J2COMMERCE_FILTERGROUP_NAME_ASC</option>
+            <option value="a.group_name DESC">COM_J2COMMERCE_FILTERGROUP_NAME_DESC</option>
             <option value="a.j2commerce_filtergroup_id ASC">JGRID_HEADING_ID_ASC</option>
             <option value="a.j2commerce_filtergroup_id DESC">JGRID_HEADING_ID_DESC</option>
         </field>


### PR DESCRIPTION
order in the select should match the order of the columns in the table