### PR TITLE
fix(customers): replace mailto links with customer edit links

### DIFF
--- a/administrator/components/com_j2commerce/tmpl/customers/default.php
+++ b/administrator/components/com_j2commerce/tmpl/customers/default.php
@@ -93,7 +93,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
                                         <?php endif; ?>
                                     </th>
                                     <td>
-                                        <a href="mailto:<?php echo $this->escape($item->email); ?>">
+                                        <a href="<?php echo Route::_('index.php?option=com_j2commerce&task=customer.edit&id=' . (int) $item->j2commerce_address_id); ?>">
                                             <?php echo $this->escape($item->email); ?>
                                         </a>
                                     </td>

--- a/administrator/components/com_j2commerce/tmpl/order/view_sidebar.php
+++ b/administrator/components/com_j2commerce/tmpl/order/view_sidebar.php
@@ -79,7 +79,7 @@ if ($orderInfo) {
                     </div>
                     <div class="customer-information-item mb-2">
                         <span class="icon-envelope me-1 fa-fw" aria-hidden="true"></span>
-                        <a href="mailto:<?php echo $this->escape($item->user_email); ?>"><?php echo $this->escape($item->user_email); ?></a>
+                        <?php echo $this->escape($item->user_email); ?>
                     </div>
                     <?php if (!empty($orderInfo->billing_phone_1)) : ?>
                         <div class="customer-information-item mb-2"><span class="icon-phone me-1 fa-fw" aria-hidden="true"></span> <?php echo $this->escape($orderInfo->billing_phone_1); ?></div>


### PR DESCRIPTION
## Summary
Fixes #254

## Changes
- **Customers list:** Email column now links to the customer edit view (same as the customer name column) instead of a non-functional `mailto:` link
- **Order view sidebar:** Email is now plain text instead of a `mailto:` link

## Files Changed
- `administrator/components/com_j2commerce/tmpl/customers/default.php` — mailto → customer edit link
- `administrator/components/com_j2commerce/tmpl/order/view_sidebar.php` — mailto → plain text

## Testing
1. Navigate to J2Commerce > Customers — click an email address → should open customer edit view
2. Navigate to J2Commerce > Orders > view an order — email in sidebar should be plain text, not clickable