### PR TITLE
feat(localisation): add Sync Values button to Weights and Lengths views

### DIFF
--- a/administrator/components/com_j2commerce/language/en-GB/com_j2commerce.ini
+++ b/administrator/components/com_j2commerce/language/en-GB/com_j2commerce.ini
@@ -206,6 +206,7 @@ COM_J2COMMERCE_TOOLBAR_INSTALL_APP="Install App"
 COM_J2COMMERCE_TOOLBAR_INSTALL_SHIPPING="Install Shipping Method"
 COM_J2COMMERCE_TOOLBAR_INSTALL_PAYMENT="Install Payment Method"
 COM_J2COMMERCE_TOOLBAR_INSTALL_REPORT="Install Report Plugin"
+COM_J2COMMERCE_TOOLBAR_SYNC_VALUES="Sync Values"
 COM_J2COMMERCE_TOOLBAR_UPDATE_RATES="Update Rates"
 
 ; Filter
@@ -410,6 +411,12 @@ COM_J2COMMERCE_ERR_WEIGHT_TITLE_REQUIRED="Weight title is required."
 COM_J2COMMERCE_ERR_WEIGHT_UNIT_REQUIRED="Weight unit is required."
 COM_J2COMMERCE_ERR_WEIGHT_VALUE_REQUIRED="Weight value is required."
 
+; Weights View - Sync Values
+COM_J2COMMERCE_WEIGHTS_SYNC_SUCCESS="Weight conversion values synced successfully relative to \"%s\"."
+COM_J2COMMERCE_WEIGHTS_SYNC_NO_ITEMS="No weight units found to sync."
+COM_J2COMMERCE_WEIGHTS_SYNC_DEFAULT_NOT_FOUND="Default weight unit (ID: %d) not found. Check your store configuration."
+COM_J2COMMERCE_WEIGHTS_SYNC_INVALID_DEFAULT="Default weight unit has an invalid conversion value."
+
 ; Lengths View - List
 COM_J2COMMERCE_LENGTHS="Lengths"
 COM_J2COMMERCE_LENGTHS_DESC="Manage length units for products and shipping"
@@ -436,6 +443,12 @@ COM_J2COMMERCE_FIELD_LENGTH_NUM_DECIMALS_DESC="Number of decimal places to displ
 COM_J2COMMERCE_ERR_LENGTH_TITLE_REQUIRED="Length title is required."
 COM_J2COMMERCE_ERR_LENGTH_UNIT_REQUIRED="Length unit is required."
 COM_J2COMMERCE_ERR_LENGTH_VALUE_REQUIRED="Length value is required."
+
+; Lengths View - Sync Values
+COM_J2COMMERCE_LENGTHS_SYNC_SUCCESS="Length conversion values synced successfully relative to \"%s\"."
+COM_J2COMMERCE_LENGTHS_SYNC_NO_ITEMS="No length units found to sync."
+COM_J2COMMERCE_LENGTHS_SYNC_DEFAULT_NOT_FOUND="Default length unit (ID: %d) not found. Check your store configuration."
+COM_J2COMMERCE_LENGTHS_SYNC_INVALID_DEFAULT="Default length unit has an invalid conversion value."
 
 ; Tax Profiles View - List
 COM_J2COMMERCE_TAXPROFILES="Tax Profiles"

--- a/administrator/components/com_j2commerce/language/en-US/com_j2commerce.ini
+++ b/administrator/components/com_j2commerce/language/en-US/com_j2commerce.ini
@@ -206,6 +206,7 @@ COM_J2COMMERCE_TOOLBAR_INSTALL_APP="Install App"
 COM_J2COMMERCE_TOOLBAR_INSTALL_SHIPPING="Install Shipping Method"
 COM_J2COMMERCE_TOOLBAR_INSTALL_PAYMENT="Install Payment Method"
 COM_J2COMMERCE_TOOLBAR_INSTALL_REPORT="Install Report Plugin"
