### PR TITLE
fix(checkout): redesign telephone country selection UX

### DIFF
--- a/administrator/components/com_j2commerce/forms/customfield.xml
+++ b/administrator/components/com_j2commerce/forms/customfield.xml
@@ -241,29 +241,33 @@
         />
     </fieldset>
 
-    <fieldset name="telephone_countries" label="COM_J2COMMERCE_FIELDSET_TELEPHONE_COUNTRIES" showon="field_type:telephone"
-        addfieldprefix="J2Commerce\Component\J2commerce\Administrator\Field">
+    <fieldset
+        name="telephone_countries"
+        label="COM_J2COMMERCE_FIELDSET_TELEPHONE_COUNTRIES"
+        showon="field_type:telephone"
+        addfieldprefix="J2Commerce\Component\J2commerce\Administrator\Field"
+    >
 
         <field
-            name="phone_all_countries"
-            type="radio"
-            label="COM_J2COMMERCE_FIELD_PHONE_ALL_COUNTRIES"
-            description="COM_J2COMMERCE_FIELD_PHONE_ALL_COUNTRIES_DESC"
-            layout="joomla.form.field.radio.switcher"
-            filter="integer"
-            default="1"
+            name="phone_country_mode"
+            type="list"
+            label="COM_J2COMMERCE_FIELD_PHONE_COUNTRY_MODE"
+            description="COM_J2COMMERCE_FIELD_PHONE_COUNTRY_MODE_DESC"
+            default="all"
         >
-            <option value="0">JNO</option>
-            <option value="1">JYES</option>
+            <option value="none">COM_J2COMMERCE_PHONE_MODE_NONE</option>
+            <option value="all">COM_J2COMMERCE_PHONE_MODE_ALL</option>
+            <option value="selected">COM_J2COMMERCE_PHONE_MODE_SELECTED</option>
         </field>
 
         <field
             name="phone_countries"
             type="PhoneCountries"
             label="COM_J2COMMERCE_FIELD_PHONE_COUNTRIES"
-            showon="phone_all_countries:0"
+            showon="phone_country_mode:selected"
             filter="raw"
             multiple="true"
+            hiddenLabel="true"
         />
 
     </fieldset>

--- a/administrator/components/com_j2commerce/language/en-GB/com_j2commerce.ini
+++ b/administrator/components/com_j2commerce/language/en-GB/com_j2commerce.ini
@@ -627,10 +627,17 @@ COM_J2COMMERCE_FIELD_BACKEND_DESC="Display this field in the admin backend"
 
 ; Customfields View - Telephone Countries Tab
 COM_J2COMMERCE_FIELDSET_TELEPHONE_COUNTRIES="Countries"
-COM_J2COMMERCE_FIELD_PHONE_ALL_COUNTRIES="Use All Countries"
-COM_J2COMMERCE_FIELD_PHONE_ALL_COUNTRIES_DESC="When enabled, all enabled countries with dial codes will appear in the telephone field dropdown."
+COM_J2COMMERCE_FIELD_PHONE_COUNTRY_MODE="Select Countries to Show"
+COM_J2COMMERCE_FIELD_PHONE_COUNTRY_MODE_DESC="Select which countries should appear in the phone field dropdown."
+COM_J2COMMERCE_PHONE_MODE_NONE="No Countries (Plain Phone Input)"
+COM_J2COMMERCE_PHONE_MODE_ALL="All Countries"
+COM_J2COMMERCE_PHONE_MODE_SELECTED="Specific Countries"
 COM_J2COMMERCE_FIELD_PHONE_COUNTRIES="Allowed Countries"
 COM_J2COMMERCE_FIELD_PHONE_COUNTRIES_DESC="Select which countries are available in the telephone dropdown. Only enabled countries in the store will appear in the frontend."
+COM_J2COMMERCE_PHONE_COUNTRIES_SEARCH="Search countries..."
+COM_J2COMMERCE_PHONE_COUNTRIES_SELECT_ALL="Select All"
+COM_J2COMMERCE_PHONE_COUNTRIES_TOGGLE="Toggle Selection"
+COM_J2COMMERCE_PHONE_COUNTRIES_DESELECT_ALL="Deselect All"
 
 ; Customfields View - Display Settings
 COM_J2COMMERCE_FIELDSET_DISPLAY_SETTINGS="Display Settings"

