### PR TITLE
fix(customfield): re-bind form data after injecting plugin area fields

### DIFF
--- a/administrator/components/com_j2commerce/src/Model/CustomfieldModel.php
+++ b/administrator/components/com_j2commerce/src/Model/CustomfieldModel.php
@@ -125,6 +125,12 @@ class CustomfieldModel extends AdminModel
 
             $xml .= '</fieldset></form>';
             $form->load(new \SimpleXMLElement($xml));
+
+            // Re-bind data so plugin area values populate the newly injected fields.
+            // The initial loadForm() binding happened before these fields existed.
+            if ($loadData) {
+                $form->bind($this->loadFormData());
+            }
         }
 
         // Let plugins inject additional fieldsets/tabs


### PR DESCRIPTION
## Core Update

### Changes
- Re-bind form data after dynamically injecting plugin area fields in CustomfieldModel
- The initial `loadForm()` binding happened before these fields existed, so saved values were never populated

### Files Modified
| Type | Count |
|------|-------|
| PHP files | 1 |

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only (non-core excluded)