### PR TITLE
fix(admin): align mobile version breakpoint with column visibility

### DIFF
--- a/administrator/components/com_j2commerce/tmpl/apps/default.php
+++ b/administrator/components/com_j2commerce/tmpl/apps/default.php
@@ -175,7 +175,7 @@ $return = rawurlencode($encodedReturn);
                                                 <?php endif; ?>
                                             </div>
                                             <div class="small d-none d-md-block"><?php echo $desc; ?></div>
-                                            <div class="small d-block d-lg-none"><b><?php echo Text::_('COM_J2COMMERCE_APP_VERSION');?>:</b> <?php echo $this->escape($item->version); ?></div>
+                                            <div class="small d-block d-md-none"><b><?php echo Text::_('COM_J2COMMERCE_APP_VERSION');?>:</b> <?php echo $this->escape($item->version); ?></div>
                                         </div>
                                     </div>
 

--- a/administrator/components/com_j2commerce/tmpl/paymentmethods/default.php
+++ b/administrator/components/com_j2commerce/tmpl/paymentmethods/default.php
@@ -201,7 +201,7 @@ $encodedReturn = base64_encode('index.php?option=com_j2commerce&view=paymentmeth
                                                     <?php echo Text::_('COM_J2COMMERCE_PAYMENT_METHOD_FILES_MISSING'); ?>
                                                 </div>
                                             <?php endif; ?>
-                                            <div class="small d-block d-lg-none"><b><?php echo Text::_('COM_J2COMMERCE_PAYMENT_METHOD_VERSION'); ?>:</b> <?php echo $this->escape($version); ?></div>
+                                            <div class="small d-block d-md-none"><b><?php echo Text::_('COM_J2COMMERCE_PAYMENT_METHOD_VERSION'); ?>:</b> <?php echo $this->escape($version); ?></div>
                                         </div>
                                     </div>
                                 </th>

--- a/administrator/components/com_j2commerce/tmpl/reports/default.php
+++ b/administrator/components/com_j2commerce/tmpl/reports/default.php
@@ -206,7 +206,7 @@ HTMLHelper::_('bootstrap.tooltip', '[data-bs-toggle="tooltip"]', ['placement' =>
                                                     <?php echo Text::_('COM_J2COMMERCE_REPORT_FILES_MISSING'); ?>
                                                 </div>
                                             <?php endif; ?>
-                                            <div class="small d-block d-lg-none"><b><?php echo Text::_('COM_J2COMMERCE_REPORT_VERSION'); ?>:</b> <?php echo $this->escape($version); ?></div>
+                                            <div class="small d-block d-md-none"><b><?php echo Text::_('COM_J2COMMERCE_REPORT_VERSION'); ?>:</b> <?php echo $this->escape($version); ?></div>
                                         </div>
                                     </div>
                                 </th>

--- a/administrator/components/com_j2commerce/tmpl/shippingmethods/default.php
+++ b/administrator/components/com_j2commerce/tmpl/shippingmethods/default.php
@@ -196,7 +196,7 @@ HTMLHelper::_('bootstrap.tooltip', '[data-bs-toggle="tooltip"]', ['placement' =>
                                                     <?php echo Text::_('COM_J2COMMERCE_SHIPPING_METHOD_FILES_MISSING'); ?>
                                                 </div>
                                             <?php endif; ?>
-                                            <div class="small d-block d-lg-none"><b><?php echo Text::_('COM_J2COMMERCE_SHIPPING_METHOD_VERSION'); ?>:</b> <?php echo $this->escape($version); ?></div>
+                                            <div class="small d-block d-md-none"><b><?php echo Text::_('COM_J2COMMERCE_SHIPPING_METHOD_VERSION'); ?>:</b> <?php echo $this->escape($version); ?></div>
                                         </div>
                                     </div>
                                 </th>


### PR DESCRIPTION
## Summary
Fixes #244

## Changes
- Changed `d-block d-lg-none` to `d-block d-md-none` on the inline version line in apps, shipping, payment, and reports views
- The inline version text now hides at the same `md` breakpoint where the version column appears, eliminating the duplication visible at tablet widths

## Testing
1. Open admin > Apps / Payment / Shipping / Reports
2. Resize to tablet width (~768px) — version shows in column only, not inline
3. Resize to mobile (~400px) — version shows inline only (column hidden)

## Files Changed
- `administrator/components/com_j2commerce/tmpl/apps/default.php`
- `administrator/components/com_j2commerce/tmpl/paymentmethods/default.php`
- `administrator/components/com_j2commerce/tmpl/shippingmethods/default.php`
- `administrator/components/com_j2commerce/tmpl/reports/default.php`