+COM_J2COMMERCE_TOOLBAR_SYNC_VALUES="Sync Values"
 COM_J2COMMERCE_TOOLBAR_UPDATE_RATES="Update Rates"
 
 ; Filter
@@ -408,6 +409,12 @@ COM_J2COMMERCE_ERR_WEIGHT_TITLE_REQUIRED="Weight title is required."
 COM_J2COMMERCE_ERR_WEIGHT_UNIT_REQUIRED="Weight unit is required."
 COM_J2COMMERCE_ERR_WEIGHT_VALUE_REQUIRED="Weight value is required."
 
+; Weights View - Sync Values
+COM_J2COMMERCE_WEIGHTS_SYNC_SUCCESS="Weight conversion values synced successfully relative to \"%s\"."
+COM_J2COMMERCE_WEIGHTS_SYNC_NO_ITEMS="No weight units found to sync."
+COM_J2COMMERCE_WEIGHTS_SYNC_DEFAULT_NOT_FOUND="Default weight unit (ID: %d) not found. Check your store configuration."
+COM_J2COMMERCE_WEIGHTS_SYNC_INVALID_DEFAULT="Default weight unit has an invalid conversion value."
+
 ; Lengths View - List
 COM_J2COMMERCE_LENGTHS="Lengths"
 COM_J2COMMERCE_LENGTHS_DESC="Manage length units for products and shipping"
@@ -434,6 +441,12 @@ COM_J2COMMERCE_FIELD_LENGTH_NUM_DECIMALS_DESC="Number of decimal places to displ
 COM_J2COMMERCE_ERR_LENGTH_TITLE_REQUIRED="Length title is required."
 COM_J2COMMERCE_ERR_LENGTH_UNIT_REQUIRED="Length unit is required."
 COM_J2COMMERCE_ERR_LENGTH_VALUE_REQUIRED="Length value is required."
+
+; Lengths View - Sync Values
+COM_J2COMMERCE_LENGTHS_SYNC_SUCCESS="Length conversion values synced successfully relative to \"%s\"."
+COM_J2COMMERCE_LENGTHS_SYNC_NO_ITEMS="No length units found to sync."
+COM_J2COMMERCE_LENGTHS_SYNC_DEFAULT_NOT_FOUND="Default length unit (ID: %d) not found. Check your store configuration."
+COM_J2COMMERCE_LENGTHS_SYNC_INVALID_DEFAULT="Default length unit has an invalid conversion value."
 
 ; Tax Profiles View - List
 COM_J2COMMERCE_TAXPROFILES="Tax Profiles"

--- a/administrator/components/com_j2commerce/src/Controller/LengthsController.php
+++ b/administrator/components/com_j2commerce/src/Controller/LengthsController.php
@@ -13,10 +13,13 @@ namespace J2Commerce\Component\J2commerce\Administrator\Controller;
 
 \defined('_JEXEC') or die;
 
