### PR TITLE
feat(core): plugin hooks for frontend view dispatch and router

### DIFF
--- a/components/com_j2commerce/src/Dispatcher/Dispatcher.php
+++ b/components/com_j2commerce/src/Dispatcher/Dispatcher.php
@@ -53,7 +53,21 @@ class Dispatcher extends ComponentDispatcher
             $strapper->addCSS();
         }
 
-        // Continue with normal dispatch
+        // Allow plugins to claim frontend views they render entirely via
+        // onAfterDispatch, bypassing the MVC chain (no View class needed).
+        $view = $input->getCmd('view', '');
+
+        if ($view !== '' && $app->isClient('site')) {
+            $claimed = J2CommerceHelper::plugin()->eventWithArray(
+                'BeforeDispatchView',
+                [$view]
+            );
+
+            if (\in_array(true, $claimed, true)) {
+                return;
+            }
+        }
+
         parent::dispatch();
     }
 }

--- a/components/com_j2commerce/src/Service/Router.php
+++ b/components/com_j2commerce/src/Service/Router.php
@@ -22,8 +22,10 @@ use Joomla\CMS\Component\Router\Rules\MenuRules;
 use Joomla\CMS\Component\Router\Rules\NomenuRules;
 use Joomla\CMS\Component\Router\Rules\StandardRules;
 use Joomla\CMS\Menu\AbstractMenu;
+use Joomla\CMS\Plugin\PluginHelper as JoomlaPluginHelper;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Database\ParameterType;
+use Joomla\Event\Event;
 
 /**
  * J2Commerce Router
@@ -127,6 +129,14 @@ class Router extends RouterView
         $this->registerView(new RouterViewConfiguration('myprofile'));
         $this->registerView(new RouterViewConfiguration('confirmation'));
         $this->registerView(new RouterViewConfiguration('categoryalias'));
+
+        // Allow J2Commerce plugins to register additional frontend views
+        // so app plugins can add SEF routes without modifying this core file.
+        JoomlaPluginHelper::importPlugin('j2commerce');
+        $app->getDispatcher()->dispatch(
+            'onJ2CommerceRegisterRouterViews',
+            new Event('onJ2CommerceRegisterRouterViews', ['router' => $this])
+        );
 
         parent::__construct($app, $menu);
 


### PR DESCRIPTION
## Core Update

### Changes
- **Dispatcher.php**: Added `BeforeDispatchView` event allowing plugins to claim frontend views they render entirely via onAfterDispatch, bypassing the MVC chain (no View class needed)
- **Router.php**: Added `onJ2CommerceRegisterRouterViews` event allowing plugins to register additional RouterViewConfiguration entries for SEF routing

This enables app plugins (e.g., vendor management) to add frontend pages without modifying core files.

### Files Modified
| Type | Count |
|------|-------|
| PHP files | 2 |

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only (non-core excluded)