### PR TITLE
fix(acl): apply default ACL rules on update for manager access (fixes #306)

### DIFF
--- a/administrator/components/com_j2commerce/script.j2commerce.php
+++ b/administrator/components/com_j2commerce/script.j2commerce.php
@@ -181,6 +181,9 @@ class Com_J2commerceInstallerScript extends InstallerScript
     {
         $this->debugLog("=== UPDATE START ===");
 
+        $this->setDefaultAcl();
+        $this->debugLog("UPDATE: default ACL rules set (if empty)");
+
         Factory::getApplication()->enqueueMessage(Text::_('COM_J2COMMERCE_UPDATE_SUCCESS'), 'success');
 
         $this->debugLog("=== UPDATE END ===");


### PR DESCRIPTION
Fixes #306

setDefaultAcl() only ran on fresh install so existing installs never granted Manager group core.manage access. Now also runs on update, guarded by the existing empty-rules check so it won't overwrite admin-customized permissions.