### PR TITLE
fix(myprofile): always dispatch plugin tab events so app plugins render

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,12 +54,6 @@
 !components/com_j2commerce/
 !components/com_j2commerce/**
 
-# Site language files
-!language/
-!language/en-GB/
-!language/en-GB/com_j2commerce.ini
-!language/en-GB/com_j2commerce.sys.ini
-
 # J2Commerce core plugins (only those in the package skill)
 !plugins/
 !plugins/j2commerce/
@@ -149,6 +143,7 @@
 # ===========================================================================
 .mcp.json
 configuration.php
+language/
 .env
 *.log
 cache/
@@ -222,3 +217,5 @@ administrator/components/com_j2commerce/tmpl/product/form_guidedbuilder.php
 # Non-core site layouts (inserted by 3rd-party plugins)
 components/com_j2commerce/layouts/app_bootstrap5/list/category/item_guidedbuilder.php
 components/com_j2commerce/layouts/app_bootstrap5/list/tag/item_guidedbuilder.php
+# Non-core site templates (created by plugins on install — do NOT whitelist)
+# components/com_j2commerce/tmpl/vendorapply/  — app_vendormanagement plugin

--- a/components/com_j2commerce/src/View/Myprofile/HtmlView.php
+++ b/components/com_j2commerce/src/View/Myprofile/HtmlView.php
@@ -158,17 +158,10 @@ class HtmlView extends BaseHtmlView
                 }
             }
 
-            // Plugin events - only dispatch legacy tab events if NOT using unified payment tab
-            // Plugins implementing onGetSavedPaymentMethods should NOT render legacy tabs
-            if ($this->useUnifiedPaymentTab) {
-                // Dispatch only non-payment-tab plugin events
-                $this->pluginTabHtml     = '';
-                $this->pluginContentHtml = '';
-            } else {
-                // Legacy: dispatch all plugin tab events
-                $this->pluginTabHtml     = J2CommerceHelper::plugin()->eventWithHtml('MyProfileTab')->getArgument('html', '');
-                $this->pluginContentHtml = J2CommerceHelper::plugin()->eventWithHtml('MyProfileTabContent', [$this->orders])->getArgument('html', '');
-            }
+            // Dispatch plugin tab events (app plugins like Change Password, Vendor Management, etc.)
+            // Payment plugins use the unified GetSavedPaymentMethods event instead
+            $this->pluginTabHtml     = J2CommerceHelper::plugin()->eventWithHtml('MyProfileTab')->getArgument('html', '');
+            $this->pluginContentHtml = J2CommerceHelper::plugin()->eventWithHtml('MyProfileTabContent', [$this->orders])->getArgument('html', '');
 
             // These plugin events should always run regardless of payment tab state
             $this->topMessagesHtml   = J2CommerceHelper::plugin()->eventWithHtml('MyProfileTopMessages', [$this->orders])->getArgument('html', '');


### PR DESCRIPTION
## Core Update

### Summary
The `useUnifiedPaymentTab` conditional in `HtmlView.php` was suppressing ALL `MyProfileTab` and `MyProfileTabContent` events when a user had saved payment methods. This blocked non-payment app plugins (Change Password, Vendor Management) from rendering their tabs.

### Fix
- **Always dispatch** `MyProfileTab`/`MyProfileTabContent` events — these are now reserved for app plugins
- Payment plugins exclusively use `GetSavedPaymentMethods` for the unified Payment Methods tab
- Updated `.gitignore` to remove deleted language file whitelist and add non-core template ignores

### Files Modified
| Type | Count |
|------|-------|
| PHP files | 1 |
| Config (.gitignore) | 1 |

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only (non-core excluded)