### PR TITLE
fix(dashboard): initialize Bootstrap Offcanvas for setup wizard (fixes #339)

### DIFF
--- a/administrator/components/com_j2commerce/src/View/Dashboard/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Dashboard/HtmlView.php
@@ -212,6 +212,7 @@ class HtmlView extends BaseHtmlView
         Text::script('COM_J2COMMERCE_LOADING');
 
         if (!SetupGuideHelper::isComplete()) {
+            HTMLHelper::_('bootstrap.offcanvas', '#j2commerce-setup-guide');
             $wa->registerAndUseScript('com_j2commerce.setup-guide', 'media/com_j2commerce/js/administrator/setup-guide.js', [], ['defer' => true]);
             $wa->registerAndUseStyle('com_j2commerce.setup-guide.css', 'media/com_j2commerce/css/administrator/setup-guide.css');
             $this->getDocument()->addScriptOptions('com_j2commerce.setupGuide', [


### PR DESCRIPTION
## Summary
Fixes #339

## Changes
- Added `HTMLHelper::_('bootstrap.offcanvas', '#j2commerce-setup-guide')` in Dashboard HtmlView before `parent::display()`
- This loads Bootstrap's Offcanvas JS module so `bootstrap.Offcanvas.getOrCreateInstance()` works in both `setup-guide.js` and the toolbar button onclick handler

## Testing
1. Open admin dashboard
2. Click "Setup Wizard" button in toolbar
3. Verify: offcanvas slides open, no console errors
4. Verify: setup guide loads status and displays checklist

## Files Changed
- `administrator/components/com_j2commerce/src/View/Dashboard/HtmlView.php` — added HTMLHelper offcanvas init