### PR TITLE
fix(navbar): null coalescing for app plugin menu items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,4 +218,4 @@ administrator/components/com_j2commerce/tmpl/product/form_guidedbuilder.php
 components/com_j2commerce/layouts/app_bootstrap5/list/category/item_guidedbuilder.php
 components/com_j2commerce/layouts/app_bootstrap5/list/tag/item_guidedbuilder.php
 # Non-core site templates (created by plugins on install — do NOT whitelist)
-# components/com_j2commerce/tmpl/vendorapply/  — app_vendormanagement plugin
+components/com_j2commerce/tmpl/vendorapply/

--- a/administrator/components/com_j2commerce/layouts/navbar/default.php
+++ b/administrator/components/com_j2commerce/layouts/navbar/default.php
@@ -94,8 +94,8 @@ if ($showWelcome) {
                                             <li><h6 class="dropdown-header"><?php echo Text::_($child['title']); ?></h6></li>
                                         <?php else : ?>
                                             <li>
-                                                <a class="dropdown-item <?php echo $active == $child['view'] ? 'active' : ''; ?>"
-                                                   id="j2c-nav-<?php echo $child['view']; ?>"
+                                                <a class="dropdown-item <?php echo $active == ($child['view'] ?? '') ? 'active' : ''; ?>"
+                                                   id="j2c-nav-<?php echo $child['view'] ?? ''; ?>"
                                                    href="<?php echo Route::_($child['link']); ?>">
                                                     <?php if (!empty($child['icon'])) : ?>
                                                         <span class="<?php echo $child['icon']; ?> fa-fw me-1"></span>


### PR DESCRIPTION
## Core Update

### Changes
- Fixed undefined array key "view" warning in admin navbar when app plugins (e.g., vendor management) inject menu children without a `view` key
- Updated `.gitignore` to properly exclude vendorapply template path

### Files Modified
| Type | Count |
|------|-------|
| PHP files | 1 |
| Config (.gitignore) | 1 |

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only (non-core excluded)