### PR TITLE
fix(emailtemplate): responsive device preview + checked_out warning

### DIFF
--- a/administrator/components/com_j2commerce/src/View/Emailtemplate/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Emailtemplate/HtmlView.php
@@ -188,7 +188,7 @@ class HtmlView extends BaseHtmlView
         $isNew      = ($this->item->j2commerce_emailtemplate_id == 0);
         $canDo      = ContentHelper::getActions('com_j2commerce', 'emailtemplate', $this->item->j2commerce_emailtemplate_id);
         $user       = Factory::getApplication()->getIdentity();
-        $checkedOut = !(\is_null($this->item->checked_out) || $this->item->checked_out == $user->id);
+        $checkedOut = !empty($this->item->checked_out) && $this->item->checked_out != $user->id;
 
         Factory::getApplication()->getInput()->set('hidemainmenu', true);
 

--- a/media/com_j2commerce/js/administrator/grapesjs-j2commerce.js
+++ b/media/com_j2commerce/js/administrator/grapesjs-j2commerce.js
@@ -100,12 +100,22 @@ function initGrapesJSEditor(options) {
 
     window._j2cGrapesEditor = editor;
 
-    // After load, swap any shortcode src attributes to placeholders (handles saved projectData)
+    // After load, inject responsive styles and swap shortcode src placeholders
     editor.on('load', () => {
         const frame = editor.Canvas.getFrameEl();
         if (!frame) return;
         const doc = frame.contentDocument;
         if (!doc) return;
+
+        // Responsive override so email tables/images scale in device preview
+        const style = doc.createElement('style');
+        style.setAttribute('data-j2c-responsive', '1');
+        style.textContent = 'body{overflow-x:hidden}'
+            + 'table{max-width:100%!important}'
+            + 'img{max-width:100%!important;height:auto!important}'
+            + 'td,th{word-break:break-word}';
+        doc.head.appendChild(style);
+
         doc.querySelectorAll('img').forEach(img => {
             const src = img.getAttribute('src') || '';
             if (/^\[[A-Z_]+\]$/.test(src)) {


### PR DESCRIPTION
## Summary
Fixes #252

## Changes
- Inject responsive CSS into GrapesJS canvas iframe on editor load — forces `max-width:100%` on tables and images so email content scales when switching to mobile/tablet device views
- Fix `Undefined property: stdClass::$checked_out` warning in Emailtemplate HtmlView (table has no `checked_out` column)

## Testing
1. Open any email template in the editor
2. Click Mobile portrait device icon
3. Verify content scales within the narrow frame — no horizontal overflow
4. Verify no PHP warnings on the edit page

## Files Changed
- `media/com_j2commerce/js/administrator/grapesjs-j2commerce.js` — responsive canvas styles
- `administrator/components/com_j2commerce/src/View/Emailtemplate/HtmlView.php` — checked_out fix