### PR TITLE
fix(payments): change default order status from Confirmed to Pending

### DIFF
--- a/plugins/j2commerce/payment_banktransfer/payment_banktransfer.xml
+++ b/plugins/j2commerce/payment_banktransfer/payment_banktransfer.xml
@@ -103,7 +103,7 @@
                     type="OrderStatus"
                     label="PLG_J2COMMERCE_PAYMENT_BANKTRANSFER_ORDER_STATUS"
                     description="PLG_J2COMMERCE_PAYMENT_BANKTRANSFER_ORDER_STATUS_DESC"
-                    default="4"
+                    default="1"
                     addfieldprefix="J2Commerce\Component\J2commerce\Administrator\Field"
                     layout="joomla.form.field.list-fancy-select"
                 />
@@ -247,5 +247,5 @@
         </fields>
     </config>
 
-    
+
 </extension>

--- a/plugins/j2commerce/payment_cash/payment_cash.xml
+++ b/plugins/j2commerce/payment_cash/payment_cash.xml
@@ -135,7 +135,7 @@
                     type="OrderStatus"
                     label="PLG_J2COMMERCE_ORDER_STATUS"
                     description="PLG_J2COMMERCE_ORDER_STATUS_DESC"
-                    default="4"
+                    default="1"
                     addfieldprefix="J2Commerce\Component\J2commerce\Administrator\Field"
                     layout="joomla.form.field.list-fancy-select"
                 />

--- a/plugins/j2commerce/payment_moneyorder/payment_moneyorder.xml
+++ b/plugins/j2commerce/payment_moneyorder/payment_moneyorder.xml
@@ -105,7 +105,7 @@
                     type="OrderStatus"
                     label="PLG_J2COMMERCE_ORDER_STATUS"
                     description="PLG_J2COMMERCE_ORDER_STATUS_DESC"
-                    default="4"
+                    default="1"
                     addfieldprefix="J2Commerce\Component\J2commerce\Administrator\Field"
                     layout="joomla.form.field.list-fancy-select"
                 />

--- a/plugins/j2commerce/payment_paypal/payment_paypal.xml
+++ b/plugins/j2commerce/payment_paypal/payment_paypal.xml
@@ -145,7 +145,7 @@
                     type="OrderStatus"
                     label="PLG_J2COMMERCE_ORDER_STATUS"
                     description="PLG_J2COMMERCE_ORDER_STATUS_DESC"
-                    default="4"
+                    default="1"
                     addfieldprefix="J2Commerce\Component\J2commerce\Administrator\Field"
                     layout="joomla.form.field.list-fancy-select"
                 />
@@ -331,5 +331,5 @@
         </fields>
     </config>
 
-    
+
 </extension>


### PR DESCRIPTION
## Summary

- Payment plugins (bank transfer, cash, money order, PayPal) had default order status set to `4` (Confirmed)
- Changed to `1` (Pending) so new installs start orders in Pending state until explicitly confirmed
- Also removed trailing whitespace in bank transfer and PayPal XML files

## Files Modified
| Type | Count |
|------|-------|
| XML/Config | 4 |

### Changed Files
- `plugins/j2commerce/payment_banktransfer/payment_banktransfer.xml`
- `plugins/j2commerce/payment_cash/payment_cash.xml`
- `plugins/j2commerce/payment_moneyorder/payment_moneyorder.xml`
- `plugins/j2commerce/payment_paypal/payment_paypal.xml`

## Pre-Flight
- [x] No secrets detected (PayPal "secret" is a config field label, not a value)
- [x] No FOF remnants
- [x] Core files only (non-core excluded)