### PR TITLE
fix(customfield): hide Countries tab for non-telephone field types

### DIFF
--- a/administrator/components/com_j2commerce/tmpl/customfield/edit.php
+++ b/administrator/components/com_j2commerce/tmpl/customfield/edit.php
@@ -315,12 +315,17 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     // Show/hide the Countries tab based on field_type
+    // Joomla 6 tab structure: <div role="tablist"><button aria-controls="telephone_countries" role="tab">...</button></div>
     function updateCountriesTab() {
         const fieldType = form.querySelector('#jform_field_type')?.value || '';
-        const tabLink = document.querySelector('[href="#telephone_countries"], [data-bs-target="#telephone_countries"]');
-        const tabItem = tabLink ? tabLink.closest('li') : null;
-        if (tabItem) {
-            tabItem.style.display = fieldType === 'telephone' ? '' : 'none';
+        const show = fieldType === 'telephone';
+        const tabBtn = document.querySelector('div[role="tablist"] > button[aria-controls="telephone_countries"]');
+        if (tabBtn) {
+            tabBtn.style.display = show ? '' : 'none';
+        }
+        const tabPane = document.getElementById('telephone_countries');
+        if (tabPane) {
+            tabPane.style.display = show ? '' : 'none';
         }
     }
 


### PR DESCRIPTION
## Summary
Fixes #36

## Root Cause
The Countries tab (telephone country configuration) was visible on all checkout field types. The JavaScript function `updateCountriesTab()` used incorrect selectors that didn't match Joomla 6's tab structure.

Joomla 6 generates: `<div role="tablist"><button aria-controls="telephone_countries" role="tab">...</button></div>`

The old code looked for `li > a` patterns that don't exist in Joomla 6.

## Changes
- Fixed `updateCountriesTab()` selector to `div[role="tablist"] > button[aria-controls="telephone_countries"]`
- Hides the tab button directly (no `closest('li')` — buttons aren't wrapped in `<li>`)
- Also hides the tab pane via `document.getElementById('telephone_countries')`

## Testing
1. Admin → Checkout Fields → edit an Email field → Countries tab is HIDDEN
2. Edit a Telephone field → Countries tab is VISIBLE
3. Change any field's type to Telephone → tab appears dynamically
4. Change back to Text/Email/etc → tab hides

## Files Changed
- `administrator/components/com_j2commerce/tmpl/customfield/edit.php` — 9 lines changed