### PR TITLE
fix(options): image picker targets wrong row in subform (fixes #59)

### DIFF
--- a/administrator/components/com_j2commerce/layouts/field/j2commerceimage.php
+++ b/administrator/components/com_j2commerce/layouts/field/j2commerceimage.php
@@ -78,7 +78,7 @@ if ($multiple) {
     </div>
 
     <?php if (!$disabled && !$readonly) : ?>
-    <button type="button" class="btn btn-sm btn-outline-secondary j2commerce-image-choose-btn" data-bs-toggle="modal" data-bs-target="#<?php echo $modalId; ?>">
+    <button type="button" class="btn btn-sm btn-outline-secondary j2commerce-image-choose-btn">
         <i class="fa-solid fa-image" aria-hidden="true"></i>
         <?php echo Text::_($multiple ? 'COM_J2COMMERCE_IMAGE_CHOOSE_MULTIPLE' : 'COM_J2COMMERCE_IMAGE_CHOOSE'); ?>
     </button>

--- a/administrator/components/com_j2commerce/src/View/Option/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Option/HtmlView.php
@@ -108,7 +108,7 @@ class HtmlView extends BaseHtmlView
         $isNew = (empty($this->item->j2commerce_option_id) || $this->item->j2commerce_option_id == 0)
                  && (empty($this->item->id) || $this->item->id == 0);
         $canDo      = ContentHelper::getActions('com_j2commerce', 'option', $this->item->j2commerce_option_id ?? 0);
-        $checkedOut = !(\is_null($this->item->checked_out) || $this->item->checked_out == $user->id);
+        $checkedOut = !(empty($this->item->checked_out) || $this->item->checked_out == $user->id);
 
         ToolbarHelper::title(
             Text::_('COM_J2COMMERCE_OPTION') . ': ' . ($isNew ? Text::_('JTOOLBAR_NEW') : Text::_('JTOOLBAR_EDIT')),

--- a/media/com_j2commerce/js/administrator/j2commerceimage.js
+++ b/media/com_j2commerce/js/administrator/j2commerceimage.js
@@ -77,6 +77,18 @@
             this.modalEl = this.element.querySelector('.uppymedia-modal');
             if (!this.modalEl) return;
 
+            // Open modal via JS instead of data-bs-target to avoid duplicate-ID
+            // issues when this field is inside a Joomla subform repeatable row.
+            const chooseBtn = this.element.querySelector('.j2commerce-image-choose-btn');
+            if (chooseBtn) {
+                chooseBtn.addEventListener('click', () => {
+                    if (!this.bsModal) {
+                        this.bsModal = new bootstrap.Modal(this.modalEl);
+                    }
+                    this.bsModal.show();
+                });
+            }
+
             this.setupModalHandlers();
             this.setupRemoveHandlers();
             this.updateChooseButton();


### PR DESCRIPTION
## Summary
Fixes #59

When adding multiple option values in a subform (without saving first), clicking the image picker on the 2nd row would open the 1st row's modal and replace its image. This happened because Joomla's subform cloning only fixes `[name]` elements — the modal `id` and button `data-bs-target` attributes were left as duplicates.

## Changes
- Removed `data-bs-toggle="modal"` and `data-bs-target` from the image picker button
- Added programmatic modal open in `J2CommerceImagePicker.init()` scoped to each instance's `this.modalEl`
- Fixed `Undefined property: checked_out` warning in Option HtmlView

## Files Changed
- `administrator/components/com_j2commerce/layouts/field/j2commerceimage.php` — removed data-bs-target
- `media/com_j2commerce/js/administrator/j2commerceimage.js` — programmatic modal open
- `administrator/components/com_j2commerce/src/View/Option/HtmlView.php` — checked_out warning fix

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only