### PR TITLE
fix(myprofile): fix saveAddress validation and self-load telephone assets

### DIFF
--- a/administrator/components/com_j2commerce/src/Helper/CustomFieldHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/CustomFieldHelper.php
@@ -288,14 +288,27 @@ class CustomFieldHelper
 
             case 'singledropdown':
                 $options = self::parseOptions($field->field_options ?? '');
-                $html .= '<div class="form-normal">'
-                    . '<label for="' . $id . '" class="form-label">' . $labelHtml . '</label>'
-                    . '<select name="' . $namekey . '" id="' . $id . '" class="form-select' . ($extraClass ? ' ' . $extraClass : '') . '"' . $requiredAttr . '>';
-                foreach ($options as $opt) {
-                    $selected = ($fieldValue === $opt['value']) ? ' selected' : '';
-                    $html .= '<option value="' . htmlspecialchars($opt['value'], ENT_QUOTES, 'UTF-8') . '"' . $selected . '>' . htmlspecialchars($opt['name'], ENT_QUOTES, 'UTF-8') . '</option>';
+                if ($isFloating) {
+                    $html .= '<div class="form-floating">'
+                        . '<select name="' . $namekey . '" id="' . $id . '" class="form-select' . ($extraClass ? ' ' . $extraClass : '') . '"' . $requiredAttr . '>'
+                        . '<option value="">' . Text::sprintf('COM_J2COMMERCE_SELECT_PLACEHOLDER', $label) . '</option>';
+                    foreach ($options as $opt) {
+                        $selected = ($fieldValue === $opt['value']) ? ' selected' : '';
+                        $html .= '<option value="' . htmlspecialchars($opt['value'], ENT_QUOTES, 'UTF-8') . '"' . $selected . '>' . htmlspecialchars($opt['name'], ENT_QUOTES, 'UTF-8') . '</option>';
+                    }
+                    $html .= '</select>'
+                        . '<label for="' . $id . '">' . $labelHtml . '</label>'
+                        . '</div>';
+                } else {
+                    $html .= '<div class="form-normal">'
+                        . '<label for="' . $id . '" class="form-label">' . $labelHtml . '</label>'
+                        . '<select name="' . $namekey . '" id="' . $id . '" class="form-select' . ($extraClass ? ' ' . $extraClass : '') . '"' . $requiredAttr . '>';
+                    foreach ($options as $opt) {
+                        $selected = ($fieldValue === $opt['value']) ? ' selected' : '';
+                        $html .= '<option value="' . htmlspecialchars($opt['value'], ENT_QUOTES, 'UTF-8') . '"' . $selected . '>' . htmlspecialchars($opt['name'], ENT_QUOTES, 'UTF-8') . '</option>';
+                    }
+                    $html .= '</select></div>';
                 }
-                $html .= '</select></div>';
                 break;
 
             case 'customtext':
@@ -443,6 +456,11 @@ class CustomFieldHelper
         string $extraClass,
         string $autocompleteAttr
     ): string {
+        // Register telephone field assets once per request
+        $wa = Factory::getApplication()->getDocument()->getWebAssetManager();
+        $wa->registerAndUseStyle('com_j2commerce.telephone.css', 'media/com_j2commerce/css/site/telephone-field.css');
+        $wa->registerAndUseScript('com_j2commerce.telephone', 'media/com_j2commerce/js/site/telephone-field.js', [], ['defer' => true]);
+
         $defaultCountry = J2CommerceHelper::config()->get('default_country', '223');
         $defaultIso     = self::getCountryIso2((int) $defaultCountry) ?: 'US';
         $parsed         = PhoneHelper::parseE164($value, $defaultIso);

--- a/components/com_j2commerce/src/Controller/MyprofileController.php
+++ b/components/com_j2commerce/src/Controller/MyprofileController.php
@@ -75,7 +75,8 @@ class MyprofileController extends BaseController
         $type = $this->input->getString('type', 'billing');
         $area = ($type === 'shipping') ? 'shipping' : 'billing';
 
-        $errors = CustomFieldHelper::validateFields($formData, $area);
+        $fields = CustomFieldHelper::getFieldsByArea($area);
+        $errors = CustomFieldHelper::validateFields($fields, $formData);
 
         if ($errors) {
             $this->jsonResponse([

--- a/components/com_j2commerce/src/Controller/MyprofileController.php
+++ b/components/com_j2commerce/src/Controller/MyprofileController.php
@@ -88,7 +88,7 @@ class MyprofileController extends BaseController
             return;
         }
 
-        $addressData = CustomFieldHelper::collectAddressData($formData, $area);
+        $addressData = CustomFieldHelper::collectAddressData($fields, $formData);
         $addressData['user_id'] = (int) $user->id;
         $addressData['type'] = $type;
         $addressData['email'] = $formData['email'] ?? $user->email;


### PR DESCRIPTION
## Summary
Fixes #178

Saving a new address from the frontend profile page threw a 500 error because of wrong argument order in two CustomFieldHelper calls, and the telephone field JS/CSS was not loaded.

## Changes
- Fixed `validateFields($formData, $area)` → `validateFields($fields, $formData)` on line 78
- Fixed `collectAddressData($formData, $area)` → `collectAddressData($fields, $formData)` on line 91
- Telephone field now self-registers its JS/CSS assets in `renderTelephoneField()` via WAM, so any view that renders a telephone field automatically gets the assets

## Testing
1. Frontend > Profile > Addresses > Add Address
2. Leave all fields empty, click Save — verify validation errors display (not 500)
3. Fill in required fields including phone — verify save works
4. Verify telephone field renders correctly with country dropdown

## Files Changed
- `components/com_j2commerce/src/Controller/MyprofileController.php` — fixed argument order
- `administrator/components/com_j2commerce/src/Helper/CustomFieldHelper.php` — self-register telephone assets