### PR TITLE
fix(install): add default email data to install SQL for fresh installs

### DIFF
--- a/administrator/components/com_j2commerce/script.j2commerce.php
+++ b/administrator/components/com_j2commerce/script.j2commerce.php
@@ -970,11 +970,29 @@ class Com_J2commerceInstallerScript extends InstallerScript
             }
 
             if ($needsEmails) {
-                $this->executeSqlFileDirect($installer->getPath('source') . '/administrator/components/com_j2commerce/sql/emailtemplates.sql');
+                $this->executeSqlFile($installer->getPath('source') . '/administrator/components/com_j2commerce/sql/emailtemplates.sql');
             }
         } catch (\Exception $e) {
             $this->debugLog("LOCALISATION: email templates error: " . $e->getMessage());
             Log::add('Error installing email templates: ' . $e->getMessage(), Log::WARNING, 'j2commerce');
+        }
+
+        // Ensure emailtype_tags have default data (install SQL may have already inserted these)
+        try {
+            if (in_array($prefix . 'j2commerce_emailtype_tags', $alltables)) {
+                $query = $db->getQuery(true)
+                    ->select('COUNT(*)')
+                    ->from($db->quoteName('#__j2commerce_emailtype_tags'));
+                $db->setQuery($query);
+
+                if (((int) $db->loadResult()) < 1) {
+                    $this->executeSqlFile($installer->getPath('source') . '/administrator/components/com_j2commerce/sql/updates/mysql/6.1.0.sql');
+                    $this->debugLog("LOCALISATION: emailtype tags/contexts loaded from 6.1.0.sql");
+                }
+            }
+        } catch (\Exception $e) {
+            $this->debugLog("LOCALISATION: emailtype data error: " . $e->getMessage());
+            Log::add('Error installing emailtype data: ' . $e->getMessage(), Log::WARNING, 'j2commerce');
         }
 
         // Install invoice templates if needed
