### PR TITLE
fix(currencies): preserve tmpl=component in modal for publish/unpublish

### DIFF
--- a/administrator/components/com_j2commerce/src/Controller/CurrenciesController.php
+++ b/administrator/components/com_j2commerce/src/Controller/CurrenciesController.php
@@ -75,6 +75,20 @@ class CurrenciesController extends AdminController
         return parent::getModel($name, $prefix, $config);
     }
 
+    /**
+     * Preserve tmpl parameter in list redirects (modal support).
+     *
+     * @return  string
+     *
+     * @since   6.1.5
+     */
+    protected function getRedirectToListAppend()
+    {
+        $tmpl = $this->input->getCmd('tmpl', '');
+
+        return $tmpl ? '&tmpl=' . $tmpl : '';
+    }
+
     public function updateRates(): void
     {
         $this->checkToken();

--- a/administrator/components/com_j2commerce/tmpl/currencies/default.php
+++ b/administrator/components/com_j2commerce/tmpl/currencies/default.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
@@ -24,11 +25,15 @@ $wa->useScript('table.columns')
 
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
+$tmpl      = Factory::getApplication()->getInput()->getCmd('tmpl', '');
+$tmplParam = $tmpl ? '&tmpl=' . $tmpl : '';
 
 ?>
-<?php echo $this->navbar; ?>
+<?php if (!$tmpl) : ?>
+    <?php echo $this->navbar; ?>
+<?php endif; ?>
 
-<form action="<?php echo Route::_('index.php?option=com_j2commerce&view=currencies'); ?>" method="post" name="adminForm" id="adminForm">
+<form action="<?php echo Route::_('index.php?option=com_j2commerce&view=currencies' . $tmplParam); ?>" method="post" name="adminForm" id="adminForm">
     <div class="row">
         <div class="col-md-12">
             <div id="j-main-container" class="j-main-container">
@@ -81,9 +86,13 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
                                     <?php echo HTMLHelper::_('jgrid.published', $item->enabled, $i, 'currencies.', true, 'cb'); ?>
                                 </td>
                                 <th scope="row">
-                                    <a href="<?php echo Route::_('index.php?option=com_j2commerce&task=currency.edit&id=' . $item->j2commerce_currency_id); ?>">
+                                    <?php if ($tmpl) : ?>
                                         <?php echo $this->escape($item->currency_title); ?>
-                                    </a>
+                                    <?php else : ?>
+                                        <a href="<?php echo Route::_('index.php?option=com_j2commerce&task=currency.edit&id=' . $item->j2commerce_currency_id); ?>">
+                                            <?php echo $this->escape($item->currency_title); ?>
+                                        </a>
+                                    <?php endif; ?>
                                 </th>
                                 <td class="d-none d-md-table-cell">
                                     <?php echo $this->escape($item->currency_code); ?>
@@ -113,4 +122,6 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
     </div>
 </form>
 
-<?php echo $this->footer ?? ''; ?>
+<?php if (!$tmpl) : ?>
+    <?php echo $this->footer ?? ''; ?>
+<?php endif; ?>


### PR DESCRIPTION
## Summary
Fixes #155

The Manage Currencies modal (opened from Configuration) broke out to the full admin view after toggling a currency's publish status, showing the Joomla sidebar, J2Commerce navbar, and toolbar inside the modal.

## Changes
- **Form action** — appends `&tmpl=component` when in modal mode
- **CurrenciesController** — overrides `getRedirectToListAppend()` to preserve `tmpl` in publish/unpublish redirects
- **Navbar** — hidden in `tmpl=component` mode
- **Footer** — hidden in `tmpl=component` mode
- **Edit links** — plain text in modal (no save button available in component mode)

## Testing
1. Go to J2Commerce > Configuration > click "Manage Currencies"
2. Toggle a currency's publish/unpublish status
3. Verify the page stays inside the modal (clean, no full admin chrome)
4. Close modal, go to Currencies directly — verify normal view still works with clickable links

## Files Changed
- `administrator/components/com_j2commerce/tmpl/currencies/default.php` — modal-aware template
- `administrator/components/com_j2commerce/src/Controller/CurrenciesController.php` — preserve tmpl in redirects