### PR TITLE
fix(payment): resolve Error 500 with bank transfer and cash (fixes #188)

### DIFF
--- a/plugins/j2commerce/payment_banktransfer/src/Extension/PaymentBanktransfer.php
+++ b/plugins/j2commerce/payment_banktransfer/src/Extension/PaymentBanktransfer.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace J2Commerce\Plugin\J2Commerce\PaymentBanktransfer\Extension;
 
+use J2Commerce\Component\J2commerce\Administrator\Helper\OrderHistoryHelper;
 use J2Commerce\Component\J2commerce\Administrator\Library\Plugins\Base;
 use J2Commerce\Component\J2commerce\Administrator\Library\Plugins\Payment;
 use J2Commerce\Component\J2commerce\Administrator\Library\Plugins\PluginLayoutTrait;
@@ -197,14 +198,6 @@ final class PaymentBanktransfer extends CMSPlugin implements SubscriberInterface
         return $this->base;
     }
 
-    private function getOrderModel(): object
-    {
-        return Factory::getApplication()
-            ->bootComponent('com_j2commerce')
-            ->getMVCFactory()
-            ->createModel('Order', 'Administrator', ['ignore_request' => true]);
-    }
-
     private function createOrderTable(): object
     {
         return Factory::getApplication()
@@ -316,7 +309,10 @@ final class PaymentBanktransfer extends CMSPlugin implements SubscriberInterface
             $order->customer_note = ($order->customer_note ?? '') . $html;
         }
 
-        // Save order_params and customer_note first
+        // Set status and save everything in a single store() call
+        $orderStateId = (int) $this->params->get('payment_status', 4);
+        $order->order_state_id = $orderStateId;
+
         if (!$order->store()) {
             Log::add('Bank transfer order save failed: ' . $order->getError(), Log::ERROR, 'com_j2commerce');
             $json['error'] = Text::_('PLG_J2COMMERCE_PAYMENT_BANKTRANSFER_ORDER_NOT_FOUND');
@@ -324,14 +320,10 @@ final class PaymentBanktransfer extends CMSPlugin implements SubscriberInterface
             return $json;
         }
 
-        // Update status via OrderModel (fires events + notifications + history)
-        $orderStateId = (int) $this->params->get('payment_status', 4);
-        $model = $this->getOrderModel();
-        $model->updateOrderStatus(
-            (int) $order->j2commerce_order_id,
-            $orderStateId,
-            true,
-            Text::sprintf('COM_J2COMMERCE_ORDER_HISTORY_PAYMENT_RECEIVED', Text::_('PLG_J2COMMERCE_PAYMENT_BANKTRANSFER'))
+        OrderHistoryHelper::add(
+            orderId: $order->order_id,
+            comment: Text::sprintf('COM_J2COMMERCE_ORDER_HISTORY_PAYMENT_RECEIVED', Text::_('PLG_J2COMMERCE_PAYMENT_BANKTRANSFER')),
+            orderStateId: $orderStateId,
         );
 
         $json['success'] = $this->params->get('onafterpayment', '');

--- a/plugins/j2commerce/payment_banktransfer/tmpl/prepayment.php
+++ b/plugins/j2commerce/payment_banktransfer/tmpl/prepayment.php
@@ -44,7 +44,7 @@ $vars = $displayData['vars'];
 
     </div>
 
-    <button type="submit"
+    <button type="button"
             id="banktransfer-submit-button"
             class="j2commerce-cart-button button btn btn-primary">
         <?php echo htmlspecialchars(Text::_($vars->button_text), ENT_QUOTES, 'UTF-8'); ?>

--- a/plugins/j2commerce/payment_cash/src/Extension/PaymentCash.php
+++ b/plugins/j2commerce/payment_cash/src/Extension/PaymentCash.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace J2Commerce\Plugin\J2Commerce\PaymentCash\Extension;
 
+use J2Commerce\Component\J2commerce\Administrator\Helper\OrderHistoryHelper;
 use J2Commerce\Component\J2commerce\Administrator\Library\Plugins\Base;
 use J2Commerce\Component\J2commerce\Administrator\Library\Plugins\Payment;
 use J2Commerce\Component\J2commerce\Administrator\Library\Plugins\PluginLayoutTrait;
@@ -216,14 +217,6 @@ final class PaymentCash extends CMSPlugin implements SubscriberInterface
         return $this->base;
     }
 
