### PR TITLE
fix(invoicetemplates): comment out created_by reference — column not yet added

### DIFF
--- a/administrator/components/com_j2commerce/tmpl/invoicetemplates/default.php
+++ b/administrator/components/com_j2commerce/tmpl/invoicetemplates/default.php
@@ -103,7 +103,9 @@ $isMultilang = Multilanguage::isEnabled();
                             <?php foreach ($this->items as $i => $item) :
                                 $canEdit = $user->authorise('core.edit', 'com_j2commerce.invoicetemplate.' . $item->j2commerce_invoicetemplate_id);
                                 $canCheckin = $user->authorise('core.manage', 'com_checkin') || $item->locked_by == $userId || is_null($item->locked_by);
-                                $canEditOwn = $user->authorise('core.edit.own', 'com_j2commerce.invoicetemplate.' . $item->j2commerce_invoicetemplate_id) && $item->created_by == $userId;
+                                // TODO: Add created_by column to j2commerce_invoicetemplates table
+                                // $canEditOwn = $user->authorise('core.edit.own', 'com_j2commerce.invoicetemplate.' . $item->j2commerce_invoicetemplate_id) && $item->created_by == $userId;
+                                $canEditOwn = false;
                                 $canChange = $user->authorise('core.edit.state', 'com_j2commerce.invoicetemplate.' . $item->j2commerce_invoicetemplate_id) && $canCheckin;
 
 


### PR DESCRIPTION
## Summary
Fixes #74

PHP warning `Undefined property: stdClass::$created_by` on the Print Templates list view.

## Changes
- Commented out `$canEditOwn` check that references non-existent `created_by` column
- Set `$canEditOwn = false` with TODO to restore when column is added

## Testing
1. Go to J2Commerce > Setup > Print Templates
2. Verify no PHP warning about `created_by`
3. Verify template list displays correctly

## Files Changed
- `administrator/components/com_j2commerce/tmpl/invoicetemplates/default.php` — commented out created_by reference