### PR TITLE
fix(security): sanitize innerHTML XSS vectors in j2commerce.js

### DIFF
--- a/media/com_j2commerce/js/site/j2commerce.js
+++ b/media/com_j2commerce/js/site/j2commerce.js
@@ -185,10 +185,18 @@ const J2Commerce = {
 
                 const notifications = form.querySelector('.j2commerce-notifications');
                 if (json.error.stock && notifications) {
-                    notifications.innerHTML = `<span class="j2error">${json.error.stock}</span>`;
+                    notifications.textContent = '';
+                    const stockErr = document.createElement('span');
+                    stockErr.className = 'j2error';
+                    stockErr.textContent = json.error.stock;
+                    notifications.appendChild(stockErr);
                 }
                 if (json.error.general && notifications) {
-                    notifications.innerHTML = `<span class="j2error">${json.error.general}</span>`;
+                    notifications.textContent = '';
+                    const generalErr = document.createElement('span');
+                    generalErr.className = 'j2error';
+                    generalErr.textContent = json.error.general;
+                    notifications.appendChild(generalErr);
                 }
                 if (json.error.product && notifications) {
                     const span = document.createElement('span');
@@ -249,7 +257,7 @@ const J2Commerce = {
             if (json?.response) {
                 Object.entries(json.response).forEach(([key, value]) => {
                     document.querySelectorAll(`.j2commerce-cart-module-${key}`).forEach(el => {
-                        el.innerHTML = value;
+                        el.textContent = value;
                     });
                 });
             }
@@ -295,7 +303,7 @@ const J2Commerce = {
             document.querySelectorAll('.wait').forEach(el => el.remove());
 
             if (container && json.msg) {
-                container.innerHTML = json.msg;
+                container.textContent = json.msg;
             }
         } catch (error) {
             console.error('Task error:', error);


### PR DESCRIPTION
## Summary
Fixes #86

Addresses the 4 HIGH RISK `.innerHTML` XSS vectors where unsanitized AJAX response data was injected directly into the DOM. Follows Joomla core guidance per [joomla/joomla-cms#34472](https://github.com/joomla/joomla-cms/pull/34472).

## Changes
- **L188**: `json.error.stock` — replaced innerHTML template literal with DOM creation + textContent
- **L191**: `json.error.general` — same pattern
- **L260**: Cart module value update — innerHTML → textContent
- **L306**: AJAX message — innerHTML → textContent

## Testing
1. Add a product to cart — verify cart count updates correctly
2. Try adding an out-of-stock item — verify error message displays
3. Remove item from cart — verify message displays
4. Check browser console for no JS errors

## Files Changed
- `media/com_j2commerce/js/site/j2commerce.js` — 4 innerHTML → textContent/DOM fixes

## Note
22 MEDIUM RISK instances (server-rendered HTML) remain — these use trusted server output and should be addressed in a separate PR.