### PR TITLE
fix(a11y): address PR #353 review feedback and restore build scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,10 @@
 !.gitignore
 !LICENSE.txt
 
+# Build scripts (package builder + install script)
+!build/
+!build/**
+
 # ===========================================================================
 # J2Commerce component files
 # Must un-ignore parent directories in order for negation to work

--- a/build/build_package.php
+++ b/build/build_package.php
@@ -1,0 +1,584 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * J2Commerce Package Builder
+ *
+ * Produces a Joomla 6 type="package" ZIP containing inner ZIPs for each
+ * sub-extension. Joomla's native package installer handles installation.
+ *
+ * @package     J2Commerce
+ * @subpackage  build
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+// ── Configuration ──────────────────────────────────────────────────────────────
+
+$joomlaRoot = dirname(__DIR__);
+$outputDir  = $joomlaRoot . '/docs/packages';
+$buildDir   = __DIR__;
+$tempDir    = sys_get_temp_dir() . '/j2commerce_pkg_build_' . time();
+
+// Read base version from j2commerce.xml manifest
+$manifestPath = $joomlaRoot . '/administrator/components/com_j2commerce/j2commerce.xml';
+$manifestContent = file_get_contents($manifestPath);
+if (!preg_match('/<version>([^<]+)<\/version>/', $manifestContent, $matches)) {
+    die("ERROR: Could not find <version> in j2commerce.xml\n");
+}
+$baseVersion = $matches[1];
+
+// Determine build number — scan for existing packages with same base version
+$baseVersionDashed = str_replace('.', '-', $baseVersion);
+$buildNum = 1;
+
+// Check both old com_ and new pkg_ patterns
+foreach (['com_j2commerce_', 'pkg_j2commerce_'] as $prefix) {
+    $existingFiles = glob($outputDir . '/' . $prefix . $baseVersionDashed . '_beta_*.zip');
+    if ($existingFiles) {
+        foreach ($existingFiles as $f) {
+            if (preg_match('/_beta_(\d+)\.zip$/', $f, $m)) {
+                $buildNum = max($buildNum, (int) $m[1] + 1);
+            }
+        }
+    }
+}
+
+// Version used in manifests — NO build number (per PRD)
+$version = $baseVersion;
+
+$excludePatterns = [
+    '.git', '.gitignore', '.github', '.claude',
+    'node_modules', 'tests', '__tests__',
+    '.DS_Store', 'Thumbs.db',
+    'composer.json', 'composer.lock',
+    'package.json', 'package-lock.json',
+    '.editorconfig', '.php-cs-fixer.php', 'phpunit.xml', 'phpcs.xml',
+    '.env', 'docs', 'build',
+    'vendorapply',
+];
+
+// ── Sub-extension definitions ─────────────────────────────────────────────────
+
+$plugins = [
+    ['group' => 'system',      'element' => 'j2commerce'],
+    ['group' => 'actionlog',   'element' => 'j2commerce'],
+    ['group' => 'console',     'element' => 'j2commerce'],
+    ['group' => 'content',     'element' => 'j2commerce'],
+    ['group' => 'finder',      'element' => 'j2commerce'],
+    ['group' => 'task',        'element' => 'j2commerce'],
+    ['group' => 'user',        'element' => 'j2commerce'],
+    ['group' => 'webservices', 'element' => 'j2commerce'],
+    ['group' => 'schemaorg',   'element' => 'ecommerce'],
+    ['group' => 'j2commerce', 'element' => 'app_bootstrap5'],
+    ['group' => 'j2commerce', 'element' => 'app_flexivariable'],
+    ['group' => 'j2commerce', 'element' => 'app_diagnostics'],
+    ['group' => 'j2commerce', 'element' => 'app_localization_data'],
+    ['group' => 'j2commerce', 'element' => 'app_currencyupdater'],
+    ['group' => 'j2commerce', 'element' => 'app_uikit'],
+    ['group' => 'j2commerce', 'element' => 'payment_cash'],
+    ['group' => 'j2commerce', 'element' => 'payment_moneyorder'],
+    ['group' => 'j2commerce', 'element' => 'payment_banktransfer'],
+    ['group' => 'j2commerce', 'element' => 'payment_paypal'],
+    ['group' => 'j2commerce', 'element' => 'shipping_standard'],
+    ['group' => 'j2commerce', 'element' => 'shipping_free'],
+    ['group' => 'j2commerce', 'element' => 'report_itemised'],
+    ['group' => 'j2commerce', 'element' => 'report_products'],
+];
+
+$adminModules = [
+    'mod_j2commerce_menu',
+    'mod_j2commerce_orders',
+    'mod_j2commerce_quickicons',
+    'mod_j2commerce_stats',
+];
+
+$siteModules = [
+    'mod_j2commerce_cart',
+    'mod_j2commerce_currency',
+    'mod_j2commerce_products',
+    'mod_j2commerce_relatedproducts',
+];
+
+// ── Helper Functions ───────────────────────────────────────────────────────────
+
+function shouldExclude(string $path, array $patterns): bool
+{
+    $parts = explode('/', str_replace('\\', '/', $path));
+    foreach ($parts as $part) {
+        if (in_array($part, $patterns, true)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function collectFiles(string $baseDir, array $excludePatterns, bool $excludeZips = false): array
+{
+    $files = [];
+    $baseDir = rtrim(str_replace('\\', '/', $baseDir), '/');
+
+    if (!is_dir($baseDir)) {
+        echo "  WARNING: Directory not found: {$baseDir}\n";
+        return $files;
+    }
+
+    $iterator = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($baseDir, RecursiveDirectoryIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::LEAVES_ONLY
+    );
+
+    foreach ($iterator as $file) {
+        $filePath = str_replace('\\', '/', $file->getPathname());
+        $relativePath = substr($filePath, strlen($baseDir) + 1);
+
+        if (shouldExclude($relativePath, $excludePatterns)) {
+            continue;
+        }
+
+        if ($excludeZips && strtolower(pathinfo($filePath, PATHINFO_EXTENSION)) === 'zip') {
+            continue;
+        }
+
+        $files[$relativePath] = $filePath;
+    }
+
+    return $files;
+}
+
+function stampVersion(string $xmlContent, string $version): string
+{
+    return preg_replace(
+        '/<version>[^<]*<\/version>/',
+        '<version>' . $version . '</version>',
+        $xmlContent
+    );
+}
+
+function stampVersionPhp(string $phpContent, string $version): string
+{
+    return preg_replace(
+        "/define\s*\(\s*['\"]J2COMMERCE_VERSION['\"]\s*,\s*['\"][^'\"]*['\"]\s*\)/",
+        "define('J2COMMERCE_VERSION', '" . $version . "')",
+        $phpContent
+    );
+}
+
+function stripUpdateServers(string $xmlContent): string
+{
+    return preg_replace('/<updateservers>.*?<\/updateservers>/s', '', $xmlContent);
+}
+
+function fixMediaFolder(string $xmlContent): string
+{
+    return str_replace(
+        '<media destination="com_j2commerce" folder="media">',
+        '<media destination="com_j2commerce" folder="media/com_j2commerce">',
+        $xmlContent
+    );
+}
+
+function formatSize(int $bytes): string
+{
+    if ($bytes >= 1048576) {
+        return sprintf('%.2f MB', $bytes / 1048576);
+    }
+    return sprintf('%.1f KB', $bytes / 1024);
+}
+
+function removeDir(string $dir): void
+{
+    if (!is_dir($dir)) return;
+    $items = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($dir, RecursiveDirectoryIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::CHILD_FIRST
+    );
+    foreach ($items as $item) {
+        $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+    }
+    rmdir($dir);
+}
+
+// ── SQL Alignment Validation ──────────────────────────────────────────────────
+
+function validateSqlAlignment(string $sqlDir, string $manifestVersion): void
+{
+    $files = glob($sqlDir . '/*.sql');
+    $highest = '0.0.0';
+
+    foreach ($files as $file) {
+        $ver = pathinfo($file, PATHINFO_FILENAME);
+        if (version_compare($ver, $highest, '>')) {
+            $highest = $ver;
+        }
+    }
+
+    // Treat sub-versions (6.1.3.6) as belonging to their parent (6.1.3)
+    // Only fail if the MAJOR.MINOR.PATCH exceeds the manifest
+    $highestParts = explode('.', $highest);
+    $highestBase = implode('.', array_slice($highestParts, 0, 3));
+
+    if (version_compare($highestBase, $manifestVersion, '>')) {
+        die(
+            "\nERROR: SQL alignment failure!\n" .
+            "  Highest SQL update file: {$highest}\n" .
+            "  Manifest version:        {$manifestVersion}\n" .
+            "  The highest SQL base version ({$highestBase}) exceeds the manifest version.\n" .
+            "  Bump the manifest version or remove/rename the SQL file.\n\n"
+        );
+    }
+
+    echo "SQL alignment OK: highest={$highest}, manifest={$manifestVersion}\n";
+}
+
+// ── Inner ZIP Builders ────────────────────────────────────────────────────────
+
+function buildComponentZip(string $joomlaRoot, string $tempDir, string $version, array $excludePatterns): string
+{
+    $zipPath = $tempDir . '/com_j2commerce.zip';
+    $zip = new ZipArchive();
+    if ($zip->open($zipPath, ZipArchive::CREATE) !== true) {
+        die("ERROR: Failed to create {$zipPath}\n");
+    }
+
+    $adminDir = $joomlaRoot . '/administrator/components/com_j2commerce';
+    $count = 0;
+
+    // 1. Manifest at root (version-stamped, update servers stripped, media folder fixed)
+    $manifestContent = file_get_contents($adminDir . '/j2commerce.xml');
+    $manifestContent = stampVersion($manifestContent, $version);
+    $manifestContent = stripUpdateServers($manifestContent);
+    $manifestContent = fixMediaFolder($manifestContent);
+    $zip->addFromString('j2commerce.xml', $manifestContent);
+    $count++;
+
+    // 2. Script at root
+    $scriptPath = $adminDir . '/script.j2commerce.php';
+    if (file_exists($scriptPath)) {
+        $zip->addFile($scriptPath, 'script.j2commerce.php');
+        $count++;
+    }
+
+    // 3. Admin component files (excluding manifest and script already at root)
+    $skipRootFiles = ['j2commerce.xml', 'script.j2commerce.php'];
+    $adminFiles = collectFiles($adminDir, $excludePatterns);
+
+    foreach ($adminFiles as $rel => $absPath) {
+        if (in_array($rel, $skipRootFiles, true)) {
+            continue;
+        }
+        if ($rel === 'version.php') {
+            $content = file_get_contents($absPath);
+            $content = stampVersionPhp($content, $version);
+            $zip->addFromString('administrator/components/com_j2commerce/' . $rel, $content);
+        } else {
+            $zip->addFile($absPath, 'administrator/components/com_j2commerce/' . $rel);
+        }
+        $count++;
+    }
+
+    // 4. Site component files
+    $siteDir = $joomlaRoot . '/components/com_j2commerce';
+    $siteFiles = collectFiles($siteDir, $excludePatterns);
+    foreach ($siteFiles as $rel => $absPath) {
+        $zip->addFile($absPath, 'components/com_j2commerce/' . $rel);
+        $count++;
+    }
+
+    // 5. Media files
+    $mediaDir = $joomlaRoot . '/media/com_j2commerce';
+    $mediaFiles = collectFiles($mediaDir, $excludePatterns);
+    foreach ($mediaFiles as $rel => $absPath) {
+        $zip->addFile($absPath, 'media/com_j2commerce/' . $rel);
+        $count++;
+    }
+
+    $zip->close();
+    echo "  com_j2commerce.zip ({$count} files)\n";
+    return $zipPath;
+}
+
+function buildPluginZip(string $joomlaRoot, string $tempDir, string $group, string $element, string $version, array $excludePatterns): ?string
+{
+    $sourceDir = $joomlaRoot . '/plugins/' . $group . '/' . $element;
+    if (!is_dir($sourceDir)) {
+        echo "  WARNING: Plugin not found: {$group}/{$element}\n";
+        return null;
+    }
+
+    $zipName = 'plg_' . $group . '_' . $element . '.zip';
+    $zipPath = $tempDir . '/' . $zipName;
+    $zip = new ZipArchive();
+    if ($zip->open($zipPath, ZipArchive::CREATE) !== true) {
+        die("ERROR: Failed to create {$zipPath}\n");
+    }
+
+    $files = collectFiles($sourceDir, $excludePatterns, true);
+    $count = 0;
+
+    foreach ($files as $rel => $absPath) {
+        if (preg_match('/^[^\/]+\.xml$/', $rel)) {
+            $content = file_get_contents($absPath);
+            $content = stampVersion($content, $version);
+            $content = stripUpdateServers($content);
+            $zip->addFromString($rel, $content);
+        } else {
+            $zip->addFile($absPath, $rel);
+        }
+        $count++;
+    }
+
+    $zip->close();
+    echo "  {$zipName} ({$count} files)\n";
+    return $zipPath;
+}
+
+function buildModuleZip(string $joomlaRoot, string $tempDir, string $module, string $client, string $version, array $excludePatterns): ?string
+{
+    $sourceDir = ($client === 'administrator')
+        ? $joomlaRoot . '/administrator/modules/' . $module
+        : $joomlaRoot . '/modules/' . $module;
+
+    if (!is_dir($sourceDir)) {
+        echo "  WARNING: Module not found: {$module} (client={$client})\n";
+        return null;
+    }
+
+    $zipPath = $tempDir . '/' . $module . '.zip';
+    $zip = new ZipArchive();
+    if ($zip->open($zipPath, ZipArchive::CREATE) !== true) {
+        die("ERROR: Failed to create {$zipPath}\n");
+    }
+
+    $files = collectFiles($sourceDir, $excludePatterns);
+    $count = 0;
+
+    foreach ($files as $rel => $absPath) {
+        if (preg_match('/^[^\/]+\.xml$/', $rel)) {
+            $content = file_get_contents($absPath);
+            $content = stampVersion($content, $version);
+            $zip->addFromString($rel, $content);
+        } else {
+            $zip->addFile($absPath, $rel);
+        }
+        $count++;
+    }
+
+    $zip->close();
+    echo "  {$module}.zip ({$count} files)\n";
+    return $zipPath;
+}
+
+function buildLibraryZip(string $joomlaRoot, string $tempDir, string $version, array $excludePatterns): string
+{
+    $sourceDir = $joomlaRoot . '/libraries/j2commerce';
+    $zipPath = $tempDir . '/lib_j2commerce.zip';
+    $zip = new ZipArchive();
+    if ($zip->open($zipPath, ZipArchive::CREATE) !== true) {
+        die("ERROR: Failed to create {$zipPath}\n");
+    }
+
+    $files = collectFiles($sourceDir, $excludePatterns);
+    $count = 0;
+
+    foreach ($files as $rel => $absPath) {
+        if (preg_match('/^[^\/]+\.xml$/', $rel)) {
+            $content = file_get_contents($absPath);
+            $content = stampVersion($content, $version);
+            $zip->addFromString($rel, $content);
+        } else {
+            $zip->addFile($absPath, $rel);
+        }
+        $count++;
+    }
+
+    $zip->close();
+    echo "  lib_j2commerce.zip ({$count} files)\n";
+    return $zipPath;
+}
+
+// ── Package Manifest Generator ────────────────────────────────────────────────
+
+function createPackageManifest(string $version, array $plugins, array $adminModules, array $siteModules): string
+{
+    $xml = '<?xml version="1.0" encoding="utf-8"?>' . "\n";
+    $xml .= '<extension type="package" method="upgrade">' . "\n";
+    $xml .= '    <name>J2Commerce</name>' . "\n";
+    $xml .= '    <packagename>j2commerce</packagename>' . "\n";
+    $xml .= '    <author>J2Commerce, LLC</author>' . "\n";
+    $xml .= '    <creationDate>' . date('Y-m') . '</creationDate>' . "\n";
+    $xml .= '    <copyright>(C)2024-2026 J2Commerce, LLC. All rights reserved.</copyright>' . "\n";
+    $xml .= '    <authorEmail>support@j2commerce.com</authorEmail>' . "\n";
+    $xml .= '    <authorUrl>https://www.j2commerce.com</authorUrl>' . "\n";
+    $xml .= '    <version>' . $version . '</version>' . "\n";
+    $xml .= '    <license>GNU General Public License version 2 or later; see LICENSE.txt</license>' . "\n";
+    $xml .= '    <description>PKG_J2COMMERCE_DESCRIPTION</description>' . "\n";
+    $xml .= "\n";
+    $xml .= '    <blockChildUninstall>true</blockChildUninstall>' . "\n";
+    $xml .= '    <scriptfile>script.pkg_j2commerce.php</scriptfile>' . "\n";
+    $xml .= "\n";
+    $xml .= '    <files>' . "\n";
+
+    // Component first
+    $xml .= '        <file type="component" id="com_j2commerce">com_j2commerce.zip</file>' . "\n";
+
+    // Library
+    $xml .= '        <file type="library" id="j2commerce">lib_j2commerce.zip</file>' . "\n";
+
+    // Plugins
+    foreach ($plugins as $p) {
+        $group = $p['group'];
+        $element = $p['element'];
+        $zipName = 'plg_' . $group . '_' . $element . '.zip';
+        $xml .= '        <file type="plugin" group="' . $group . '" id="' . $element . '">' . $zipName . '</file>' . "\n";
+    }
+
+    // Admin modules
+    foreach ($adminModules as $mod) {
+        $xml .= '        <file type="module" id="' . $mod . '" client="administrator">' . $mod . '.zip</file>' . "\n";
+    }
+
+    // Site modules
+    foreach ($siteModules as $mod) {
+        $xml .= '        <file type="module" id="' . $mod . '" client="site">' . $mod . '.zip</file>' . "\n";
+    }
+
+    $xml .= '    </files>' . "\n";
+    $xml .= "\n";
+    $xml .= '    <languages folder="language">' . "\n";
+    $xml .= '        <language tag="en-GB">en-GB/pkg_j2commerce.sys.ini</language>' . "\n";
+    $xml .= '    </languages>' . "\n";
+    $xml .= "\n";
+    $xml .= '    <updateservers>' . "\n";
+    $xml .= '        <server type="extension" priority="1" name="J2Commerce Package Updates">' . "\n";
+    $xml .= '            https://updates.j2commerce.com/pkg_j2commerce.xml' . "\n";
+    $xml .= '        </server>' . "\n";
+    $xml .= '    </updateservers>' . "\n";
+    $xml .= '</extension>' . "\n";
+
+    return $xml;
+}
+
+// ── Main Build ─────────────────────────────────────────────────────────────────
+
+echo "\n=== J2Commerce Package Builder (type=package) ===\n";
+echo "Version: {$version}\n";
+echo "Build Number: {$buildNum}\n";
+echo "Joomla Root: {$joomlaRoot}\n\n";
+
+@mkdir($outputDir, 0777, true);
+@mkdir($tempDir, 0777, true);
+
+// Validate SQL alignment
+$sqlDir = $joomlaRoot . '/administrator/components/com_j2commerce/sql/updates/mysql';
+validateSqlAlignment($sqlDir, $version);
+
+$finalZipName = "pkg_j2commerce_{$baseVersionDashed}_beta_{$buildNum}.zip";
+$finalZipPath = $outputDir . '/' . $finalZipName;
+echo "\nBuilding: {$finalZipName}\n\n";
+
+$innerZips = [];
+$totalFiles = 0;
+
+// ── 1. Build inner ZIPs ──────────────────────────────────────────────────────
+
+echo "Building component ZIP...\n";
+$innerZips[] = buildComponentZip($joomlaRoot, $tempDir, $version, $excludePatterns);
+
+echo "\nBuilding library ZIP...\n";
+$innerZips[] = buildLibraryZip($joomlaRoot, $tempDir, $version, $excludePatterns);
+
+echo "\nBuilding plugin ZIPs...\n";
+$pluginZipCount = 0;
+foreach ($plugins as $plugin) {
+    $result = buildPluginZip($joomlaRoot, $tempDir, $plugin['group'], $plugin['element'], $version, $excludePatterns);
+    if ($result) {
+        $innerZips[] = $result;
+        $pluginZipCount++;
+    }
+}
+
+echo "\nBuilding admin module ZIPs...\n";
+foreach ($adminModules as $module) {
+    $result = buildModuleZip($joomlaRoot, $tempDir, $module, 'administrator', $version, $excludePatterns);
+    if ($result) {
+        $innerZips[] = $result;
+    }
+}
+
+echo "\nBuilding site module ZIPs...\n";
+foreach ($siteModules as $module) {
+    $result = buildModuleZip($joomlaRoot, $tempDir, $module, 'site', $version, $excludePatterns);
+    if ($result) {
+        $innerZips[] = $result;
+    }
+}
+
+// ── 2. Assemble outer package ZIP ─────────────────────────────────────────────
+
+echo "\nAssembling package ZIP...\n";
+
+$outerZip = new ZipArchive();
+if ($outerZip->open($finalZipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE) !== true) {
+    die("ERROR: Failed to create {$finalZipPath}\n");
+}
+
+// Package manifest (generated)
+$pkgManifest = createPackageManifest($version, $plugins, $adminModules, $siteModules);
+$outerZip->addFromString('pkg_j2commerce.xml', $pkgManifest);
+
+// Package install script
+$pkgScript = $buildDir . '/script.pkg_j2commerce.php';
+if (file_exists($pkgScript)) {
+    $outerZip->addFile($pkgScript, 'script.pkg_j2commerce.php');
+} else {
+    echo "  WARNING: Package script not found at {$pkgScript}\n";
+}
+
+// Package language file
+$pkgLang = $buildDir . '/language/en-GB/pkg_j2commerce.sys.ini';
+if (file_exists($pkgLang)) {
+    $outerZip->addFile($pkgLang, 'language/en-GB/pkg_j2commerce.sys.ini');
+} else {
+    echo "  WARNING: Package language file not found at {$pkgLang}\n";
+}
+
+// Add all inner ZIPs (flat, at package root)
+foreach ($innerZips as $innerZipPath) {
+    $name = basename($innerZipPath);
+    $outerZip->addFile($innerZipPath, $name);
+}
+
+$outerZip->close();
+
+// ── 3. Summary ────────────────────────────────────────────────────────────────
+
+$totalSize = filesize($finalZipPath);
+$innerCount = count($innerZips);
+$extTotal = 1 + 1 + $pluginZipCount + count($adminModules) + count($siteModules); // component + library + plugins + modules
+
+echo "\n╔══════════════════════════════════════════════════════════════╗\n";
+echo "║                  PACKAGE BUILD SUMMARY                      ║\n";
+echo "╠══════════════════════════════════════════════════════════════╣\n";
+printf("║  Package Type:    %-40s ║\n", "type=\"package\" (Joomla native)");
+printf("║  Build Number:    %-40s ║\n", $buildNum);
+printf("║  Version:         %-40s ║\n", $version);
+printf("║  Extensions:      %-40s ║\n", $extTotal . " (1 component + 1 library + " . $pluginZipCount . " plugins + " . (count($adminModules) + count($siteModules)) . " modules)");
+printf("║  Inner ZIPs:      %-40s ║\n", $innerCount);
+printf("║  Total Size:      %-40s ║\n", formatSize($totalSize));
+printf("║  Output:          %-40s ║\n", $finalZipName);
+echo "╠══════════════════════════════════════════════════════════════╣\n";
+echo "║  Inner ZIP Breakdown:                                       ║\n";
+printf("║    %-42s %10s ║\n", "Component (com_j2commerce.zip)", "1");
+printf("║    %-42s %10s ║\n", "Library (lib_j2commerce.zip)", "1");
+printf("║    %-42s %10s ║\n", "Plugin ZIPs", $pluginZipCount);
+printf("║    %-42s %10s ║\n", "Admin module ZIPs", count($adminModules));
+printf("║    %-42s %10s ║\n", "Site module ZIPs", count($siteModules));
+echo "╚══════════════════════════════════════════════════════════════╝\n";
+
+// Clean up temp directory
+removeDir($tempDir);
+
+echo "\nPackage ready: {$finalZipPath}\n";

--- a/build/script.pkg_j2commerce.php
+++ b/build/script.pkg_j2commerce.php
@@ -1,0 +1,505 @@
+<?php
+
+declare(strict_types=1);
+
+\defined('_JEXEC') or die;
+
+use Joomla\CMS\Factory;
+use Joomla\CMS\Installer\InstallerScript;
+use Joomla\CMS\Log\Log;
+use Joomla\Database\DatabaseInterface;
+use Joomla\Database\ParameterType;
+use Joomla\Registry\Registry;
+
+class Pkg_J2commerceInstallerScript extends InstallerScript
+{
+    protected $minimumJoomlaVersion = '6.0';
+    protected $minimumPhpVersion = '8.1';
+    private string $debugLogFile = '';
+
+    /**
+     * Plugin enable/disable configuration.
+     * Joomla installs all plugins as disabled by default.
+     * [group, element, enableOnFreshInstall]
+     */
+    private array $pluginConfig = [
+        ['system',      'j2commerce',           true],
+        ['actionlog',   'j2commerce',           true],
+        ['console',     'j2commerce',           true],
+        ['content',     'j2commerce',           true],
+        ['finder',      'j2commerce',           true],
+        ['task',        'j2commerce',           true],
+        ['user',        'j2commerce',           false],
+        ['webservices', 'j2commerce',           true],
+        ['schemaorg',   'ecommerce',            true],
+        ['j2commerce',  'app_bootstrap5',       true],
+        ['j2commerce',  'app_flexivariable',    true],
+        ['j2commerce',  'app_diagnostics',      true],
+        ['j2commerce',  'app_localization_data', true],
+        ['j2commerce',  'app_currencyupdater',  true],
+        ['j2commerce',  'app_uikit',            true],
+        ['j2commerce',  'payment_cash',         true],
+        ['j2commerce',  'payment_moneyorder',   true],
+        ['j2commerce',  'payment_banktransfer', true],
+        ['j2commerce',  'payment_paypal',       false],
+        ['j2commerce',  'shipping_standard',    true],
+        ['j2commerce',  'shipping_free',        true],
+        ['j2commerce',  'report_itemised',      true],
+        ['j2commerce',  'report_products',      true],
+    ];
+
+    /**
+     * Module configuration for fresh installs.
+     * [element, client_id (1=admin, 0=site), position, published, params]
+     */
+    private array $moduleConfig = [
+        ['mod_j2commerce_menu',       1, 'status', 1, []],
+        ['mod_j2commerce_orders',     1, 'j2commerce-dashboard-module-side-tab', 1, [
+            'limit' => 5,
+            'filter_status' => ['1'],
+        ]],
+        ['mod_j2commerce_quickicons', 1, 'icon', 1, [
+            'show_dashboard'    => 1,
+            'show_orders'       => 1,
+            'show_products'     => 1,
+            'show_customers'    => 0,
+            'show_apps'         => 1,
+            'show_payment'      => 0,
+            'show_shipping'     => 0,
+            'show_statistics'   => 1,
+            'show_reports'      => 0,
+            'show_config'       => 1,
+            'show_plugin_icons' => 1,
+        ]],
+        ['mod_j2commerce_stats',      1, 'j2commerce-dashboard-main-tab', 1, [
+            'order_status' => ['1', '2', '7'],
+        ]],
+        ['mod_j2commerce_cart',              0, '', 0, []],
+        ['mod_j2commerce_currency',          0, '', 0, []],
+        ['mod_j2commerce_products',          0, '', 0, []],
+        ['mod_j2commerce_relatedproducts',   0, '', 0, []],
+    ];
+
+    /**
+     * Additional module instances for fresh installs (second quickicons on J2Commerce dashboard).
+     */
+    private array $additionalModuleInstances = [
+        [
+            'module'   => 'mod_j2commerce_quickicons',
+            'position' => 'j2commerce-dashboard-module-main-tab',
+            'params'   => [
+                'show_dashboard'    => 0,
+                'show_orders'       => 1,
+                'show_products'     => 1,
+                'show_customers'    => 1,
+                'show_apps'         => 1,
+                'show_payment'      => 1,
+                'show_shipping'     => 1,
+                'show_statistics'   => 1,
+                'show_reports'      => 1,
+                'show_config'       => 1,
+                'show_plugin_icons' => 0,
+            ],
+        ],
+    ];
+
+    private function debugLog(string $message): void
+    {
+        if (!$this->debugLogFile) {
+            $this->debugLogFile = JPATH_ROOT . '/tmp/j2commerce_install_debug.log';
+        }
+        file_put_contents($this->debugLogFile, date('[Y-m-d H:i:s] ') . $message . "\n", FILE_APPEND);
+    }
+
+    public function preflight($route, $parent)
+    {
+        $this->debugLog("=== PKG PREFLIGHT START (route={$route}) ===");
+
+        if (version_compare(JVERSION, '6.0.0', '<')) {
+            Log::add('J2Commerce requires Joomla 6.0.0 or later. Your version: ' . JVERSION, Log::WARNING, 'jerror');
+            return false;
+        }
+
+        if (!\function_exists('curl_init') || !\is_callable('curl_init')) {
+            Log::add('cURL extension is not enabled in your PHP installation.', Log::WARNING, 'jerror');
+            return false;
+        }
+
+        if (!\function_exists('json_encode')) {
+            Log::add('JSON extension is not enabled in your PHP installation.', Log::WARNING, 'jerror');
+            return false;
+        }
+
+        $this->debugLog("PKG PREFLIGHT: passed all checks");
+        return true;
+    }
+
+    public function postflight($route, $parent)
+    {
+        $this->debugLog("=== PKG POSTFLIGHT START (route={$route}) ===");
+
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
+
+        if ($route === 'install') {
+            $this->debugLog("PKG POSTFLIGHT: fresh install");
+            $this->enablePlugins($db);
+            $this->configureModules($db);
+            $this->createAdditionalModuleInstances($db);
+        } elseif ($route === 'update') {
+            $this->enableNewPlugins($db);
+            $this->migrateLeafletParams($db);
+            $this->migrateUppymediaParams($db);
+        }
+
+        // Clear autoload cache so new namespaces are discovered
+        $cacheFile = JPATH_ADMINISTRATOR . '/cache/autoload_psr4.php';
+        if (file_exists($cacheFile)) {
+            @unlink($cacheFile);
+        }
+
+        $this->debugLog("=== PKG POSTFLIGHT END ===");
+    }
+
+    /**
+     * Enable all plugins marked for auto-enable on fresh install.
+     */
+    private function enablePlugins(DatabaseInterface $db): void
+    {
+        foreach ($this->pluginConfig as [$group, $element, $enable]) {
+            if (!$enable) {
+                continue;
+            }
+
+            $this->enablePlugin($db, $group, $element);
+        }
+    }
+
+    /**
+     * Enable only plugins that are freshly discovered (enabled = -1).
+     * Does not override user's manual disable.
+     */
+    private function enableNewPlugins(DatabaseInterface $db): void
+    {
+        foreach ($this->pluginConfig as [$group, $element, $enable]) {
+            if (!$enable) {
+                continue;
+            }
+
+            $this->enablePluginIfNew($db, $group, $element);
+        }
+    }
+
+    private function enablePlugin(DatabaseInterface $db, string $group, string $element): void
+    {
+        $query = $db->getQuery(true)
+            ->update($db->quoteName('#__extensions'))
+            ->set($db->quoteName('enabled') . ' = 1')
+            ->where($db->quoteName('type') . ' = ' . $db->quote('plugin'))
+            ->where($db->quoteName('folder') . ' = :group')
+            ->where($db->quoteName('element') . ' = :element')
+            ->bind(':group', $group)
+            ->bind(':element', $element);
+
+        $db->setQuery($query)->execute();
+        $this->debugLog("ENABLE PLUGIN: {$group}/{$element}");
+    }
+
+    /**
+     * Enable a plugin only if it is in the newly-discovered state (enabled = -1).
+     * Plugins the user has explicitly disabled (enabled = 0) are left alone.
+     */
+    private function enablePluginIfNew(DatabaseInterface $db, string $group, string $element): void
+    {
+        $disabled = -1;
+        $query = $db->getQuery(true)
+            ->update($db->quoteName('#__extensions'))
+            ->set($db->quoteName('enabled') . ' = 1')
+            ->where($db->quoteName('type') . ' = ' . $db->quote('plugin'))
+            ->where($db->quoteName('folder') . ' = :group')
+            ->where($db->quoteName('element') . ' = :element')
+            ->where($db->quoteName('enabled') . ' = :disabled')
+            ->bind(':group', $group)
+            ->bind(':element', $element)
+            ->bind(':disabled', $disabled, ParameterType::INTEGER);
+
+        $db->setQuery($query)->execute();
+
+        if ($db->getAffectedRows() > 0) {
+            $this->debugLog("ENABLE NEW PLUGIN: {$group}/{$element}");
+        }
+    }
+
+    /**
+     * Configure module positions, published state, and params on fresh install.
+     */
+    private function configureModules(DatabaseInterface $db): void
+    {
+        foreach ($this->moduleConfig as [$element, $clientId, $position, $published, $params]) {
+            $this->configureModule($db, $element, $clientId, $position, $published, $params);
+        }
+    }
+
+    private function configureModule(
+        DatabaseInterface $db,
+        string $element,
+        int $clientId,
+        string $position,
+        int $published,
+        array $params
+    ): void {
+        // Find the module
+        $query = $db->getQuery(true)
+            ->select($db->quoteName('id'))
+            ->from($db->quoteName('#__modules'))
+            ->where($db->quoteName('module') . ' = :element')
+            ->where($db->quoteName('client_id') . ' = :client')
+            ->bind(':element', $element)
+            ->bind(':client', $clientId, ParameterType::INTEGER)
+            ->setLimit(1);
+
+        $moduleId = (int) $db->setQuery($query)->loadResult();
+
+        if ($moduleId === 0) {
+            $this->debugLog("CONFIGURE MODULE: {$element} not found, skipping");
+            return;
+        }
+
+        // Update position, published, params
+        $paramsJson = !empty($params) ? json_encode($params) : '{}';
+
+        $update = $db->getQuery(true)
+            ->update($db->quoteName('#__modules'))
+            ->where($db->quoteName('id') . ' = :id')
+            ->bind(':id', $moduleId, ParameterType::INTEGER);
+
+        if ($position !== '') {
+            $update->set($db->quoteName('position') . ' = ' . $db->quote($position));
+        }
+
+        $update->set($db->quoteName('published') . ' = ' . (int) $published);
+
+        if (!empty($params)) {
+            $update->set($db->quoteName('params') . ' = ' . $db->quote($paramsJson));
+        }
+
+        $db->setQuery($update)->execute();
+        $this->debugLog("CONFIGURE MODULE: {$element} → position={$position}, published={$published}");
+
+        // Assign to all pages
+        $this->assignModuleToAllPages($db, $moduleId);
+    }
+
+    private function assignModuleToAllPages(DatabaseInterface $db, int $moduleId): void
+    {
+        // Check if already assigned
+        $query = $db->getQuery(true)
+            ->select('COUNT(*)')
+            ->from($db->quoteName('#__modules_menu'))
+            ->where($db->quoteName('moduleid') . ' = :id')
+            ->bind(':id', $moduleId, ParameterType::INTEGER);
+
+        if ((int) $db->setQuery($query)->loadResult() > 0) {
+            return;
+        }
+
+        // Assign to all pages (menuid = 0)
+        $obj = (object) [
+            'moduleid' => $moduleId,
+            'menuid'   => 0,
+        ];
+        $db->insertObject('#__modules_menu', $obj);
+        $this->debugLog("ASSIGN MODULE: id={$moduleId} to all pages");
+    }
+
+    /**
+     * Create additional module instances (e.g., second quickicons for J2Commerce dashboard).
+     */
+    private function createAdditionalModuleInstances(DatabaseInterface $db): void
+    {
+        foreach ($this->additionalModuleInstances as $config) {
+            $module   = $config['module'];
+            $position = $config['position'];
+            $params   = $config['params'];
+
+            // Check if an instance with this position already exists
+            $query = $db->getQuery(true)
+                ->select('COUNT(*)')
+                ->from($db->quoteName('#__modules'))
+                ->where($db->quoteName('module') . ' = :module')
+                ->where($db->quoteName('position') . ' = :position')
+                ->bind(':module', $module)
+                ->bind(':position', $position);
+
+            if ((int) $db->setQuery($query)->loadResult() > 0) {
+                $this->debugLog("ADDITIONAL MODULE: {$module} at {$position} already exists, skipping");
+                continue;
+            }
+
+            // Find the original module to clone its basic properties
+            $clientId = 1;
+            $query = $db->getQuery(true)
+                ->select([$db->quoteName('title'), $db->quoteName('access'), $db->quoteName('language')])
+                ->from($db->quoteName('#__modules'))
+                ->where($db->quoteName('module') . ' = :module')
+                ->where($db->quoteName('client_id') . ' = :client')
+                ->bind(':module', $module)
+                ->bind(':client', $clientId, ParameterType::INTEGER)
+                ->setLimit(1);
+
+            $original = $db->setQuery($query)->loadObject();
+
+            if (!$original) {
+                $this->debugLog("ADDITIONAL MODULE: original {$module} not found, skipping");
+                continue;
+            }
+
+            // Create the new instance
+            $obj = (object) [
+                'title'      => $original->title,
+                'module'     => $module,
+                'position'   => $position,
+                'published'  => 1,
+                'client_id'  => $clientId,
+                'access'     => $original->access ?? 1,
+                'ordering'   => 0,
+                'language'   => $original->language ?? '*',
+                'params'     => json_encode($params),
+            ];
+
+            $db->insertObject('#__modules', $obj, 'id');
+            $newId = (int) $obj->id;
+            $this->debugLog("ADDITIONAL MODULE: created {$module} at {$position} (id={$newId})");
+
+            // Assign to all pages
+            $this->assignModuleToAllPages($db, $newId);
+        }
+    }
+
+    /**
+     * Migrate leaflet plugin params to system/j2commerce plugin.
+     */
+    private function migrateLeafletParams(DatabaseInterface $db): void
+    {
+        $query = $db->getQuery(true)
+            ->select([$db->quoteName('extension_id'), $db->quoteName('params')])
+            ->from($db->quoteName('#__extensions'))
+            ->where($db->quoteName('element') . ' = ' . $db->quote('leafletmap'))
+            ->where($db->quoteName('folder') . ' = ' . $db->quote('system'))
+            ->where($db->quoteName('type') . ' = ' . $db->quote('plugin'));
+
+        try {
+            $leaflet = $db->setQuery($query)->loadObject();
+        } catch (\Throwable $e) {
+            return;
+        }
+
+        if (!$leaflet) {
+            return;
+        }
+
+        $oldParams = new Registry($leaflet->params ?? '{}');
+
+        $query = $db->getQuery(true)
+            ->select([$db->quoteName('extension_id'), $db->quoteName('params')])
+            ->from($db->quoteName('#__extensions'))
+            ->where($db->quoteName('element') . ' = ' . $db->quote('j2commerce'))
+            ->where($db->quoteName('folder') . ' = ' . $db->quote('system'))
+            ->where($db->quoteName('type') . ' = ' . $db->quote('plugin'));
+
+        $target = $db->setQuery($query)->loadObject();
+
+        if (!$target) {
+            return;
+        }
+
+        $targetParams = new Registry($target->params ?? '{}');
+        $migrated = false;
+
+        foreach (['leaflet_enabled', 'leaflet_provider', 'leaflet_custom_url'] as $key) {
+            $val = $oldParams->get($key);
+
+            if ($val !== null && $targetParams->get($key) === null) {
+                $targetParams->set($key, $val);
+                $migrated = true;
+            }
+        }
+
+        if ($migrated) {
+            $paramsJson = $targetParams->toString();
+            $extId      = (int) $target->extension_id;
+
+            $update = $db->getQuery(true)
+                ->update($db->quoteName('#__extensions'))
+                ->set($db->quoteName('params') . ' = :params')
+                ->where($db->quoteName('extension_id') . ' = :id')
+                ->bind(':params', $paramsJson)
+                ->bind(':id', $extId, ParameterType::INTEGER);
+
+            $db->setQuery($update)->execute();
+            $this->debugLog("MIGRATE LEAFLET: params migrated to system/j2commerce");
+        }
+    }
+
+    /**
+     * Migrate uppymedia filesystem plugin params to component config.
+     */
+    private function migrateUppymediaParams(DatabaseInterface $db): void
+    {
+        $query = $db->getQuery(true)
+            ->select([$db->quoteName('extension_id'), $db->quoteName('params')])
+            ->from($db->quoteName('#__extensions'))
+            ->where($db->quoteName('element') . ' = ' . $db->quote('uppymedia'))
+            ->where($db->quoteName('folder') . ' = ' . $db->quote('filesystem'))
+            ->where($db->quoteName('type') . ' = ' . $db->quote('plugin'));
+
+        try {
+            $plugin = $db->setQuery($query)->loadObject();
+        } catch (\Throwable $e) {
+            return;
+        }
+
+        if (!$plugin) {
+            return;
+        }
+
+        $pluginParams = new Registry($plugin->params ?? '{}');
+        $maxSize = $pluginParams->get('max_file_size');
+
+        if ($maxSize === null) {
+            return;
+        }
+
+        // Load component config
+        $query = $db->getQuery(true)
+            ->select([$db->quoteName('extension_id'), $db->quoteName('params')])
+            ->from($db->quoteName('#__extensions'))
+            ->where($db->quoteName('element') . ' = ' . $db->quote('com_j2commerce'))
+            ->where($db->quoteName('type') . ' = ' . $db->quote('component'));
+
+        $component = $db->setQuery($query)->loadObject();
+
+        if (!$component) {
+            return;
+        }
+
+        $compParams = new Registry($component->params ?? '{}');
+
+        if ($compParams->get('upload_max_file_size') !== null) {
+            return;
+        }
+
+        $compParams->set('upload_max_file_size', $maxSize);
+        $paramsJson = $compParams->toString();
+        $extId      = (int) $component->extension_id;
+
+        $update = $db->getQuery(true)
+            ->update($db->quoteName('#__extensions'))
+            ->set($db->quoteName('params') . ' = :params')
+            ->where($db->quoteName('extension_id') . ' = :id')
+            ->bind(':params', $paramsJson)
+            ->bind(':id', $extId, ParameterType::INTEGER);
+
+        $db->setQuery($update)->execute();
+        $this->debugLog("MIGRATE UPPYMEDIA: max_file_size migrated to component config");
+    }
+}

