### PR TITLE
fix(taxrates): remove non-functional ordering sort option

### DIFF
--- a/administrator/components/com_j2commerce/forms/filter_taxrates.xml
+++ b/administrator/components/com_j2commerce/forms/filter_taxrates.xml
@@ -38,7 +38,7 @@
             name="fullordering"
             type="list"
             label="JGLOBAL_SORT_BY"
-            default="a.ordering ASC"
+            default="a.taxrate_name ASC"
             onchange="this.form.submit();"
         >
             <option value="">JGLOBAL_SORT_BY</option>
@@ -50,8 +50,6 @@
             <option value="a.tax_percent DESC">COM_J2COMMERCE_HEADING_TAX_PERCENT_DESC</option>
             <option value="g.geozone_name ASC">COM_J2COMMERCE_HEADING_GEOZONE_NAME_ASC</option>
             <option value="g.geozone_name DESC">COM_J2COMMERCE_HEADING_GEOZONE_NAME_DESC</option>
-            <option value="a.ordering ASC">JGRID_HEADING_ORDERING_ASC</option>
-            <option value="a.ordering DESC">JGRID_HEADING_ORDERING_DESC</option>
             <option value="a.j2commerce_taxrate_id ASC">JGRID_HEADING_ID_ASC</option>
             <option value="a.j2commerce_taxrate_id DESC">JGRID_HEADING_ID_DESC</option>
         </field>

--- a/administrator/components/com_j2commerce/src/Model/TaxratesModel.php
+++ b/administrator/components/com_j2commerce/src/Model/TaxratesModel.php
@@ -58,7 +58,7 @@ class TaxratesModel extends ListModel
      *
      * @since   6.0.3
      */
-    protected function populateState($ordering = 'a.ordering', $direction = 'asc'): void
+    protected function populateState($ordering = 'a.taxrate_name', $direction = 'asc'): void
     {
         $search = $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search', '', 'string');
         $this->setState('filter.search', $search);


### PR DESCRIPTION
## Summary
Fixes #43

## Changes
- Removed "Ordering ASC/DESC" sort options from tax rates filter dropdown (non-functional — no ordering column in list view)
- Changed default sort from `a.ordering` to `a.taxrate_name` (consistent with tax profiles)

## Files Changed
- `administrator/components/com_j2commerce/forms/filter_taxrates.xml` — removed ordering options, updated default
- `administrator/components/com_j2commerce/src/Model/TaxratesModel.php` — updated populateState default ordering

## Testing
1. Navigate to J2Commerce > Tax Rates in admin
2. Open the "Sort By" dropdown
3. Verify "Ordering ASC/DESC" options are gone
4. Verify list defaults to sorting by tax rate name

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only