### PR TITLE
fix(onboarding): create country-based geozones for non-US stores (fixes #296)

### DIFF
--- a/administrator/components/com_j2commerce/src/Helper/OnboardingHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/OnboardingHelper.php
@@ -261,8 +261,18 @@ class OnboardingHelper
         DatabaseInterface $db,
     ): array {
         $countryName = self::getCountryName($countryId, $db);
-        $zoneName    = ($zoneId > 0) ? self::getZoneName($zoneId, $db) : '';
-        $geoName     = $zoneName !== '' ? "$zoneName, $countryName Tax Zone" : "$countryName Tax Zone";
+        $isUS        = ($countryId === 223);
+
+        if ($isUS && $zoneId > 0) {
+            $zoneName    = self::getZoneName($zoneId, $db);
+            $geoName     = "$zoneName, $countryName Tax Zone";
+            $ruleZoneId  = $zoneId;
+            $rateName    = "$zoneName Sales Tax";
+        } else {
+            $geoName     = "$countryName Tax Zone";
+            $ruleZoneId  = 0;
+            $rateName    = "$countryName Tax";
+        }
 
         $geozone = (object) [
             'geozone_name' => $geoName,
@@ -275,11 +285,9 @@ class OnboardingHelper
         $geoRule = (object) [
             'geozone_id' => $geozoneId,
             'country_id' => $countryId,
-            'zone_id'    => $zoneId,
+            'zone_id'    => $ruleZoneId,
         ];
         $db->insertObject('#__j2commerce_geozonerules', $geoRule, 'j2commerce_geozonerule_id');
-
-        $rateName = $zoneName !== '' ? "$zoneName Sales Tax" : 'Default Tax';
         $taxRate  = (object) [
             'geozone_id'   => $geozoneId,
             'taxrate_name' => $rateName,

--- a/administrator/components/com_j2commerce/src/Helper/OnboardingHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/OnboardingHelper.php
@@ -265,11 +265,11 @@ class OnboardingHelper
 
         if ($isUS && $zoneId > 0) {
             $zoneName    = self::getZoneName($zoneId, $db);
-            $geoName     = "$zoneName, $countryName Tax Zone";
+            $geoName     = $zoneName;
             $ruleZoneId  = $zoneId;
             $rateName    = "$zoneName Sales Tax";
         } else {
-            $geoName     = "$countryName Tax Zone";
+            $geoName     = $countryName;
             $ruleZoneId  = 0;
             $rateName    = "$countryName Tax";
         }
@@ -299,7 +299,7 @@ class OnboardingHelper
         $taxRateId = (int) $taxRate->j2commerce_taxrate_id;
 
         $taxProfile = (object) [
-            'taxprofile_name' => 'Taxable Goods',
+            'taxprofile_name' => 'Tax',
             'enabled'         => 1,
             'ordering'        => 1,
         ];


### PR DESCRIPTION
## Summary
Fixes #296

The onboarding wizard now creates country-level geozones for non-US stores instead of zone/state-based ones, since tax rates outside the US are set nationally.

## Changes
- **US stores (country_id=223):** Geozone rule remains zone/state-based (e.g. geozone named "Texas", rate "Texas Sales Tax")
- **All other countries:** Geozone rule uses zone_id=0 (country-level), named after the country (e.g. "United Kingdom", rate "United Kingdom Tax")
- **Tax profile** renamed from "Taxable Goods" to "Tax"
- Store config (country_id + zone_id) saving is unaffected

## Testing
1. Reset onboarding (set `onboarding_complete=0` in component params)
2. Run onboarding with US + a state → verify geozone is state-based (e.g. "Texas")
3. Run onboarding with UK (country_id=222) → verify geozone is "United Kingdom" with zone_id=0

## Files Changed
- `administrator/components/com_j2commerce/src/Helper/OnboardingHelper.php` — branched geozone creation logic by country