### PR TITLE
fix(currency-updater): report unsupported Frankfurter currencies (fixes #304)

### DIFF
--- a/plugins/j2commerce/app_currencyupdater/language/en-GB/plg_j2commerce_app_currencyupdater.ini
+++ b/plugins/j2commerce/app_currencyupdater/language/en-GB/plg_j2commerce_app_currencyupdater.ini
@@ -56,4 +56,4 @@ PLG_J2COMMERCE_APP_CURRENCYUPDATER_ERROR_NO_BASE_CURRENCY="No shop base currency
 PLG_J2COMMERCE_APP_CURRENCYUPDATER_ERROR_NO_CURRENCIES="No enabled currencies found to update (besides the base currency)."
 PLG_J2COMMERCE_APP_CURRENCYUPDATER_ERROR_API_RESPONSE="API error from %s: %s"
 PLG_J2COMMERCE_APP_CURRENCYUPDATER_ERROR_MISSING_API_KEY="An API key is required for %s. Configure it in the Currency Updater app settings."
-PLG_J2COMMERCE_APP_CURRENCYUPDATER_ERROR_UNSUPPORTED_CURRENCIES="The following currencies are not supported and were skipped: %s"
+PLG_J2COMMERCE_APP_CURRENCYUPDATER_ERROR_UNSUPPORTED_CURRENCIES="The following currencies are not supported by the chosen provider and were skipped: %s. You may want to try a different provider."

--- a/plugins/j2commerce/app_currencyupdater/language/en-GB/plg_j2commerce_app_currencyupdater.ini
+++ b/plugins/j2commerce/app_currencyupdater/language/en-GB/plg_j2commerce_app_currencyupdater.ini
@@ -56,3 +56,4 @@ PLG_J2COMMERCE_APP_CURRENCYUPDATER_ERROR_NO_BASE_CURRENCY="No shop base currency
 PLG_J2COMMERCE_APP_CURRENCYUPDATER_ERROR_NO_CURRENCIES="No enabled currencies found to update (besides the base currency)."
 PLG_J2COMMERCE_APP_CURRENCYUPDATER_ERROR_API_RESPONSE="API error from %s: %s"
 PLG_J2COMMERCE_APP_CURRENCYUPDATER_ERROR_MISSING_API_KEY="An API key is required for %s. Configure it in the Currency Updater app settings."
+PLG_J2COMMERCE_APP_CURRENCYUPDATER_ERROR_UNSUPPORTED_CURRENCIES="The following currencies are not supported and were skipped: %s"

--- a/plugins/j2commerce/app_currencyupdater/language/en-US/plg_j2commerce_app_currencyupdater.ini
+++ b/plugins/j2commerce/app_currencyupdater/language/en-US/plg_j2commerce_app_currencyupdater.ini
@@ -56,4 +56,4 @@ PLG_J2COMMERCE_APP_CURRENCYUPDATER_ERROR_NO_BASE_CURRENCY="No store base currenc
 PLG_J2COMMERCE_APP_CURRENCYUPDATER_ERROR_NO_CURRENCIES="No enabled currencies found to update (besides the base currency)."
 PLG_J2COMMERCE_APP_CURRENCYUPDATER_ERROR_API_RESPONSE="API error from %s: %s"
 PLG_J2COMMERCE_APP_CURRENCYUPDATER_ERROR_MISSING_API_KEY="An API key is required for %s. Configure it in the Currency Updater app settings."
-PLG_J2COMMERCE_APP_CURRENCYUPDATER_ERROR_UNSUPPORTED_CURRENCIES="The following currencies are not supported and were skipped: %s"
+PLG_J2COMMERCE_APP_CURRENCYUPDATER_ERROR_UNSUPPORTED_CURRENCIES="The following currencies are not supported by the chosen provider and were skipped: %s. You may want to try a different provider."

--- a/plugins/j2commerce/app_currencyupdater/language/en-US/plg_j2commerce_app_currencyupdater.ini
+++ b/plugins/j2commerce/app_currencyupdater/language/en-US/plg_j2commerce_app_currencyupdater.ini
@@ -56,3 +56,4 @@ PLG_J2COMMERCE_APP_CURRENCYUPDATER_ERROR_NO_BASE_CURRENCY="No store base currenc
 PLG_J2COMMERCE_APP_CURRENCYUPDATER_ERROR_NO_CURRENCIES="No enabled currencies found to update (besides the base currency)."
 PLG_J2COMMERCE_APP_CURRENCYUPDATER_ERROR_API_RESPONSE="API error from %s: %s"
 PLG_J2COMMERCE_APP_CURRENCYUPDATER_ERROR_MISSING_API_KEY="An API key is required for %s. Configure it in the Currency Updater app settings."
+PLG_J2COMMERCE_APP_CURRENCYUPDATER_ERROR_UNSUPPORTED_CURRENCIES="The following currencies are not supported and were skipped: %s"

--- a/plugins/j2commerce/app_currencyupdater/src/Extension/AppCurrencyupdater.php
+++ b/plugins/j2commerce/app_currencyupdater/src/Extension/AppCurrencyupdater.php
@@ -176,12 +176,103 @@ final class AppCurrencyupdater extends CMSPlugin implements SubscriberInterface
                 'ExchangeRate.host',
                 'error'
             ),
