### PR TITLE
fix(admin): consistent untruncated descriptions across plugin views

### DIFF
--- a/administrator/components/com_j2commerce/tmpl/apps/default.php
+++ b/administrator/components/com_j2commerce/tmpl/apps/default.php
@@ -174,7 +174,7 @@ $return = rawurlencode($encodedReturn);
                                                     <span class="badge text-bg-info ms-1"><?php echo $this->escape($item->folder); ?></span>
                                                 <?php endif; ?>
                                             </div>
-                                            <div class="small d-none d-md-block"><?php echo Text::_(HTMLHelper::_('string.truncate', $desc, 120, true, true));?></div>
+                                            <div class="small d-none d-md-block"><?php echo $desc; ?></div>
                                             <div class="small d-block d-lg-none"><b><?php echo Text::_('COM_J2COMMERCE_APP_VERSION');?>:</b> <?php echo $this->escape($item->version); ?></div>
                                         </div>
                                     </div>

--- a/administrator/components/com_j2commerce/tmpl/paymentmethods/default.php
+++ b/administrator/components/com_j2commerce/tmpl/paymentmethods/default.php
@@ -193,7 +193,7 @@ $encodedReturn = base64_encode('index.php?option=com_j2commerce&view=paymentmeth
                                                 <?php endif; ?>
                                             </div>
                                             <?php if ($desc) : ?>
-                                                <div class="small d-none d-md-block"><?php echo Text::_($desc); ?></div>
+                                                <div class="small d-none d-md-block"><?php echo $desc; ?></div>
                                             <?php endif; ?>
                                             <?php if (!$item->files_exist) : ?>
                                                 <div class="small text-danger">


### PR DESCRIPTION
## Summary
Fixes #243

## Changes
- **Apps**: Removed 120-character truncation from description — now shows full text like other views
- **Payment**: Removed redundant double `Text::_()` wrapping on description output
- Shipping and Reports were already consistent — no changes needed

All four views now render descriptions identically: `<div class="small d-none d-md-block"><?php echo $desc; ?></div>`

## Testing
1. Open admin > J2Commerce > Apps, Payment, Shipping, Reports
2. Verify descriptions display in full (no truncation) and look identical across all four views

## Files Changed
- `administrator/components/com_j2commerce/tmpl/apps/default.php` — removed truncation
- `administrator/components/com_j2commerce/tmpl/paymentmethods/default.php` — removed double Text::_()