### PR TITLE
fix(reports): add CSRF token to export CSV URL

### DIFF
--- a/plugins/j2commerce/report_itemised/src/Extension/ReportItemised.php
+++ b/plugins/j2commerce/report_itemised/src/Extension/ReportItemised.php
@@ -19,6 +19,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Router\Route;
+use Joomla\CMS\Session\Session;
 use Joomla\Database\DatabaseAwareTrait;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Event\DispatcherInterface;
@@ -179,7 +180,8 @@ final class ReportItemised extends CMSPlugin implements SubscriberInterface
 
         if ($toolbar) {
             $exportUrl = Route::_(
-                'index.php?option=com_j2commerce&task=reportplugin.exportCsv&plugin=' . $this->_element,
+                'index.php?option=com_j2commerce&task=reportplugin.exportCsv&plugin=' . $this->_element
+                . '&' . Session::getFormToken() . '=1',
                 false
             );
             $toolbar->linkButton('export', 'PLG_J2COMMERCE_REPORT_ITEMISED_EXPORT_CSV')

--- a/plugins/j2commerce/report_products/src/Extension/ReportProducts.php
+++ b/plugins/j2commerce/report_products/src/Extension/ReportProducts.php
@@ -19,6 +19,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Router\Route;
+use Joomla\CMS\Session\Session;
 use Joomla\Database\DatabaseAwareTrait;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Event\DispatcherInterface;
@@ -177,7 +178,8 @@ final class ReportProducts extends CMSPlugin implements SubscriberInterface
 
         if ($toolbar) {
             $exportUrl = Route::_(
-                'index.php?option=com_j2commerce&task=reportplugin.exportCsv&plugin=' . $this->_element,
+                'index.php?option=com_j2commerce&task=reportplugin.exportCsv&plugin=' . $this->_element
+                . '&' . Session::getFormToken() . '=1',
                 false
             );
             $toolbar->linkButton('export', 'PLG_J2COMMERCE_REPORT_PRODUCTS_EXPORT_CSV')


### PR DESCRIPTION
## Summary
Fixes #116

The "Export CSV" toolbar button URL was missing the CSRF token, so `checkToken('get')` in `ReportpluginController::exportCsv()` rejected the request with an "Invalid Token" error.

## Changes
- Added `Session::getFormToken()` to the export URL in `report_itemised` plugin
- Added `Session::getFormToken()` to the export URL in `report_products` plugin

## Testing
1. Go to J2Commerce > Reports > Itemised Report (or Products Report)
2. Click "Export CSV" toolbar button
3. Verify CSV file downloads without "Invalid Token" error

## Files Changed
- `plugins/j2commerce/report_itemised/src/Extension/ReportItemised.php` — added token to URL
- `plugins/j2commerce/report_products/src/Extension/ReportProducts.php` — added token to URL