### PR TITLE
fix(assets): use relative paths for WAM asset registration

### DIFF
--- a/administrator/components/com_j2commerce/src/Helper/StrapperHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/StrapperHelper.php
@@ -447,7 +447,7 @@ class StrapperHelper
             $context = $forceContext ?? $this->getViewContext();
 
             $wa->registerAndUseScript('com_j2commerce.site', 'media/com_j2commerce/js/site/j2commerce.js', [], ['defer' => true]);
-            $wa->registerAndUseScript('plg_j2commerce_app_flexivariable.flexivariable', Uri::root() . 'media/plg_j2commerce_app_flexivariable/js/flexivariable.js', [], ['defer' => true]);
+            $wa->registerAndUseScript('plg_j2commerce_app_flexivariable.flexivariable', 'media/plg_j2commerce_app_flexivariable/js/flexivariable.js', [], ['defer' => true]);
 
             // Load context-specific scripts
             match ($context) {
@@ -626,17 +626,17 @@ class StrapperHelper
         if (file_exists(JPATH_SITE . '/media/templates/site/' . $template . '/css/j2commerce.css')) {
             // Template override - register and use dynamically
             $wa->registerAndUseStyle(
-                'j2commerce-site-override',
-                Uri::root() . 'media/templates/site/' . $template . '/css/j2commerce.css'
+                'com_j2commerce.site',
+                'media/templates/site/' . $template . '/css/j2commerce.css'
             );
         } elseif (file_exists(JPATH_SITE . '/templates/' . $template . '/css/j2commerce.css')) {
             // Legacy template folder pattern - register and use dynamically
             $wa->registerAndUseStyle(
-                'j2commerce-site-override',
-                Uri::root() . 'templates/' . $template . '/css/j2commerce.css'
+                'com_j2commerce.site',
+                'templates/' . $template . '/css/j2commerce.css'
             );
         } else {
-            $wa->registerAndUseStyle('com_j2commerce.site.css', 'media/com_j2commerce/css/site/j2commerce.css');
+            $wa->registerAndUseStyle('com_j2commerce.site', 'media/com_j2commerce/css/site/j2commerce.css');
         }
     }
 

--- a/components/com_j2commerce/tmpl/checkout/default.php
+++ b/components/com_j2commerce/tmpl/checkout/default.php
@@ -28,9 +28,7 @@ $wa  = Factory::getApplication()->getDocument()->getWebAssetManager();
 $wa->useScript('bootstrap.collapse');
 $wa->useScript('bootstrap.dropdown');
 
-$wa->registerAndUseStyle('checkout.style', Uri::root() .'media/com_j2commerce/css/site/checkout.css', [], [], []);
-$wa->registerAndUseStyle('com_j2commerce.telephone.css', 'media/com_j2commerce/css/site/telephone-field.css');
-$wa->registerAndUseScript('com_j2commerce.telephone', 'media/com_j2commerce/js/site/telephone-field.js', [], ['defer' => true]);
+$wa->registerAndUseStyle('checkout.style', 'media/com_j2commerce/css/site/checkout.css', [], [], []);
 
 // Grand total for mobile toggle button
 $grandTotal = '';

--- a/components/com_j2commerce/tmpl/checkout/default.php
+++ b/components/com_j2commerce/tmpl/checkout/default.php
@@ -29,6 +29,8 @@ $wa->useScript('bootstrap.collapse');
 $wa->useScript('bootstrap.dropdown');
 
 $wa->registerAndUseStyle('checkout.style', 'media/com_j2commerce/css/site/checkout.css', [], [], []);
+$wa->registerAndUseStyle('com_j2commerce.telephone.css', 'media/com_j2commerce/css/site/telephone-field.css');
+$wa->registerAndUseScript('com_j2commerce.telephone', 'media/com_j2commerce/js/site/telephone-field.js', [], ['defer' => true]);
 
 // Grand total for mobile toggle button
 $grandTotal = '';

--- a/components/com_j2commerce/tmpl/products/default.php
+++ b/components/com_j2commerce/tmpl/products/default.php
@@ -25,9 +25,9 @@ use Joomla\Registry\Registry;
 
 $app = Factory::getApplication();
 $wa = $app->getDocument()->getWebAssetManager();
