### PR TITLE
fix(orders): disable order edit until fully implemented

### DIFF
--- a/administrator/components/com_j2commerce/src/View/Order/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Order/HtmlView.php
@@ -169,12 +169,13 @@ class HtmlView extends BaseHtmlView
 
             $toolbar->cancel('order.cancel', 'JTOOLBAR_CLOSE');
 
-            if ($canEditOrders && $canDo->get('core.edit')) {
-                $toolbar->linkButton('edit')
-                    ->text('JTOOLBAR_EDIT')
-                    ->url('index.php?option=com_j2commerce&view=order&layout=edit&id=' . (int) $this->item->j2commerce_order_id)
-                    ->icon('icon-pencil-alt');
-            }
+            // TODO: Re-enable Edit button in a future release when order editing is fully implemented
+            // if ($canEditOrders && $canDo->get('core.edit')) {
+            //     $toolbar->linkButton('edit')
+            //         ->text('JTOOLBAR_EDIT')
+            //         ->url('index.php?option=com_j2commerce&view=order&layout=edit&id=' . (int) $this->item->j2commerce_order_id)
+            //         ->icon('icon-pencil-alt');
+            // }
 
             $toolbar->linkButton('print')
                 ->text('COM_J2COMMERCE_PRINT_INVOICE')

--- a/administrator/components/com_j2commerce/tmpl/orders/default.php
+++ b/administrator/components/com_j2commerce/tmpl/orders/default.php
@@ -159,9 +159,10 @@ $dateFormat = ComponentHelper::getParams('com_j2commerce')->get('date_format', '
                                             <a href="<?php echo $orderViewUrl; ?>" class="btn btn-sm btn-link" title="<?php echo Text::_('COM_J2COMMERCE_VIEW'); ?>">
                                                 <span class="icon-eye" aria-hidden="true"></span>
                                             </a>
-                                            <a href="<?php echo $orderEditUrl; ?>" class="btn btn-sm btn-link" title="<?php echo Text::_('JACTION_EDIT'); ?>">
+                                            <?php // TODO: Re-enable edit link in a future release when order editing is fully implemented ?>
+                                            <?php /* <a href="<?php echo $orderEditUrl; ?>" class="btn btn-sm btn-link" title="<?php echo Text::_('JACTION_EDIT'); ?>">
                                                 <span class="icon-pencil-alt" aria-hidden="true"></span>
-                                            </a>
+                                            </a> */ ?>
                                         </div>
                                         <div class="form-check form-switch mt-1 d-flex align-items-center justify-content-center gap-1">
                                             <input type="checkbox" class="form-check-input order-notify-check me-2" role="switch" id="notify_<?php echo (int) $item->j2commerce_order_id; ?>" data-order-id="<?php echo (int) $item->j2commerce_order_id; ?>" style="position: relative;top: -3px;" />


### PR DESCRIPTION
## Summary
Fixes #192
Fixes #193

## Changes
- Comment out Edit toolbar button in `view=order&layout=view`
- Comment out edit pencil icon link in `view=orders` list (`.j2commerce-order-actions`)
- View (eye) icon remains functional

Both are marked with TODO comments for re-enabling in a future release.

## Note
There are more items beyond #192 and #193 that need updating for full order editing support. This PR kicks the can down the road — edit functionality will be re-enabled in a later release when the full order editing workflow is complete.

## Files Changed
- `administrator/components/com_j2commerce/src/View/Order/HtmlView.php` — toolbar Edit button commented out
- `administrator/components/com_j2commerce/tmpl/orders/default.php` — edit link in actions column commented out