### PR TITLE
fix(checkout): remove Change link when navigating back to active step

### DIFF
--- a/components/com_j2commerce/tmpl/checkout/default.php
+++ b/components/com_j2commerce/tmpl/checkout/default.php
@@ -561,26 +561,28 @@ document.addEventListener('DOMContentLoaded', function() {
     // Heading edit link clicks - open that step
     document.addEventListener('click', function(e) {
         var link = e.target.closest('.checkout-heading a');
-        if (!link) return;
+        if (!link || link.classList.contains('checkout-logout')) return;
         e.preventDefault();
         var step = link.closest('[id]');
         if (!step) return;
         hideAllContents();
         slideDown(getContent(step.id));
-        link.setAttribute('aria-expanded', 'true');
+        // Remove the edit link from the step we just navigated to —
+        // being ON a step means its own "Change" link is redundant.
+        link.remove();
     });
 
     // Keyboard accessibility for edit links (Enter/Space)
     document.addEventListener('keydown', function(e) {
         if (e.key !== 'Enter' && e.key !== ' ') return;
         var link = e.target.closest('.checkout-heading a');
-        if (!link) return;
+        if (!link || link.classList.contains('checkout-logout')) return;
         e.preventDefault();
         var step = link.closest('[id]');
         if (!step) return;
         hideAllContents();
         slideDown(getContent(step.id));
-        link.setAttribute('aria-expanded', 'true');
+        link.remove();
     });
 
     // Toggle existing/new address form visibility (billing)


### PR DESCRIPTION
## Summary
Fixes #311

When clicking a "Change" link to navigate back to an earlier checkout step, the link remained visible on the step heading even though the user was already on that step. This was most noticeable on step 1 (login/register) where "Change" appeared with nothing to change back to.

## Changes
- Edit link click handler now removes the link from the active step's heading after navigating to it
- Same fix applied to the keyboard accessibility handler (Enter/Space)
- Added `checkout-logout` guard so the logout link is never intercepted by the edit link handler

## Testing
1. Go to frontend checkout (not logged in)
2. Fill step 1 (register/guest), click Continue to step 2
3. Click "Change" on step 1 heading to go back
4. Verify: no "Change" link visible on step 1
5. Continue forward again — verify "Change" links reappear on completed steps
6. Test with logged-in user — verify logout link still works

## Files Changed
- `components/com_j2commerce/tmpl/checkout/default.php` — Edit link click/keyboard handlers