### PR TITLE
feat(customfields): batch display settings, field type dropdown, SQL migration

### DIFF
--- a/administrator/components/com_j2commerce/sql/updates/mysql/6.1.5.sql
+++ b/administrator/components/com_j2commerce/sql/updates/mysql/6.1.5.sql
@@ -1,0 +1,7 @@
+--
+-- J2Commerce 6.1.5 Update Script
+-- Rename campaign_addr_id to params on addresses table for plugin JSON metadata storage.
+--
+
+ALTER TABLE `#__j2commerce_addresses`
+  CHANGE `campaign_addr_id` `params` TEXT NULL;

--- a/administrator/components/com_j2commerce/src/Controller/CustomfieldsController.php
+++ b/administrator/components/com_j2commerce/src/Controller/CustomfieldsController.php
@@ -13,10 +13,14 @@ namespace J2Commerce\Component\J2commerce\Administrator\Controller;
 
 \defined('_JEXEC') or die;
 
+use J2Commerce\Component\J2commerce\Administrator\Helper\CustomFieldHelper;
 use Joomla\CMS\Application\CMSApplication;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Controller\AdminController;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
+use Joomla\CMS\Router\Route;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Input\Input;
 use Joomla\Utilities\ArrayHelper;
 
@@ -67,6 +71,113 @@ class CustomfieldsController extends AdminController
     public function getModel($name = 'Customfield', $prefix = 'Administrator', $config = ['ignore_request' => true])
     {
         return parent::getModel($name, $prefix, $config);
+    }
+
+    /**
+     * Batch update display settings for selected custom fields.
+     *
+     * Core areas (billing, shipping, etc.) update DB columns directly.
+     * Plugin areas update the field_display JSON column.
+     *
+     * @return  void
+     *
+     * @since   6.2.0
+     */
+    public function batch(): void
+    {
+        $this->checkToken();
+
+        $pks = $this->input->post->get('cid', [], 'array');
+        $pks = ArrayHelper::toInteger($pks);
+        $pks = array_filter($pks);
+
+        if (empty($pks)) {
+            $this->setMessage(Text::_('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST'), 'warning');
+            $this->setRedirect(Route::_('index.php?option=com_j2commerce&view=customfields', false));
+            return;
+        }
+
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
+
+        // Core display areas — map to direct DB columns
+        $coreAreas = ['billing', 'shipping', 'payment', 'register', 'guest', 'guest_shipping'];
+        $coreUpdates = [];
+
+        foreach ($coreAreas as $area) {
+            $val = $this->input->post->getString('batch_display_' . $area, '');
+            if ($val !== '') {
+                $coreUpdates['field_display_' . $area] = (int) $val;
+            }
+        }
+
+        // Plugin display areas — stored in field_display JSON
+        $pluginAreas = CustomFieldHelper::getRegisteredAreas();
+        $pluginUpdates = [];
+
+        foreach ($pluginAreas as $area) {
+            $key = $area['key'] ?? '';
+            if ($key === '') {
+                continue;
+            }
+            $val = $this->input->post->getString('batch_plugin_' . $key, '');
+            if ($val !== '') {
+                $pluginUpdates[$key] = (int) $val;
+            }
+        }
+
+        if (empty($coreUpdates) && empty($pluginUpdates)) {
+            $this->setMessage(Text::_('COM_J2COMMERCE_BATCH_NOCHANGE_MSG'), 'notice');
+            $this->setRedirect(Route::_('index.php?option=com_j2commerce&view=customfields', false));
+            return;
+        }
+
+        $updated = 0;
+
+        foreach ($pks as $pk) {
+            // Apply core column updates
+            if (!empty($coreUpdates)) {
+                $query = $db->getQuery(true)
+                    ->update($db->quoteName('#__j2commerce_customfields'))
+                    ->where($db->quoteName('j2commerce_customfield_id') . ' = ' . $pk);
+
+                foreach ($coreUpdates as $col => $val) {
+                    $query->set($db->quoteName($col) . ' = ' . $val);
+                }
+
+                $db->setQuery($query);
+                $db->execute();
+            }
+
+            // Apply plugin area updates to field_display JSON
+            if (!empty($pluginUpdates)) {
+                $query = $db->getQuery(true)
+                    ->select($db->quoteName('field_display'))
+                    ->from($db->quoteName('#__j2commerce_customfields'))
+                    ->where($db->quoteName('j2commerce_customfield_id') . ' = ' . $pk);
+                $db->setQuery($query);
+                $currentJson = (string) $db->loadResult();
+
+                $display = json_decode($currentJson, true) ?: [];
+
+                foreach ($pluginUpdates as $key => $val) {
+                    $display[$key] = $val;
+                }
+
+                $newJson = json_encode($display);
+
+                $update = $db->getQuery(true)
+                    ->update($db->quoteName('#__j2commerce_customfields'))
+                    ->set($db->quoteName('field_display') . ' = ' . $db->quote($newJson))
+                    ->where($db->quoteName('j2commerce_customfield_id') . ' = ' . $pk);
+                $db->setQuery($update);
+                $db->execute();
+            }
+
+            $updated++;
+        }
+
+        $this->setMessage(Text::plural('COM_J2COMMERCE_N_ITEMS_UPDATED', $updated));
+        $this->setRedirect(Route::_('index.php?option=com_j2commerce&view=customfields', false));
     }
 
     public function saveOrderAjax(): void