-use Joomla\CMS\Application\CMSApplication;
+use J2Commerce\Component\J2commerce\Administrator\Helper\ConfigHelper;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Controller\AdminController;
-use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
-use Joomla\Input\Input;
+use Joomla\CMS\Router\Route;
+use Joomla\CMS\Session\Session;
+use Joomla\Database\ParameterType;
 
 /**
  * Lengths list controller class.
@@ -37,21 +40,6 @@ class LengthsController extends AdminController
     protected $text_prefix = 'COM_J2COMMERCE';
 
     /**
-     * Constructor.
-     *
-     * @param   array                     $config   An optional associative array of configuration settings.
-     * @param   MVCFactoryInterface|null  $factory  The factory.
-     * @param   CMSApplication|null       $app      The Application for the dispatcher
-     * @param   Input|null                $input    Input
-     *
-     * @since   6.0.2
-     */
-    public function __construct($config = [], ?MVCFactoryInterface $factory = null, ?CMSApplication $app = null, ?Input $input = null)
-    {
-        parent::__construct($config, $factory, $app, $input);
-    }
-
-    /**
      * Proxy for getModel.
      *
      * @param   string  $name    The model name. Optional.
@@ -65,5 +53,148 @@ class LengthsController extends AdminController
     public function getModel($name = 'Length', $prefix = 'Administrator', $config = ['ignore_request' => true])
     {
         return parent::getModel($name, $prefix, $config);
+    }
+
+    /**
+     * Sync length conversion values relative to the configured default length unit.
+     *
+     * Sets the default length unit value to 1.0 and recalculates all other
+     * length values using standard conversion factors. Unknown units are
+     * scaled proportionally from the previous base.
+     *
+     * @return  void
+     *
+     * @since   6.0.3
+     */
+    public function syncValues(): void
+    {
+        Session::checkToken('get') || Session::checkToken() || jexit(Text::_('JINVALID_TOKEN'));
+
+        $redirectUrl = Route::_('index.php?option=com_j2commerce&view=lengths', false);
+
+        // ACL check
+        $user = Factory::getApplication()->getIdentity();
+
+        if (!$user->authorise('core.edit', 'com_j2commerce')) {
+            $this->setMessage(Text::_('JLIB_APPLICATION_ERROR_EDITSTATE_NOT_PERMITTED'), 'error');
+            $this->setRedirect($redirectUrl);
+
+            return;
+        }
+
+        $defaultId = ConfigHelper::getDefaultLengthClassId();
+
+        // Standard lengths: how many millimetres per 1 unit
+        $mmPerUnit = [
+            'mm' => 1.0,
+            'cm' => 10.0,
+            'm'  => 1000.0,
+            'km' => 1000000.0,
+            'in' => 25.4,
+            'ft' => 304.8,
+            'yd' => 914.4,
+            'mi' => 1609344.0,
+        ];
+
+        $db = Factory::getContainer()->get('DatabaseDriver');
+
+        // Load all length records
+        $query = $db->getQuery(true)
+            ->select([
+                $db->quoteName('j2commerce_length_id'),
+                $db->quoteName('length_title'),
+                $db->quoteName('length_unit'),
+                $db->quoteName('length_value'),
+            ])
+            ->from($db->quoteName('#__j2commerce_lengths'));
+        $lengths = $db->setQuery($query)->loadObjectList();
+
+        if (empty($lengths)) {
+            $this->setMessage(Text::_('COM_J2COMMERCE_LENGTHS_SYNC_NO_ITEMS'), 'warning');
+            $this->setRedirect($redirectUrl);
+
+            return;
+        }
+
+        // Find the default length
+        $defaultLength = null;
+
+        foreach ($lengths as $length) {
+            if ((int) $length->j2commerce_length_id === $defaultId) {
+                $defaultLength = $length;
+                break;
+            }
+        }
+
+        if ($defaultLength === null) {
+            $this->setMessage(Text::sprintf('COM_J2COMMERCE_LENGTHS_SYNC_DEFAULT_NOT_FOUND', $defaultId), 'error');
+            $this->setRedirect($redirectUrl);
+
+            return;
+        }
+
+        $defaultUnit = strtolower(trim($defaultLength->length_unit));
+
+        // Check if we know the default unit
+        if (!isset($mmPerUnit[$defaultUnit])) {
+            // Unknown default unit — just rebase proportionally
+            $oldDefaultValue = (float) $defaultLength->length_value;
+
+            if ($oldDefaultValue <= 0.0) {
+                $this->setMessage(Text::_('COM_J2COMMERCE_LENGTHS_SYNC_INVALID_DEFAULT'), 'error');
+                $this->setRedirect($redirectUrl);
+
+                return;
+            }
+
+            foreach ($lengths as $length) {
+                $formattedValue = number_format((float) $length->length_value / $oldDefaultValue, 8, '.', '');
+                $lengthId       = (int) $length->j2commerce_length_id;
+                $update         = $db->getQuery(true)
+                    ->update($db->quoteName('#__j2commerce_lengths'))
+                    ->set($db->quoteName('length_value') . ' = :value')
+                    ->where($db->quoteName('j2commerce_length_id') . ' = :id')
+                    ->bind(':value', $formattedValue)
+                    ->bind(':id', $lengthId, ParameterType::INTEGER);
+                $db->setQuery($update)->execute();
+            }
+
+            $this->setMessage(Text::sprintf('COM_J2COMMERCE_LENGTHS_SYNC_SUCCESS', $defaultLength->length_title));
+            $this->setRedirect($redirectUrl);
+
+            return;
+        }
+
+        // Known default unit — use standard conversion factors
+        $mmPerDefault = $mmPerUnit[$defaultUnit];
+
+        foreach ($lengths as $length) {
+            $unit = strtolower(trim($length->length_unit));
+
+            if (isset($mmPerUnit[$unit])) {
+                $newValue = $mmPerDefault / $mmPerUnit[$unit];
+            } else {
+                $oldDefaultValue = (float) $defaultLength->length_value;
+
+                if ($oldDefaultValue > 0.0) {
+                    $newValue = (float) $length->length_value / $oldDefaultValue;
+                } else {
+                    continue;
+                }
+            }
+
+            $formattedValue = number_format($newValue, 8, '.', '');
+            $lengthId       = (int) $length->j2commerce_length_id;
+            $update         = $db->getQuery(true)
+                ->update($db->quoteName('#__j2commerce_lengths'))
+                ->set($db->quoteName('length_value') . ' = :value')
+                ->where($db->quoteName('j2commerce_length_id') . ' = :id')
+                ->bind(':value', $formattedValue)
+                ->bind(':id', $lengthId, ParameterType::INTEGER);
+            $db->setQuery($update)->execute();
+        }
+
+        $this->setMessage(Text::sprintf('COM_J2COMMERCE_LENGTHS_SYNC_SUCCESS', $defaultLength->length_title));
+        $this->setRedirect($redirectUrl);
     }
 }

