### PR TITLE
fix(config): update email default settings

### DIFF
--- a/administrator/components/com_j2commerce/config.xml
+++ b/administrator/components/com_j2commerce/config.xml
@@ -1318,7 +1318,7 @@
             type="list"
             label="COM_J2COMMERCE_CONFIG_EMAIL_TEMPLATE_MODE"
             description="COM_J2COMMERCE_CONFIG_EMAIL_TEMPLATE_MODE_DESC"
-            default="1"
+            default="0"
             validate="options"
         >
             <option value="0">COM_J2COMMERCE_EMAIL_CONFIGURED_ONLY</option>
@@ -1331,7 +1331,7 @@
             label="COM_J2COMMERCE_CONFIG_EMAIL_SHOW_IMAGE"
             description="COM_J2COMMERCE_CONFIG_EMAIL_SHOW_IMAGE_DESC"
             layout="joomla.form.field.radio.switcher"
-            default="0"
+            default="1"
             filter="integer"
         >
             <option value="0">JHIDE</option>

--- a/administrator/components/com_j2commerce/sql/updates/mysql/6.1.4.sql
+++ b/administrator/components/com_j2commerce/sql/updates/mysql/6.1.4.sql
@@ -1,0 +1,12 @@
+-- J2Commerce 6.1.4
+-- Update email config defaults for existing installs:
+--   send_default_email_template: 1 → 0 (configured templates only)
+--   show_thumb_email: 0 → 1 (show product thumbnails in emails)
+
+UPDATE `#__extensions`
+SET `params` = JSON_SET(
+    JSON_SET(`params`, '$.send_default_email_template', '0'),
+    '$.show_thumb_email', '1'
+)
+WHERE `element` = 'com_j2commerce'
+AND `type` = 'component';


### PR DESCRIPTION
## Core Update

### Changes
- `send_default_email_template` default changed from `1` to `0` (configured templates only)
- `show_thumb_email` default changed from `0` to `1` (show product thumbnails in emails)
- New SQL update `6.1.4.sql` applies these defaults to existing installs via `JSON_SET`

### Files Modified
| Type | Count |
|------|-------|
| XML/Config | 1 |
| SQL | 1 |

### Pre-Flight
- [x] No PHP files changed (XML + SQL only)
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only (non-core excluded)