### PR TITLE
fix(customfields): batch modal inside form so values submit

### DIFF
--- a/administrator/components/com_j2commerce/config.xml
+++ b/administrator/components/com_j2commerce/config.xml
@@ -551,6 +551,20 @@
                 filter="integer"
                 showon="enable_inventory:1"
             />
+
+            <field
+                name="onboarding_complete"
+                type="hidden"
+                default="0"
+                filter="integer"
+            />
+
+            <field
+                name="onboarding_last_step"
+                type="hidden"
+                default="0"
+                filter="integer"
+            />
         </fieldset>
 
         <!-- ========================================== -->

--- a/administrator/components/com_j2commerce/tmpl/customfields/default.php
+++ b/administrator/components/com_j2commerce/tmpl/customfields/default.php
@@ -154,7 +154,7 @@ if ($saveOrder && !empty($this->items)) {
             </div>
         </div>
     </div>
-</form>
 
-<?php echo $this->loadTemplate('batch'); ?>
+    <?php echo $this->loadTemplate('batch'); ?>
+</form>
 <?php echo $this->footer ?? ''; ?>


### PR DESCRIPTION
## Core Update

### Changes
- Move batch modal template include inside `<form>` tag in customfields view
- The batch modal was rendered after `</form>`, so select values were never submitted
- This caused the controller to always report "No changes were made"
- Also includes config.xml onboarding fields from previous commit

### Files Modified
| Type | Count |
|------|-------|
| PHP files | 1 |
| XML/Config | 1 |

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only (non-core excluded)