--- a/administrator/components/com_j2commerce/src/Controller/WeightsController.php
+++ b/administrator/components/com_j2commerce/src/Controller/WeightsController.php
@@ -13,10 +13,13 @@ namespace J2Commerce\Component\J2commerce\Administrator\Controller;
 
 \defined('_JEXEC') or die;
 
-use Joomla\CMS\Application\CMSApplication;
+use J2Commerce\Component\J2commerce\Administrator\Helper\ConfigHelper;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Controller\AdminController;
-use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
-use Joomla\Input\Input;
+use Joomla\CMS\Router\Route;
+use Joomla\CMS\Session\Session;
+use Joomla\Database\ParameterType;
 
 /**
  * Weights list controller class.
@@ -37,21 +40,6 @@ class WeightsController extends AdminController
     protected $text_prefix = 'COM_J2COMMERCE';
 
     /**
-     * Constructor.
-     *
-     * @param   array                     $config   An optional associative array of configuration settings.
-     * @param   MVCFactoryInterface|null  $factory  The factory.
-     * @param   CMSApplication|null       $app      The Application for the dispatcher
-     * @param   Input|null                $input    Input
-     *
-     * @since   6.0.2
-     */
-    public function __construct($config = [], ?MVCFactoryInterface $factory = null, ?CMSApplication $app = null, ?Input $input = null)
-    {
-        parent::__construct($config, $factory, $app, $input);
-    }
-
-    /**
      * Proxy for getModel.
      *
      * @param   string  $name    The model name. Optional.
@@ -65,5 +53,146 @@ class WeightsController extends AdminController
     public function getModel($name = 'Weight', $prefix = 'Administrator', $config = ['ignore_request' => true])
     {
         return parent::getModel($name, $prefix, $config);
+    }
+
+    /**
+     * Sync weight conversion values relative to the configured default weight unit.
+     *
+     * Sets the default weight unit value to 1.0 and recalculates all other
+     * weight values using standard conversion factors. Unknown units are
+     * scaled proportionally from the previous base.
+     *
+     * @return  void
+     *
+     * @since   6.0.3
+     */
+    public function syncValues(): void
+    {
+        Session::checkToken('get') || Session::checkToken() || jexit(Text::_('JINVALID_TOKEN'));
+
+        $redirectUrl = Route::_('index.php?option=com_j2commerce&view=weights', false);
+
+        // ACL check
+        $user = Factory::getApplication()->getIdentity();
+
+        if (!$user->authorise('core.edit', 'com_j2commerce')) {
+            $this->setMessage(Text::_('JLIB_APPLICATION_ERROR_EDITSTATE_NOT_PERMITTED'), 'error');
+            $this->setRedirect($redirectUrl);
+
+            return;
+        }
+
+        $defaultId = ConfigHelper::getDefaultWeightClassId();
+
+        // Standard weights: how many grams per 1 unit
+        $gramsPerUnit = [
+            'kg' => 1000.0,
+            'g'  => 1.0,
+            'mg' => 0.001,
+            'oz' => 28.3495231,
+            'lb' => 453.59237,
+            't'  => 1000000.0,
+        ];
+
+        $db = Factory::getContainer()->get('DatabaseDriver');
+
+        // Load all weight records
+        $query = $db->getQuery(true)
+            ->select([
+                $db->quoteName('j2commerce_weight_id'),
+                $db->quoteName('weight_title'),
+                $db->quoteName('weight_unit'),
+                $db->quoteName('weight_value'),
+            ])
+            ->from($db->quoteName('#__j2commerce_weights'));
+        $weights = $db->setQuery($query)->loadObjectList();
+
+        if (empty($weights)) {
+            $this->setMessage(Text::_('COM_J2COMMERCE_WEIGHTS_SYNC_NO_ITEMS'), 'warning');
+            $this->setRedirect($redirectUrl);
+
+            return;
+        }
+
+        // Find the default weight
+        $defaultWeight = null;
+
+        foreach ($weights as $weight) {
+            if ((int) $weight->j2commerce_weight_id === $defaultId) {
+                $defaultWeight = $weight;
+                break;
+            }
+        }
+
+        if ($defaultWeight === null) {
+            $this->setMessage(Text::sprintf('COM_J2COMMERCE_WEIGHTS_SYNC_DEFAULT_NOT_FOUND', $defaultId), 'error');
+            $this->setRedirect($redirectUrl);
+
+            return;
+        }
+
+        $defaultUnit = strtolower(trim($defaultWeight->weight_unit));
+
+        // Check if we know the default unit
+        if (!isset($gramsPerUnit[$defaultUnit])) {
+            // Unknown default unit — just rebase proportionally
+            $oldDefaultValue = (float) $defaultWeight->weight_value;
+
+            if ($oldDefaultValue <= 0.0) {
+                $this->setMessage(Text::_('COM_J2COMMERCE_WEIGHTS_SYNC_INVALID_DEFAULT'), 'error');
+                $this->setRedirect($redirectUrl);
+
+                return;
+            }
+
+            foreach ($weights as $weight) {
+                $formattedValue = number_format((float) $weight->weight_value / $oldDefaultValue, 8, '.', '');
+                $weightId       = (int) $weight->j2commerce_weight_id;
+                $update         = $db->getQuery(true)
+                    ->update($db->quoteName('#__j2commerce_weights'))
+                    ->set($db->quoteName('weight_value') . ' = :value')
+                    ->where($db->quoteName('j2commerce_weight_id') . ' = :id')
+                    ->bind(':value', $formattedValue)
+                    ->bind(':id', $weightId, ParameterType::INTEGER);
+                $db->setQuery($update)->execute();
+            }
+
+            $this->setMessage(Text::sprintf('COM_J2COMMERCE_WEIGHTS_SYNC_SUCCESS', $defaultWeight->weight_title));
+            $this->setRedirect($redirectUrl);
+
+            return;
+        }
+
+        // Known default unit — use standard conversion factors
+        $gramsPerDefault = $gramsPerUnit[$defaultUnit];
+
+        foreach ($weights as $weight) {
+            $unit = strtolower(trim($weight->weight_unit));
+
+            if (isset($gramsPerUnit[$unit])) {
+                $newValue = $gramsPerDefault / $gramsPerUnit[$unit];
+            } else {
+                $oldDefaultValue = (float) $defaultWeight->weight_value;
+
+                if ($oldDefaultValue > 0.0) {
+                    $newValue = (float) $weight->weight_value / $oldDefaultValue;
+                } else {
+                    continue;
+                }
+            }
+
+            $formattedValue = number_format($newValue, 8, '.', '');
+            $weightId       = (int) $weight->j2commerce_weight_id;
+            $update         = $db->getQuery(true)
+                ->update($db->quoteName('#__j2commerce_weights'))
+                ->set($db->quoteName('weight_value') . ' = :value')
+                ->where($db->quoteName('j2commerce_weight_id') . ' = :id')
+                ->bind(':value', $formattedValue)
+                ->bind(':id', $weightId, ParameterType::INTEGER);
+            $db->setQuery($update)->execute();
+        }
+
+        $this->setMessage(Text::sprintf('COM_J2COMMERCE_WEIGHTS_SYNC_SUCCESS', $defaultWeight->weight_title));
+        $this->setRedirect($redirectUrl);
     }
 }