--- a/components/com_j2commerce/tmpl/myprofile/default_payment_methods.php
+++ b/components/com_j2commerce/tmpl/myprofile/default_payment_methods.php
@@ -47,7 +47,7 @@ $csrfToken = Session::getFormToken();
                             $lastFour = htmlspecialchars($method->last4, ENT_QUOTES, 'UTF-8');
                             ?>
                             <div class="j2commerce-payment-method mb-3">
-                                <div class="border py-3 px-4 rounded-3 mb-3 j2commerce-payment-card" data-provider="<?php echo htmlspecialchars($method->provider, ENT_QUOTES, 'UTF-8'); ?>" data-method-id="<?php echo htmlspecialchars($method->id, ENT_QUOTES, 'UTF-8'); ?>">
+                                <div class="border py-3 px-4 rounded-3 mb-3 j2commerce-payment-card" data-provider="<?php echo htmlspecialchars($method->provider, ENT_QUOTES, 'UTF-8'); ?>" data-method-id="<?php echo (int) $method->id; ?>">
                                     <div class="j2commerce-payment-method-inner d-flex justify-content-between align-items-center">
                                         <div class="j2commerce-payment-method-details d-flex align-items-center">
                                             <?php if($method->getBrandIcon()):?>
@@ -72,19 +72,18 @@ $csrfToken = Session::getFormToken();
                                         </div>
                                         <div class="d-flex align-items-center">
                                         <span class="dropdown dropstart">
