### PR TITLE
fix(setup-guide): timezone check a11y and button styling (fixes #284)

### DIFF
--- a/administrator/components/com_j2commerce/src/SetupGuide/Checks/TimezoneCheck.php
+++ b/administrator/components/com_j2commerce/src/SetupGuide/Checks/TimezoneCheck.php
@@ -105,21 +105,21 @@ class TimezoneCheck extends AbstractSetupCheck
 
         // Store Time (from Joomla global config)
         $html .= '<div class="col-6">'
-            . '<div class="text-center p-3 rounded" style="background:rgba(255,255,255,.06);">'
-            . '<span class="fa-regular fa-clock" style="font-size:2rem;color:#0d6efd;" aria-hidden="true"></span>'
+            . '<div class="text-center p-3 rounded" style="background:rgba(255,255,255,.1);">'
+            . '<span class="fa-regular fa-clock" style="font-size:2rem;" aria-hidden="true"></span>'
             . '<p class="fw-bold fs-4 mb-0 mt-2" id="j2c-store-time">' . ($timeStr !== '' ? $timeStr : '--:--') . '</p>'
-            . '<p class="small mb-1" style="color:rgba(255,255,255,.55);">' . $storeTzLabel . '</p>'
-            . '<p class="small mb-0 fw-semibold" style="color:rgba(255,255,255,.8);">' . $escapedTz . '</p>'
+            . '<p class="small text-body-secondary mb-1">' . $storeTzLabel . '</p>'
+            . '<p class="small mb-0 fw-semibold">' . $escapedTz . '</p>'
             . '</div>'
             . '</div>';
 
         // Local Time (detected from browser via Intl API)
         $html .= '<div class="col-6">'
-            . '<div class="text-center p-3 rounded" style="background:rgba(255,255,255,.06);">'
-            . '<span class="fa-regular fa-clock" style="font-size:2rem;color:#0d6efd;" aria-hidden="true"></span>'
+            . '<div class="text-center p-3 rounded" style="background:rgba(255,255,255,.1);">'
+            . '<span class="fa-regular fa-clock" style="font-size:2rem;" aria-hidden="true"></span>'
             . '<p class="fw-bold fs-4 mb-0 mt-2" id="j2c-local-time">--:--</p>'
-            . '<p class="small mb-1" style="color:rgba(255,255,255,.55);">' . $localTzLabel . '</p>'
-            . '<p class="small mb-0 fw-semibold" id="j2c-local-tz-name" style="color:rgba(255,255,255,.8);">…</p>'
+            . '<p class="small text-body-secondary mb-1">' . $localTzLabel . '</p>'
+            . '<p class="small mb-0 fw-semibold" id="j2c-local-tz-name">…</p>'
             . '</div>'
             . '</div>';
 
@@ -143,7 +143,7 @@ class TimezoneCheck extends AbstractSetupCheck
                 . '</button>';
         }
 
-        $html .= '<a href="' . $globalConfig . '" class="btn btn-link btn-sm text-light w-100 mt-2">'
+        $html .= '<a href="' . $globalConfig . '" class="btn btn-outline-light btn-sm w-100 mt-2">'
             . Text::_('COM_J2COMMERCE_SETUP_GUIDE_CHECK_TIMEZONE_CHANGE')
             . '</a>';
 


### PR DESCRIPTION
## Summary
Fixes #284

Addresses feedback from @brianteeman on the timezone setup guide panel:

1. **Hard-to-read text** — Clock labels ("Store Time", "Local Time") and timezone names used low-contrast inline `rgba(255,255,255,.55)` styles. Replaced with Bootstrap's `text-body-secondary` class which properly adapts to the dark-themed offcanvas panel.

2. **Link doesn't look like a button** — "Change in Global Configuration" used `btn-link text-light` which was nearly invisible. Changed to `btn btn-outline-light` for clear button affordance.

## Changes
- `src/SetupGuide/Checks/TimezoneCheck.php` — Replace inline rgba color styles with Bootstrap classes, change link to outline button

## Testing
1. Open J2Commerce Dashboard
2. Click the timezone item in the setup guide sidebar
3. Verify clock labels are clearly readable
4. Verify "Change in Global Configuration" looks like a proper button