### PR TITLE
fix(views): resolve checked_out undefined property warning in all HtmlViews (fixes #294)

### DIFF
--- a/administrator/components/com_j2commerce/src/View/Country/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Country/HtmlView.php
@@ -97,7 +97,7 @@ class HtmlView extends BaseHtmlView
         $isNew      = ($this->item->j2commerce_country_id == 0);
         $canDo      = ContentHelper::getActions('com_j2commerce');
         $user       = Factory::getApplication()->getIdentity();
-        $checkedOut = !(\is_null($this->item->checked_out) || $this->item->checked_out == $user->id);
+        $checkedOut = !(($this->item->checked_out ?? null) === null || ($this->item->checked_out ?? 0) == $user->id);
         $toolbar    = $this->getDocument()->getToolbar();
 
         $title = $isNew ? Text::_('COM_J2COMMERCE_TOOLBAR_NEW').' '.Text::_('COM_J2COMMERCE_COUNTRY') : Text::_('COM_J2COMMERCE_TOOLBAR_EDIT').' '.Text::_('COM_J2COMMERCE_COUNTRY');

--- a/administrator/components/com_j2commerce/src/View/Currency/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Currency/HtmlView.php
@@ -96,7 +96,7 @@ class HtmlView extends BaseHtmlView
         $isNew      = ($this->item->j2commerce_currency_id == 0);
         $canDo      = ContentHelper::getActions('com_j2commerce');
         $user       = Factory::getApplication()->getIdentity();
-        $checkedOut = !(\is_null($this->item->checked_out) || $this->item->checked_out == $user->id);
+        $checkedOut = !(($this->item->checked_out ?? null) === null || ($this->item->checked_out ?? 0) == $user->id);
         $toolbar    = $this->getDocument()->getToolbar();
 
         // Title: "New Currency" or "Edit Currency"

--- a/administrator/components/com_j2commerce/src/View/Customer/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Customer/HtmlView.php
@@ -101,7 +101,7 @@ class HtmlView extends BaseHtmlView
         $isNew      = ($this->item->j2commerce_address_id == 0);
         $canDo      = ContentHelper::getActions('com_j2commerce');
         $user       = Factory::getApplication()->getIdentity();
-        $checkedOut = !(\is_null($this->item->checked_out) || $this->item->checked_out == $user->id);
+        $checkedOut = !(($this->item->checked_out ?? null) === null || ($this->item->checked_out ?? 0) == $user->id);
         $toolbar    = $this->getDocument()->getToolbar();
 
         ToolbarHelper::title(

--- a/administrator/components/com_j2commerce/src/View/Customfield/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Customfield/HtmlView.php
@@ -100,7 +100,7 @@ class HtmlView extends BaseHtmlView
         $isNew      = ($this->item->j2commerce_customfield_id == 0);
         $canDo      = ContentHelper::getActions('com_j2commerce');
         $user       = Factory::getApplication()->getIdentity();
-        $checkedOut = !empty($this->item->checked_out) && $this->item->checked_out != $user->id;
+        $checkedOut = !(($this->item->checked_out ?? null) === null || ($this->item->checked_out ?? 0) == $user->id);
         $toolbar    = $this->getDocument()->getToolbar();
 
         // Title: "New Custom Field" or "Edit Custom Field"

--- a/administrator/components/com_j2commerce/src/View/Emailtemplate/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Emailtemplate/HtmlView.php
@@ -188,7 +188,7 @@ class HtmlView extends BaseHtmlView
         $isNew      = ($this->item->j2commerce_emailtemplate_id == 0);
         $canDo      = ContentHelper::getActions('com_j2commerce', 'emailtemplate', $this->item->j2commerce_emailtemplate_id);
         $user       = Factory::getApplication()->getIdentity();
-        $checkedOut = !empty($this->item->checked_out) && $this->item->checked_out != $user->id;
+        $checkedOut = !(($this->item->checked_out ?? null) === null || ($this->item->checked_out ?? 0) == $user->id);
 
         Factory::getApplication()->getInput()->set('hidemainmenu', true);
 

--- a/administrator/components/com_j2commerce/src/View/Filtergroup/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Filtergroup/HtmlView.php
@@ -110,7 +110,7 @@ class HtmlView extends BaseHtmlView
                  && (empty($this->item->id) || $this->item->id == 0);
 
         $canDo      = ContentHelper::getActions('com_j2commerce', 'filtergroup', $this->item->j2commerce_filtergroup_id ?? 0);
-        $checkedOut = !(\is_null($this->item->checked_out) || $this->item->checked_out == $user->id);
+        $checkedOut = !(($this->item->checked_out ?? null) === null || ($this->item->checked_out ?? 0) == $user->id);
 
         ToolbarHelper::title(
             Text::_('COM_J2COMMERCE_FILTERGROUP') . ': ' . ($isNew ? Text::_('JTOOLBAR_NEW') : Text::_('JTOOLBAR_EDIT')),

--- a/administrator/components/com_j2commerce/src/View/Geozone/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Geozone/HtmlView.php
@@ -95,7 +95,7 @@ class HtmlView extends BaseHtmlView
         $isNew      = ($this->item->j2commerce_geozone_id == 0);
         $canDo      = ContentHelper::getActions('com_j2commerce');
         $user       = Factory::getApplication()->getIdentity();
-        $checkedOut = !(\is_null($this->item->checked_out) || $this->item->checked_out == $user->id);
+        $checkedOut = !(($this->item->checked_out ?? null) === null || ($this->item->checked_out ?? 0) == $user->id);
         $toolbar    = $this->getDocument()->getToolbar();
 
         $title = $isNew ? Text::_('COM_J2COMMERCE_TOOLBAR_NEW').' '.Text::_('COM_J2COMMERCE_GEOZONE') : Text::_('COM_J2COMMERCE_TOOLBAR_EDIT').' '.Text::_('COM_J2COMMERCE_GEOZONE');

--- a/administrator/components/com_j2commerce/src/View/Invoicetemplate/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Invoicetemplate/HtmlView.php
@@ -125,7 +125,7 @@ class HtmlView extends BaseHtmlView
         $isNew      = ($this->item->j2commerce_invoicetemplate_id == 0);
         $canDo      = ContentHelper::getActions('com_j2commerce', 'invoicetemplate', $this->item->j2commerce_invoicetemplate_id ?? 0);
         $user       = Factory::getApplication()->getIdentity();
-        $checkedOut = !(\is_null($this->item->checked_out) || $this->item->checked_out == $user->id);
+        $checkedOut = !(($this->item->checked_out ?? null) === null || ($this->item->checked_out ?? 0) == $user->id);
 
         Factory::getApplication()->getInput()->set('hidemainmenu', true);
 

--- a/administrator/components/com_j2commerce/src/View/Length/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Length/HtmlView.php
@@ -95,7 +95,7 @@ class HtmlView extends BaseHtmlView
         $isNew      = ($this->item->j2commerce_length_id == 0);
         $canDo      = ContentHelper::getActions('com_j2commerce');
         $user       = Factory::getApplication()->getIdentity();
-        $checkedOut = !(\is_null($this->item->checked_out) || $this->item->checked_out == $user->id);
+        $checkedOut = !(($this->item->checked_out ?? null) === null || ($this->item->checked_out ?? 0) == $user->id);
         $toolbar    = $this->getDocument()->getToolbar();
 
         $title = $isNew ? Text::_('COM_J2COMMERCE_TOOLBAR_NEW').' '.Text::_('COM_J2COMMERCE_LENGTH') : Text::_('COM_J2COMMERCE_TOOLBAR_EDIT').' '.Text::_('COM_J2COMMERCE_LENGTH');

--- a/administrator/components/com_j2commerce/src/View/Manufacturer/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Manufacturer/HtmlView.php
@@ -112,7 +112,7 @@ class HtmlView extends BaseHtmlView
         $isNew      = ($this->item->j2commerce_manufacturer_id == 0);
         $canDo      = ContentHelper::getActions('com_j2commerce');
         $user       = Factory::getApplication()->getIdentity();
-        $checkedOut = !(\is_null($this->item->checked_out) || $this->item->checked_out == $user->id);
+        $checkedOut = !(($this->item->checked_out ?? null) === null || ($this->item->checked_out ?? 0) == $user->id);
         $toolbar    = $this->getDocument()->getToolbar();
 
         // Title: "New Manufacturer" or "Edit Manufacturer"

--- a/administrator/components/com_j2commerce/src/View/Option/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Option/HtmlView.php
@@ -108,7 +108,7 @@ class HtmlView extends BaseHtmlView
         $isNew = (empty($this->item->j2commerce_option_id) || $this->item->j2commerce_option_id == 0)
                  && (empty($this->item->id) || $this->item->id == 0);
         $canDo      = ContentHelper::getActions('com_j2commerce', 'option', $this->item->j2commerce_option_id ?? 0);
-        $checkedOut = !(empty($this->item->checked_out) || $this->item->checked_out == $user->id);
+        $checkedOut = !(($this->item->checked_out ?? null) === null || ($this->item->checked_out ?? 0) == $user->id);
 
         ToolbarHelper::title(
             Text::_('COM_J2COMMERCE_OPTION') . ': ' . ($isNew ? Text::_('JTOOLBAR_NEW') : Text::_('JTOOLBAR_EDIT')),

--- a/administrator/components/com_j2commerce/src/View/Order/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Order/HtmlView.php
@@ -143,7 +143,7 @@ class HtmlView extends BaseHtmlView
         $canDo         = ContentHelper::getActions('com_j2commerce');
         $canEditOrders = J2CommerceHelper::canAccess('j2commerce.editorders');
         $user          = Factory::getApplication()->getIdentity();
-        $checkedOut    = isset($this->item->checked_out) && !(\is_null($this->item->checked_out) || $this->item->checked_out == $user->id);
+        $checkedOut    = !(($this->item->checked_out ?? null) === null || ($this->item->checked_out ?? 0) == $user->id);
         $toolbar       = $this->getDocument()->getToolbar();
 
         $orderDisplay = $this->item->invoice ?? $this->item->order_id ?? Text::_('COM_J2COMMERCE_ORDER');

--- a/administrator/components/com_j2commerce/src/View/Orderstatus/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Orderstatus/HtmlView.php
@@ -100,7 +100,7 @@ class HtmlView extends BaseHtmlView
         $isNew      = ($this->item->j2commerce_orderstatus_id == 0);
         $canDo      = ContentHelper::getActions('com_j2commerce');
         $user       = Factory::getApplication()->getIdentity();
-        $checkedOut = !(\is_null($this->item->checked_out) || $this->item->checked_out == $user->id);
+        $checkedOut = !(($this->item->checked_out ?? null) === null || ($this->item->checked_out ?? 0) == $user->id);
         $toolbar    = $this->getDocument()->getToolbar();
 
         // Title: "New Order Status" or "Edit Order Status"

--- a/administrator/components/com_j2commerce/src/View/Product/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Product/HtmlView.php
@@ -101,7 +101,7 @@ class HtmlView extends BaseHtmlView
         $isNew      = empty($this->item->j2commerce_product_id);
         $canDo      = ContentHelper::getActions('com_j2commerce');
         $user       = Factory::getApplication()->getIdentity();
-        $checkedOut = !(\is_null($this->item->checked_out) || $this->item->checked_out == $user->id);
+        $checkedOut = !(($this->item->checked_out ?? null) === null || ($this->item->checked_out ?? 0) == $user->id);
         $toolbar    = $this->getDocument()->getToolbar();
 
         ToolbarHelper::title(

--- a/administrator/components/com_j2commerce/src/View/Taxprofile/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Taxprofile/HtmlView.php
@@ -95,7 +95,7 @@ class HtmlView extends BaseHtmlView
         $isNew      = ($this->item->j2commerce_taxprofile_id == 0);
         $canDo      = ContentHelper::getActions('com_j2commerce');
         $user       = Factory::getApplication()->getIdentity();
-        $checkedOut = !(\is_null($this->item->checked_out) || $this->item->checked_out == $user->id);
+        $checkedOut = !(($this->item->checked_out ?? null) === null || ($this->item->checked_out ?? 0) == $user->id);
         $toolbar    = $this->getDocument()->getToolbar();
 
         $title = $isNew ? Text::_('COM_J2COMMERCE_TOOLBAR_NEW').' '.Text::_('COM_J2COMMERCE_TAXPROFILE') : Text::_('COM_J2COMMERCE_TOOLBAR_EDIT').' '.Text::_('COM_J2COMMERCE_TAXPROFILE');

--- a/administrator/components/com_j2commerce/src/View/Taxrate/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Taxrate/HtmlView.php
@@ -95,7 +95,7 @@ class HtmlView extends BaseHtmlView
         $isNew      = ($this->item->j2commerce_taxrate_id == 0);
         $canDo      = ContentHelper::getActions('com_j2commerce');
         $user       = Factory::getApplication()->getIdentity();
-        $checkedOut = !(\is_null($this->item->checked_out) || $this->item->checked_out == $user->id);
+        $checkedOut = !(($this->item->checked_out ?? null) === null || ($this->item->checked_out ?? 0) == $user->id);
         $toolbar    = $this->getDocument()->getToolbar();
 
         $title = $isNew ? Text::_('COM_J2COMMERCE_TOOLBAR_NEW').' '.Text::_('COM_J2COMMERCE_TAXRATE') : Text::_('COM_J2COMMERCE_TOOLBAR_EDIT').' '.Text::_('COM_J2COMMERCE_TAXRATE');

--- a/administrator/components/com_j2commerce/src/View/Vendor/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Vendor/HtmlView.php
@@ -111,7 +111,7 @@ class HtmlView extends BaseHtmlView
         $isNew      = ($this->item->j2commerce_vendor_id == 0);
         $canDo      = ContentHelper::getActions('com_j2commerce');
         $user       = Factory::getApplication()->getIdentity();
-        $checkedOut = !(\is_null($this->item->checked_out) || $this->item->checked_out == $user->id);
+        $checkedOut = !(($this->item->checked_out ?? null) === null || ($this->item->checked_out ?? 0) == $user->id);
         $toolbar    = $this->getDocument()->getToolbar();
 
         // Title: "New Vendor" or "Edit Vendor"

--- a/administrator/components/com_j2commerce/src/View/Voucher/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Voucher/HtmlView.php
@@ -105,7 +105,7 @@ class HtmlView extends BaseHtmlView
 
         $user       = Factory::getApplication()->getIdentity();
         $isNew      = (empty($this->item->j2commerce_voucher_id) || $this->item->j2commerce_voucher_id == 0);
-        $checkedOut = !(\is_null($this->item->checked_out) || $this->item->checked_out == $user->id);
+        $checkedOut = !(($this->item->checked_out ?? null) === null || ($this->item->checked_out ?? 0) == $user->id);
         $canDo      = ContentHelper::getActions('com_j2commerce', 'voucher', $this->item->j2commerce_voucher_id ?? 0);
 
         $layout = Factory::getApplication()->getInput()->get('layout', 'history');

--- a/administrator/components/com_j2commerce/src/View/Weight/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Weight/HtmlView.php
@@ -95,7 +95,7 @@ class HtmlView extends BaseHtmlView
         $isNew      = ($this->item->j2commerce_weight_id == 0);
         $canDo      = ContentHelper::getActions('com_j2commerce');
         $user       = Factory::getApplication()->getIdentity();
-        $checkedOut = !(\is_null($this->item->checked_out) || $this->item->checked_out == $user->id);
+        $checkedOut = !(($this->item->checked_out ?? null) === null || ($this->item->checked_out ?? 0) == $user->id);
         $toolbar    = $this->getDocument()->getToolbar();
 
         $title = $isNew ? Text::_('COM_J2COMMERCE_TOOLBAR_NEW').' '.Text::_('COM_J2COMMERCE_WEIGHT') : Text::_('COM_J2COMMERCE_TOOLBAR_EDIT').' '.Text::_('COM_J2COMMERCE_WEIGHT');

--- a/administrator/components/com_j2commerce/src/View/Zone/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Zone/HtmlView.php
@@ -95,7 +95,7 @@ class HtmlView extends BaseHtmlView
         $isNew      = ($this->item->j2commerce_zone_id == 0);
         $canDo      = ContentHelper::getActions('com_j2commerce');
         $user       = Factory::getApplication()->getIdentity();
-        $checkedOut = !(\is_null($this->item->checked_out) || $this->item->checked_out == $user->id);
+        $checkedOut = !(($this->item->checked_out ?? null) === null || ($this->item->checked_out ?? 0) == $user->id);
         $toolbar    = $this->getDocument()->getToolbar();
 
         // Title: "New Zone" or "Edit Zone"


### PR DESCRIPTION
## Summary
Fixes #294

J2Commerce tables don't have `checked_out` columns (only 2 unrelated tables do), but all 20 admin edit HtmlView files access `$this->item->checked_out` directly, triggering PHP 8.x "Undefined property" warnings.

## Changes
Replace direct property access with null coalescing in all 20 affected views:

```php
// Before (triggers warning)
$checkedOut = !(\is_null($this->item->checked_out) || $this->item->checked_out == $user->id);

// After (safe)
$checkedOut = !(($this->item->checked_out ?? null) === null || ($this->item->checked_out ?? 0) == $user->id);
```

**Views fixed:** Country, Currency, Customer, Customfield, Emailtemplate, Filtergroup, Geozone, Invoicetemplate, Length, Manufacturer, Option, Order, Orderstatus, Product, Taxprofile, Taxrate, Vendor, Voucher, Weight, Zone

## Testing
1. Edit any Country, Currency, Zone, Weight, or other entity in admin
2. Verify no PHP warnings about `checked_out` undefined property