--- a/administrator/components/com_j2commerce/language/en-US/com_j2commerce.ini
+++ b/administrator/components/com_j2commerce/language/en-US/com_j2commerce.ini
@@ -627,10 +627,17 @@ COM_J2COMMERCE_FIELD_BACKEND_DESC="Display this field in the admin backend"
 
 ; Customfields View - Telephone Countries Tab
 COM_J2COMMERCE_FIELDSET_TELEPHONE_COUNTRIES="Countries"
-COM_J2COMMERCE_FIELD_PHONE_ALL_COUNTRIES="Use All Countries"
-COM_J2COMMERCE_FIELD_PHONE_ALL_COUNTRIES_DESC="When enabled, all enabled countries with dial codes will appear in the telephone field dropdown."
+COM_J2COMMERCE_FIELD_PHONE_COUNTRY_MODE="Select Countries to Show"
+COM_J2COMMERCE_FIELD_PHONE_COUNTRY_MODE_DESC="Select which countries should appear in the phone field dropdown."
+COM_J2COMMERCE_PHONE_MODE_NONE="No Countries (Plain Phone Input)"
+COM_J2COMMERCE_PHONE_MODE_ALL="All Countries"
+COM_J2COMMERCE_PHONE_MODE_SELECTED="Specific Countries"
 COM_J2COMMERCE_FIELD_PHONE_COUNTRIES="Allowed Countries"
 COM_J2COMMERCE_FIELD_PHONE_COUNTRIES_DESC="Select which countries are available in the telephone dropdown. Only enabled countries in the store will appear in the frontend."
+COM_J2COMMERCE_PHONE_COUNTRIES_SEARCH="Search countries..."
+COM_J2COMMERCE_PHONE_COUNTRIES_SELECT_ALL="Select All"
+COM_J2COMMERCE_PHONE_COUNTRIES_TOGGLE="Toggle Selection"
+COM_J2COMMERCE_PHONE_COUNTRIES_DESELECT_ALL="Deselect All"
 
 ; Customfields View - Display Settings
 COM_J2COMMERCE_FIELDSET_DISPLAY_SETTINGS="Display Settings"

--- a/administrator/components/com_j2commerce/src/Field/PhoneCountriesField.php
+++ b/administrator/components/com_j2commerce/src/Field/PhoneCountriesField.php
@@ -14,58 +14,18 @@ namespace J2Commerce\Component\J2commerce\Administrator\Field;
 \defined('_JEXEC') or die;
 
 use Joomla\CMS\Form\Field\CheckboxesField;