-            default => $this->fetchRatesFromEndpoint(
-                "https://api.frankfurter.dev/v1/latest?from={$baseCurrency}&to=" . implode(',', $targetCodes),
-                'Frankfurter',
-                'message'
-            ),
+            default => $this->fetchBulkFromFrankfurter($baseCurrency, $targetCodes),
         };
+    }
+
+    private function fetchBulkFromFrankfurter(string $base, array $codes): array
+    {
+        $source = 'Frankfurter';
+        $url = "https://api.frankfurter.dev/v1/latest?from={$base}&to=" . implode(',', $codes);
+
+        try {
+            $http = $this->createHttp();
+            $response = $http->get($url, [], 30);
+            $statusCode = $response->getStatusCode();
+            $body = (string) $response->getBody();
+
+            // Bulk request succeeded — parse and report any missing currencies
+            if ($statusCode === 200) {
+                $data = json_decode($body, false, 512, JSON_THROW_ON_ERROR);
+
+                if (!isset($data->rates) || !\is_object($data->rates)) {
+                    $this->surfaceError($source, $data->message ?? 'No rates in response');
+                    return [];
+                }
+
+                $rates = [];
+                foreach ($data->rates as $code => $rate) {
+                    $rates[(string) $code] = (float) $rate;
+                }
+
+                // Report currencies that were requested but missing from the response
+                $missing = array_diff($codes, array_keys($rates));
+                if (!empty($missing)) {
+                    $this->getApplication()->enqueueMessage(
+                        Text::sprintf(
+                            'PLG_J2COMMERCE_APP_CURRENCYUPDATER_ERROR_UNSUPPORTED_CURRENCIES',
+                            implode(', ', $missing)
+                        ),
+                        'warning'
+                    );
+                }
+
+                return $rates;
+            }
+
+            // 404 means one or more currencies are not supported by Frankfurter
+            if ($statusCode === 404) {
+                // Single currency — report it directly as unsupported
+                if (\count($codes) === 1) {
+                    $this->getApplication()->enqueueMessage(
+                        Text::sprintf(
+                            'PLG_J2COMMERCE_APP_CURRENCYUPDATER_ERROR_UNSUPPORTED_CURRENCIES',
+                            $codes[0]
+                        ),
+                        'warning'
+                    );
+                    return [];
+                }
+
+                // Multiple currencies — retry individually to salvage supported ones
+                $rates = [];
+                $unsupported = [];
+
+                foreach ($codes as $code) {
+                    $singleUrl = "https://api.frankfurter.dev/v1/latest?from={$base}&to={$code}";
+                    $singleResponse = $http->get($singleUrl, [], 30);
+
+                    if ($singleResponse->getStatusCode() === 200) {
+                        $singleData = json_decode((string) $singleResponse->getBody(), false, 512, JSON_THROW_ON_ERROR);
+
+                        if (isset($singleData->rates->$code)) {
+                            $rates[$code] = (float) $singleData->rates->$code;
+                        }
+                    } else {
+                        $unsupported[] = $code;
+                    }
+                }
+
+                if (!empty($unsupported)) {
+                    $this->getApplication()->enqueueMessage(
+                        Text::sprintf(
+                            'PLG_J2COMMERCE_APP_CURRENCYUPDATER_ERROR_UNSUPPORTED_CURRENCIES',
+                            implode(', ', $unsupported)
+                        ),
+                        'warning'
+                    );
+                }
+
+                return $rates;
+            }
+
+            // Other error
+            $this->surfaceError($source, "HTTP {$statusCode}: " . substr($body, 0, 200));
+            return [];
+        } catch (\Throwable $e) {
+            $this->surfaceError($source, $e->getMessage());
+            return [];
+        }
     }
 
     private function fetchRatesFromEndpoint(string $url, string $source, string $errorProperty = 'message'): array


### PR DESCRIPTION
Fixes #304

Frankfurter API returns 200 but silently omits unsupported currencies (e.g. ARS). Previously supported currencies were updated but no indication was given that others were skipped.

Now detects missing currencies after a successful response and shows a clear warning listing which were skipped. Also handles 404 for a single unsupported currency with a helpful message instead of raw HTTP error.