### PR TITLE
Remove unused index.html files from j2commerce directories

### DIFF
--- a/administrator/components/com_j2commerce/forms/index.html
+++ b/administrator/components/com_j2commerce/forms/index.html
@@ -1,7 +1,0 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title></title>
-</head>
-<body></body>
-</html>

--- a/components/com_j2commerce/src/index.html
+++ b/components/com_j2commerce/src/index.html
@@ -1,7 +1,0 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title></title>
-</head>
-<body></body>
-</html>

--- a/components/com_j2commerce/tmpl/index.html
+++ b/components/com_j2commerce/tmpl/index.html
@@ -1,7 +1,0 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title></title>
-</head>
-<body></body>
-</html>

--- a/media/com_j2commerce/images/index.html
+++ b/media/com_j2commerce/images/index.html
@@ -1,7 +1,0 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title></title>
-</head>
-<body></body>
-</html>


### PR DESCRIPTION
The only time you MIGHT need to use one is if you have an empty folder as zip doesnt like empty folders.

In this case they can simply be removed