### PR TITLE
fix(inventory): add missing getIsEmptyState() for empty state template

### DIFF
--- a/administrator/components/com_j2commerce/src/Model/InventoryModel.php
+++ b/administrator/components/com_j2commerce/src/Model/InventoryModel.php
@@ -718,4 +718,11 @@ class InventoryModel extends ListModel
 
         return $form;
     }
+
+    public function getIsEmptyState(): bool
+    {
+        $filters = $this->getActiveFilters();
+
+        return empty($filters);
+    }
 }


### PR DESCRIPTION
## Summary
Fixes #253

The inventory list view calls `$this->get('IsEmptyState')` which delegates to `InventoryModel::getIsEmptyState()`, but that method did not exist. It returned `null` (falsy), so the `emptystate.php` layout was never used — even when there are no items and no active filters.

## Changes
- Added `getIsEmptyState(): bool` to `InventoryModel` — returns `true` when no filters are active (same pattern as `AppsModel`, `PaymentmethodsModel`, `ShippingmethodsModel`, `ReportsModel`)

## Testing
1. Open admin > J2Commerce > Inventory
2. With no products, verify the empty state template renders instead of an empty table
3. With products present, verify the normal inventory list still displays correctly

## Files Changed
- `administrator/components/com_j2commerce/src/Model/InventoryModel.php` — added `getIsEmptyState()` method