### PR TITLE
fix(orders): pass JACTION_DELETE string to JS for order note trash icon

### DIFF
--- a/administrator/components/com_j2commerce/src/View/Order/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Order/HtmlView.php
@@ -123,6 +123,7 @@ class HtmlView extends BaseHtmlView
                 [],
                 ['defer' => true]
             );
+            Text::script('JACTION_DELETE');
         }
 
         $this->addToolbar($layout);


### PR DESCRIPTION
## Summary
Fixes #195

The trash icon on order admin notes showed the raw language key `JACTION_DELETE` instead of the translated "Delete" string.

## Changes
- Added `Text::script('JACTION_DELETE')` in the Order view so the string is available to `Joomla.Text._()` in JavaScript

## Testing
1. Navigate to J2Commerce > Sales > Orders
2. Click into any order (view layout)
3. Add an admin note
4. Verify the trash icon tooltip shows "Delete" (not "JACTION_DELETE")

## Files Changed
- `administrator/components/com_j2commerce/src/View/Order/HtmlView.php` — added `Text::script('JACTION_DELETE')`