### PR TITLE
fix(security): restrict template overrides and file upload to super users (fixes #305)

### DIFF
--- a/administrator/components/com_j2commerce/src/Controller/OverridesController.php
+++ b/administrator/components/com_j2commerce/src/Controller/OverridesController.php
@@ -13,6 +13,7 @@ namespace J2Commerce\Component\J2commerce\Administrator\Controller;
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Factory;
 use Joomla\CMS\MVC\Controller\BaseController;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
@@ -20,8 +21,16 @@ use Joomla\CMS\Language\Text;
 
 class OverridesController extends BaseController
 {
+    private function requireSuperUser(): void
+    {
+        if (!Factory::getApplication()->getIdentity()->authorise('core.admin')) {
+            throw new \RuntimeException(Text::_('JLIB_APPLICATION_ERROR_ACCESS_FORBIDDEN'), 403);
+        }
+    }
+
     public function createOverride(): void
     {
+        $this->requireSuperUser();
         Session::checkToken('get') || Session::checkToken() || jexit(Text::_('JINVALID_TOKEN'));
 
         $plugin = $this->input->get('plugin', '', 'cmd');
@@ -47,6 +56,7 @@ class OverridesController extends BaseController
 
     public function revertOverride(): void
     {
+        $this->requireSuperUser();
         Session::checkToken('get') || Session::checkToken() || jexit(Text::_('JINVALID_TOKEN'));
 
         $plugin = $this->input->get('plugin', '', 'cmd');
@@ -66,6 +76,7 @@ class OverridesController extends BaseController
 
     public function save(): void
     {
+        $this->requireSuperUser();
         Session::checkToken() || jexit(Text::_('JINVALID_TOKEN'));
 
         $data = $this->input->post->get('jform', [], 'array');

--- a/administrator/components/com_j2commerce/src/Helper/MenuHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/MenuHelper.php
@@ -190,30 +190,36 @@ class MenuHelper
 
         // Design
         if ($user->authorise('core.manage', 'com_j2commerce')) {
+            $designChildren = [];
+
+            // Template overrides — super users only (can write arbitrary PHP)
+            if ($user->authorise('core.admin')) {
+                $designChildren[] = [
+                    'title' => 'COM_J2COMMERCE_TEMPLATE_OVERRIDES',
+                    'view' => 'overrides',
+                    'link' => 'index.php?option=com_j2commerce&view=overrides',
+                    'icon' => 'fa-solid fa-layer-group'
+                ];
+            }
+
+            $designChildren[] = [
+                'title' => 'COM_J2COMMERCE_TEMPLATES_EMAIL',
+                'view' => 'emailtemplates',
+                'link' => 'index.php?option=com_j2commerce&view=emailtemplates',
+                'icon' => 'fa-solid fa-envelope'
+            ];
+            $designChildren[] = [
+                'title' => 'COM_J2COMMERCE_TEMPLATES_INVOICE',
+                'view' => 'invoice',
+                'link' => 'index.php?option=com_j2commerce&view=invoicetemplates',
+                'icon' => 'fa-solid fa-print'
+            ];
+
             $items[] = [
                 'title' => 'COM_J2COMMERCE_DESIGN',
-                'view' => 'overrides',
+                'view' => !empty($designChildren) && $designChildren[0]['view'] === 'overrides' ? 'overrides' : 'emailtemplates',
                 'icon' => 'fa-solid fa-compass-drafting',
-                'children' => [
-                    [
-                        'title' => 'COM_J2COMMERCE_TEMPLATE_OVERRIDES',
-                        'view' => 'overrides',
-                        'link' => 'index.php?option=com_j2commerce&view=overrides',
-                        'icon' => 'fa-solid fa-layer-group'
-                    ],
-                    [
-                        'title' => 'COM_J2COMMERCE_TEMPLATES_EMAIL',
-                        'view' => 'emailtemplates',
-                        'link' => 'index.php?option=com_j2commerce&view=emailtemplates',
-                        'icon' => 'fa-solid fa-envelope'
-                    ],
-                    [
-                        'title' => 'COM_J2COMMERCE_TEMPLATES_INVOICE',
-                        'view' => 'invoice',
-                        'link' => 'index.php?option=com_j2commerce&view=invoicetemplates',
-                        'icon' => 'fa-solid fa-print'
-                    ]
-                ]
+                'children' => $designChildren,
             ];
         }
         // Setup

--- a/administrator/components/com_j2commerce/src/Model/EmailtemplateModel.php
+++ b/administrator/components/com_j2commerce/src/Model/EmailtemplateModel.php
@@ -139,6 +139,14 @@ class EmailtemplateModel extends AdminModel
             return false;
         }
 
+        // File-based body source can execute arbitrary PHP — restrict to super users
+        if (($validData['body_source'] ?? '') === 'file'
+            && !Factory::getApplication()->getIdentity()->authorise('core.admin')
+        ) {
+            $this->setError(Text::_('JLIB_APPLICATION_ERROR_ACCESS_FORBIDDEN'));
+            return false;
+        }
+
         return $validData;
     }
 

--- a/administrator/components/com_j2commerce/src/View/Emailtemplate/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Emailtemplate/HtmlView.php
@@ -57,6 +57,26 @@ class HtmlView extends BaseHtmlView
         $this->state      = $model->getState();
         $this->shortcodes = $model->getAvailableShortcodes();
 
+        // File-based body source can execute arbitrary PHP — restrict to super users
+        if (!Factory::getApplication()->getIdentity()->authorise('core.admin')) {
+            $this->form->setFieldAttribute('body_source', 'filter', 'cmd');
+            $bodySourceField = $this->form->getField('body_source');
+            if ($bodySourceField) {
+                $element = $bodySourceField->__get('element');
+                foreach ($element->children() as $option) {
+                    if ((string) $option['value'] === 'file') {
+                        $dom = dom_import_simplexml($option);
+                        $dom->parentNode->removeChild($dom);
+                        break;
+                    }
+                }
+            }
+            // Force back to visual if currently set to file
+            if (($this->item->body_source ?? '') === 'file') {
+                $this->form->setValue('body_source', null, 'visual');
+            }
+        }
+
         // Merge type-specific shortcodes when editing a non-transactional email template
         $emailType = $this->item->email_type ?? 'transactional';
         if ($emailType !== 'transactional') {

--- a/administrator/components/com_j2commerce/src/View/Overrides/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Overrides/HtmlView.php
@@ -42,6 +42,11 @@ class HtmlView extends BaseHtmlView
 
     public function display($tpl = null): void
     {
+        // Template overrides can write arbitrary PHP — restrict to super users
+        if (!Factory::getApplication()->getIdentity()->authorise('core.admin')) {
+            throw new \Exception(Text::_('JLIB_APPLICATION_ERROR_ACCESS_FORBIDDEN'), 403);
+        }
+
         $this->loadAdminAssets();
         $this->navbar = $this->getNavbar();
 


### PR DESCRIPTION
Fixes #305

Template overrides and email template file-based body source allow writing arbitrary PHP. Like Joomla core, these are now restricted to super users only.

Changes:
- Overrides view and controller: 403 for non-super users
- Overrides menu item: hidden for non-super users
- Email template File body source: removed from dropdown and blocked server-side for non-super users