### PR TITLE
Update $text_prefix from 'COM_J2COMMERCE_OPTIONS' to 'COM_J2COMMERCE'

### DIFF
--- a/administrator/components/com_j2commerce/src/Controller/OptionsController.php
+++ b/administrator/components/com_j2commerce/src/Controller/OptionsController.php
@@ -26,7 +26,7 @@ class OptionsController extends AdminController
      * @var    string
      * @since  6.0.0
      */
-    protected $text_prefix = 'COM_J2COMMERCE_OPTIONS';
+    protected $text_prefix = 'COM_J2COMMERCE';
 
     /**
      * Method to get a model object, loading it if required.


### PR DESCRIPTION
This ensures that the correct strings are loaded when changing the state of an option.

Before it was trying COM_J2COMMERCE_OPTIONS_N_ITEMS_UNPUBLISHED which doesnt exist.

With this PR it is correctly using the generic COM_J2COMMERCE_N_ITEMS_UNPUBLISHED