### PR TITLE
fix(jquery): remove last jQuery usage from ArticleHelper

### DIFF
--- a/administrator/components/com_j2commerce/src/Helper/ArticleHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/ArticleHelper.php
@@ -207,8 +207,8 @@ class ArticleHelper
                 $wa->addInlineScript("
 				window.jSelectJ2Article_" . $id . " = function (id, title, catid, object, url, language) {
 					window.processModalSelect('Article', '" . $id . "', id, title, catid, object, url, language);
-					jQuery('body').removeClass('modal-open');
-                    jQuery('.modal-backdrop').remove();
+					document.body.classList.remove('modal-open');
+                    document.querySelectorAll('.modal-backdrop').forEach(el => el.remove());
 				}",
                     [],
                     ['type' => 'module']


### PR DESCRIPTION
## Summary
Fixes #56

## Root Cause
ArticleHelper.php used jQuery to clean up Bootstrap modal backdrop after article selection. This was the last remaining jQuery reference in J2Commerce core (inventory view jQuery was fixed in PR #136).

## Changes
- `jQuery('body').removeClass('modal-open')` → `document.body.classList.remove('modal-open')`
- `jQuery('.modal-backdrop').remove()` → `document.querySelectorAll('.modal-backdrop').forEach(el => el.remove())`

**J2Commerce is now completely jQuery-free.**

## Testing
1. Admin → edit a product article with article selector field
2. Open article picker modal → select an article
3. Verify modal closes cleanly, no grey backdrop remains
4. Browser console: zero jQuery errors

## Files Changed
- `administrator/components/com_j2commerce/src/Helper/ArticleHelper.php` — 2 lines replaced