### PR TITLE
fix(config+myprofile): update defaults and show token lookup for all users

### DIFF
--- a/administrator/components/com_j2commerce/config.xml
+++ b/administrator/components/com_j2commerce/config.xml
@@ -54,7 +54,7 @@
             name="store_zip"
             type="text"
             label="COM_J2COMMERCE_CONFIG_STORE_ZIP"
-            required="true"
+            required="false"
         />
 
         <field
@@ -1254,7 +1254,7 @@
             label="COM_J2COMMERCE_CONFIG_SHOW_TERMS"
             description="COM_J2COMMERCE_CONFIG_SHOW_TERMS_DESC"
             layout="joomla.form.field.radio.switcher"
-            default="1"
+            default="0"
             filter="integer"
         >
             <option value="0">JNO</option>

--- a/components/com_j2commerce/tmpl/myprofile/default_login.php
+++ b/components/com_j2commerce/tmpl/myprofile/default_login.php
@@ -66,7 +66,6 @@ $returnUrl = base64_encode(Uri::getInstance()->toString());
         </div>
         <?php endif; ?>
 
-        <?php if ($params->get('allow_guest_checkout', 0)): ?>
         <div class="col-lg-6">
             <div class="card">
                 <div class="card-header"><h4 class="mb-0"><?php echo Text::_('COM_J2COMMERCE_ORDER_GUEST_VIEW'); ?></h4></div>
@@ -87,6 +86,5 @@ $returnUrl = base64_encode(Uri::getInstance()->toString());
                 </div>
             </div>
         </div>
-        <?php endif; ?>
     </div>
 </div>


### PR DESCRIPTION
## Core Update

### Changes
- `show_terms` default changed from `1` to `0` (off by default for new installs)
- `store_zip` required changed from `true` to `false` (zip code no longer mandatory)
- Token/email lookup form on myprofile login page now visible regardless of guest checkout setting — all customers receive order tokens in confirmation emails, so this form should always be accessible

### Files Modified
| Type | Count |
|------|-------|
| XML/Config | 1 |
| PHP templates | 1 |

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only (non-core excluded)