### PR TITLE
fix(orders): add missing $params property to admin Order HtmlView

### DIFF
--- a/administrator/components/com_j2commerce/src/View/Order/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Order/HtmlView.php
@@ -41,6 +41,7 @@ class HtmlView extends BaseHtmlView
     protected string $currencySymbol = '';
     protected string $currencyCode = '';
     protected bool $hasPackingSlip = false;
+    protected ?Registry $params = null;
 
     public function display($tpl = null): void
     {
@@ -57,8 +58,9 @@ class HtmlView extends BaseHtmlView
         $this->item  = $model->getItem();
         $this->state = $model->getState();
         $this->orderStatuses = $this->getOrderStatuses();
+        $this->params = ComponentHelper::getParams('com_j2commerce');
 
-        $this->dateFormat = ComponentHelper::getParams('com_j2commerce')->get('date_format', 'Y-m-d H:i:s');
+        $this->dateFormat = $this->params->get('date_format', 'Y-m-d H:i:s');
 
         // Currency formatting
         $this->currencyCode = $this->item->currency_code ?? '';


### PR DESCRIPTION
## Core Update

### Changes
- Added `protected ?Registry $params` property to admin Order HtmlView
- Populated `$this->params` from `ComponentHelper::getParams('com_j2commerce')` in `display()`
- Refactored `$this->dateFormat` to reuse `$this->params` instead of a redundant call
- Fixes: `Warning: Undefined property: ...HtmlView::$params in view_items.php on line 53`

### Files Modified
| Type | Count |
|------|-------|
| PHP files | 1 |

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only (non-core excluded)