### PR TITLE
fix(onboarding): create default geozone in step 1 for shipping/tax (fixes #337)

### DIFF
--- a/administrator/components/com_j2commerce/src/Controller/OnboardingController.php
+++ b/administrator/components/com_j2commerce/src/Controller/OnboardingController.php
@@ -269,6 +269,10 @@ class OnboardingController extends BaseController
         // Swap address_1/address_2 ordering based on country convention
         OnboardingHelper::reorderAddressFields($countryId, $db);
 
+        // Create default geozone so it's available for tax (step 3) and shipping (step 4)
+        $zoneId = $this->input->getInt('zone_id', 0);
+        $geo    = OnboardingHelper::createDefaultGeozone($countryId, $zoneId, $db);
+
         // Get recommended defaults for Step 2 pre-fill (currency only now)
         $defaults = OnboardingHelper::getCountryDefaults($countryId);
 
@@ -283,6 +287,7 @@ class OnboardingController extends BaseController
         return [
             'defaults'       => $defaults,
             'languagePrompt' => $languagePrompt,
+            'geozone'        => $geo,
         ];
     }
 

--- a/administrator/components/com_j2commerce/src/Helper/OnboardingHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/OnboardingHelper.php
@@ -250,28 +250,40 @@ class OnboardingHelper
     }
 
     /**
-     * Create a default tax setup: geozone → geozone rule → tax rate → tax profile → tax rule.
+     * Create the default geozone and rule for a country/zone pair.
      *
-     * @return array{geozone_id: int, taxrate_id: int, taxprofile_id: int, taxrule_id: int}
+     * Idempotent: if a geozone with the same name already exists, it is reused.
+     * For US (country_id 223): geozone name = zone name.
+     * For all others: geozone name = country name.
+     *
+     * @return array{geozone_id: int, geozone_name: string}
      */
-    public static function createDefaultTax(
+    public static function createDefaultGeozone(
         int $countryId,
         int $zoneId,
-        float $taxPercent,
         DatabaseInterface $db,
     ): array {
         $countryName = self::getCountryName($countryId, $db);
         $isUS        = ($countryId === 223);
 
         if ($isUS && $zoneId > 0) {
-            $zoneName    = self::getZoneName($zoneId, $db);
-            $geoName     = $zoneName;
-            $ruleZoneId  = $zoneId;
-            $rateName    = "$zoneName Sales Tax";
+            $geoName    = self::getZoneName($zoneId, $db);
+            $ruleZoneId = $zoneId;
         } else {
-            $geoName     = $countryName;
-            $ruleZoneId  = 0;
-            $rateName    = "$countryName Tax";
+            $geoName    = $countryName;
+            $ruleZoneId = 0;
+        }
+
+        // Check if a geozone with this name already exists
+        $query = $db->getQuery(true)
+            ->select($db->quoteName('j2commerce_geozone_id'))
+            ->from($db->quoteName('#__j2commerce_geozones'))
+            ->where($db->quoteName('geozone_name') . ' = :name')
+            ->bind(':name', $geoName);
+        $existingId = (int) $db->setQuery($query)->loadResult();
+
+        if ($existingId > 0) {
+            return ['geozone_id' => $existingId, 'geozone_name' => $geoName];
         }
 
         $geozone = (object) [
@@ -288,6 +300,32 @@ class OnboardingHelper
             'zone_id'    => $ruleZoneId,
         ];
         $db->insertObject('#__j2commerce_geozonerules', $geoRule, 'j2commerce_geozonerule_id');
+
+        return ['geozone_id' => $geozoneId, 'geozone_name' => $geoName];
+    }
+
+    /**
+     * Create a default tax setup: geozone → geozone rule → tax rate → tax profile → tax rule.
+     *
+     * Reuses the geozone from createDefaultGeozone() if it already exists.
+     *
+     * @return array{geozone_id: int, taxrate_id: int, taxprofile_id: int, taxrule_id: int}
+     */
+    public static function createDefaultTax(
+        int $countryId,
+        int $zoneId,
+        float $taxPercent,
+        DatabaseInterface $db,
+    ): array {
+        $geo       = self::createDefaultGeozone($countryId, $zoneId, $db);
+        $geozoneId = $geo['geozone_id'];
+        $geoName   = $geo['geozone_name'];
+
+        $isUS = ($countryId === 223);
+        $rateName = $isUS && $zoneId > 0
+            ? "$geoName Sales Tax"
+            : "$geoName Tax";
+
         $taxRate  = (object) [
             'geozone_id'   => $geozoneId,
             'taxrate_name' => $rateName,

--- a/media/com_j2commerce/js/administrator/onboarding.js
+++ b/media/com_j2commerce/js/administrator/onboarding.js
@@ -403,9 +403,22 @@ document.addEventListener('DOMContentLoaded', () => {
         if (lengthEl   && defaults.length_id) lengthEl.value = defaults.length_id;
     }
 
+    function populateGeozoneDropdowns(geozone) {
+        if (!geozone || !geozone.geozone_id) return;
+        modal.querySelectorAll('.ob-rate-geozone').forEach(select => {
+            // Clear existing options and add the new geozone
+            select.replaceChildren();
+            const opt = document.createElement('option');
+            opt.value = geozone.geozone_id;
+            opt.textContent = geozone.geozone_name;
+            select.appendChild(opt);
+        });
+    }
+
     async function handlePostSave(stepNum, data) {
         switch (stepNum) {
             case 1: {
+                populateGeozoneDropdowns(data.geozone);
                 if (data.languagePrompt === true) {
                     const prompt = modal.querySelector('#ob-lang-prompt');
                     if (prompt) prompt.classList.remove('d-none');


### PR DESCRIPTION
## Summary
Fixes #337

The shipping step (step 4) geozone dropdown was empty during onboarding because geozones were only created in step 3 (tax) — and only if the user entered a tax rate > 0.

## Changes
- **New `OnboardingHelper::createDefaultGeozone()`** — Extracted geozone + geozone rule creation into a standalone idempotent method. For US (country_id 223): geozone name = zone name. For all others: geozone name = country name. Checks for existing geozone by name to avoid duplicates.
- **`OnboardingController::saveStep1()`** — Now calls `createDefaultGeozone()` after country/zone is set, returns geozone data `{geozone_id, geozone_name}` in the AJAX response
- **`OnboardingHelper::createDefaultTax()`** — Refactored to delegate geozone creation to `createDefaultGeozone()`, preventing duplicate geozones when both step 1 and step 3 run
- **`onboarding.js`** — New `populateGeozoneDropdowns()` function replaces the empty "NONE" dropdown with the real geozone after step 1 saves

## Testing
1. Fresh install (or reset onboarding state)
2. Start onboarding wizard
3. Complete Step 1 with **US country + zone** (e.g., California)
4. Advance to Step 4 → select "Fixed rates"
5. Verify geozone dropdown shows **"California"** (not "NONE")
6. Repeat with **non-US country** (e.g., UK) → verify dropdown shows **"United Kingdom"**
7. Complete full wizard including tax step → verify no duplicate geozones

## Files Changed
- `administrator/components/com_j2commerce/src/Helper/OnboardingHelper.php` — new `createDefaultGeozone()`, refactored `createDefaultTax()`
- `administrator/components/com_j2commerce/src/Controller/OnboardingController.php` — call geozone creation in `saveStep1()`
- `media/com_j2commerce/js/administrator/onboarding.js` — populate geozone dropdowns after step 1