### PR TITLE
fix(pricing): use currency decimal places for admin price fields

### DIFF
--- a/administrator/components/com_j2commerce/layouts/field/price.php
+++ b/administrator/components/com_j2commerce/layouts/field/price.php
@@ -75,7 +75,10 @@ if ($options) {
     $list = 'list="' . $id . '_datalist"';
 }
 
-$currencySymbol = (new J2Commerce\Component\J2commerce\Administrator\Helper\CurrencyHelper)->getSymbol();
+$currencyHelper  = new J2Commerce\Component\J2commerce\Administrator\Helper\CurrencyHelper();
+$currencySymbol  = $currencyHelper->getSymbol();
+$currencyDecimals = CurrencyHelper::getDecimalPlace();
+$value = number_format((float) ($value ?? 0), $currencyDecimals, '.', '');
 
 
 $attributes = [

--- a/administrator/components/com_j2commerce/src/Field/VariantPriceField.php
+++ b/administrator/components/com_j2commerce/src/Field/VariantPriceField.php
@@ -47,12 +47,16 @@ class VariantPriceField extends FormField
         $currencyHelper = new CurrencyHelper();
         $currencySymbol = $currencyHelper->getSymbol();
 
+        // Format value to match the currency's configured decimal places
+        $decimals = CurrencyHelper::getDecimalPlace();
+        $value    = number_format((float) ($this->value ?? 0), $decimals, '.', '');
+
         // Build attributes
         $attributes = [];
         $attributes[] = 'type="text"';
         $attributes[] = 'name="' . htmlspecialchars($this->name, ENT_COMPAT, 'UTF-8') . '"';
         $attributes[] = 'id="' . htmlspecialchars($this->id, ENT_COMPAT, 'UTF-8') . '"';
-        $attributes[] = 'value="' . htmlspecialchars((string) $this->value, ENT_COMPAT, 'UTF-8') . '"';
+        $attributes[] = 'value="' . htmlspecialchars($value, ENT_COMPAT, 'UTF-8') . '"';
         $attributes[] = 'class="form-control' . ($this->class ? ' ' . htmlspecialchars($this->class, ENT_COMPAT, 'UTF-8') : '') . '"';
         $attributes[] = 'inputmode="decimal"';
 

--- a/administrator/components/com_j2commerce/tmpl/advancedpricing/default.php
+++ b/administrator/components/com_j2commerce/tmpl/advancedpricing/default.php
@@ -17,7 +17,9 @@ use Joomla\CMS\Router\Route;
 
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
-$currencySymbol = (new CurrencyHelper())->getSymbol();
+$currencySymbol  = (new CurrencyHelper())->getSymbol();
+$currencyDecimals = CurrencyHelper::getDecimalPlace();
+$stepValue        = $currencyDecimals > 0 ? '0.' . str_repeat('0', $currencyDecimals - 1) . '1' : '1';
 
 $wa = $this->getDocument()->getWebAssetManager();
 $wa->useScript('table.columns');
@@ -123,10 +125,11 @@ $wa->useScript('multiselect');
                                             <span class="input-group-text"><?php echo $currencySymbol; ?></span>
                                             <input type="number"
                                                    class="form-control form-control-sm advancedpricing-price-input"
-                                                   value="<?php echo number_format((float) $item->price, 2, '.', ''); ?>"
+                                                   value="<?php echo number_format((float) $item->price, $currencyDecimals, '.', ''); ?>"
                                                    data-id="<?php echo (int) $item->j2commerce_productprice_id; ?>"
-                                                   data-original="<?php echo number_format((float) $item->price, 2, '.', ''); ?>"
-                                                   step="0.01"
+                                                   data-original="<?php echo number_format((float) $item->price, $currencyDecimals, '.', ''); ?>"
+                                                   data-decimals="<?php echo $currencyDecimals; ?>"
+                                                   step="<?php echo $stepValue; ?>"
                                                    min="0" />
                                             <button type="button" class="btn btn-sm btn-primary price-save-btn" data-id="<?php echo (int) $item->j2commerce_productprice_id; ?>" title="<?php echo Text::_('JAPPLY'); ?>">
                                                 <span class="icon-save" aria-hidden="true"></span>

--- a/administrator/components/com_j2commerce/tmpl/productprice/productpricing.php
+++ b/administrator/components/com_j2commerce/tmpl/productprice/productpricing.php
@@ -28,7 +28,8 @@ $row_class = 'row';
 $col_class = 'col-md-';
 $app = Factory::getApplication();
 $input = $app->getInput();
-$currencySymbol = (new CurrencyHelper())->getSymbol();
+$currencySymbol   = (new CurrencyHelper())->getSymbol();
+$currencyDecimals = CurrencyHelper::getDecimalPlace();
 
 // Initialize tooltips
 HTMLHelper::_('bootstrap.tooltip', '[data-bs-toggle="tooltip"]', ['placement' => 'top']);
@@ -218,6 +219,7 @@ $wa->addInlineScript($script);
         $this->form->setValue('date_to', null, '');
         $this->form->setValue('quantity_from', null, '');
         $this->form->setValue('customer_group_id', null, 1);
+        $this->form->setValue('price', null, number_format(0, $currencyDecimals, '.', ''));
         ?>
         <div class="note <?php echo $row_class; ?> mb-3">
             <fieldset class="options-form">
@@ -373,7 +375,7 @@ $wa->addInlineScript($script);
                                     <span class="input-group-text"><?php echo $currencySymbol; ?></span>
                                     <input type="text"
                                            name="<?php echo $fieldPrefix; ?>[price]"
-                                           value="<?php echo number_format((float) $pricing->price, 5, '.', ''); ?>"
+                                           value="<?php echo number_format((float) $pricing->price, $currencyDecimals, '.', ''); ?>"
                                            class="form-control" />
                                 </div>
                                 <input type="hidden"

--- a/media/com_j2commerce/js/administrator/admin-advancedpricing.js
+++ b/media/com_j2commerce/js/administrator/admin-advancedpricing.js
@@ -52,7 +52,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
             if (result.success) {
                 // Update original value
-                input.dataset.original = newPrice.toFixed(2);
+                const decimals = parseInt(input.dataset.decimals, 10) || 2;
+                input.dataset.original = newPrice.toFixed(decimals);
 
                 // Show success feedback
                 saveBtn.innerHTML = '<span class="icon-check" aria-hidden="true"></span>';


### PR DESCRIPTION
## Summary
Fixes #307

Price inputs in the backend admin displayed raw database precision (5 decimals) instead of respecting the currency's configured `currency_num_decimals` setting. A store with 2 decimal places would show `0.00000` in price fields.

## Changes
- **VariantPriceField.php** — Format value using `CurrencyHelper::getDecimalPlace()` before rendering
- **layouts/field/price.php** — Format simple product price layout to currency decimal places
- **tmpl/advancedpricing/default.php** — Replace hardcoded `2` with dynamic currency decimals for value, data-original, and step attributes
- **tmpl/productprice/productpricing.php** — Set formatted default for new price field; fix existing prices from hardcoded `5` to currency decimals
- **admin-advancedpricing.js** — Read decimals from `data-decimals` attribute instead of hardcoded `toFixed(2)`

## Files Modified
| Type | Count |
|------|-------|
| PHP files | 4 |
| JS assets | 1 |

## Testing
1. Set currency to 2 decimal places in J2Commerce > Currencies
2. Edit a simple product — price tab should show `0.00` not `0.00000`
3. Edit a variable product — variant price should show `0.00`
4. Open Advanced Pricing modal — new price field shows `0.00`, existing prices show 2 decimals
5. Advanced Pricing list view — prices show 2 decimals
6. (Optional) Set currency to 0 decimals (e.g., JPY) — verify whole numbers display

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only (non-core excluded)