### PR TITLE
fix(css): correct invalid CSS property -btn-bg to --btn-bg

### DIFF
--- a/media/com_j2commerce/css/administrator/j2commerce_admin.css
+++ b/media/com_j2commerce/css/administrator/j2commerce_admin.css
@@ -60,7 +60,7 @@ body.com_j2commerce #content, #fieldset-j2commerce-product-settings, .j2commerce
     }
 
     .btn-success {
-        -btn-bg: var(--success)!important;
+        --btn-bg: var(--success)!important;
         background-color:var(--success)!important;
         border-color:var(--success)!important;
         color:#fff!important;


### PR DESCRIPTION
## Summary
Fixes #67

## Changes
- Fixed typo in `j2commerce_admin.css` line 63: `-btn-bg` → `--btn-bg` (missing leading dash on CSS custom property)

## Testing
1. Open any J2Commerce admin page with a `.btn-success` button
2. Inspect element — verify `--btn-bg` property is valid

## Files Changed
- `media/com_j2commerce/css/administrator/j2commerce_admin.css` — fixed CSS property name