### PR TITLE
fix(vendor): make User, Country, Zone optional — only Company required

### DIFF
--- a/administrator/components/com_j2commerce/forms/vendor.xml
+++ b/administrator/components/com_j2commerce/forms/vendor.xml
@@ -22,7 +22,6 @@
             type="user"
             label="COM_J2COMMERCE_FIELD_VENDOR_USER"
             description="COM_J2COMMERCE_FIELD_VENDOR_USER_DESC"
-            required="true"
         />
 
         <!-- Hidden address_id field (internal link to address table) -->
@@ -152,7 +151,6 @@
             type="Country"
             label="COM_J2COMMERCE_FIELD_COUNTRY"
             description="COM_J2COMMERCE_FIELD_COUNTRY_DESC"
-            required="true"
             addfieldprefix ="J2Commerce\Component\J2commerce\Administrator\Field"
             class="form-select"
         >
@@ -163,7 +161,6 @@
             name="zone_id"
             type="Zone"
             label="COM_J2COMMERCE_FIELD_ADDRESS_ZONE"
-            required="true"
             addfieldprefix ="J2Commerce\Component\J2commerce\Administrator\Field"
             class="form-select"
             default=""


### PR DESCRIPTION
## Summary
Fixes #61

Per discussion in the issue, only Company should be required for vendors. Store owners need flexibility to create vendors without linking to a Joomla user or specifying location. This matches the Manufacturer form where only Company is required.

## Changes
- Removed `required="true"` from `j2commerce_user_id` (User)
- Removed `required="true"` from `country_id` (Country)
- Removed `required="true"` from `zone_id` (Zone)
- Company name remains the only required field

## Testing
1. Go to J2Commerce > Catalog > Vendors > New
2. Fill only Company name, leave User/Country/Zone empty
3. Save — should succeed without validation errors
4. Try saving without Company — should still be required

## Files Changed
- `administrator/components/com_j2commerce/forms/vendor.xml` — removed required from 3 fields