### PR TITLE
fix(product): default shipping to enabled for new products

### DIFF
--- a/administrator/components/com_j2commerce/forms/variant_shipping.xml
+++ b/administrator/components/com_j2commerce/forms/variant_shipping.xml
@@ -18,7 +18,7 @@
             label="COM_J2COMMERCE_PRODUCT_ENABLE_SHIPPING"
             layout="joomla.form.field.radio.switcher"
             filter="integer"
-            default="0"
+            default="1"
         >
             <option value="0">JNO</option>
             <option value="1">JYES</option>

--- a/administrator/components/com_j2commerce/src/Table/VariantTable.php
+++ b/administrator/components/com_j2commerce/src/Table/VariantTable.php
@@ -77,7 +77,7 @@ class VariantTable extends Table
         }
 
         if (!isset($this->shipping) || $this->shipping === null) {
-            $this->shipping = 0;
+            $this->shipping = 1;
         }
 
         if (!isset($this->manage_stock) || $this->manage_stock === null) {


### PR DESCRIPTION
## Summary
Fixes #255

When creating a new product, "Enable Shipping" defaulted to **No**. Changed to default to **Yes** for all product types (simple, variant, flexivariant, bundle, configurable, guided builder, box builder).

## Changes
- `variant_shipping.xml` — changed `default="0"` to `default="1"` (variant/flexivariant XML form)
- `VariantTable.php` — changed `$this->shipping = 0` to `$this->shipping = 1` in `check()` (simple/bundle/etc.)

## Files Modified
| Type | Count |
|------|-------|
| PHP files | 1 |
| XML/Config | 1 |

## Testing
1. Create a new **Simple** product → Shipping tab → "Enable Shipping" should be **Yes**
2. Create a new **Variant** product → expand variant → shipping should be **Yes**
3. Create a new **Flexivariant** product → expand variant → shipping should be **Yes**
4. Edit an **existing** product → shipping value should be unchanged

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only (non-core excluded)