### PR TITLE
Remove country description from manufacturer and vendor form fields

### DIFF
--- a/administrator/components/com_j2commerce/forms/manufacturer.xml
+++ b/administrator/components/com_j2commerce/forms/manufacturer.xml
@@ -144,7 +144,6 @@
             name="country_id"
             type="Country"
             label="COM_J2COMMERCE_FIELD_COUNTRY"
-            description="COM_J2COMMERCE_FIELD_COUNTRY_DESC"
             addfieldprefix ="J2Commerce\Component\J2commerce\Administrator\Field"
             class="form-select"
         >

--- a/administrator/components/com_j2commerce/forms/vendor.xml
+++ b/administrator/components/com_j2commerce/forms/vendor.xml
@@ -150,7 +150,6 @@
             name="country_id"
             type="Country"
             label="COM_J2COMMERCE_FIELD_COUNTRY"
-            description="COM_J2COMMERCE_FIELD_COUNTRY_DESC"
             addfieldprefix ="J2Commerce\Component\J2commerce\Administrator\Field"
             class="form-select"
         >


### PR DESCRIPTION
The description is really not needed here BUT more importantly the text had been modified for zones so it didnt really make any sense

Makes sense here

<img width="908" height="497" alt="image" src="https://github.com/user-attachments/assets/f84fca8c-35e8-49f2-9ba6-d926ccceb9be" />

Doesnt make sense here and its not needed
<img width="1430" height="760" alt="image" src="https://github.com/user-attachments/assets/501116d1-b24d-4c9f-be7c-22428043fe75" />