-                                           <button type="button" class="btn btn-link text-reset dropdown-toggle p-0" id="paymentDropdown<?php echo htmlspecialchars($method->id, ENT_QUOTES, 'UTF-8'); ?>" data-bs-toggle="dropdown" data-bs-offset="-20,20" aria-expanded="false" aria-label="<?php echo Text::_('COM_J2COMMERCE_ACTIONS'); ?>">
+                                           <button type="button" class="btn btn-link text-reset dropdown-toggle p-0" id="paymentDropdown<?php echo (int) $method->id; ?>" data-bs-toggle="dropdown" data-bs-offset="-20,20" aria-expanded="false" aria-label="<?php echo Text::_('COM_J2COMMERCE_ACTIONS'); ?>">
                                               <span class="fa-solid fa-ellipsis-vertical" aria-hidden="true"></span>
-                                              <span class="visually-hidden"><?php echo Text::_('COM_J2COMMERCE_ACTIONS'); ?></span>
                                            </button>
-                                           <span class="dropdown-menu" aria-labelledby="paymentDropdown<?php echo htmlspecialchars($method->id, ENT_QUOTES, 'UTF-8'); ?>">
+                                           <span class="dropdown-menu" aria-labelledby="paymentDropdown<?php echo (int) $method->id; ?>">
                                               <?php if ($method->canDelete()) : ?>
