### PR TITLE
fix(pricing): add currency symbol to advanced pricing inputs

### DIFF
--- a/administrator/components/com_j2commerce/tmpl/advancedpricing/default.php
+++ b/administrator/components/com_j2commerce/tmpl/advancedpricing/default.php
@@ -9,6 +9,7 @@
 
 defined('_JEXEC') or die;
 
+use J2Commerce\Component\J2commerce\Administrator\Helper\CurrencyHelper;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
@@ -16,6 +17,7 @@ use Joomla\CMS\Router\Route;
 
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
+$currencySymbol = (new CurrencyHelper())->getSymbol();
 
 $wa = $this->getDocument()->getWebAssetManager();
 $wa->useScript('table.columns');
@@ -118,6 +120,7 @@ $wa->useScript('multiselect');
                                     </td>
                                     <td>
                                         <div class="input-group input-group-sm">
+                                            <span class="input-group-text"><?php echo $currencySymbol; ?></span>
                                             <input type="number"
                                                    class="form-control form-control-sm advancedpricing-price-input"
                                                    value="<?php echo number_format((float) $item->price, 2, '.', ''); ?>"

--- a/administrator/components/com_j2commerce/tmpl/productprice/productpricing.php
+++ b/administrator/components/com_j2commerce/tmpl/productprice/productpricing.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 \defined('_JEXEC') or die;
 // phpcs:enable PSR1.Files.SideEffects
 
+use J2Commerce\Component\J2commerce\Administrator\Helper\CurrencyHelper;
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
@@ -26,6 +27,7 @@ $row_class = 'row';
 $col_class = 'col-md-';
 $app = Factory::getApplication();
 $input = $app->getInput();
+$currencySymbol = (new CurrencyHelper())->getSymbol();
 
 // Initialize tooltips
 HTMLHelper::_('bootstrap.tooltip', '[data-bs-toggle="tooltip"]', ['placement' => 'top']);
@@ -264,7 +266,10 @@ $wa->addInlineScript($script);
                             <?php echo $this->form->renderField('customer_group_id'); ?>
                         </td>
                         <td>
-                            <?php echo $this->form->renderField('price'); ?>
+                            <div class="input-group">
+                                <span class="input-group-text"><?php echo $currencySymbol; ?></span>
+                                <?php echo $this->form->getField('price')->input; ?>
+                            </div>
                         </td>
                         <td class="text-end">
                             <button type="button"
@@ -364,10 +369,13 @@ $wa->addInlineScript($script);
                                 ?>
                             </td>
                             <td>
-                                <input type="text"
-                                       name="<?php echo $fieldPrefix; ?>[price]"
-                                       value="<?php echo number_format((float) $pricing->price, 5, '.', ''); ?>"
-                                       class="form-control" />
+                                <div class="input-group">
+                                    <span class="input-group-text"><?php echo $currencySymbol; ?></span>
+                                    <input type="text"
+                                           name="<?php echo $fieldPrefix; ?>[price]"
+                                           value="<?php echo number_format((float) $pricing->price, 5, '.', ''); ?>"
+                                           class="form-control" />
+                                </div>
                                 <input type="hidden"
                                        name="<?php echo $fieldPrefix; ?>[j2commerce_productprice_id]"
                                        value="<?php echo $priceId; ?>" />


### PR DESCRIPTION
## Summary
Fixes #154

## Changes
- Added currency symbol (via `CurrencyHelper::getSymbol()`) as Bootstrap input-group prepend to price inputs in the Advanced Pricing list view (`advancedpricing/default.php`)
- Also added currency symbol to the product pricing modal — both the "new price" form field and existing price rows (`productprice/productpricing.php`)

## Testing
1. Navigate to J2Commerce > Advanced Pricing
2. Verify: currency symbol appears inline before each price input
3. Edit a product > Pricing tab > Set Advanced Pricing modal
4. Verify: currency symbol appears before price inputs there too

## Files Changed
- `administrator/components/com_j2commerce/tmpl/advancedpricing/default.php` — added currency symbol prepend
- `administrator/components/com_j2commerce/tmpl/productprice/productpricing.php` — added currency symbol to new and existing price inputs

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only