### PR TITLE
fix(currency): update session when config default currency changes

### DIFF
--- a/administrator/components/com_j2commerce/src/Helper/CurrencyHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/CurrencyHelper.php
@@ -146,15 +146,21 @@ class CurrencyHelper
         $input   = $app->getInput();
 
         $requestedCurrency = $input->getString('currency', '');
+        $params            = ComponentHelper::getParams('com_j2commerce');
+        $defaultCurrency   = $params->get('config_currency', 'USD');
 
         if (!empty($requestedCurrency) && self::has($requestedCurrency)) {
             self::setCurrencyInternal($requestedCurrency);
         } elseif ($session->has('j2commerce_currency') && self::has($session->get('j2commerce_currency', ''))) {
-            self::$currentCode = $session->get('j2commerce_currency', '');
-        } else {
-            $params          = ComponentHelper::getParams('com_j2commerce');
-            $defaultCurrency = $params->get('config_currency', 'USD');
+            $sessionCurrency = $session->get('j2commerce_currency', '');
 
+            // If the config default changed, update session to match
+            if ($sessionCurrency !== $defaultCurrency && self::has($defaultCurrency)) {
+                self::setCurrencyInternal($defaultCurrency);
+            } else {
+                self::$currentCode = $sessionCurrency;
+            }
+        } else {
             if (self::has($defaultCurrency)) {
                 self::setCurrencyInternal($defaultCurrency);
             } elseif (!empty(self::$currencies)) {


### PR DESCRIPTION
## Summary
Fixes #173

## Changes
- In `CurrencyHelper::initialize()`, when a session currency exists, compare it against the config default (`config_currency`)
- If they differ (admin changed the config), reset to the new config value and update the session
- The `?currency=` URL param (frontend currency switcher) still takes top priority

## Testing
1. Go to J2Commerce > Configuration
2. Change the default currency (e.g. USD to EUR)
3. Save and navigate to any page showing prices
4. Verify: new currency symbol appears immediately without logout

## Files Changed
- `administrator/components/com_j2commerce/src/Helper/CurrencyHelper.php` — compare session currency against config default in `initialize()`

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only