### PR TITLE
Prevent double translation

### DIFF
--- a/administrator/components/com_j2commerce/src/View/Apps/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Apps/HtmlView.php
@@ -108,7 +108,7 @@ class HtmlView extends BaseHtmlView
 
         if ($user->authorise('core.manage', 'com_installer')) {
             $toolbar->link(
-                Text::_('COM_J2COMMERCE_TOOLBAR_INSTALL_APP'),
+                'COM_J2COMMERCE_TOOLBAR_INSTALL_APP',
                 Uri::base() . 'index.php?option=com_installer&view=install'
             )
                 ->icon('fa-solid fa-download')

--- a/administrator/components/com_j2commerce/src/View/Paymentmethods/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Paymentmethods/HtmlView.php
@@ -180,7 +180,7 @@ class HtmlView extends BaseHtmlView
 
         if ($user->authorise('core.manage', 'com_installer')) {
             $toolbar->link(
-                Text::_('COM_J2COMMERCE_TOOLBAR_INSTALL_PAYMENT'),
+                'COM_J2COMMERCE_TOOLBAR_INSTALL_PAYMENT',
                 Uri::base() . 'index.php?option=com_installer&view=install'
             )
                 ->icon('fa-solid fa-download')

--- a/administrator/components/com_j2commerce/src/View/Reports/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Reports/HtmlView.php
@@ -180,7 +180,7 @@ class HtmlView extends BaseHtmlView
 
         if ($user->authorise('core.manage', 'com_installer')) {
             $toolbar->link(
-                Text::_('COM_J2COMMERCE_TOOLBAR_INSTALL_REPORT'),
+                'COM_J2COMMERCE_TOOLBAR_INSTALL_REPORT',
                 Uri::base() . 'index.php?option=com_installer&view=install'
             )
                 ->icon('fa-solid fa-download')

--- a/administrator/components/com_j2commerce/src/View/Shippingmethods/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Shippingmethods/HtmlView.php
@@ -179,7 +179,7 @@ class HtmlView extends BaseHtmlView
 
         if ($this->getCurrentUser()->authorise('core.manage', 'com_installer')) {
             $toolbar->link(
-                Text::_('COM_J2COMMERCE_TOOLBAR_INSTALL_SHIPPING'),
+                'COM_J2COMMERCE_TOOLBAR_INSTALL_SHIPPING',
                 Uri::base() . 'index.php?option=com_installer&view=install'
             )
                 ->icon('fa-solid fa-download')


### PR DESCRIPTION
Replace Text::_ calls with string constants for toolbar install links

with debug languages on you can see its trying to translate twice and failing once

## before
<img width="728" height="205" alt="image" src="https://github.com/user-attachments/assets/abe8f8e9-6a4f-4fcd-be86-75c0a70c2f4a" />

## after
<img width="893" height="206" alt="image" src="https://github.com/user-attachments/assets/b3ccedff-a554-44b0-8a34-0229019f9ede" />

note the actions button has a similar problem but thats a core bug not j2commerce and no one has found the fix for that yet