### PR TITLE
fix(views): guard navbar in emptystate templates (fixes #302)

### DIFF
--- a/administrator/components/com_j2commerce/tmpl/apps/emptystate.php
+++ b/administrator/components/com_j2commerce/tmpl/apps/emptystate.php
@@ -20,7 +20,7 @@ use Joomla\CMS\Layout\LayoutHelper;
 J2CommerceHelper::strapper()->addCSS();
 ?>
 
-<?php echo $this->navbar; ?>
+<?php echo $this->navbar ?? ''; ?>
 
 <div class="container">
     <div class="row">

--- a/administrator/components/com_j2commerce/tmpl/countries/emptystate.php
+++ b/administrator/components/com_j2commerce/tmpl/countries/emptystate.php
@@ -27,7 +27,7 @@ if ($user->authorise('core.create', 'com_j2commerce')) {
     $displayData['createURL'] = 'index.php?option=com_j2commerce&task=country.add';
 }
 
-echo $this->navbar;
+echo $this->navbar ?? '';
 
 echo LayoutHelper::render('joomla.content.emptystate', $displayData);
 

--- a/administrator/components/com_j2commerce/tmpl/coupons/emptystate.php
+++ b/administrator/components/com_j2commerce/tmpl/coupons/emptystate.php
@@ -28,7 +28,7 @@ if ($user->authorise('core.create', 'com_j2commerce')) {
     $displayData['createURL'] = 'index.php?option=com_j2commerce&task=coupon.add';
 }
 
-echo $this->navbar;
+echo $this->navbar ?? '';
 
 echo LayoutHelper::render('joomla.content.emptystate', $displayData);
 

--- a/administrator/components/com_j2commerce/tmpl/currencies/emptystate.php
+++ b/administrator/components/com_j2commerce/tmpl/currencies/emptystate.php
@@ -27,7 +27,7 @@ if ($user->authorise('core.create', 'com_j2commerce')) {
     $displayData['createURL'] = 'index.php?option=com_j2commerce&task=currency.add';
 }
 
-echo $this->navbar;
+echo $this->navbar ?? '';
 
 echo LayoutHelper::render('joomla.content.emptystate', $displayData);
 

--- a/administrator/components/com_j2commerce/tmpl/customers/emptystate.php
+++ b/administrator/components/com_j2commerce/tmpl/customers/emptystate.php
@@ -27,7 +27,7 @@ if ($user->authorise('core.create', 'com_j2commerce')) {
     $displayData['createURL'] = 'index.php?option=com_j2commerce&task=customer.add';
 }
 
-echo $this->navbar;
+echo $this->navbar ?? '';
 
 echo LayoutHelper::render('joomla.content.emptystate', $displayData);
 

--- a/administrator/components/com_j2commerce/tmpl/customfields/emptystate.php
+++ b/administrator/components/com_j2commerce/tmpl/customfields/emptystate.php
@@ -27,7 +27,7 @@ if ($user->authorise('core.create', 'com_j2commerce')) {
     $displayData['createURL'] = 'index.php?option=com_j2commerce&task=customfield.add';
 }
 
-echo $this->navbar;
+echo $this->navbar ?? '';
 
 echo LayoutHelper::render('joomla.content.emptystate', $displayData);
 

--- a/administrator/components/com_j2commerce/tmpl/emailtemplates/emptystate.php
+++ b/administrator/components/com_j2commerce/tmpl/emailtemplates/emptystate.php
@@ -27,7 +27,7 @@ if ($user->authorise('core.create', 'com_j2commerce')) {
     $displayData['createURL'] = 'index.php?option=com_j2commerce&task=emailtemplate.add';
 }
 
-echo $this->navbar;
+echo $this->navbar ?? '';
 
 echo LayoutHelper::render('joomla.content.emptystate', $displayData);
 

--- a/administrator/components/com_j2commerce/tmpl/filtergroups/emptystate.php
+++ b/administrator/components/com_j2commerce/tmpl/filtergroups/emptystate.php
@@ -27,7 +27,7 @@ if ($user->authorise('core.create', 'com_j2commerce')) {
     $displayData['createURL'] = 'index.php?option=com_j2commerce&task=filtergroup.add';
 }
 
-echo $this->navbar;
+echo $this->navbar ?? '';
 
 echo LayoutHelper::render('joomla.content.emptystate', $displayData);
 

--- a/administrator/components/com_j2commerce/tmpl/geozones/emptystate.php
+++ b/administrator/components/com_j2commerce/tmpl/geozones/emptystate.php
@@ -27,7 +27,7 @@ if ($user->authorise('core.create', 'com_j2commerce')) {
     $displayData['createURL'] = 'index.php?option=com_j2commerce&task=geozone.add';
 }
 
-echo $this->navbar;
+echo $this->navbar ?? '';
 
 echo LayoutHelper::render('joomla.content.emptystate', $displayData);
 

--- a/administrator/components/com_j2commerce/tmpl/inventory/emptystate.php
+++ b/administrator/components/com_j2commerce/tmpl/inventory/emptystate.php
@@ -21,7 +21,7 @@ $displayData = [
     'icon'       => 'icon-fa-solid fa-barcode',
 ];
 
-echo $this->navbar;
+echo $this->navbar ?? '';
 
 echo LayoutHelper::render('joomla.content.emptystate', $displayData);
 

--- a/administrator/components/com_j2commerce/tmpl/invoicetemplates/emptystate.php
+++ b/administrator/components/com_j2commerce/tmpl/invoicetemplates/emptystate.php
@@ -27,7 +27,7 @@ if ($user->authorise('core.create', 'com_j2commerce')) {
     $displayData['createURL'] = 'index.php?option=com_j2commerce&task=invoicetemplate.add';
 }
 
-echo $this->navbar;
+echo $this->navbar ?? '';
 
 echo LayoutHelper::render('joomla.content.emptystate', $displayData);
 

--- a/administrator/components/com_j2commerce/tmpl/lengths/emptystate.php
+++ b/administrator/components/com_j2commerce/tmpl/lengths/emptystate.php
@@ -27,7 +27,7 @@ if ($user->authorise('core.create', 'com_j2commerce')) {
     $displayData['createURL'] = 'index.php?option=com_j2commerce&task=length.add';
 }
 
-echo $this->navbar;
+echo $this->navbar ?? '';
 
 echo LayoutHelper::render('joomla.content.emptystate', $displayData);
 

--- a/administrator/components/com_j2commerce/tmpl/manufacturers/emptystate.php
+++ b/administrator/components/com_j2commerce/tmpl/manufacturers/emptystate.php
@@ -27,7 +27,7 @@ if ($user->authorise('core.create', 'com_j2commerce')) {
     $displayData['createURL'] = 'index.php?option=com_j2commerce&task=manufacturer.add';
 }
 
-echo $this->navbar;
+echo $this->navbar ?? '';
 
 echo LayoutHelper::render('joomla.content.emptystate', $displayData);
 

--- a/administrator/components/com_j2commerce/tmpl/options/emptystate.php
+++ b/administrator/components/com_j2commerce/tmpl/options/emptystate.php
@@ -27,7 +27,7 @@ if ($user->authorise('core.create', 'com_j2commerce')) {
     $displayData['createURL'] = 'index.php?option=com_j2commerce&task=option.add';
 }
 
-echo $this->navbar;
+echo $this->navbar ?? '';
 
 echo LayoutHelper::render('joomla.content.emptystate', $displayData);
 

--- a/administrator/components/com_j2commerce/tmpl/orders/emptystate.php
+++ b/administrator/components/com_j2commerce/tmpl/orders/emptystate.php
@@ -21,7 +21,7 @@ $displayData = [
     'icon'       => 'icon-shopping-cart fas fa-shopping-cart',
 ];
 
-echo $this->navbar;
+echo $this->navbar ?? '';
 
 echo  LayoutHelper::render('joomla.content.emptystate', $displayData);
 

--- a/administrator/components/com_j2commerce/tmpl/orderstatuses/emptystate.php
+++ b/administrator/components/com_j2commerce/tmpl/orderstatuses/emptystate.php
@@ -27,7 +27,7 @@ if ($user->authorise('core.create', 'com_j2commerce')) {
     $displayData['createURL'] = 'index.php?option=com_j2commerce&task=orderstatus.add';
 }
 
-echo $this->navbar;
+echo $this->navbar ?? '';
 
 echo LayoutHelper::render('joomla.content.emptystate', $displayData);
 

--- a/administrator/components/com_j2commerce/tmpl/paymentmethods/emptystate.php
+++ b/administrator/components/com_j2commerce/tmpl/paymentmethods/emptystate.php
@@ -33,7 +33,7 @@ if ($user->authorise('core.create', 'com_j2commerce')
     $displayData['createURL'] = 'index.php?option=com_installer&view=install';
 }
 
-echo $this->navbar;
+echo $this->navbar ?? '';
 
 echo LayoutHelper::render('joomla.content.emptystate', $displayData);
 

--- a/administrator/components/com_j2commerce/tmpl/products/emptystate.php
+++ b/administrator/components/com_j2commerce/tmpl/products/emptystate.php
@@ -30,7 +30,7 @@ if ($user->authorise('core.create', 'com_j2commerce')) {
     $displayData['createURL'] = Route::_('index.php?option=com_content&view=article&layout=edit&return=' . $return, false);
 }
 
-echo $this->navbar;
+echo $this->navbar ?? '';
 
 echo LayoutHelper::render('joomla.content.emptystate', $displayData);
 

--- a/administrator/components/com_j2commerce/tmpl/queuelogs/emptystate.php
+++ b/administrator/components/com_j2commerce/tmpl/queuelogs/emptystate.php
@@ -15,7 +15,7 @@ use Joomla\CMS\Layout\LayoutHelper;
 
 /** @var \J2Commerce\Component\J2commerce\Administrator\View\Queuelogs\HtmlView $this */
 
-echo $this->navbar;
+echo $this->navbar ?? '';
 
 echo LayoutHelper::render('joomla.content.emptystate', [
     'textPrefix' => 'COM_J2COMMERCE_QUEUE_LOGS',

--- a/administrator/components/com_j2commerce/tmpl/queues/emptystate.php
+++ b/administrator/components/com_j2commerce/tmpl/queues/emptystate.php
@@ -16,7 +16,7 @@ use Joomla\CMS\Layout\LayoutHelper;
 
 /** @var \J2Commerce\Component\J2commerce\Administrator\View\Queues\HtmlView $this */
 
-echo $this->navbar;
+echo $this->navbar ?? '';
 
 echo LayoutHelper::render('joomla.content.emptystate', [
     'textPrefix' => 'COM_J2COMMERCE_QUEUE',

--- a/administrator/components/com_j2commerce/tmpl/reports/emptystate.php
+++ b/administrator/components/com_j2commerce/tmpl/reports/emptystate.php
@@ -32,7 +32,7 @@ if ($user->authorise('core.create', 'com_j2commerce')
     || count($user->getAuthorisedCategories('com_j2commerce', 'core.create')) > 0) {
     $displayData['createURL'] = 'index.php?option=com_installer&view=install';
 }
-echo $this->navbar;
+echo $this->navbar ?? '';
 
 echo LayoutHelper::render('joomla.content.emptystate', $displayData);
 

--- a/administrator/components/com_j2commerce/tmpl/shippingmethods/emptystate.php
+++ b/administrator/components/com_j2commerce/tmpl/shippingmethods/emptystate.php
@@ -33,7 +33,7 @@ if ($user->authorise('core.create', 'com_j2commerce')
     $displayData['createURL'] = 'index.php?option=com_installer&view=install';
 }
 
-echo $this->navbar;
+echo $this->navbar ?? '';
 
 echo LayoutHelper::render('joomla.content.emptystate', $displayData);
 

--- a/administrator/components/com_j2commerce/tmpl/taxprofiles/emptystate.php
+++ b/administrator/components/com_j2commerce/tmpl/taxprofiles/emptystate.php
@@ -27,7 +27,7 @@ if ($user->authorise('core.create', 'com_j2commerce')) {
     $displayData['createURL'] = 'index.php?option=com_j2commerce&task=taxprofile.add';
 }
 
-echo $this->navbar;
+echo $this->navbar ?? '';
 
 echo LayoutHelper::render('joomla.content.emptystate', $displayData);
 

--- a/administrator/components/com_j2commerce/tmpl/taxrates/emptystate.php
+++ b/administrator/components/com_j2commerce/tmpl/taxrates/emptystate.php
@@ -27,7 +27,7 @@ if ($user->authorise('core.create', 'com_j2commerce')) {
     $displayData['createURL'] = 'index.php?option=com_j2commerce&task=taxrate.add';
 }
 
-echo $this->navbar;
+echo $this->navbar ?? '';
 
 echo LayoutHelper::render('joomla.content.emptystate', $displayData);
 

--- a/administrator/components/com_j2commerce/tmpl/taxrules/emptystate.php
+++ b/administrator/components/com_j2commerce/tmpl/taxrules/emptystate.php
@@ -27,7 +27,7 @@ if ($user->authorise('core.create', 'com_j2commerce')) {
     $displayData['createURL'] = 'index.php?option=com_j2commerce&task=taxrule.add';
 }
 
-echo $this->navbar;
+echo $this->navbar ?? '';
 
 echo LayoutHelper::render('joomla.content.emptystate', $displayData);
 

--- a/administrator/components/com_j2commerce/tmpl/vendors/emptystate.php
+++ b/administrator/components/com_j2commerce/tmpl/vendors/emptystate.php
@@ -27,7 +27,7 @@ if ($user->authorise('core.create', 'com_j2commerce')) {
     $displayData['createURL'] = 'index.php?option=com_j2commerce&task=vendor.add';
 }
 
-echo $this->navbar;
+echo $this->navbar ?? '';
 
 echo LayoutHelper::render('joomla.content.emptystate', $displayData);
 

--- a/administrator/components/com_j2commerce/tmpl/vouchers/emptystate.php
+++ b/administrator/components/com_j2commerce/tmpl/vouchers/emptystate.php
@@ -27,7 +27,7 @@ if ($user->authorise('core.create', 'com_j2commerce')) {
     $displayData['createURL'] = 'index.php?option=com_j2commerce&task=voucher.add';
 }
 
-echo $this->navbar;
+echo $this->navbar ?? '';
 
 echo LayoutHelper::render('joomla.content.emptystate', $displayData);
 

--- a/administrator/components/com_j2commerce/tmpl/weights/emptystate.php
+++ b/administrator/components/com_j2commerce/tmpl/weights/emptystate.php
@@ -27,7 +27,7 @@ if ($user->authorise('core.create', 'com_j2commerce')) {
     $displayData['createURL'] = 'index.php?option=com_j2commerce&task=weight.add';
 }
 
-echo $this->navbar;
+echo $this->navbar ?? '';
 
 echo LayoutHelper::render('joomla.content.emptystate', $displayData);
 

--- a/administrator/components/com_j2commerce/tmpl/zones/emptystate.php
+++ b/administrator/components/com_j2commerce/tmpl/zones/emptystate.php
@@ -27,7 +27,7 @@ if ($user->authorise('core.create', 'com_j2commerce')) {
     $displayData['createURL'] = 'index.php?option=com_j2commerce&task=zone.add';
 }
 
-echo $this->navbar;
+echo $this->navbar ?? '';
 
 echo LayoutHelper::render('joomla.content.emptystate', $displayData);
 


### PR DESCRIPTION
## Summary
Fixes #302

When emptystate views render inside a modal (tmpl=component), $this->navbar is never set by the HtmlView, causing a PHP undefined property warning. This adds null coalescing to all 29 emptystate templates.

## Changes
- All 29 emptystate.php templates: added null coalescing operator for navbar property
- Matches the safe pattern already used in advancedpricing/default.php and report/view.php

## Testing
1. Have no products in the store
2. Go to create a new coupon
3. Click Add Products button
4. Modal opens - verify no PHP warning about undefined navbar property

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only