### PR TITLE
fix(editor): split Mobile into portrait/landscape devices in GrapesJS email editor

### DIFF
--- a/media/com_j2commerce/js/administrator/grapesjs-j2commerce.js
+++ b/media/com_j2commerce/js/administrator/grapesjs-j2commerce.js
@@ -59,8 +59,9 @@ function initGrapesJSEditor(options) {
         deviceManager: {
             devices: [
                 { name: 'Desktop', width: '' },
-                { name: 'Tablet', width: '600px' },
-                { name: 'Mobile', width: '320px', widthMedia: '480px' },
+                { name: 'Tablet', width: '768px', widthMedia: '992px' },
+                { name: 'Mobile landscape', width: '480px', widthMedia: '768px' },
+                { name: 'Mobile portrait', width: '320px', widthMedia: '480px' },
             ],
         },
     };


### PR DESCRIPTION
## Summary
Fixes #107

The email template visual editor displayed the same width for mobile portrait and landscape because only a single "Mobile" device (320px) was defined in the GrapesJS device manager.

## Changes
- Split single "Mobile" device into "Mobile portrait" (320px) and "Mobile landscape" (480px)
- Updated Tablet width from 600px to 768px with proper widthMedia breakpoints

## Testing
1. Edit an email template (visual editor / drag & drop mode)
2. Click Mobile Portrait — verify preview narrows to 320px
3. Click Mobile Landscape — verify preview widens to 480px
4. Verify Desktop and Tablet buttons still work

## Files Changed
- `media/com_j2commerce/js/administrator/grapesjs-j2commerce.js` — updated deviceManager config