### PR TITLE
Change cart table header last cell from <th> to <td> in default_item.php

### DIFF
--- a/components/com_j2commerce/tmpl/carts/default_items.php
+++ b/components/com_j2commerce/tmpl/carts/default_items.php
@@ -39,7 +39,7 @@ $checkoutPriceDisplay = $this->params->get('checkout_price_display_options', 0);
                     <th class="start"><?php echo Text::_('COM_J2COMMERCE_CART_LINE_ITEM_TAX'); ?></th>
                 <?php endif; ?>
                 <th class="text-end" style="width: 120px;"><?php echo Text::_('COM_J2COMMERCE_CART_LINE_ITEM_TOTAL'); ?></th>
-                <th class="text-end"></th>
+                <td class="text-end"></td>
             </tr>
         </thead>
         <tbody>


### PR DESCRIPTION
Empty table header found! Table headers should never be empty. Changed to a td

Alternatively you could add a table header with a class of sr-only

<img width="1028" height="379" alt="image" src="https://github.com/user-attachments/assets/7ad9073b-5139-472a-927f-e165a559c724" />
