### PR TITLE
fix(shipping): move info cards above shipping methods table (fixes #345)

### DIFF
--- a/administrator/components/com_j2commerce/tmpl/shippingmethods/default.php
+++ b/administrator/components/com_j2commerce/tmpl/shippingmethods/default.php
@@ -47,6 +47,8 @@ HTMLHelper::_('bootstrap.tooltip', '[data-bs-toggle="tooltip"]', ['placement' =>
 
 <?php echo $this->navbar; ?>
 
+<?php echo $this->shippingCards; ?>
+
 <form action="<?php echo Route::_('index.php?option=com_j2commerce&view=shippingmethods'); ?>" method="post" name="adminForm" id="adminForm">
     <div class="row">
         <div class="col-md-12">
@@ -223,6 +225,4 @@ HTMLHelper::_('bootstrap.tooltip', '[data-bs-toggle="tooltip"]', ['placement' =>
         </div>
     </div>
 </form>
-<?php echo $this->shippingCards;?>
-
 <?php echo $this->footer ?? ''; ?>


### PR DESCRIPTION
## Summary

Fixes #345 — Moves the shipping method info/diagnostic cards from below the table (below the fold) to above the form, right after the navbar. Critical information is now the first thing store owners see.

## Changes

- `tmpl/shippingmethods/default.php` — moved `$this->shippingCards` from after the `</form>` to before the `<form>`, directly below the navbar

## Pre-Flight
- [x] PHP syntax check passed
- [x] Core file only (1 file)