### PR TITLE
fix(filtergroup): improve new filter group UX and fix checked_out warning (fixes #66)

### DIFF
--- a/administrator/components/com_j2commerce/language/en-GB/com_j2commerce.ini
+++ b/administrator/components/com_j2commerce/language/en-GB/com_j2commerce.ini
@@ -3051,6 +3051,8 @@ COM_J2COMMERCE_FILTERGROUP_ERROR_NAME_EXISTS="A filter group with this name alre
 COM_J2COMMERCE_FILTERGROUP_ERROR_FORM_NOT_LOADED="Could not load the filter group form"
 COM_J2COMMERCE_FILTERGROUP_ERROR_ITEM_NOT_FOUND="Filter group not found"
 COM_J2COMMERCE_FILTERGROUPS_ERROR_RETRIEVING_DATA="Error retrieving filter groups data"
+COM_J2COMMERCE_FILTERGROUP_SAVED_NOW_ADD_FILTERS="Filter group saved. You can now add filters below."
+COM_J2COMMERCE_FILTERGROUP_SAVE_FIRST_TO_ADD_FILTERS="Please save this filter group first, then you can add filters to it."
 COM_J2COMMERCE_ERROR_FILTERGROUP_GROUP_NAME_REQUIRED="Filter group name is required"
 
 ; ============================================

--- a/administrator/components/com_j2commerce/language/en-US/com_j2commerce.ini
+++ b/administrator/components/com_j2commerce/language/en-US/com_j2commerce.ini
@@ -3036,6 +3036,8 @@ COM_J2COMMERCE_FILTERGROUP_ERROR_NAME_EXISTS="A filter group with this name alre
 COM_J2COMMERCE_FILTERGROUP_ERROR_FORM_NOT_LOADED="Could not load the filter group form"
 COM_J2COMMERCE_FILTERGROUP_ERROR_ITEM_NOT_FOUND="Filter group not found"
 COM_J2COMMERCE_FILTERGROUPS_ERROR_RETRIEVING_DATA="Error retrieving filter groups data"
+COM_J2COMMERCE_FILTERGROUP_SAVED_NOW_ADD_FILTERS="Filter group saved. You can now add filters below."
+COM_J2COMMERCE_FILTERGROUP_SAVE_FIRST_TO_ADD_FILTERS="Please save this filter group first, then you can add filters to it."
 COM_J2COMMERCE_ERROR_FILTERGROUP_GROUP_NAME_REQUIRED="Filter group name is required"
 
 ; ============================================

--- a/administrator/components/com_j2commerce/src/Controller/FiltergroupController.php
+++ b/administrator/components/com_j2commerce/src/Controller/FiltergroupController.php
@@ -11,6 +11,7 @@ namespace J2Commerce\Component\J2commerce\Administrator\Controller;
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Controller\FormController;
 use Joomla\CMS\Router\Route;
 
@@ -63,6 +64,39 @@ class FiltergroupController extends FormController
 
         // Since there is no item, fall back to component permissions.
         return parent::allowEdit($data, $key);
+    }
+
+    /**
+     * Method to save a record, redirecting new items to the edit view
+     * so users can immediately add filters after the first save.
+     *
+     * @param   string  $key     The name of the primary key of the URL variable.
+     * @param   string  $urlVar  The name of the URL variable if different from the primary key.
+     *
+     * @return  boolean  True if save succeeded.
+     *
+     * @since  6.0.0
+     */
+    public function save($key = null, $urlVar = 'id')
+    {
+        $isNew = empty($this->input->getInt('id', 0));
+
+        $result = parent::save($key, $urlVar);
+
+        if ($result && $isNew && $this->getTask() === 'save2close') {
+            $model    = $this->getModel();
+            $recordId = (int) $model->getState('filtergroup.id');
+
+            if ($recordId) {
+                $this->setRedirect(
+                    Route::_('index.php?option=com_j2commerce&task=filtergroup.edit&id=' . $recordId, false),
+                    Text::_('COM_J2COMMERCE_FILTERGROUP_SAVED_NOW_ADD_FILTERS'),
+                    'success'
+                );
+            }
+        }
+
+        return $result;
     }
 
     /**

--- a/administrator/components/com_j2commerce/tmpl/filtergroup/edit.php
+++ b/administrator/components/com_j2commerce/tmpl/filtergroup/edit.php
@@ -45,6 +45,11 @@ $tmpl    = Factory::getApplication()->input->get('tmpl', '', 'cmd') === 'compone
                             <legend><?php echo Text::sprintf('COM_J2COMMERCE_FILTERGROUP_FIELDSET_FILTERS', $this->item->group_name); ?> </legend>
                             <?php echo $this->form->renderField('filters'); ?>
                         </fieldset>
+                        <?php else : ?>
+                        <div class="alert alert-info">
+                            <span class="icon-info-circle" aria-hidden="true"></span>
+                            <?php echo Text::_('COM_J2COMMERCE_FILTERGROUP_SAVE_FIRST_TO_ADD_FILTERS'); ?>
+                        </div>
                         <?php endif; ?>
 
                         <?php echo $this->form->renderField('id'); ?>

--- a/administrator/language/en-GB/com_j2commerce.ini
+++ b/administrator/language/en-GB/com_j2commerce.ini
@@ -3036,6 +3036,8 @@ COM_J2COMMERCE_FILTERGROUP_ERROR_NAME_EXISTS="A filter group with this name alre
 COM_J2COMMERCE_FILTERGROUP_ERROR_FORM_NOT_LOADED="Could not load the filter group form"
 COM_J2COMMERCE_FILTERGROUP_ERROR_ITEM_NOT_FOUND="Filter group not found"
 COM_J2COMMERCE_FILTERGROUPS_ERROR_RETRIEVING_DATA="Error retrieving filter groups data"
+COM_J2COMMERCE_FILTERGROUP_SAVED_NOW_ADD_FILTERS="Filter group saved. You can now add filters below."
+COM_J2COMMERCE_FILTERGROUP_SAVE_FIRST_TO_ADD_FILTERS="Please save this filter group first, then you can add filters to it."
 COM_J2COMMERCE_ERROR_FILTERGROUP_GROUP_NAME_REQUIRED="Filter group name is required"
 
 ; ============================================


### PR DESCRIPTION
## Summary
Fixes #66

When creating a new filter group and clicking "Save & Close", the user landed on the list page with no way to discover how to add filters. The filters fieldset only appears after the group has been saved.

## Changes
- **Edit template**: Show info alert "Please save this filter group first, then you can add filters to it." for new (unsaved) filter groups
- **Controller**: Override `save()` to redirect new filter groups back to edit view after "Save & Close", with success message guiding user to add filters
- **List template**: Fix `$item->checked_out` property reference causing PHP warning; comment out checkedout UI block until DB columns are added
- **Language files**: Added 2 new strings, synced to both admin directories

## Testing
1. Navigate to J2Commerce > Filter Groups
2. Verify no PHP warnings about `checked_out` on the list page
3. Click "New" — verify info alert about saving first
4. Enter a group name, click "Save & Close"
5. Verify: redirected to EDIT view (not list) with success message, filters fieldset now visible
6. Click "Save & Close" again (editing existing) — verify it goes to LIST as normal

## Files Changed
- `administrator/components/com_j2commerce/tmpl/filtergroup/edit.php` — info alert for new items
- `administrator/components/com_j2commerce/src/Controller/FiltergroupController.php` — save() override for redirect
- `administrator/components/com_j2commerce/tmpl/filtergroups/default.php` — remove checked_out warning
- `administrator/components/com_j2commerce/language/en-GB/com_j2commerce.ini` — 2 new strings
- `administrator/language/en-GB/com_j2commerce.ini` — mirror sync