### PR TITLE
fix(config): remove unused prepare_content option (fixes #308)

### DIFF
--- a/administrator/components/com_j2commerce/config.xml
+++ b/administrator/components/com_j2commerce/config.xml
@@ -1302,19 +1302,6 @@
             addfieldprefix="Joomla\Component\Content\Administrator\Field"
             showon="show_terms:1"
         />
-
-        <field
-            name="prepare_content"
-            type="radio"
-            label="COM_J2COMMERCE_CONFIG_PREPARE_CONTENT"
-            description="COM_J2COMMERCE_CONFIG_PREPARE_CONTENT_DESC"
-            layout="joomla.form.field.radio.switcher"
-            default="0"
-            filter="integer"
-        >
-            <option value="0">JNO</option>
-            <option value="1">JYES</option>
-        </field>
     </fieldset>
 
 

--- a/administrator/components/com_j2commerce/src/Helper/ConfigHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/ConfigHelper.php
@@ -1072,18 +1072,6 @@ class ConfigHelper
     }
 
     /**
-     * Check if content should be prepared (plugins)
-     *
-     * @return  bool  True to prepare
-     *
-     * @since   6.0.0
-     */
-    public static function shouldPrepareContent(): bool
-    {
-        return (int) self::get('prepare_content', 0) === 1;
-    }
-
-    /**
      * Get the download ID for updates
      *
      * @return  string  Download ID


### PR DESCRIPTION
## Summary
Fixes #308

The `prepare_content` config option was a legacy toggle to "run content plugins on product descriptions." Since product descriptions are Joomla articles that already run content plugins natively, this option was redundant and never wired up (the helper method had zero callers).

## Changes
- Removed `prepare_content` radio switcher field from `config.xml`
- Removed unused `shouldPrepareContent()` method from `ConfigHelper.php`

## Files Modified
| Type | Count |
|------|-------|
| XML/Config | 1 |
| PHP files | 1 |

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only

## Test Plan
1. Navigate to J2Commerce > Configuration > Orders tab
2. Verify the "Prepare Content" radio switcher is no longer present
3. Save configuration — no errors