--- a/administrator/components/com_j2commerce/src/Field/CustomFieldTypeField.php
+++ b/administrator/components/com_j2commerce/src/Field/CustomFieldTypeField.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Administrator\Field;
+
+defined('_JEXEC') or die;
+
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
+use Joomla\CMS\Form\Field\ListField;
+use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Language\Text;
+
+/**
+ * CustomFieldType field — provides a dropdown of custom field types.
+ *
+ * Core types are defined here. Plugins can extend the list via onJ2CommerceGetCustomFieldTypes.
+ *
+ * @since  6.1.5
+ */
+class CustomFieldTypeField extends ListField
+{
+    protected $type = 'CustomFieldType';
+
+    protected static ?array $cachedTypes = null;
+
+    /**
+     * Get all available field types (core + plugin-registered).
+     *
+     * @return  array  Associative array of type_key => translated_label
+     *
+     * @since   6.1.5
+     */
+    public static function getFieldTypes(): array
+    {
+        $types = [
+            'text'           => Text::_('COM_J2COMMERCE_FIELDTYPE_TEXT'),
+            'email'          => Text::_('COM_J2COMMERCE_FIELDTYPE_EMAIL'),
+            'textarea'       => Text::_('COM_J2COMMERCE_FIELDTYPE_TEXTAREA'),
+            'wysiwyg'        => Text::_('COM_J2COMMERCE_FIELDTYPE_WYSIWYG'),
+            'radio'          => Text::_('COM_J2COMMERCE_FIELDTYPE_RADIO'),
+            'checkbox'       => Text::_('COM_J2COMMERCE_FIELDTYPE_CHECKBOX'),
+            'singledropdown' => Text::_('COM_J2COMMERCE_FIELDTYPE_SINGLEDROPDOWN'),
+            'zone'           => Text::_('COM_J2COMMERCE_FIELDTYPE_ZONE'),
+            'date'           => Text::_('COM_J2COMMERCE_FIELDTYPE_DATE'),
+            'time'           => Text::_('COM_J2COMMERCE_FIELDTYPE_TIME'),
+            'datetime'       => Text::_('COM_J2COMMERCE_FIELDTYPE_DATETIME'),
+            'customtext'     => Text::_('COM_J2COMMERCE_FIELDTYPE_CUSTOMTEXT'),
+            'telephone'      => Text::_('COM_J2COMMERCE_FIELDTYPE_TELEPHONE'),
+            'multiuploader'  => Text::_('COM_J2COMMERCE_FIELDTYPE_MULTIUPLOADER'),
+        ];
+
+        // Allow plugins to register additional field types
+        J2CommerceHelper::plugin()->event('GetCustomFieldTypes', [&$types]);
+
+        return $types;
+    }
+
+    public function getOptions(): array
+    {
+        $options = parent::getOptions();
+
+        if (self::$cachedTypes !== null) {
+            foreach (self::$cachedTypes as $value => $label) {
+                $options[] = HTMLHelper::_('select.option', $value, $label);
+            }
+
+            return $options;
+        }
+
+        $fieldTypes = self::getFieldTypes();
+        asort($fieldTypes);
+        self::$cachedTypes = $fieldTypes;
+
+        foreach ($fieldTypes as $value => $label) {
+            $options[] = HTMLHelper::_('select.option', $value, $label);
+        }
+
+        return $options;
+    }
+
+    public static function clearCache(): void
+    {
+        self::$cachedTypes = null;
+    }
+}

