### PR TITLE
fix(emailtemplates): show import form even when no templates exist

### DIFF
--- a/administrator/components/com_j2commerce/src/View/Emailtemplates/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Emailtemplates/HtmlView.php
@@ -101,7 +101,9 @@ class HtmlView extends BaseHtmlView
         $this->filterForm    = $model->getFilterForm();
         $this->activeFilters = $model->getActiveFilters();
 
-        if ((!is_array($this->items) || !\count($this->items)) && $this->isEmptyState = $this->getModel()->getIsEmptyState()) {
+        $requestedLayout = Factory::getApplication()->getInput()->get('layout', '');
+
+        if ((!is_array($this->items) || !\count($this->items)) && !$requestedLayout && $this->isEmptyState = $this->getModel()->getIsEmptyState()) {
             $this->setLayout('emptystate');
         }
 


### PR DESCRIPTION
## Core Update

Closes #73

### Problem
When no email templates exist, clicking the "Import Templates" toolbar button redirects to `layout=import`, but the view's `display()` method overrides the layout to `emptystate` because `items` is empty. The import form never renders.

### Fix
Check if a layout was explicitly requested via URL parameter before switching to the emptystate layout. If the user navigated to `layout=import`, respect that request.

### Files Modified
| Type | Count |
|------|-------|
| PHP (View) | 1 |

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only (non-core excluded)