### PR TITLE
J2Commerce content tabs need to be easier to spot

### DIFF
--- a/administrator/language/en-GB/plg_content_j2commerce.ini
+++ b/administrator/language/en-GB/plg_content_j2commerce.ini
@@ -57,7 +57,7 @@ PLG_CONTENT_J2COMMERCE_MAIN_IMAGE_WIDTH="Main Image Width"
 PLG_CONTENT_J2COMMERCE_MAIN_IMAGE_WIDTH_DESC="Width in pixels for the main product image in article view."
 
 ; Form Tab
-PLG_CONTENT_J2COMMERCE_TAB_LABEL="J2Commerce"
+PLG_CONTENT_J2COMMERCE_TAB_LABEL="<span class=\"p-1 fa-solid fa-cart-shopping\" aria-hidden=\"true\"></span> J2Commerce"
 PLG_CONTENT_J2COMMERCE_TAB_NOT_DISPLAYED="The J2Commerce tab may not be displayed. Please enable 'Show Article Options' in Content component settings."
 PLG_CONTENT_J2COMMERCE_FIELD_LABEL="Product Configuration"
 PLG_CONTENT_J2COMMERCE_FIELD_DESC="Configure the J2Commerce product settings for this article."

--- a/administrator/language/en-GB/plg_content_j2commerce.sys.ini
+++ b/administrator/language/en-GB/plg_content_j2commerce.sys.ini
@@ -60,7 +60,7 @@ PLG_CONTENT_J2COMMERCE_MAIN_IMAGE_WIDTH="Main Image Width"
 PLG_CONTENT_J2COMMERCE_MAIN_IMAGE_WIDTH_DESC="Width in pixels for the main product image in article view."
 
 ; Form Tab (Article Editor)
-PLG_CONTENT_J2COMMERCE_TAB_LABEL="J2Commerce"
+PLG_CONTENT_J2COMMERCE_TAB_LABEL="<span class=\"p-1 fa-solid fa-cart-shopping\" aria-hidden=\"true\"></span> J2Commerce"
 PLG_CONTENT_J2COMMERCE_TAB_NOT_DISPLAYED="The J2Commerce tab may not be displayed. Please enable 'Show Article Options' in Content component settings."
 PLG_CONTENT_J2COMMERCE_FIELD_LABEL="Product Configuration"
 PLG_CONTENT_J2COMMERCE_FIELD_DESC="Configure the J2Commerce product settings for this article."

--- a/plugins/content/j2commerce/forms/category.xml
+++ b/plugins/content/j2commerce/forms/category.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <form>
     <fields name="params">
-        <fieldset name="j2commerce" label="J2Commerce"
+        <fieldset name="j2commerce" label="PLG_CONTENT_J2COMMERCE_TAB_LABEL"
             addfieldprefix="J2Commerce\Component\J2commerce\Administrator\Field">
 
             <field name="category_view_type" type="list" default=""

--- a/plugins/content/j2commerce/language/en-GB/plg_content_j2commerce.ini
+++ b/plugins/content/j2commerce/language/en-GB/plg_content_j2commerce.ini
@@ -57,7 +57,7 @@ PLG_CONTENT_J2COMMERCE_MAIN_IMAGE_WIDTH="Main Image Width"
 PLG_CONTENT_J2COMMERCE_MAIN_IMAGE_WIDTH_DESC="Width in pixels for the main product image in article view."
 
 ; Form Tab
-PLG_CONTENT_J2COMMERCE_TAB_LABEL="J2Commerce"
+PLG_CONTENT_J2COMMERCE_TAB_LABEL="<span class=\"p-1 fa-solid fa-cart-shopping\" aria-hidden=\"true\"></span> J2Commerce"
 PLG_CONTENT_J2COMMERCE_TAB_NOT_DISPLAYED="The J2Commerce tab may not be displayed. Please enable 'Show Article Options' in Content component settings."
 PLG_CONTENT_J2COMMERCE_FIELD_LABEL="Product Configuration"
 PLG_CONTENT_J2COMMERCE_FIELD_DESC="Configure the J2Commerce product settings for this article."

--- a/plugins/content/j2commerce/language/en-GB/plg_content_j2commerce.sys.ini
+++ b/plugins/content/j2commerce/language/en-GB/plg_content_j2commerce.sys.ini
@@ -60,7 +60,7 @@ PLG_CONTENT_J2COMMERCE_MAIN_IMAGE_WIDTH="Main Image Width"
 PLG_CONTENT_J2COMMERCE_MAIN_IMAGE_WIDTH_DESC="Width in pixels for the main product image in article view."
 
 ; Form Tab (Article Editor)
-PLG_CONTENT_J2COMMERCE_TAB_LABEL="J2Commerce"
+PLG_CONTENT_J2COMMERCE_TAB_LABEL="<span class=\"p-1 fa-solid fa-cart-shopping\" aria-hidden=\"true\"></span> J2Commerce"
 PLG_CONTENT_J2COMMERCE_TAB_NOT_DISPLAYED="The J2Commerce tab may not be displayed. Please enable 'Show Article Options' in Content component settings."
 PLG_CONTENT_J2COMMERCE_FIELD_LABEL="Product Configuration"
 PLG_CONTENT_J2COMMERCE_FIELD_DESC="Configure the J2Commerce product settings for this article."


### PR DESCRIPTION
This is something we wanted to include in our 4.x version of J2Commerce.
Content tabs are easier to spot if we add an icon to them.

An additional benefit is that we can target the tabs twice while running guided tours.
For instance, when creating a product guided tour, it is not possible to target the J2Commerce tab twice.
However it is needed in the tour.
Adding an icon allows targeting the full button the first time it is needed in the tour and targeting the icon the second time.