### PR TITLE
fix(uppy): wire browse button for multi-image uploader (fixes #285)

### DIFF
--- a/media/com_j2commerce/js/administrator/multiimageuploader.js
+++ b/media/com_j2commerce/js/administrator/multiimageuploader.js
@@ -130,6 +130,16 @@
             this.modalEl.addEventListener('hidden.bs.modal', () => {
                 this.browserSelections.clear();
                 this.uploadedInSession = [];
+                // Reset Uppy so it reinitializes fresh on next modal open
+                if (this.dashboardObserver) {
+                    this.dashboardObserver.disconnect();
+                    this.dashboardObserver = null;
+                }
+                if (this.uppy) {
+                    this.uppy.clear();
+                    this.uppy.destroy();
+                    this.uppy = null;
+                }
             });
 
             // Done button
@@ -205,15 +215,29 @@
                 locale: this.getLocale(),
             });
 
-            // Replace Uppy's default AddFiles UI with a button + hint matching the empty state
-            const addFilesEl = dashboardTarget.querySelector('.uppy-Dashboard-AddFiles');
-            if (addFilesEl) {
+            // Replace Uppy's default AddFiles UI with custom button + hint.
+            // Uses MutationObserver because Uppy re-renders AddFiles when "+ Add more" is clicked.
+            const customizeAddFiles = () => {
+                const addFilesEl = dashboardTarget.querySelector('.uppy-Dashboard-AddFiles');
+                if (!addFilesEl || addFilesEl.dataset.j2customized) return;
+                addFilesEl.dataset.j2customized = '1';
                 const inner = addFilesEl.querySelector('.uppy-Dashboard-AddFiles-title');
                 if (inner) {
                     inner.innerHTML = `<span class="uppymedia-uppy-btn"><i class="fa-solid fa-images" aria-hidden="true"></i> ${this.escapeHtml(this.getText('COM_J2COMMERCE_MULTIIMAGEUPLOADER_ADD_PRODUCT_IMAGES'))}</span>`
                         + `<p class="uppymedia-uppy-hint">${this.escapeHtml(this.getText('COM_J2COMMERCE_MULTIIMAGEUPLOADER_DRAG_DROP_NOTE'))}</p>`;
                 }
-            }
+                const browseSpan = addFilesEl.querySelector('.uppymedia-uppy-btn');
+                if (browseSpan) {
+                    browseSpan.style.cursor = 'pointer';
+                    browseSpan.addEventListener('click', () => {
+                        const fileInput = dashboardTarget.querySelector('.uppy-Dashboard-input');
+                        if (fileInput) fileInput.click();
+                    });
+                }
+            };
+            customizeAddFiles();
+            this.dashboardObserver = new MutationObserver(() => customizeAddFiles());
+            this.dashboardObserver.observe(dashboardTarget, { childList: true, subtree: true });
 
             if (!this.options.fileMode) {
                 this.uppy.use(Uppy.ThumbnailGenerator, {


### PR DESCRIPTION
## Summary
Fixes #285

The "Add Product Images" button and drag-to-browse area in the multi-image uploader modal did nothing when clicked. Also, clicking "+ Add more" after selecting a file showed Uppy's default UI instead of the custom J2Commerce button.

## Changes
- Wire custom browse button click to Uppy's hidden file input (ported from j2commerceimage.js)
- Reset Uppy instance on modal close so it reinitializes fresh
- Use MutationObserver to re-apply custom UI when Uppy re-renders on "+ Add more"

## Files Modified
| Type | Count |
|------|-------|
| JS assets | 1 |

## Pre-Flight
- [x] Core files only (non-core excluded)
- [x] No secrets detected
- [x] No FOF remnants

## Testing
1. Edit any product → Images tab → click "Add Product Images"
2. Click the purple button → file browser should open
3. Select a file → click "+ Add more" → custom button should appear
4. Close modal, reopen → should work fresh