--- a/administrator/components/com_j2commerce/src/View/Lengths/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Lengths/HtmlView.php
@@ -20,9 +20,9 @@ use Joomla\CMS\Form\Form;
 use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
-use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Pagination\Pagination;
+use Joomla\CMS\Session\Session;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\Registry\Registry;
 
@@ -147,8 +147,7 @@ class HtmlView extends BaseHtmlView
      */
     protected function addToolbar(): void
     {
-        $canDo = ContentHelper::getActions('com_j2commerce');
-        $user  = Factory::getApplication()->getIdentity();
+        $canDo   = ContentHelper::getActions('com_j2commerce');
         $toolbar = $this->getDocument()->getToolbar();
 
         ToolbarHelper::title(Text::_('COM_J2COMMERCE_LENGTHS'), 'fa-solid fa-ruler-combined');
@@ -178,6 +177,14 @@ class HtmlView extends BaseHtmlView
 
         if ($canDo->get('core.delete') && ($this->state->get('filter.enabled') == -2)) {
             $toolbar->delete('lengths.delete', 'JTOOLBAR_DELETE_FROM_TRASH')->listCheck(true);
+        }
+
+        if (!$this->isEmptyState && $canDo->get('core.edit')) {
+            $syncUrl = 'index.php?option=com_j2commerce&task=lengths.syncValues&' . Session::getFormToken() . '=1';
+            $toolbar->linkButton('sync-values', 'COM_J2COMMERCE_TOOLBAR_SYNC_VALUES')
+                ->url($syncUrl)
+                ->icon('fa-solid fa-arrows-rotate')
+                ->buttonClass('btn btn-info');
         }
 
         if ($canDo->get('core.admin') || $canDo->get('core.options')) {

--- a/administrator/components/com_j2commerce/src/View/Weights/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Weights/HtmlView.php
@@ -20,9 +20,9 @@ use Joomla\CMS\Form\Form;
 use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
-use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Pagination\Pagination;
+use Joomla\CMS\Session\Session;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\Registry\Registry;
 
@@ -147,8 +147,7 @@ class HtmlView extends BaseHtmlView
      */
     protected function addToolbar(): void
     {
-        $canDo = ContentHelper::getActions('com_j2commerce');
-        $user  = Factory::getApplication()->getIdentity();
+        $canDo   = ContentHelper::getActions('com_j2commerce');
         $toolbar = $this->getDocument()->getToolbar();
 
         ToolbarHelper::title(Text::_('COM_J2COMMERCE_WEIGHTS'), 'fa-solid fa-weight-scale');
@@ -178,6 +177,14 @@ class HtmlView extends BaseHtmlView
 
         if ($canDo->get('core.delete') && ($this->state->get('filter.enabled') == -2)) {
             $toolbar->delete('weights.delete', 'JTOOLBAR_DELETE_FROM_TRASH')->listCheck(true);
+        }
+
+        if (!$this->isEmptyState && $canDo->get('core.edit')) {
+            $syncUrl = 'index.php?option=com_j2commerce&task=weights.syncValues&' . Session::getFormToken() . '=1';
+            $toolbar->linkButton('sync-values', 'COM_J2COMMERCE_TOOLBAR_SYNC_VALUES')
+                ->url($syncUrl)
+                ->icon('fa-solid fa-arrows-rotate')
+                ->buttonClass('btn btn-info');
         }
 
         if ($canDo->get('core.admin') || $canDo->get('core.options')) {

--- a/administrator/language/en-GB/com_j2commerce.ini
+++ b/administrator/language/en-GB/com_j2commerce.ini
@@ -206,6 +206,7 @@ COM_J2COMMERCE_TOOLBAR_INSTALL_APP="Install App"
 COM_J2COMMERCE_TOOLBAR_INSTALL_SHIPPING="Install Shipping Method"
 COM_J2COMMERCE_TOOLBAR_INSTALL_PAYMENT="Install Payment Method"
 COM_J2COMMERCE_TOOLBAR_INSTALL_REPORT="Install Report Plugin"
+COM_J2COMMERCE_TOOLBAR_SYNC_VALUES="Sync Values"
 COM_J2COMMERCE_TOOLBAR_UPDATE_RATES="Update Rates"
 
 ; Filter
@@ -410,6 +411,12 @@ COM_J2COMMERCE_ERR_WEIGHT_TITLE_REQUIRED="Weight title is required."
 COM_J2COMMERCE_ERR_WEIGHT_UNIT_REQUIRED="Weight unit is required."
 COM_J2COMMERCE_ERR_WEIGHT_VALUE_REQUIRED="Weight value is required."
 
+; Weights View - Sync Values
+COM_J2COMMERCE_WEIGHTS_SYNC_SUCCESS="Weight conversion values synced successfully relative to \"%s\"."
+COM_J2COMMERCE_WEIGHTS_SYNC_NO_ITEMS="No weight units found to sync."
+COM_J2COMMERCE_WEIGHTS_SYNC_DEFAULT_NOT_FOUND="Default weight unit (ID: %d) not found. Check your store configuration."
+COM_J2COMMERCE_WEIGHTS_SYNC_INVALID_DEFAULT="Default weight unit has an invalid conversion value."
+
 ; Lengths View - List
 COM_J2COMMERCE_LENGTHS="Lengths"
 COM_J2COMMERCE_LENGTHS_DESC="Manage length units for products and shipping"
@@ -436,6 +443,12 @@ COM_J2COMMERCE_FIELD_LENGTH_NUM_DECIMALS_DESC="Number of decimal places to displ
 COM_J2COMMERCE_ERR_LENGTH_TITLE_REQUIRED="Length title is required."
 COM_J2COMMERCE_ERR_LENGTH_UNIT_REQUIRED="Length unit is required."
 COM_J2COMMERCE_ERR_LENGTH_VALUE_REQUIRED="Length value is required."
+
+; Lengths View - Sync Values
+COM_J2COMMERCE_LENGTHS_SYNC_SUCCESS="Length conversion values synced successfully relative to \"%s\"."
+COM_J2COMMERCE_LENGTHS_SYNC_NO_ITEMS="No length units found to sync."
+COM_J2COMMERCE_LENGTHS_SYNC_DEFAULT_NOT_FOUND="Default length unit (ID: %d) not found. Check your store configuration."
+COM_J2COMMERCE_LENGTHS_SYNC_INVALID_DEFAULT="Default length unit has an invalid conversion value."
 
 ; Tax Profiles View - List
 COM_J2COMMERCE_TAXPROFILES="Tax Profiles"

--- a/administrator/language/en-US/com_j2commerce.ini
+++ b/administrator/language/en-US/com_j2commerce.ini
@@ -206,6 +206,7 @@ COM_J2COMMERCE_TOOLBAR_INSTALL_APP="Install App"
 COM_J2COMMERCE_TOOLBAR_INSTALL_SHIPPING="Install Shipping Method"
 COM_J2COMMERCE_TOOLBAR_INSTALL_PAYMENT="Install Payment Method"
 COM_J2COMMERCE_TOOLBAR_INSTALL_REPORT="Install Report"
+COM_J2COMMERCE_TOOLBAR_SYNC_VALUES="Sync Values"
 COM_J2COMMERCE_TOOLBAR_UPDATE_RATES="Update Rates"
 
 ; Filter
@@ -397,6 +398,12 @@ COM_J2COMMERCE_ERR_WEIGHT_TITLE_REQUIRED="Weight title is required."
 COM_J2COMMERCE_ERR_WEIGHT_UNIT_REQUIRED="Weight unit is required."
 COM_J2COMMERCE_ERR_WEIGHT_VALUE_REQUIRED="Weight value is required."
 
+; Weights View - Sync Values
+COM_J2COMMERCE_WEIGHTS_SYNC_SUCCESS="Weight conversion values synced successfully relative to \"%s\"."
+COM_J2COMMERCE_WEIGHTS_SYNC_NO_ITEMS="No weight units found to sync."
+COM_J2COMMERCE_WEIGHTS_SYNC_DEFAULT_NOT_FOUND="Default weight unit (ID: %d) not found. Check your store configuration."
+COM_J2COMMERCE_WEIGHTS_SYNC_INVALID_DEFAULT="Default weight unit has an invalid conversion value."
+
 ; Lengths View - List
 COM_J2COMMERCE_LENGTHS="Lengths"
 COM_J2COMMERCE_LENGTHS_DESC="Manage length units for products and shipping"
@@ -419,6 +426,12 @@ COM_J2COMMERCE_FIELD_LENGTH_NUM_DECIMALS_DESC="Number of decimal places to displ
 COM_J2COMMERCE_ERR_LENGTH_TITLE_REQUIRED="Length title is required."
 COM_J2COMMERCE_ERR_LENGTH_UNIT_REQUIRED="Length unit is required."
 COM_J2COMMERCE_ERR_LENGTH_VALUE_REQUIRED="Length value is required."
+
+; Lengths View - Sync Values
+COM_J2COMMERCE_LENGTHS_SYNC_SUCCESS="Length conversion values synced successfully relative to \"%s\"."
+COM_J2COMMERCE_LENGTHS_SYNC_NO_ITEMS="No length units found to sync."
+COM_J2COMMERCE_LENGTHS_SYNC_DEFAULT_NOT_FOUND="Default length unit (ID: %d) not found. Check your store configuration."
+COM_J2COMMERCE_LENGTHS_SYNC_INVALID_DEFAULT="Default length unit has an invalid conversion value."
 
 ; Tax Profiles View - List
 COM_J2COMMERCE_TAXPROFILES="Tax Profiles"


### PR DESCRIPTION
## Core Update

Closes #45

### Changes
- Added **Sync Values** toolbar button to both Weights and Lengths list views
- Button recalculates all conversion values relative to the configured default weight/length unit
- Uses standard conversion factor lookup tables (6 weight units, 8 length units)
- Falls back to proportional scaling for custom/unknown units
- ACL-gated (`core.edit` permission) with CSRF token validation
- Prepared statements with `bind()` and `ParameterType::INTEGER`
- Language strings added to all 4 language files (en-US canonical, en-US mirror, en-GB canonical, en-GB mirror)
- Removed redundant constructors and unused imports from both controllers and views

### Files Modified
| Type | Count |
|------|-------|
| PHP Controllers | 2 |
| PHP Views | 2 |
| Language files (en-US + en-GB) | 4 |
| **Total** | **8** |

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only (non-core excluded)