### PR TITLE
fix(toolbar): Empty Trash button missing in Options, Filtergroups, Invoicetemplates

### DIFF
--- a/administrator/components/com_j2commerce/src/View/Filtergroups/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Filtergroups/HtmlView.php
@@ -178,7 +178,7 @@ class HtmlView extends BaseHtmlView
 
 
 
-            if ($this->state->get('filter.enabled') === -2 && $canDo->get('core.delete')) {
+            if ($this->state->get('filter.enabled') == -2 && $canDo->get('core.delete')) {
                 $toolbar->delete('filtergroups.delete')
                     ->text('JTOOLBAR_EMPTY_TRASH')
                     ->message('JGLOBAL_CONFIRM_DELETE')

--- a/administrator/components/com_j2commerce/src/View/Invoicetemplates/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Invoicetemplates/HtmlView.php
@@ -174,7 +174,7 @@ class HtmlView extends BaseHtmlView
             }
 
 
-            if ($this->state->get('filter.enabled') === -2 && $canDo->get('core.delete')) {
+            if ($this->state->get('filter.enabled') == -2 && $canDo->get('core.delete')) {
                 $toolbar->delete('invoicetemplates.delete')
                     ->text('JTOOLBAR_EMPTY_TRASH')
                     ->message('JGLOBAL_CONFIRM_DELETE')

--- a/administrator/components/com_j2commerce/src/View/Options/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Options/HtmlView.php
@@ -175,7 +175,7 @@ class HtmlView extends BaseHtmlView
                 }
             }
 
-            if ($this->state->get('filter.enabled') === -2 && $canDo->get('core.delete')) {
+            if ($this->state->get('filter.enabled') == -2 && $canDo->get('core.delete')) {
                 $toolbar->delete('options.delete')
                     ->text('JTOOLBAR_EMPTY_TRASH')
                     ->message('JGLOBAL_CONFIRM_DELETE')


### PR DESCRIPTION
## Summary
Fixes #204

The "Empty Trash" / "Delete" toolbar button was never shown when filtering by Trashed status in the Options, Filter Groups, and Invoice Templates list views.

## Root Cause
The visibility check used strict comparison (`=== -2`) but filter state values from form submissions are strings (`"-2"`), so `"-2" === -2` always returned `false`. Changed to loose comparison (`== -2`) to match the pattern used by all other list views.

## Changes
- `View/Options/HtmlView.php` — `=== -2` → `== -2`
- `View/Filtergroups/HtmlView.php` — `=== -2` → `== -2`
- `View/Invoicetemplates/HtmlView.php` — `=== -2` → `== -2`

## Testing
1. Navigate to J2Commerce > Catalog > Options
2. Set status filter to "Trashed"
3. Verify "Empty Trash" button appears in toolbar
4. Repeat for Filter Groups and Invoice Templates

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] Core files only