### PR TITLE
Correct typo in getFormattedInvoice method name

### DIFF
--- a/administrator/components/com_j2commerce/src/Helper/InvoiceHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/InvoiceHelper.php
@@ -287,7 +287,7 @@ class InvoiceHelper
      *
      * @since   6.0.0
      */
-    public function getFormatedInvoice(object $order): string
+    public function getFormattedInvoice(object $order): string
     {
         $text = $this->loadInvoiceTemplate($order);
         $template = EmailHelper::getInstance()->processTags($text, $order, []);


### PR DESCRIPTION
I can't see it being used but every other function is spelled correctly with tt so it is bound to cause problems in the future if this one is left incorrectly with a single t