### PR TITLE
fix(onboarding): translate payment plugin display names (fixes #338)

### DIFF
--- a/administrator/components/com_j2commerce/tmpl/dashboard/default_onboarding.php
+++ b/administrator/components/com_j2commerce/tmpl/dashboard/default_onboarding.php
@@ -82,12 +82,14 @@ $unpublishedPlugins = [];
 
 foreach ($allPaymentPlugins as $plugin) {
     $langPrefix = 'plg_j2commerce_' . $plugin->element;
-    $lang->load($langPrefix, JPATH_ADMINISTRATOR);
-    $lang->load($langPrefix, JPATH_PLUGINS . '/j2commerce/' . $plugin->element);
+    $lang->load($langPrefix . '.sys', JPATH_ADMINISTRATOR)
+        || $lang->load($langPrefix . '.sys', JPATH_PLUGINS . '/j2commerce/' . $plugin->element);
+    $lang->load($langPrefix, JPATH_ADMINISTRATOR)
+        || $lang->load($langPrefix, JPATH_PLUGINS . '/j2commerce/' . $plugin->element);
 
     $params = new \Joomla\Registry\Registry($plugin->params);
     $displayName = $params->get('display_name', '');
-    $plugin->display_name = $displayName ?: Text::_(strtoupper('PLG_J2COMMERCE_' . $plugin->element));
+    $plugin->display_name = $displayName ? Text::_($displayName) : Text::_(strtoupper('PLG_J2COMMERCE_' . $plugin->element));
 
     if ((int) $plugin->enabled === 1) {
         $paymentPlugins[] = $plugin;


### PR DESCRIPTION
## Summary
Fixes #338

## Changes
- Added `.sys.ini` language file loading for payment plugins in onboarding template
- Wrapped `display_name` param value in `Text::_()` — the XML default attribute stores raw language keys (e.g. `PLG_J2COMMERCE_PAYMENT_BANKTRANSFER_DEFAULT`) which were displayed untranslated

## Root Cause
Plugin XML has `default="PLG_J2COMMERCE_PAYMENT_BANKTRANSFER_DEFAULT"` for the `display_name` field. On fresh install with no saved params, `$params->get('display_name')` returns this raw key. The onboarding code used it directly without `Text::_()`.

## Testing
1. Fresh install or clear plugin params
2. Open dashboard → onboarding → payment step
3. Verify: shows "Bank Transfer", "Cash on Delivery", etc. — not raw language keys

## Files Changed
- `administrator/components/com_j2commerce/tmpl/dashboard/default_onboarding.php` — load .sys.ini + translate display_name