-    private function getOrderModel(): object
-    {
-        return Factory::getApplication()
-            ->bootComponent('com_j2commerce')
-            ->getMVCFactory()
-            ->createModel('Order', 'Administrator', ['ignore_request' => true]);
-    }
-
     private function createOrderTable(): object
     {
         return Factory::getApplication()
@@ -356,7 +349,10 @@ final class PaymentCash extends CMSPlugin implements SubscriberInterface
             return $json;
         }
 
-        // Save any order changes first
+        // Set status and save in a single store() call
+        $orderStateId = (int) $this->params->get('payment_status', 4);
+        $order->order_state_id = $orderStateId;
+
         if (!$order->store()) {
             Log::add('Cash payment order save failed: ' . $order->getError(), Log::ERROR, 'com_j2commerce');
             $json['error'] = Text::_('PLG_J2COMMERCE_PAYMENT_CASH_ORDER_NOT_FOUND');
@@ -364,14 +360,10 @@ final class PaymentCash extends CMSPlugin implements SubscriberInterface
             return $json;
         }
 
-        // Update status via OrderModel (fires events + notifications + history)
-        $orderStateId = (int) $this->params->get('payment_status', 4);
-        $model = $this->getOrderModel();
-        $model->updateOrderStatus(
-            (int) $order->j2commerce_order_id,
-            $orderStateId,
-            true,
-            Text::sprintf('COM_J2COMMERCE_ORDER_HISTORY_PAYMENT_RECEIVED', Text::_('PLG_J2COMMERCE_PAYMENT_CASH'))
+        OrderHistoryHelper::add(
+            orderId: $order->order_id,
+            comment: Text::sprintf('COM_J2COMMERCE_ORDER_HISTORY_PAYMENT_RECEIVED', Text::_('PLG_J2COMMERCE_PAYMENT_CASH')),
+            orderStateId: $orderStateId,
         );
 
         $json['success'] = $this->params->get('onafterpayment', '');

--- a/plugins/j2commerce/payment_cash/tmpl/prepayment.php
+++ b/plugins/j2commerce/payment_cash/tmpl/prepayment.php
@@ -47,7 +47,7 @@ $vars = $displayData['vars'];
 
     </div>
 
-    <button type="submit"
+    <button type="button"
             id="cash-submit-button"
             class="j2commerce-cart-button button btn btn-primary">
         <?php echo htmlspecialchars(Text::_($vars->button_text), ENT_QUOTES, 'UTF-8'); ?>


### PR DESCRIPTION
## Summary
Fixes #188

Bank transfer and cash payment plugins caused Error 500 when placing an order. Money order and Authorize.Net worked fine.

## Root Cause
Both plugins called `OrderModel::updateOrderStatus()` with `notify=true` from inside the payment event handler. This invoked `sendOrderNotification()` → `EmailHelper::getOrderEmails()` without the `try/catch` wrapper that the checkout controller uses. If email template processing failed, the uncaught exception produced the 500.

## Changes
- Replace `OrderModel::updateOrderStatus()` with direct `$order->store()` + `OrderHistoryHelper::add()` — matching the proven moneyorder/authorizenet pattern
- Remove unused `getOrderModel()` methods from both plugins
- Change button `type="submit"` → `type="button"` for consistency with other payment plugins (checkout JS handles all payment forms via AJAX)

## Files Changed
- `plugins/j2commerce/payment_banktransfer/src/Extension/PaymentBanktransfer.php` — fixed payment processing
- `plugins/j2commerce/payment_banktransfer/tmpl/prepayment.php` — button type fix
- `plugins/j2commerce/payment_cash/src/Extension/PaymentCash.php` — fixed payment processing
- `plugins/j2commerce/payment_cash/tmpl/prepayment.php` — button type fix

## Testing
1. Add item to cart → checkout → select Bank Transfer → place order
2. Verify: no 500 error, order created with correct status, redirected to confirmation
3. Repeat with Cash/Payment on Delivery
4. Repeat with Money Order to confirm no regression
5. Check admin Orders: verify history entry was created

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only