+use Joomla\CMS\Language\Text;
 use J2Commerce\Component\J2commerce\Administrator\Helper\PhoneHelper;
 
 /**
- * Renders a checkbox list of all countries from PhoneHelper::DIAL_DATA,
- * with flag image, country name, and dial code.
- *
- * Stores selected ISO2 codes as a JSON array.
+ * Renders continent-grouped checkboxes for selecting allowed phone countries.
+ * Layout matches Joomla core Menu Assignment pattern: bordered cards with
+ * Toggle Selection buttons, 2-column grid of continent cards.
  */
 class PhoneCountriesField extends CheckboxesField
 {
     protected $type = 'PhoneCountries';
 
-    /** @return  \SimpleXMLElement[] */
-    protected function getOptions(): array
-    {
-        $dialData = PhoneHelper::getDialData();
-        $countries = PhoneHelper::getCountryListForDropdown();
-
-        // Build a name map from the DB-enabled countries
-        $nameMap = [];
-        foreach ($countries as $c) {
-            $nameMap[$c['iso2']] = $c['name'];
-        }
-
-        // Build options for all entries in DIAL_DATA, sorted by name
-        $options = [];
-        foreach ($dialData as $iso2 => $data) {
-            $name = $nameMap[$iso2] ?? $iso2;
-
-            $options[$name . $iso2] = [
-                'value' => $iso2,
-                'text'  => htmlspecialchars($name, ENT_QUOTES, 'UTF-8')
-                    . ' <span class="text-muted">+' . htmlspecialchars($data['code'], ENT_QUOTES, 'UTF-8') . '</span>',
-            ];
-        }
-
-        ksort($options);
-
-        $result = [];
-        foreach ($options as $opt) {
-            $o        = new \stdClass();
-            $o->value = $opt['value'];
-            $o->text  = $opt['text'];
-            $result[] = $o;
-        }
-
-        return $result;
-    }
-
-    /**
-     * The field stores a JSON array; decode it to an array of checked values.
-     */
     protected function getChecked(): array
     {
         $value = $this->value;
@@ -89,32 +49,181 @@ class PhoneCountriesField extends CheckboxesField
 
     protected function getInput(): string
     {
-        $checked = $this->getChecked();
-        $options = $this->getOptions();
-        $name    = $this->name;
-        $id      = $this->id;
+        $checked      = $this->getChecked();
+        $dialData     = PhoneHelper::getDialData();
+        $continentMap = PhoneHelper::getContinentMap();
+        $name         = $this->name;
+        $id           = $this->id;
 
-        $cols = 3;
-        $colClass = 'col-md-' . (12 / $cols);
-
-        $html = '<div class="row g-2">';
-        foreach ($options as $i => $opt) {
-            $isChecked = \in_array($opt->value, $checked, true) ? ' checked' : '';
-            $optId     = $id . '_' . $i;
-            $html .= '<div class="' . $colClass . '">'
-                . '<div class="form-check">'
-                . '<input type="checkbox" class="form-check-input" '
-                . 'name="' . htmlspecialchars($name, ENT_QUOTES, 'UTF-8') . '" '
-                . 'id="' . htmlspecialchars($optId, ENT_QUOTES, 'UTF-8') . '" '
-                . 'value="' . htmlspecialchars($opt->value, ENT_QUOTES, 'UTF-8') . '"'
-                . $isChecked . '>'
-                . '<label class="form-check-label" for="' . htmlspecialchars($optId, ENT_QUOTES, 'UTF-8') . '">'
-                . $opt->text
-                . '</label>'
-                . '</div>'
-                . '</div>';
+        // Build name map from DB-enabled countries
+        $countries = PhoneHelper::getCountryListForDropdown();
+        $nameMap   = [];
+        foreach ($countries as $c) {
+            $nameMap[$c['iso2']] = $c['name'];
         }
-        $html .= '</div>';
+
+        // Build ISO2 → dial code map
+        $dialCodeMap = [];
+        foreach ($dialData as $iso2 => $data) {
+            $dialCodeMap[$iso2] = $data['code'];
+        }
+
+        // Track which ISO2 codes have been placed in a continent
+        $placed = [];
+        foreach ($continentMap as $codes) {
+            foreach ($codes as $iso2) {
+                $placed[$iso2] = true;
+            }
+        }
+
+        // Collect any dial-data countries not in the continent map into "Other"
+        $other = [];
+        foreach ($dialData as $iso2 => $data) {
+            if (!isset($placed[$iso2])) {
+                $other[] = $iso2;
+            }
+        }
+
+        $allContinents = $continentMap;
+        if ($other) {
+            $allContinents['Other'] = $other;
+        }
+
+        $esc = static fn(string $s): string => htmlspecialchars($s, ENT_QUOTES, 'UTF-8');
+
+        $searchLabel      = Text::_('COM_J2COMMERCE_PHONE_COUNTRIES_SEARCH');
+        $toggleAllLabel   = Text::_('COM_J2COMMERCE_PHONE_COUNTRIES_SELECT_ALL');
+        $toggleLabel      = Text::_('COM_J2COMMERCE_PHONE_COUNTRIES_TOGGLE');
+
+        $masterCheckId = $id . '_master';
+
+        $html  = '<div class="j2c-phone-countries-picker" data-field-id="' . $esc($id) . '">';
+
+        // Search input
+        $html .= '<div class="mb-3">'
+            . '<input type="text" class="form-control j2c-phone-countries-search" '
+            . 'placeholder="' . $esc($searchLabel) . '" autocomplete="off">'
+            . '</div>';
+
+        // Master Toggle All Selections button (matches Joomla Menu Assignment style)
+        $html .= '<div class="mb-3">'
+            . '<button type="button" class="btn btn-outline-primary btn-sm j2c-phone-master-toggle" id="' . $esc($masterCheckId) . '">'
+            . '<span class="icon-checkbox me-1" aria-hidden="true"></span>'
+            . $esc($toggleAllLabel)
+            . '</button>'
+            . '</div>';
+
+        // 2-column grid of continent cards (matching Menu Assignment layout)
+        $html .= '<div class="row g-3">';
+
+        $checkIndex = 0;
+
+        foreach ($allContinents as $continentName => $isoCodes) {
+            $validCodes = array_filter($isoCodes, static fn(string $iso) => isset($dialCodeMap[$iso]));
+
+            if (empty($validCodes)) {
+                continue;
+            }
+
+            usort($validCodes, static function (string $a, string $b) use ($nameMap): int {
+                return strcmp($nameMap[$a] ?? $a, $nameMap[$b] ?? $b);
+            });
+
+            $continentId = $id . '_continent_' . strtolower(preg_replace('/\W+/', '_', $continentName));
+
+            // Continent card
+            $html .= '<div class="col-md-6 j2c-phone-continent" data-continent="' . $esc($continentName) . '">';
+            $html .= '<div class="card border">';
+
+            // Card body with Toggle Selection button + continent name
+            $html .= '<div class="card-body">';
+            $html .= '<button type="button" class="btn btn-outline-primary btn-sm mb-2 j2c-phone-continent-toggle" '
+                . 'data-continent="' . $esc($continentName) . '">'
+                . '<span class="icon-checkbox me-1" aria-hidden="true"></span>'
+                . $esc($toggleLabel ?? 'Toggle Selection')
+                . '</button>';
+            $html .= '<div class="fw-bold mb-2">' . $esc($continentName) . '</div>';
+
+            // Single-column list of country checkboxes
+            foreach ($validCodes as $iso2) {
+                $dialCode    = $dialCodeMap[$iso2];
+                $countryName = $nameMap[$iso2] ?? $iso2;
+                $isChecked   = \in_array($iso2, $checked, true) ? ' checked' : '';
+                $optId       = $id . '_' . $checkIndex;
+
+                $html .= '<div class="form-check j2c-phone-country-item" '
+                    . 'data-name="' . $esc(strtolower($countryName)) . '" '
+                    . 'data-code="' . $esc($dialCode) . '">'
+                    . '<input type="checkbox" class="form-check-input j2c-phone-country-check" '
+                    . 'name="' . $esc($name) . '" '
+                    . 'id="' . $esc($optId) . '" '
+                    . 'value="' . $esc($iso2) . '"'
+                    . $isChecked . ' '
+                    . 'data-continent="' . $esc($continentName) . '">'
+                    . '<label class="form-check-label" for="' . $esc($optId) . '">'
+                    . $esc($countryName) . ' <span class="text-muted">+' . $esc($dialCode) . '</span>'
+                    . '</label>'
+                    . '</div>';
+
+                $checkIndex++;
+            }
+
+            $html .= '</div>'; // card-body
+            $html .= '</div>'; // card
+            $html .= '</div>'; // col-md-6
+        }
+
+        $html .= '</div>'; // row
+        $html .= '</div>'; // picker
+
+        // Inline script for search, toggle-all, and continent-toggle logic
+        $html .= <<<'SCRIPT'
+<script>
+(function(){
+    const picker = document.currentScript.previousElementSibling;
+    if (!picker) return;
+
+    const search = picker.querySelector('.j2c-phone-countries-search');
+    const masterBtn = picker.querySelector('.j2c-phone-master-toggle');
+    const continentBtns = picker.querySelectorAll('.j2c-phone-continent-toggle');
+    const countryChecks = picker.querySelectorAll('.j2c-phone-country-check');
+
+    // Search filter
+    if (search) {
+        search.addEventListener('input', function() {
+            const q = search.value.toLowerCase();
+            picker.querySelectorAll('.j2c-phone-continent').forEach(function(cont) {
+                let anyVisible = false;
+                cont.querySelectorAll('.j2c-phone-country-item').forEach(function(item) {
+                    const match = !q || item.dataset.name.indexOf(q) !== -1 || item.dataset.code.indexOf(q) !== -1;
+                    item.style.display = match ? '' : 'none';
+                    if (match) anyVisible = true;
+                });
+                cont.style.display = anyVisible ? '' : 'none';
+            });
+        });
+    }
+
+    // Master toggle all
+    if (masterBtn) {
+        masterBtn.addEventListener('click', function() {
+            const allChecked = Array.from(countryChecks).every(function(c) { return c.checked; });
+            countryChecks.forEach(function(c) { c.checked = !allChecked; });
+        });
+    }
+
+    // Continent toggle
+    continentBtns.forEach(function(btn) {
+        btn.addEventListener('click', function() {
+            const continent = btn.dataset.continent;
+            const items = picker.querySelectorAll('.j2c-phone-country-check[data-continent="' + continent + '"]');
+            const allChecked = Array.from(items).every(function(c) { return c.checked; });
+            items.forEach(function(c) { c.checked = !allChecked; });
+        });
+    });
+})();
+</script>
+SCRIPT;
 
         return $html;
     }

--- a/administrator/components/com_j2commerce/src/Helper/CustomFieldHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/CustomFieldHelper.php
@@ -356,7 +356,7 @@ class CustomFieldHelper
         $dialCode       = $parsed['code'];
 
         // Determine which countries to show based on field settings stored in field_options
-        $allowedIso2 = null;
+        $allowedIso2  = null;
         $fieldOptions = [];
         if (!empty($field->field_options)) {
             $decoded = json_decode($field->field_options, true);
@@ -364,8 +364,41 @@ class CustomFieldHelper
                 $fieldOptions = $decoded;
             }
         }
-        $phoneAllCountries = (int) ($fieldOptions['phone_all_countries'] ?? 1);
-        if ($phoneAllCountries === 0 && !empty($fieldOptions['phone_countries'])) {
+
+        // Resolve phone_country_mode with backward compat for legacy phone_all_countries
+        if (isset($fieldOptions['phone_country_mode'])) {
+            $phoneMode = $fieldOptions['phone_country_mode'];
+        } elseif (isset($fieldOptions['phone_all_countries'])) {
+            $phoneMode = ((int) $fieldOptions['phone_all_countries'] === 1) ? 'all' : 'selected';
+        } else {
+            $phoneMode = 'all';
+        }
+
+        // Handle "none" mode: plain tel input, no country dropdown
+        if ($phoneMode === 'none') {
+            $escapedValue = htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+            $escapedAc    = htmlspecialchars($field->field_autocomplete ?? 'tel', ENT_QUOTES, 'UTF-8');
+            $plainInput   = '<input type="tel" class="form-control" '
+                . 'name="' . $namekey . '" id="' . $id . '" '
+                . 'value="' . $escapedValue . '" '
+                . 'autocomplete="' . $escapedAc . '" '
+                . 'data-mode="none"'
+                . $requiredAttr . '>';
+
+            if ($isFloating) {
+                return '<div class="form-floating">'
+                    . $plainInput
+                    . '<label for="' . $id . '">' . $labelHtml . '</label>'
+                    . '</div>';
+            }
+
+            return '<div class="form-normal">'
+                . '<label for="' . $id . '" class="form-label">' . $labelHtml . '</label>'
+                . $plainInput
+                . '</div>';
+        }
+
+        if ($phoneMode === 'selected' && !empty($fieldOptions['phone_countries'])) {
             $allowedIso2 = (array) $fieldOptions['phone_countries'];
         }
 

--- a/administrator/components/com_j2commerce/src/Helper/PhoneHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/PhoneHelper.php
@@ -217,6 +217,38 @@ class PhoneHelper
         'VI' => ['code' => '1',    'min' => 7,  'max' => 10],
     ];
 
+    private const CONTINENT_MAP = [
+        'Africa'   => [
+            'DZ','AO','BJ','BW','BF','BI','CM','CV','CF','TD','KM','CD','CG','CI','DJ','EG',
+            'GQ','ER','ET','GA','GM','GH','GN','GW','KE','LS','LR','LY','MG','MW','ML','MR',
+            'MU','MA','MZ','NA','NE','NG','RW','SN','SC','SL','SO','ZA','SD','TZ','TG','TN',
+            'UG','ZM','ZW',
+        ],
+        'Americas' => [
+            'AG','AI','AR','BB','BS','BZ','BM','BO','BR','CA','CL','CO','CR','CU','DM','DO',
+            'EC','SV','GD','GT','GU','GY','HT','HN','JM','MX','KN','KY','LC','MP','MS','NI',
+            'PA','PY','PE','PR','SX','TC','TT','US','UY','VE','VC','VG','VI',
+        ],
+        'Asia'     => [
+            'AF','AM','AZ','BH','BD','BT','BN','KH','CN','GE','HK','IN','ID','IR','IQ','IL',
+            'JP','JO','KZ','KR','KW','KG','LA','LB','MO','MY','MV','MN','MM','NP','OM','PK',
+            'PH','QA','SA','SG','LK','SY','TW','TJ','TH','TM','AE','UZ','VN','YE',
+        ],
+        'Europe'   => [
+            'AL','AD','AT','BY','BE','BA','BG','HR','CY','CZ','DK','EE','FI','FR','DE','GI',
+            'GL','GR','HU','IS','IE','IT','LV','LI','LT','LU','MT','MD','MC','ME','MK','NL',
+            'NO','PL','PT','RO','RU','RS','SK','SI','ES','SE','CH','TR','UA','GB',
+        ],
+        'Oceania'  => [
+            'AU','FJ','KI','MH','FM','NR','NZ','PW','PG','WS','SB','TO','TV','VU',
+        ],
+    ];
+
+    public static function getContinentMap(): array
+    {
+        return self::CONTINENT_MAP;
+    }
+
     public static function getDialData(): array
     {
         return self::DIAL_DATA;

--- a/administrator/components/com_j2commerce/src/Model/CustomfieldModel.php
+++ b/administrator/components/com_j2commerce/src/Model/CustomfieldModel.php
@@ -142,8 +142,15 @@ class CustomfieldModel extends AdminModel
                     if (isset($options['zone_type'])) {
                         $data->field_zonetype = $options['zone_type'];
                     }
-                    // Phone country settings
-                    $data->phone_all_countries = (int) ($options['phone_all_countries'] ?? 1);
+                    // Phone country settings — support both new (phone_country_mode) and legacy (phone_all_countries) formats
+                    if (isset($options['phone_country_mode'])) {
+                        $data->phone_country_mode = $options['phone_country_mode'];
+                    } elseif (isset($options['phone_all_countries'])) {
+                        // Backward compat: map old boolean flag to new 3-option mode
+                        $data->phone_country_mode = ((int) $options['phone_all_countries'] === 1) ? 'all' : 'selected';
+                    } else {
+                        $data->phone_country_mode = 'all';
+                    }
                     if (isset($options['phone_countries'])) {
                         // Stored as JSON array; form field expects the raw array
                         $data->phone_countries = $options['phone_countries'];
@@ -249,10 +256,17 @@ class CustomfieldModel extends AdminModel
         }
 
         if ($data['field_type'] === 'telephone') {
-            $phoneAllCountries = (int) ($data['phone_all_countries'] ?? 1);
-            $fieldOptionsData['phone_all_countries'] = $phoneAllCountries;
-            if ($phoneAllCountries === 0 && isset($data['phone_countries'])) {
-                // phone_countries arrives as array from the checkboxes field; flatten forceMultiple wrapping
+            $mode = $data['phone_country_mode'] ?? 'all';
+            // Ensure only valid mode values are stored
+            if (!\in_array($mode, ['none', 'all', 'selected'], true)) {
+                $mode = 'all';
+            }
+            $fieldOptionsData['phone_country_mode'] = $mode;
+            // Remove legacy key on save to keep options clean
+            unset($fieldOptionsData['phone_all_countries']);
+
+            if ($mode === 'selected' && isset($data['phone_countries'])) {
+                // phone_countries arrives as array from the checkboxes field
                 $raw = $data['phone_countries'];
                 if (\is_array($raw) && isset($raw[0]) && \is_array($raw[0])) {
                     $raw = $raw[0];
@@ -269,7 +283,7 @@ class CustomfieldModel extends AdminModel
         }
 
         // Remove virtual fields before save
-        unset($data['field_zonetype'], $data['phone_all_countries'], $data['phone_countries']);
+        unset($data['field_zonetype'], $data['phone_all_countries'], $data['phone_country_mode'], $data['phone_countries']);
 
         // Encode field_value subform data to JSON for dropdown/radio/checkbox options
         if (\in_array($data['field_type'], ['singledropdown', 'radio', 'checkbox'], true)) {

--- a/administrator/components/com_j2commerce/tmpl/customfield/edit.php
+++ b/administrator/components/com_j2commerce/tmpl/customfield/edit.php
@@ -104,8 +104,7 @@ foreach ($translationKeys as $key) {
                 <fieldset id="fieldset-telephone-countries" class="options-form">
                     <legend><?php echo Text::_('COM_J2COMMERCE_FIELDSET_TELEPHONE_COUNTRIES'); ?></legend>
                     <div class="form-grid">
-                        <?php echo $this->form->renderField('phone_all_countries'); ?>
-                        <div class="small text-muted mb-2" data-showon='[{"field":"jform[phone_all_countries]","values":["0"],"sign":"=","op":""}]'><?php echo Text::_('COM_J2COMMERCE_FIELD_PHONE_COUNTRIES_DESC'); ?></div>
+                        <?php echo $this->form->renderField('phone_country_mode'); ?>
                         <?php echo $this->form->renderField('phone_countries'); ?>
                     </div>
                 </fieldset>

--- a/administrator/language/en-GB/com_j2commerce.ini
+++ b/administrator/language/en-GB/com_j2commerce.ini
@@ -627,10 +627,17 @@ COM_J2COMMERCE_FIELD_BACKEND_DESC="Display this field in the admin backend"
 
 ; Customfields View - Telephone Countries Tab
 COM_J2COMMERCE_FIELDSET_TELEPHONE_COUNTRIES="Countries"
-COM_J2COMMERCE_FIELD_PHONE_ALL_COUNTRIES="Use All Countries"
-COM_J2COMMERCE_FIELD_PHONE_ALL_COUNTRIES_DESC="When enabled, all enabled countries with dial codes will appear in the telephone field dropdown."
+COM_J2COMMERCE_FIELD_PHONE_COUNTRY_MODE="Select Countries to Show"
+COM_J2COMMERCE_FIELD_PHONE_COUNTRY_MODE_DESC="Select which countries should appear in the phone field dropdown."
+COM_J2COMMERCE_PHONE_MODE_NONE="No Countries (Plain Phone Input)"
+COM_J2COMMERCE_PHONE_MODE_ALL="All Countries"
+COM_J2COMMERCE_PHONE_MODE_SELECTED="Specific Countries"
 COM_J2COMMERCE_FIELD_PHONE_COUNTRIES="Allowed Countries"
 COM_J2COMMERCE_FIELD_PHONE_COUNTRIES_DESC="Select which countries are available in the telephone dropdown. Only enabled countries in the store will appear in the frontend."
+COM_J2COMMERCE_PHONE_COUNTRIES_SEARCH="Search countries..."
+COM_J2COMMERCE_PHONE_COUNTRIES_SELECT_ALL="Select All"
+COM_J2COMMERCE_PHONE_COUNTRIES_TOGGLE="Toggle Selection"
+COM_J2COMMERCE_PHONE_COUNTRIES_DESELECT_ALL="Deselect All"
 
 ; Customfields View - Display Settings
 COM_J2COMMERCE_FIELDSET_DISPLAY_SETTINGS="Display Settings"

--- a/administrator/language/en-US/com_j2commerce.ini
+++ b/administrator/language/en-US/com_j2commerce.ini
@@ -611,10 +611,17 @@ COM_J2COMMERCE_FIELD_BACKEND_DESC="Display this field in the admin backend"
 
 ; Customfields View - Telephone Countries Tab
 COM_J2COMMERCE_FIELDSET_TELEPHONE_COUNTRIES="Countries"
-COM_J2COMMERCE_FIELD_PHONE_ALL_COUNTRIES="Use All Countries"
-COM_J2COMMERCE_FIELD_PHONE_ALL_COUNTRIES_DESC="When enabled, all enabled countries with dial codes will appear in the telephone field dropdown."
+COM_J2COMMERCE_FIELD_PHONE_COUNTRY_MODE="Select Countries to Show"
+COM_J2COMMERCE_FIELD_PHONE_COUNTRY_MODE_DESC="Select which countries should appear in the phone field dropdown."
+COM_J2COMMERCE_PHONE_MODE_NONE="No Countries (Plain Phone Input)"
+COM_J2COMMERCE_PHONE_MODE_ALL="All Countries"
+COM_J2COMMERCE_PHONE_MODE_SELECTED="Specific Countries"
 COM_J2COMMERCE_FIELD_PHONE_COUNTRIES="Allowed Countries"
 COM_J2COMMERCE_FIELD_PHONE_COUNTRIES_DESC="Select which countries are available in the telephone dropdown. Only enabled countries in the store will appear in the frontend."
+COM_J2COMMERCE_PHONE_COUNTRIES_SEARCH="Search countries..."
+COM_J2COMMERCE_PHONE_COUNTRIES_SELECT_ALL="Select All"
+COM_J2COMMERCE_PHONE_COUNTRIES_TOGGLE="Toggle Selection"
+COM_J2COMMERCE_PHONE_COUNTRIES_DESELECT_ALL="Deselect All"
 
 ; Customfields View - Display Settings
 COM_J2COMMERCE_FIELDSET_DISPLAY_SETTINGS="Display Settings"

--- a/media/com_j2commerce/js/site/telephone-field.js
+++ b/media/com_j2commerce/js/site/telephone-field.js
@@ -46,6 +46,11 @@
     observer.observe(document.body, { childList: true, subtree: true });
 
     function initTelephoneField(container) {
+        // "none" mode renders a plain <input type="tel" data-mode="none"> without the
+        // .j2c-telephone-field wrapper, so this function is never called for none-mode
+        // fields. The guard below handles any edge case where it might be.
+        if (container.dataset.mode === 'none') return;
+
         var countries;
         try {
             countries = JSON.parse(container.dataset.countries || '[]');


### PR DESCRIPTION
## Summary
Fixes #37

## Root Cause
The "Use All Countries" radio switcher was confusing — it read like all-or-nothing but actually meant all vs selected. Store owners couldn't tell what "No" meant without clicking it first.

## Changes (11 files)
- **3-option select** replacing radio switcher: No Countries (plain phone input), All Countries (default), Specific Countries
- **Continent-grouped checkboxes** matching Joomla core Menu Assignment pattern: bordered cards in 2-column grid with Toggle Selection buttons, search input, and master Toggle All
- **PhoneHelper** continent mapping for 5 continents
- **Model** backward compat: existing `phone_all_countries` data auto-maps to new `phone_country_mode` on load
- **Frontend rendering** handles 3 modes: none (plain tel input), all, selected
- **9 new language strings**, 2 old strings removed

## Testing
1. Admin → Checkout Fields → edit telephone field → Countries tab
2. "Select Countries to Show" dropdown shows 3 options
3. Select "Specific Countries" → continent cards appear with search + toggle buttons
4. Select "No Countries" → frontend shows plain phone input
5. Select "All Countries" → full country dropdown on frontend
6. Existing telephone fields with old data load correctly (backward compat)

## Files Changed
- `customfield.xml` — new 3-option list field
- `PhoneCountriesField.php` — continent-grouped card layout
- `PhoneHelper.php` — continent mapping
- `CustomfieldModel.php` — load/save with backward compat
- `CustomFieldHelper.php` — 3-mode frontend rendering
- `telephone-field.js` — none mode guard
- `edit.php` — render new field name
- 4 language INI files