-                                                <a role="button" class="dropdown-item j2commerce-delete-card-btn" href="#" data-provider="<?php echo htmlspecialchars($method->provider, ENT_QUOTES, 'UTF-8'); ?>" data-method-id="<?php echo htmlspecialchars($method->id, ENT_QUOTES, 'UTF-8'); ?>">
+                                                <a role="button" class="dropdown-item j2commerce-delete-card-btn" href="#" data-provider="<?php echo htmlspecialchars($method->provider, ENT_QUOTES, 'UTF-8'); ?>" data-method-id="<?php echo (int) $method->id; ?>">
                                                     <span class="fa-solid fa-trash text-danger fa-fw" aria-hidden="true"></span>
                                                     <span class="ms-1"><?php echo Text::_('JACTION_DELETE'); ?></span>
                                                 </a>
                                               <?php endif; ?>
                                                <?php if ($method->canSetDefault() && !$method->isDefault) : ?>
-                                                   <a role="button" class="dropdown-item j2commerce-set-default-btn" href="#" data-provider="<?php echo htmlspecialchars($method->provider, ENT_QUOTES, 'UTF-8'); ?>" data-method-id="<?php echo htmlspecialchars($method->id, ENT_QUOTES, 'UTF-8'); ?>">
+                                                   <a role="button" class="dropdown-item j2commerce-set-default-btn" href="#" data-provider="<?php echo htmlspecialchars($method->provider, ENT_QUOTES, 'UTF-8'); ?>" data-method-id="<?php echo (int) $method->id; ?>">
                                                        <span class="fa-solid fa-star fa-fw" aria-hidden="true"></span>
                                                        <span class="ms-1"><?php echo Text::_('COM_J2COMMERCE_PAYMENT_METHODS_SET_DEFAULT'); ?></span>
                                                   </a>


### PR DESCRIPTION
## Summary
Follow-up to #353 addressing @brianteeman's review feedback and restoring accidentally deleted build scripts.

## Changes

### Review feedback from #353
1. **Remove unnecessary `htmlspecialchars()` on IDs** — `$method->id` is numeric, replaced with `(int)` cast throughout the file (5 occurrences)
2. **Remove redundant `visually-hidden` span** — the button already has `aria-label`, so the hidden text was duplicate

### Build scripts restored
- `build/build_package.php` and `build/script.pkg_j2commerce.php` were accidentally deleted in #353 (branch carried over from earlier work)
- Added `!build/` whitelist to `.gitignore` so they stay tracked
- Build scripts are excluded from the generated package (already in `$excludePatterns`)

## Testing
1. Navigate to frontend My Profile → Payment Methods
2. Inspect dropdown trigger — should be `<button>` with `aria-label`
3. No `visually-hidden` span inside the button
4. All `data-method-id` attributes use plain numeric IDs
5. `php build/build_package.php` still works

## Files Changed
- `.gitignore` — whitelist `build/` directory
- `build/build_package.php` — restored
- `build/script.pkg_j2commerce.php` — restored
- `components/com_j2commerce/tmpl/myprofile/default_payment_methods.php` — review fixes