-$wa->registerAndUseStyle('com_j2commerce.site', Uri::root() . 'media/com_j2commerce/css/site/j2commerce.css');
-$wa->registerAndUseScript('com_j2commerce.site', Uri::root() . 'media/com_j2commerce/js/site/j2commerce.js', [], ['defer' => true], []);
-$wa->registerAndUseScript('com_j2commerce.filters', Uri::root() . 'media/com_j2commerce/js/site/j2commerce-filters.es6.js', [], ['defer' => true], []);
+$wa->registerAndUseStyle('com_j2commerce.site,css', 'media/com_j2commerce/css/site/j2commerce.css');
+$wa->registerAndUseScript('com_j2commerce.site', 'media/com_j2commerce/js/site/j2commerce.js', [], ['defer' => true], []);
+$wa->registerAndUseScript('com_j2commerce.filters', 'media/com_j2commerce/js/site/j2commerce-filters.es6.js', [], ['defer' => true], []);
 
 $itemId = isset($this->active_menu->id) ? (int) $this->active_menu->id : 0;
 $activeLink = Route::_(RouteHelper::getProductsRoute($this->filter_catid ?? null));

--- a/media/com_j2commerce/joomla.asset.json
+++ b/media/com_j2commerce/joomla.asset.json
@@ -96,7 +96,7 @@
       "version": "6.0.0"
     },
     {
-      "name": "com_j2commerce.site.css",
+      "name": "com_j2commerce.site",
       "type": "style",
       "uri": "com_j2commerce/css/site/j2commerce.css",
       "version": "6.0.0"

--- a/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/default.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/default.php
@@ -25,9 +25,9 @@ use Joomla\Registry\Registry;
 
 $app = Factory::getApplication();
 $wa = $app->getDocument()->getWebAssetManager();
-$wa->registerAndUseStyle('com_j2commerce.site', Uri::root() . 'media/com_j2commerce/css/site/j2commerce.css');
-$wa->registerAndUseScript('com_j2commerce.site', Uri::root() . 'media/com_j2commerce/js/site/j2commerce.js', [], ['defer' => true], []);
-$wa->registerAndUseScript('com_j2commerce.filters', Uri::root() . 'media/com_j2commerce/js/site/j2commerce-filters.es6.js', [], ['defer' => true], []);
+$wa->registerAndUseStyle('com_j2commerce.site', 'media/com_j2commerce/css/site/j2commerce.css');
+$wa->registerAndUseScript('com_j2commerce.site', 'media/com_j2commerce/js/site/j2commerce.js', [], ['defer' => true], []);
+$wa->registerAndUseScript('com_j2commerce.filters', 'media/com_j2commerce/js/site/j2commerce-filters.es6.js', [], ['defer' => true], []);
 
 $itemId = isset($this->active_menu->id) ? (int) $this->active_menu->id : 0;
 $activeLink = Route::_(RouteHelper::getProductsRoute(!empty($this->filter_catid) ? (int) $this->filter_catid : null));

--- a/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/default.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/default.php
@@ -25,9 +25,9 @@ use Joomla\Registry\Registry;
 
 $app = Factory::getApplication();
 $wa = $app->getDocument()->getWebAssetManager();
-$wa->registerAndUseStyle('com_j2commerce.site', Uri::root() . 'media/com_j2commerce/css/site/j2commerce.css');
-$wa->registerAndUseScript('com_j2commerce.site', Uri::root() . 'media/com_j2commerce/js/site/j2commerce.js', [], ['defer' => true], []);
-$wa->registerAndUseScript('com_j2commerce.filters', Uri::root() . 'media/com_j2commerce/js/site/j2commerce-filters.es6.js', [], ['defer' => true], []);
+$wa->registerAndUseStyle('com_j2commerce.site', 'media/com_j2commerce/css/site/j2commerce.css');
+$wa->registerAndUseScript('com_j2commerce.site', 'media/com_j2commerce/js/site/j2commerce.js', [], ['defer' => true], []);
+$wa->registerAndUseScript('com_j2commerce.filters', 'media/com_j2commerce/js/site/j2commerce-filters.es6.js', [], ['defer' => true], []);
 
 $itemId = isset($this->active_menu->id) ? (int) $this->active_menu->id : 0;
 $activeLink = Route::_(RouteHelper::getProductsRoute(null));

--- a/plugins/j2commerce/app_uikit/tmpl/tag_uikit/default.php
+++ b/plugins/j2commerce/app_uikit/tmpl/tag_uikit/default.php
@@ -25,9 +25,9 @@ use Joomla\Registry\Registry;
 
 $app = Factory::getApplication();
 $wa = $app->getDocument()->getWebAssetManager();
-$wa->registerAndUseStyle('com_j2commerce.site', Uri::root() . 'media/com_j2commerce/css/site/j2commerce.css');
-$wa->registerAndUseScript('com_j2commerce.site', Uri::root() . 'media/com_j2commerce/js/site/j2commerce.js', [], ['defer' => true], []);
-$wa->registerAndUseScript('com_j2commerce.filters', Uri::root() . 'media/com_j2commerce/js/site/j2commerce-filters.es6.js', [], ['defer' => true], []);
+$wa->registerAndUseStyle('com_j2commerce.site', 'media/com_j2commerce/css/site/j2commerce.css');
+$wa->registerAndUseScript('com_j2commerce.site', 'media/com_j2commerce/js/site/j2commerce.js', [], ['defer' => true], []);
+$wa->registerAndUseScript('com_j2commerce.filters', 'media/com_j2commerce/js/site/j2commerce-filters.es6.js', [], ['defer' => true], []);
 
 $itemId = isset($this->active_menu->id) ? (int) $this->active_menu->id : 0;
 $activeLink = Route::_(RouteHelper::getProductsRoute(null));

--- a/plugins/j2commerce/app_uikit/tmpl/uikit/default.php
+++ b/plugins/j2commerce/app_uikit/tmpl/uikit/default.php
@@ -25,9 +25,9 @@ use Joomla\Registry\Registry;
 
 $app = Factory::getApplication();
 $wa = $app->getDocument()->getWebAssetManager();
-$wa->registerAndUseStyle('com_j2commerce.site', Uri::root() . 'media/com_j2commerce/css/site/j2commerce.css');
-$wa->registerAndUseScript('com_j2commerce.site', Uri::root() . 'media/com_j2commerce/js/site/j2commerce.js', [], ['defer' => true], []);
-$wa->registerAndUseScript('com_j2commerce.filters', Uri::root() . 'media/com_j2commerce/js/site/j2commerce-filters.es6.js', [], ['defer' => true], []);
+$wa->registerAndUseStyle('com_j2commerce.site', 'media/com_j2commerce/css/site/j2commerce.css');
+$wa->registerAndUseScript('com_j2commerce.site', 'media/com_j2commerce/js/site/j2commerce.js', [], ['defer' => true], []);
+$wa->registerAndUseScript('com_j2commerce.filters', 'media/com_j2commerce/js/site/j2commerce-filters.es6.js', [], ['defer' => true], []);
 
 $itemId = isset($this->active_menu->id) ? (int) $this->active_menu->id : 0;
 $activeLink = Route::_(RouteHelper::getProductsRoute(!empty($this->filter_catid) ? (int) $this->filter_catid : null));


### PR DESCRIPTION
## Summary
Fixes #176

## Changes
- Removed `Uri::root()` from all `registerAndUseScript`/`registerAndUseStyle` WAM calls — WAM expects relative paths and adds the base URL itself
- Renamed CSS asset name `com_j2commerce.site.css` to `com_j2commerce.site` to match the script asset name, preventing duplicate CSS loading via WAM auto-pairing

## Files Changed
- `administrator/.../Helper/StrapperHelper.php` — flexivariable JS, template override CSS, asset name
- `components/.../tmpl/products/default.php` — site CSS/JS/filters
- `components/.../tmpl/checkout/default.php` — checkout CSS
- `plugins/.../app_bootstrap5/tmpl/bootstrap5/default.php` — site CSS/JS/filters
- `plugins/.../app_bootstrap5/tmpl/tag_bootstrap5/default.php` — site CSS/JS/filters
- `plugins/.../app_uikit/tmpl/uikit/default.php` — site CSS/JS/filters
- `plugins/.../app_uikit/tmpl/tag_uikit/default.php` — site CSS/JS/filters
- `media/com_j2commerce/joomla.asset.json` — renamed style asset

## Testing
1. Product list page — view source, verify CSS/JS use relative paths (no full domain)
2. Tag product list (BS5 and UIkit) — same check
3. Checkout page — verify checkout.css uses relative path
4. Category page — verify j2commerce.css loads once (not duplicated)