--- a/administrator/components/com_j2commerce/tmpl/customfields/default.php
+++ b/administrator/components/com_j2commerce/tmpl/customfields/default.php
@@ -156,4 +156,5 @@ if ($saveOrder && !empty($this->items)) {
     </div>
 </form>
 
+<?php echo $this->loadTemplate('batch'); ?>
 <?php echo $this->footer ?? ''; ?>

--- a/administrator/components/com_j2commerce/tmpl/customfields/default_batch.php
+++ b/administrator/components/com_j2commerce/tmpl/customfields/default_batch.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * Batch modal for bulk-updating custom field display settings.
+ * Core areas (billing, shipping, etc.) update DB columns directly.
+ * Plugin areas (via GetCustomFieldDisplayAreas event) update field_display JSON.
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+defined('_JEXEC') or die;
+
+use J2Commerce\Component\J2commerce\Administrator\Helper\CustomFieldHelper;
+use Joomla\CMS\Language\Text;
+
+// Core display areas — these map to direct DB columns
+$coreAreas = [
+    'billing'         => 'COM_J2COMMERCE_FIELD_DISPLAY_BILLING',
+    'shipping'        => 'COM_J2COMMERCE_FIELD_DISPLAY_SHIPPING',
+    'payment'         => 'COM_J2COMMERCE_FIELD_DISPLAY_PAYMENT',
+    'register'        => 'COM_J2COMMERCE_FIELD_DISPLAY_REGISTER',
+    'guest'           => 'COM_J2COMMERCE_FIELD_DISPLAY_GUEST',
+    'guest_shipping'  => 'COM_J2COMMERCE_FIELD_DISPLAY_GUEST_SHIPPING',
+];
+
+// Plugin-registered display areas (e.g., vendor_application from vendormanagement)
+$pluginAreas = CustomFieldHelper::getRegisteredAreas();
+
+$noChange = Text::_('COM_J2COMMERCE_BATCH_NOCHANGE');
+?>
+
+<div class="modal fade" id="collapseModal" tabindex="-1" aria-labelledby="collapseModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="collapseModalLabel"><?php echo Text::_('COM_J2COMMERCE_BATCH_DISPLAY_TITLE'); ?></h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="<?php echo Text::_('JCLOSE'); ?>"></button>
+            </div>
+            <div class="modal-body px-4 pt-4 pb-2">
+                <p class="text-muted small mb-3"><?php echo Text::_('COM_J2COMMERCE_BATCH_DISPLAY_DESC'); ?></p>
+
+                <h6 class="fw-bold mb-2"><?php echo Text::_('COM_J2COMMERCE_BATCH_DISPLAY_CORE_HEADING'); ?></h6>
+                <div class="row">
+                    <?php foreach ($coreAreas as $areaKey => $labelKey) : ?>
+                        <?php $safeKey = htmlspecialchars($areaKey, ENT_QUOTES, 'UTF-8'); ?>
+                        <div class="form-group col-md-6 col-lg-4 mb-3">
+                            <label for="batch_display_<?php echo $safeKey; ?>">
+                                <?php echo Text::_($labelKey); ?>
+                            </label>
+                            <select name="batch_display_<?php echo $safeKey; ?>"
+                                    id="batch_display_<?php echo $safeKey; ?>"
+                                    class="form-select form-select-sm">
+                                <option value=""><?php echo $noChange; ?></option>
+                                <option value="1"><?php echo Text::_('JYES'); ?></option>
+                                <option value="0"><?php echo Text::_('JNO'); ?></option>
+                            </select>
+                        </div>
+                    <?php endforeach; ?>
+                </div>
+
+                <?php if (!empty($pluginAreas)) : ?>
+                    <hr class="my-3">
+                    <h6 class="fw-bold mb-2"><?php echo Text::_('COM_J2COMMERCE_BATCH_DISPLAY_PLUGIN_HEADING'); ?></h6>
+                    <div class="row">
+                        <?php foreach ($pluginAreas as $area) : ?>
+                            <?php
+                            $areaKey  = $area['key'] ?? '';
+                            $areaName = $area['label'] ?? $areaKey;
+                            if ($areaKey === '') {
+                                continue;
+                            }
+                            ?>
+                            <div class="form-group col-md-6 col-lg-4 mb-3">
+                                <label for="batch_plugin_<?php echo htmlspecialchars($areaKey, ENT_QUOTES, 'UTF-8'); ?>">
+                                    <?php echo Text::_($areaName); ?>
+                                </label>
+                                <select name="batch_plugin_<?php echo htmlspecialchars($areaKey, ENT_QUOTES, 'UTF-8'); ?>"
+                                        id="batch_plugin_<?php echo htmlspecialchars($areaKey, ENT_QUOTES, 'UTF-8'); ?>"
+                                        class="form-select form-select-sm">
+                                    <option value=""><?php echo $noChange; ?></option>
+                                    <option value="1"><?php echo Text::_('JYES'); ?></option>
+                                    <option value="0"><?php echo Text::_('JNO'); ?></option>
+                                </select>
+                            </div>
+                        <?php endforeach; ?>
+                    </div>
+                <?php endif; ?>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal"><?php echo Text::_('JCANCEL'); ?></button>
+                <joomla-toolbar-button task="customfields.batch">
+                    <button type="button" class="btn btn-primary"><?php echo Text::_('JGLOBAL_BATCH_PROCESS'); ?></button>
+                </joomla-toolbar-button>
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
Adds batch update functionality for custom field display settings, restoring capability that was lost in a previous PR.

## Changes
- **Batch modal** (`default_batch.php`) — bulk-update display areas (billing, shipping, payment, register, guest, guest_shipping) plus plugin-registered areas
- **Batch controller** (`CustomfieldsController::batch()`) — processes core DB column updates + plugin JSON field_display updates
- **Batch include** (`default.php`) — loads the batch modal template in the list view
- **CustomFieldTypeField** — form field class for field type dropdown
- **6.1.5 SQL migration** — renames `campaign_addr_id` to `params` on addresses table for plugin JSON metadata storage

## Files Changed
| Type | File |
|------|------|
| New | `administrator/.../tmpl/customfields/default_batch.php` |
| New | `administrator/.../src/Field/CustomFieldTypeField.php` |
| New | `administrator/.../sql/updates/mysql/6.1.5.sql` |
| Modified | `administrator/.../tmpl/customfields/default.php` |
| Modified | `administrator/.../src/Controller/CustomfieldsController.php` |

## Testing
1. Navigate to Checkout Fields list view
2. Select one or more fields
3. Click Status → Batch in the toolbar
4. Set display areas to Yes/No
5. Click Process → verify fields updated