@@ -990,7 +1008,7 @@ class Com_J2commerceInstallerScript extends InstallerScript
             }
 
             if ($needsInvoices) {
-                $this->executeSqlFileDirect($installer->getPath('source') . '/administrator/components/com_j2commerce/sql/invoicetemplates.sql');
+                $this->executeSqlFile($installer->getPath('source') . '/administrator/components/com_j2commerce/sql/invoicetemplates.sql');
             }
         } catch (\Exception $e) {
             $this->debugLog("LOCALISATION: invoice templates error: " . $e->getMessage());

--- a/administrator/components/com_j2commerce/sql/install.mysql.utf8.sql
+++ b/administrator/components/com_j2commerce/sql/install.mysql.utf8.sql
@@ -355,6 +355,28 @@ CREATE TABLE IF NOT EXISTS `#__j2commerce_emailtype_tags` (
   KEY `idx_tag_name` (`tag_name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
+-- Default tags for transactional email type
+INSERT IGNORE INTO `#__j2commerce_emailtype_tags`
+  (`email_type`, `tag_name`, `tag_label`, `tag_description`, `tag_group`, `ordering`)
+VALUES
+  ('transactional', 'ORDER_ID', 'COM_J2COMMERCE_EMAILTEMPLATE_TAG_ORDERID', 'COM_J2COMMERCE_EMAILTEMPLATE_TAG_ORDERID_DESC', 'order', 1),
+  ('transactional', 'ORDER_DATE', 'COM_J2COMMERCE_EMAILTEMPLATE_TAG_ORDERDATE', 'COM_J2COMMERCE_EMAILTEMPLATE_TAG_ORDERDATE_DESC', 'order', 2),
+  ('transactional', 'ORDER_STATUS', 'COM_J2COMMERCE_EMAILTEMPLATE_TAG_ORDERSTATUS', 'COM_J2COMMERCE_EMAILTEMPLATE_TAG_ORDERSTATUS_DESC', 'order', 3),
+  ('transactional', 'ORDER_TOTAL', 'COM_J2COMMERCE_EMAILTEMPLATE_TAG_ORDERAMOUNT', 'COM_J2COMMERCE_EMAILTEMPLATE_TAG_ORDERAMOUNT_DESC', 'order', 4),
+  ('transactional', 'ORDER_SUBTOTAL', 'COM_J2COMMERCE_EMAILTEMPLATE_TAG_SUBTOTAL', 'COM_J2COMMERCE_EMAILTEMPLATE_TAG_SUBTOTAL_DESC', 'order', 5),
+  ('transactional', 'ORDER_TAX', 'COM_J2COMMERCE_EMAILTEMPLATE_TAG_TAX_AMOUNT', 'COM_J2COMMERCE_EMAILTEMPLATE_TAG_TAX_AMOUNT_DESC', 'order', 6),
+  ('transactional', 'ORDER_SHIPPING', 'COM_J2COMMERCE_EMAILTEMPLATE_TAG_SHIPPING_AMOUNT', 'COM_J2COMMERCE_EMAILTEMPLATE_TAG_SHIPPING_AMOUNT_DESC', 'order', 7),
+  ('transactional', 'ORDER_DISCOUNT', 'COM_J2COMMERCE_EMAILTEMPLATE_TAG_DISCOUNT_AMOUNT', 'COM_J2COMMERCE_EMAILTEMPLATE_TAG_DISCOUNT_AMOUNT_DESC', 'order', 8),
+  ('transactional', 'ORDER_ITEMS', 'COM_J2COMMERCE_EMAILTEMPLATE_TAG_ITEMS', 'COM_J2COMMERCE_EMAILTEMPLATE_TAG_ITEMS_DESC', 'order', 9),
+  ('transactional', 'CUSTOMER_NAME', 'COM_J2COMMERCE_EMAILTEMPLATE_SHORTCODE_CUSTOMER_NAME', 'COM_J2COMMERCE_EMAILTEMPLATE_SHORTCODE_CUSTOMER_NAME_DESC', 'customer', 10),
+  ('transactional', 'CUSTOMER_EMAIL', 'COM_J2COMMERCE_EMAILTEMPLATE_SHORTCODE_CUSTOMER_EMAIL', 'COM_J2COMMERCE_EMAILTEMPLATE_SHORTCODE_CUSTOMER_EMAIL_DESC', 'customer', 11),
+  ('transactional', 'BILLING_ADDRESS', 'COM_J2COMMERCE_EMAILTEMPLATE_TAG_BILLING_ADDRESS', 'COM_J2COMMERCE_EMAILTEMPLATE_TAG_BILLING_ADDRESS_DESC', 'customer', 12),
+  ('transactional', 'SHIPPING_ADDRESS', 'COM_J2COMMERCE_EMAILTEMPLATE_TAG_SHIPPING_ADDRESS', 'COM_J2COMMERCE_EMAILTEMPLATE_TAG_SHIPPING_ADDRESS_DESC', 'customer', 13),
+  ('transactional', 'PAYMENT_METHOD', 'COM_J2COMMERCE_EMAILTEMPLATE_SHORTCODE_PAYMENT_METHOD', 'COM_J2COMMERCE_EMAILTEMPLATE_SHORTCODE_PAYMENT_METHOD_DESC', 'payment', 14),
+  ('transactional', 'SHIPPING_METHOD', 'COM_J2COMMERCE_EMAILTEMPLATE_SHORTCODE_SHIPPING_METHOD', 'COM_J2COMMERCE_EMAILTEMPLATE_SHORTCODE_SHIPPING_METHOD_DESC', 'shipping', 15),
+  ('transactional', 'SITE_NAME', 'COM_J2COMMERCE_EMAILTEMPLATE_SHORTCODE_SITE_NAME', 'COM_J2COMMERCE_EMAILTEMPLATE_SHORTCODE_SITE_NAME_DESC', 'store', 16),
+  ('transactional', 'SITE_URL', 'COM_J2COMMERCE_EMAILTEMPLATE_SHORTCODE_STORE_URL', 'COM_J2COMMERCE_EMAILTEMPLATE_SHORTCODE_STORE_URL_DESC', 'store', 17);
+
 -- --------------------------------------------------------
 -- Table structure for table `#__j2commerce_emailtype_contexts`
 -- Defines contexts for each email type (sent, expired, etc.)
@@ -371,6 +393,15 @@ CREATE TABLE IF NOT EXISTS `#__j2commerce_emailtype_contexts` (
   UNIQUE KEY `idx_type_context` (`email_type`, `context`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
+-- Default contexts for transactional email type
+INSERT IGNORE INTO `#__j2commerce_emailtype_contexts`
+  (`email_type`, `context`, `label`, `description`, `ordering`)
+VALUES
+  ('transactional', 'order_confirmed', 'COM_J2COMMERCE_EMAILTYPE_CONTEXT_ORDER_CONFIRMED', '', 1),
+  ('transactional', 'order_cancelled', 'COM_J2COMMERCE_EMAILTYPE_CONTEXT_ORDER_CANCELLED', '', 2),
+  ('transactional', 'order_shipped', 'COM_J2COMMERCE_EMAILTYPE_CONTEXT_ORDER_SHIPPED', '', 3),
+  ('transactional', 'order_refunded', 'COM_J2COMMERCE_EMAILTYPE_CONTEXT_ORDER_REFUNDED', '', 4),
+  ('transactional', 'payment_received', 'COM_J2COMMERCE_EMAILTYPE_CONTEXT_PAYMENT_RECEIVED', '', 5);
 
 -- --------------------------------------------------------
 -- Table structure for table `#__j2commerce_filtergroups`


### PR DESCRIPTION
## Core Update

### Changes
- Added INSERT IGNORE statements for emailtype_tags (17 rows) and emailtype_contexts (5 rows) to `install.mysql.utf8.sql`
- Switched `emailtemplates.sql` and `invoicetemplates.sql` loading from `executeSqlFileDirect()` to `executeSqlFile()` for proper SQL splitting
- Added safety-net loading of emailtype data in `installLocalisation()` for edge cases

On fresh install, Joomla skips update SQL files — so the data from `6.1.0.sql` was never inserted, leaving the email system non-functional.

### Files Modified
| Type | Count |
|------|-------|
| PHP files | 1 |
| SQL files | 1 |

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only (non-core excluded)