### PR TITLE
feat(sampledata): add sample data plugin with dashboard integration (fixes #347)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,6 +121,9 @@
 !plugins/webservices/
 !plugins/webservices/j2commerce/
 !plugins/webservices/j2commerce/**
+!plugins/sampledata/
+!plugins/sampledata/j2commerce/
+!plugins/sampledata/j2commerce/**
 
 # J2Commerce core frontend modules (only those in the package skill)
 !modules/
@@ -137,6 +140,8 @@
 !media/
 !media/com_j2commerce/
 !media/com_j2commerce/**
+!media/plg_sampledata_j2commerce/
+!media/plg_sampledata_j2commerce/**
 !media/lib_j2commerce/
 !media/lib_j2commerce/**
 

--- a/administrator/components/com_j2commerce/src/CliCommands/LoadSampleDataCommand.php
+++ b/administrator/components/com_j2commerce/src/CliCommands/LoadSampleDataCommand.php
@@ -35,6 +35,11 @@ class LoadSampleDataCommand extends AbstractCommand
         $this->addOption('yes', 'y', InputOption::VALUE_NONE, 'Skip confirmation prompt');
         $this->addOption('clean', null, InputOption::VALUE_NONE, 'Remove existing sample data before loading');
         $this->addOption('remove', null, InputOption::VALUE_NONE, 'Remove all sample data and exit');
+        $this->addOption('categories', null, InputOption::VALUE_OPTIONAL, 'Override number of categories');
+        $this->addOption('products', null, InputOption::VALUE_OPTIONAL, 'Override number of simple products');
+        $this->addOption('variable', null, InputOption::VALUE_OPTIONAL, 'Override number of variable products');
+        $this->addOption('customers', null, InputOption::VALUE_OPTIONAL, 'Override number of customers');
+        $this->addOption('orders', null, InputOption::VALUE_OPTIONAL, 'Override number of orders');
     }
 
     protected function doExecute(InputInterface $input, OutputInterface $output): int
@@ -81,10 +86,36 @@ class LoadSampleDataCommand extends AbstractCommand
             }
         }
 
+        // Collect numeric override options
+        $overrides = [];
+        $overrideMap = [
+            'categories' => 'categories',
+            'products'   => 'simple',
+            'variable'   => 'variable',
+            'customers'  => 'customers',
+            'orders'     => 'orders',
+        ];
+
+        foreach ($overrideMap as $optionName => $profileKey) {
+            $value = $input->getOption($optionName);
+
+            if ($value !== null && is_numeric($value) && (int) $value >= 0) {
+                $overrides[$profileKey] = (int) $value;
+            }
+        }
+
         $io->section(sprintf('Loading sample data (profile: %s)...', $profile));
 
+        if (!empty($overrides)) {
+            $io->text('Applying overrides: ' . implode(', ', array_map(
+                fn($k, $v) => "$k=$v",
+                array_keys($overrides),
+                $overrides
+            )));
+        }
+
         try {
-            $result = $helper->load($profile);
+            $result = $helper->load($profile, $overrides);
         } catch (\Throwable $e) {
             $io->error('Failed to load sample data: ' . $e->getMessage());
             return 2;

--- a/administrator/components/com_j2commerce/src/Controller/DashboardController.php
+++ b/administrator/components/com_j2commerce/src/Controller/DashboardController.php
@@ -15,6 +15,8 @@ namespace J2Commerce\Component\J2commerce\Administrator\Controller;
 \defined('_JEXEC') or die;
 
 use J2Commerce\Component\J2commerce\Administrator\Helper\CurrencyHelper;
+use J2Commerce\Component\J2commerce\Administrator\Helper\SampleDataHelper;
+use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
 use Joomla\CMS\MVC\Controller\BaseController;
@@ -115,6 +117,72 @@ class DashboardController extends BaseController
             $this->app->setHeader('Content-Type', 'application/json; charset=utf-8');
             echo new JsonResponse($data);
         } catch (\Exception $e) {
+            Log::add($e->getMessage(), Log::ERROR, 'com_j2commerce');
+            $this->app->setHeader('Content-Type', 'application/json; charset=utf-8');
+            $this->app->setHeader('status', '500');
+            echo new JsonResponse(null, Text::_('COM_J2COMMERCE_ERROR_INTERNAL'), true);
+        }
+
+        $this->app->close();
+    }
+
+    public function loadSampleData(): void
+    {
+        if (!Session::checkToken('post')) {
+            $this->app->setHeader('Content-Type', 'application/json; charset=utf-8');
+            $this->app->setHeader('status', '403');
+            echo new JsonResponse(null, Text::_('COM_J2COMMERCE_ERROR_INVALID_TOKEN'), true);
+            $this->app->close();
+            return;
+        }
+
+        if (!$this->app->getIdentity()->authorise('core.admin', 'com_j2commerce')) {
+            $this->app->setHeader('Content-Type', 'application/json; charset=utf-8');
+            $this->app->setHeader('status', '403');
+            echo new JsonResponse(null, Text::_('COM_J2COMMERCE_ERROR_ACCESS_DENIED'), true);
+            $this->app->close();
+            return;
+        }
+
+        try {
+            $db = Factory::getContainer()->get(\Joomla\Database\DatabaseInterface::class);
+            $summary = (new SampleDataHelper($db))->load('standard');
+            $this->app->setHeader('Content-Type', 'application/json; charset=utf-8');
+            echo new JsonResponse($summary, Text::_('COM_J2COMMERCE_DASHBOARD_SAMPLEDATA_LOADED'));
+        } catch (\Throwable $e) {
+            Log::add($e->getMessage(), Log::ERROR, 'com_j2commerce');
+            $this->app->setHeader('Content-Type', 'application/json; charset=utf-8');
+            $this->app->setHeader('status', '500');
+            echo new JsonResponse(null, Text::_('COM_J2COMMERCE_ERROR_INTERNAL'), true);
+        }
+
+        $this->app->close();
+    }
+
+    public function removeSampleData(): void
+    {
+        if (!Session::checkToken('post')) {
+            $this->app->setHeader('Content-Type', 'application/json; charset=utf-8');
+            $this->app->setHeader('status', '403');
+            echo new JsonResponse(null, Text::_('COM_J2COMMERCE_ERROR_INVALID_TOKEN'), true);
+            $this->app->close();
+            return;
+        }
+
+        if (!$this->app->getIdentity()->authorise('core.admin', 'com_j2commerce')) {
+            $this->app->setHeader('Content-Type', 'application/json; charset=utf-8');
+            $this->app->setHeader('status', '403');
+            echo new JsonResponse(null, Text::_('COM_J2COMMERCE_ERROR_ACCESS_DENIED'), true);
+            $this->app->close();
+            return;
+        }
+
+        try {
+            $db = Factory::getContainer()->get(\Joomla\Database\DatabaseInterface::class);
+            $summary = (new SampleDataHelper($db))->remove();
+            $this->app->setHeader('Content-Type', 'application/json; charset=utf-8');
+            echo new JsonResponse($summary, Text::_('COM_J2COMMERCE_DASHBOARD_SAMPLEDATA_REMOVED'));
+        } catch (\Throwable $e) {
             Log::add($e->getMessage(), Log::ERROR, 'com_j2commerce');
             $this->app->setHeader('Content-Type', 'application/json; charset=utf-8');
             $this->app->setHeader('status', '500');

--- a/administrator/components/com_j2commerce/src/Helper/SampleDataHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/SampleDataHelper.php
@@ -18,6 +18,7 @@ use Joomla\CMS\Table\Table;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Database\ParameterType;
 
+
 /**
  * Generates and removes sample data for a J2Commerce store.
  *
@@ -223,6 +224,29 @@ final class SampleDataHelper
         ['name' => 'Student Discount', 'code' => 'STUDENT', 'value' => 10.00, 'value_type' => 'percentage', 'free_shipping' => 0, 'min_subtotal' => '0'],
     ];
 
+    private const DESCRIPTIONS = [
+        'electronics' => [
+            'introtext' => '<p>Experience cutting-edge technology with the <strong>%s</strong>. Designed for performance and built to last, this product delivers everything you need for modern life.</p>',
+            'fulltext'  => '<p>The <strong>%s</strong> combines innovative engineering with sleek design to give you a product that stands out from the crowd. Whether you\'re a professional or an enthusiast, this device will exceed your expectations.</p><h3>Key Features</h3><ul><li>Premium build quality with durable materials</li><li>Advanced technology for maximum performance</li><li>Intuitive design for effortless use</li><li>Energy efficient and environmentally responsible</li><li>Backed by our comprehensive warranty</li></ul><h3>Specifications</h3><p>Compatible with all major operating systems and platforms. Plug-and-play installation requires no technical expertise.</p>',
+        ],
+        'clothing' => [
+            'introtext' => '<p>Elevate your wardrobe with the <strong>%s</strong>. Crafted from premium materials, this piece offers the perfect blend of comfort and style for everyday wear.</p>',
+            'fulltext'  => '<p>The <strong>%s</strong> is designed for those who demand quality without sacrificing comfort. Made from carefully selected fabrics, it offers a fit that flatters every body type and keeps you looking sharp all day long.</p><h3>Features</h3><ul><li>Premium fabric blend for comfort and durability</li><li>Available in multiple sizes and colours</li><li>Easy care — machine washable</li><li>Reinforced stitching at stress points</li><li>Versatile style for casual and smart-casual occasions</li></ul><h3>Care Instructions</h3><p>Machine wash cold with similar colours. Tumble dry low. Do not bleach. Iron on low heat if needed.</p>',
+        ],
+        'home' => [
+            'introtext' => '<p>Transform your living space with the <strong>%s</strong>. Thoughtfully designed to blend seamlessly with any home decor while delivering outstanding functionality.</p>',
+            'fulltext'  => '<p>The <strong>%s</strong> is the perfect addition to any home. Crafted with attention to detail and made from sustainable materials, it brings both beauty and practicality to your everyday life.</p><h3>Why You\'ll Love It</h3><ul><li>Sustainable and eco-friendly materials</li><li>Timeless design that complements any decor</li><li>Easy to clean and maintain</li><li>Durable construction for years of use</li><li>Makes an ideal gift for any occasion</li></ul><h3>Dimensions</h3><p>Please refer to the size guide for exact measurements. Assembly instructions included where required.</p>',
+        ],
+        'sporting' => [
+            'introtext' => '<p>Take your performance to the next level with the <strong>%s</strong>. Engineered for athletes and fitness enthusiasts who demand the best from their equipment.</p>',
+            'fulltext'  => '<p>The <strong>%s</strong> is designed by athletes for athletes. Whether you\'re training for competition or staying fit for life, this equipment gives you the edge you need to reach your goals.</p><h3>Performance Benefits</h3><ul><li>Professional-grade materials for peak performance</li><li>Ergonomic design reduces fatigue and injury risk</li><li>Suitable for all fitness levels from beginner to advanced</li><li>Lightweight yet incredibly durable</li><li>Tested by certified sports performance coaches</li></ul><h3>Training Tips</h3><p>For best results, incorporate this equipment into a structured training programme. Consult a fitness professional for personalised guidance.</p>',
+        ],
+        'books' => [
+            'introtext' => '<p>Expand your knowledge and skills with <strong>%s</strong>. Written by industry experts, this book delivers practical insights you can apply immediately.</p>',
+            'fulltext'  => '<p><strong>%s</strong> is a comprehensive guide that takes you from the fundamentals to advanced techniques. Whether you\'re a complete beginner or looking to sharpen existing skills, this book has something valuable to offer.</p><h3>What\'s Inside</h3><ul><li>Step-by-step guidance with real-world examples</li><li>Expert tips and insider knowledge from practitioners</li><li>Practical exercises to reinforce your learning</li><li>Reference material you\'ll return to again and again</li><li>Up-to-date content reflecting current best practices</li></ul><h3>Who Is This For</h3><p>This book is suitable for readers at all stages. Whether you are just starting out or are an experienced professional seeking fresh perspectives, you will find immense value in these pages.</p>',
+        ],
+    ];
+
     private const OPTIONS_DATA = [
         ['name' => 'Color', 'type' => 'radio', 'values' => ['Red', 'Blue', 'Green', 'Black', 'White', 'Yellow', 'Purple', 'Orange']],
         ['name' => 'Size', 'type' => 'select', 'values' => ['XS', 'S', 'M', 'L', 'XL', 'XXL', '2XL', '3XL']],
@@ -302,6 +326,10 @@ final class SampleDataHelper
             $summary['products_downloadable'] = count($dlIds);
         }
 
+        // 4b. Create product images
+        $imageCount = $this->createProductImages($productIds, $catIds);
+        $summary['product_images'] = $imageCount;
+
         // 5. Create customers
         $customerIds = $this->createCustomers((int) $cfg['customers'], $now);
         $summary['customers'] = count($customerIds);
@@ -313,6 +341,18 @@ final class SampleDataHelper
         // 7. Create coupons
         $couponCount = $this->createCoupons((int) $cfg['coupons'], $now);
         $summary['coupons'] = $couponCount;
+
+        // 8. Create advanced pricing for full profile
+        if ($profile === 'full' && !empty($productIds)) {
+            $advancedPricingCount = $this->createAdvancedPricing($productIds, $this->db);
+            $summary['advanced_pricing'] = $advancedPricingCount;
+        }
+
+        // 9. Ensure store has basic tax, shipping, and payment configured
+        $storeSetup = $this->ensureStoreSetup($this->db);
+        foreach ($storeSetup as $key => $value) {
+            $summary['setup_' . $key] = $value;
+        }
 
         $summary['profile'] = $profile;
         $summary['success'] = true;
@@ -345,6 +385,15 @@ final class SampleDataHelper
             $productIds = array_column($db->loadObjectList(), 'j2commerce_product_id');
 
             if (!empty($productIds)) {
+                // Remove product images first
+                $db->setQuery(
+                    $db->getQuery(true)
+                        ->delete($db->quoteName('#__j2commerce_productimages'))
+                        ->whereIn($db->quoteName('product_id'), $productIds)
+                );
+                $db->execute();
+                $counts['product_images'] = $db->getAffectedRows();
+
                 // Collect variant IDs first for quantity cleanup
                 $variantQuery = $db->getQuery(true)
                     ->select('j2commerce_variant_id')
@@ -367,6 +416,15 @@ final class SampleDataHelper
                             ->whereIn($db->quoteName('variant_id'), $variantIds)
                     );
                     $db->execute();
+
+                    // Remove advanced pricing rows for sample product variants
+                    $db->setQuery(
+                        $db->getQuery(true)
+                            ->delete($db->quoteName('#__j2commerce_product_prices'))
+                            ->whereIn($db->quoteName('variant_id'), $variantIds)
+                    );
+                    $db->execute();
+                    $counts['advanced_pricing'] = $db->getAffectedRows();
                 }
 
                 // Remove product option linkage
@@ -431,21 +489,21 @@ final class SampleDataHelper
                     $db->setQuery(
                         $db->getQuery(true)
                             ->delete($db->quoteName('#__j2commerce_orderitems'))
-                            ->whereIn($db->quoteName('order_id'), $orderNos)
+                            ->whereIn($db->quoteName('order_id'), $orderNos, ParameterType::STRING)
                     );
                     $db->execute();
 
                     $db->setQuery(
                         $db->getQuery(true)
                             ->delete($db->quoteName('#__j2commerce_orderinfos'))
-                            ->whereIn($db->quoteName('order_id'), $orderNos)
+                            ->whereIn($db->quoteName('order_id'), $orderNos, ParameterType::STRING)
                     );
                     $db->execute();
 
                     $db->setQuery(
                         $db->getQuery(true)
                             ->delete($db->quoteName('#__j2commerce_orderhistories'))
-                            ->whereIn($db->quoteName('order_id'), $orderNos)
+                            ->whereIn($db->quoteName('order_id'), $orderNos, ParameterType::STRING)
                     );
                     $db->execute();
 
@@ -592,14 +650,21 @@ final class SampleDataHelper
 
     private function getOrCreateJ2CommerceRootCategory(string $now): int
     {
-        $db    = $this->db;
+        $db = $this->db;
+
+        // Check if a "Shop" category tagged as sample data already exists
+        $ext = 'com_content';
         $query = $db->getQuery(true)
             ->select('id')
             ->from($db->quoteName('#__categories'))
             ->where($db->quoteName('extension') . ' = :ext')
-            ->where($db->quoteName('parent_id') . ' = 1')
-            ->bind(':ext', $ext);
-        $ext   = 'com_content';
+            ->where($db->quoteName('alias') . ' = :alias')
+            ->where($db->quoteName('metakey') . ' = :tag')
+            ->bind(':ext', $ext)
+            ->bind(':alias', $shopAlias)
+            ->bind(':tag', $sampleTag);
+        $shopAlias = 'shop';
+        $sampleTag = self::SAMPLE_TAG;
         $db->setQuery($query);
         $existing = (int) $db->loadResult();
 
@@ -607,8 +672,32 @@ final class SampleDataHelper
             return $existing;
         }
 
-        // Return global root — we'll nest under root (id=1) using com_content
-        // Products reference com_content category IDs
+        // Create "Shop" as a sibling of "Uncategorised" under the global root (id=1)
+        $table = Table::getInstance('Category');
+        $table->extension        = 'com_content';
+        $table->title            = 'Shop';
+        $table->alias            = $this->uniqueAlias('shop', 'categories');
+        $table->published        = 1;
+        $table->access           = 1;
+        $table->language         = '*';
+        $table->description      = '';
+        $table->note             = '';
+        $table->metadesc         = '';
+        $table->metakey          = self::SAMPLE_TAG;
+        $table->metadata         = '';
+        $table->params           = '{}';
+        $table->created_time     = $now;
+        $table->modified_time    = $now;
+        $table->created_user_id  = 0;
+        $table->modified_user_id = 0;
+        $table->hits             = 0;
+        $table->version          = 1;
+        $table->setLocation(1, 'last-child');
+
+        if ($table->check() && $table->store()) {
+            return (int) $table->id;
+        }
+
         return 1;
     }
 
@@ -770,10 +859,11 @@ final class SampleDataHelper
             // Create Joomla content article as the product source
             $alias   = $this->uniqueAlias(strtolower(preg_replace('/[^a-z0-9]+/i', '-', $uniqueName)), 'content');
             $article = new \stdClass();
+            $descTemplates = self::DESCRIPTIONS[$catKey] ?? self::DESCRIPTIONS['electronics'];
             $article->title       = $uniqueName;
             $article->alias       = $alias;
-            $article->introtext   = '<p>Sample product: ' . htmlspecialchars($uniqueName) . '</p>';
-            $article->fulltext    = '';
+            $article->introtext   = sprintf($descTemplates['introtext'], htmlspecialchars($uniqueName));
+            $article->fulltext    = sprintf($descTemplates['fulltext'], htmlspecialchars($uniqueName));
             $article->state       = 1;
             $article->catid       = $catId;
             $article->created     = $now;
@@ -912,10 +1002,11 @@ final class SampleDataHelper
 
             $alias   = $this->uniqueAlias(strtolower(preg_replace('/[^a-z0-9]+/i', '-', $productName)), 'content');
             $article = new \stdClass();
+            $descTemplates = self::DESCRIPTIONS[$catKey] ?? self::DESCRIPTIONS['electronics'];
             $article->title       = $productName;
             $article->alias       = $alias;
-            $article->introtext   = '<p>Variable product: ' . htmlspecialchars($productName) . '</p>';
-            $article->fulltext    = '';
+            $article->introtext   = sprintf($descTemplates['introtext'], htmlspecialchars($productName));
+            $article->fulltext    = sprintf($descTemplates['fulltext'], htmlspecialchars($productName));
             $article->state       = 1;
             $article->catid       = $catId;
             $article->created     = $now;
@@ -1220,18 +1311,21 @@ final class SampleDataHelper
             $shipping = $subtotal > 50 ? 0.0 : 7.99;
             $total    = round($subtotal + $tax + $shipping, 5);
 
-            $orderId    = 'J2C-' . strtoupper(dechex($i + 1000)) . '-' . str_pad((string) $i, 6, '0', STR_PAD_LEFT);
             $addrEntry  = $addrData[$i % $addrCount];
 
+            // Use a temporary order_id; will be replaced after insert with time() . PK
+            $tempOrderId = (string) strtotime($createdOn);
+            $invoicePrefix = J2CommerceHelper::config()->get('invoice_prefix', 'INV-');
+
             $order                         = new \stdClass();
-            $order->order_id               = $orderId;
+            $order->order_id               = $tempOrderId;
             $order->order_type             = 'normal';
             $order->parent_id              = null;
             $order->subscription_id        = null;
             $order->cart_id                = $i + 1;
-            $order->invoice_prefix         = 'INV';
+            $order->invoice_prefix         = $invoicePrefix;
             $order->invoice_number         = $i + 1001;
-            $order->token                  = md5($orderId . $createdOn);
+            $order->token                  = '';
             $order->user_id                = $customer['id'];
             $order->user_email             = $customer['email'];
             $order->order_total            = $total;
@@ -1247,7 +1341,7 @@ final class SampleDataHelper
             $order->order_surcharge        = 0.0;
             $order->order_fees             = 0.0;
             $order->orderpayment_type      = 'plg_j2commerce_payment_cod';
-            $order->transaction_id         = 'TXN-' . $orderId;
+            $order->transaction_id         = 'TXN-SAMPLE-' . ($i + 1);
             $order->transaction_status     = 'success';
             $order->transaction_details    = '';
             $order->currency_id            = 1;
@@ -1269,7 +1363,22 @@ final class SampleDataHelper
             $order->campaign_double_opt_in = null;
             $order->campaign_order_id      = null;
 
-            $db->insertObject('#__j2commerce_orders', $order);
+            $db->insertObject('#__j2commerce_orders', $order, 'j2commerce_order_id');
+            $pk = (int) $order->j2commerce_order_id;
+
+            // Generate real order_id: timestamp + PK (matches CartOrder / OrderTable pattern)
+            $orderId = (string) (strtotime($createdOn) . $pk);
+            $orderToken = md5($orderId . bin2hex(random_bytes(8)));
+
+            $updateOrder = $db->getQuery(true)
+                ->update($db->quoteName('#__j2commerce_orders'))
+                ->set($db->quoteName('order_id') . ' = :oid')
+                ->set($db->quoteName('token') . ' = :token')
+                ->where($db->quoteName('j2commerce_order_id') . ' = :pk')
+                ->bind(':oid', $orderId)
+                ->bind(':token', $orderToken)
+                ->bind(':pk', $pk, ParameterType::INTEGER);
+            $db->setQuery($updateOrder)->execute();
 
             // Create order info
             $info                     = new \stdClass();
@@ -1394,11 +1503,9 @@ final class SampleDataHelper
             $coupon->ordering    = $i + 1;
             $coupon->value       = $couponData['value'];
             $coupon->value_type  = $couponData['value_type'];
-            $coupon->max_value   = null;
+            $coupon->max_value   = '';
             $coupon->free_shipping = $couponData['free_shipping'];
             $coupon->max_uses    = 1000;
-            $coupon->max_quantity = 0;
-            $coupon->user_group  = null;
             $coupon->logged      = 0;
             $coupon->max_customer_uses = 0;
             $coupon->valid_from  = $nullDate;
@@ -1407,11 +1514,231 @@ final class SampleDataHelper
             $coupon->products    = '';
             $coupon->min_subtotal = $couponData['min_subtotal'];
             $coupon->users       = '';
-            $coupon->mycategory  = null;
+            $coupon->mycategory  = '';
             $coupon->brand_ids   = '';
 
             $db->insertObject('#__j2commerce_coupons', $coupon);
             $created++;
+        }
+
+        return $created;
+    }
+
+    private function createProductImages(array $productIds, array $catIds): int
+    {
+        if (empty($productIds)) {
+            return 0;
+        }
+
+        $db = $this->db;
+
+        // Build a lookup of product_id → category key using the catIds we created
+        $catKeyByIndex = [];
+        foreach ($catIds as $index => $catEntry) {
+            $catKeyByIndex[$index] = $catEntry['key'] ?? 'electronics';
+        }
+
+        $imageBase   = 'media/plg_sampledata_j2commerce/images';
+        $categories  = ['electronics', 'clothing', 'home', 'sporting', 'books'];
+        $imageCount  = 5;
+        $created     = 0;
+
+        foreach ($productIds as $index => $productData) {
+            $productId = (int) ($productData['id'] ?? 0);
+
+            if ($productId <= 0) {
+                continue;
+            }
+
+            // Determine category from rotation
+            $catCount = count($catIds);
+            $catEntry = $catCount > 0 ? $catIds[$index % $catCount] : null;
+            $catKey   = $catEntry['key'] ?? $categories[$index % count($categories)];
+
+            $imageNum  = ($index % $imageCount) + 1;
+            $imagePath = $imageBase . '/' . $catKey . '/' . $imageNum . '.svg';
+
+            $img                          = new \stdClass();
+            $img->product_id              = $productId;
+            $img->main_image              = $imagePath;
+            $img->main_image_alt          = '';
+            $img->thumb_image             = $imagePath;
+            $img->thumb_image_alt         = '';
+            $img->tiny_image              = $imagePath;
+            $img->tiny_image_alt          = '';
+            $img->additional_images       = null;
+            $img->additional_images_alt   = null;
+            $img->additional_thumb_images = null;
+            $img->additional_thumb_images_alt = null;
+            $img->additional_tiny_images  = null;
+            $img->additional_tiny_images_alt = null;
+
+            $db->insertObject('#__j2commerce_productimages', $img);
+
+            if ((int) $db->insertid() > 0) {
+                $created++;
+            }
+        }
+
+        return $created;
+    }
+
+    /**
+     * Ensure the store has minimal tax, shipping, and payment configured.
+     *
+     * Checks are additive only — nothing is created if it already exists.
+     * These records are NOT tagged as sample data and persist after remove().
+     *
+     * @return array<string, string>  Human-readable messages about what was done.
+     */
+    private function ensureStoreSetup(DatabaseInterface $db): array
+    {
+        $results = [];
+
+        // --- Tax ---
+        $taxCheck = $db->getQuery(true)
+            ->select('COUNT(*)')
+            ->from($db->quoteName('#__j2commerce_taxprofiles'));
+        $taxCount = (int) $db->setQuery($taxCheck)->loadResult();
+
+        if ($taxCount === 0) {
+            OnboardingHelper::createDefaultTax(223, 0, 8.25, $db);
+            $results['tax'] = 'Created default US tax profile (8.25%)';
+        } else {
+            $results['tax'] = 'Tax profile already exists — skipped';
+        }
+
+        // --- Shipping ---
+        $shipCheck = $db->getQuery(true)
+            ->select('COUNT(*)')
+            ->from($db->quoteName('#__j2commerce_shippingmethods'))
+            ->where($db->quoteName('published') . ' = 1');
+        $shipCount = (int) $db->setQuery($shipCheck)->loadResult();
+
+        if ($shipCount === 0) {
+            // Enable the standard shipping plugin if it exists
+            OnboardingHelper::setPluginEnabled('shipping_standard', 'j2commerce', 1, $db);
+
+            // Create a flat-rate shipping method (type 1 = Standard)
+            $methodId = OnboardingHelper::createShippingMethod('Standard Shipping', 1, $db);
+
+            if ($methodId > 0) {
+                // Create a single worldwide rate at $5.99
+                OnboardingHelper::createShippingRates($methodId, [
+                    ['geozone_id' => 0, 'price' => 5.99, 'handling' => 0, 'weight_start' => 0, 'weight_end' => 0],
+                ], $db);
+                $results['shipping'] = 'Created default flat-rate shipping method ($5.99)';
+            } else {
+                $results['shipping'] = 'Could not create shipping method';
+            }
+        } else {
+            $results['shipping'] = 'Shipping method already exists — skipped';
+        }
+
+        // --- Payment ---
+        $payCheck = $db->getQuery(true)
+            ->select('COUNT(*)')
+            ->from($db->quoteName('#__extensions'))
+            ->where($db->quoteName('type') . ' = ' . $db->quote('plugin'))
+            ->where($db->quoteName('folder') . ' = ' . $db->quote('j2commerce'))
+            ->where($db->quoteName('element') . ' LIKE ' . $db->quote('payment_%'))
+            ->where($db->quoteName('enabled') . ' = 1');
+        $payCount = (int) $db->setQuery($payCheck)->loadResult();
+
+        if ($payCount === 0) {
+            OnboardingHelper::setPluginEnabled('payment_cash', 'j2commerce', 1, $db);
+            $results['payment'] = 'Enabled cash-on-delivery payment plugin';
+        } else {
+            $results['payment'] = 'Payment plugin already enabled — skipped';
+        }
+
+        return $results;
+    }
+
+    /**
+     * Create advanced / sale pricing for a random selection of products.
+     *
+     * Used only for the "full" profile to showcase advanced pricing features.
+     *
+     * @param  array<array{id: int, variant_id: int, price: float, ...}>  $productIds
+     * @return int  Number of price rows created.
+     */
+    private function createAdvancedPricing(array $productIds, DatabaseInterface $db): int
+    {
+        if (empty($productIds)) {
+            return 0;
+        }
+
+        $created  = 0;
+        $total    = count($productIds);
+
+        // Pick 5 products (or fewer if not enough exist)
+        $pickCount = min(5, $total);
+        $indices   = array_rand($productIds, $pickCount);
+
+        if (!is_array($indices)) {
+            $indices = [$indices];
+        }
+
+        $selected = array_map(fn($i) => $productIds[$i], $indices);
+
+        $now      = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+        $dateFrom = $now->modify('-30 days')->format('Y-m-d H:i:s');
+        $dateTo   = $now->modify('+30 days')->format('Y-m-d H:i:s');
+
+        foreach ($selected as $k => $product) {
+            $variantId = (int) ($product['variant_id'] ?? 0);
+            $basePrice = (float) ($product['price'] ?? 0.0);
+
+            if ($variantId <= 0 || $basePrice <= 0.0) {
+                continue;
+            }
+
+            if ($k < 3) {
+                // Sale / special price: 20% off, active now
+                $salePrice = round($basePrice * 0.80, 5);
+
+                $row                  = new \stdClass();
+                $row->variant_id      = $variantId;
+                $row->quantity_from   = null;
+                $row->quantity_to     = null;
+                $row->date_from       = $dateFrom;
+                $row->date_to         = $dateTo;
+                $row->customer_group_id = null;
+                $row->price           = number_format($salePrice, 5, '.', '');
+                $row->params          = null;
+
+                $db->insertObject('#__j2commerce_product_prices', $row);
+                $created++;
+            } else {
+                // Quantity-based tier pricing
+                $tiers = [
+                    ['qty_from' => 5.00000,  'qty_to' => 9.00000,  'discount' => 0.10],
+                    ['qty_from' => 10.00000, 'qty_to' => 24.00000, 'discount' => 0.15],
+                    ['qty_from' => 25.00000, 'qty_to' => null,     'discount' => 0.20],
+                ];
+
+                foreach ($tiers as $tier) {
+                    $tierPrice = round($basePrice * (1.0 - $tier['discount']), 5);
+                    $qtyFrom   = number_format($tier['qty_from'], 5, '.', '');
+                    $qtyTo     = $tier['qty_to'] !== null
+                        ? number_format($tier['qty_to'], 5, '.', '')
+                        : null;
+
+                    $row                  = new \stdClass();
+                    $row->variant_id      = $variantId;
+                    $row->quantity_from   = $qtyFrom;
+                    $row->quantity_to     = $qtyTo;
+                    $row->date_from       = null;
+                    $row->date_to         = null;
+                    $row->customer_group_id = null;
+                    $row->price           = number_format($tierPrice, 5, '.', '');
+                    $row->params          = null;
+
+                    $db->insertObject('#__j2commerce_product_prices', $row);
+                    $created++;
+                }
+            }
         }
 
         return $created;

--- a/administrator/components/com_j2commerce/src/View/Dashboard/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Dashboard/HtmlView.php
@@ -18,6 +18,7 @@ use J2Commerce\Component\J2commerce\Administrator\Helper\CurrencyHelper;
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 use J2Commerce\Component\J2commerce\Administrator\Helper\MenuHelper;
 use J2Commerce\Component\J2commerce\Administrator\Helper\OnboardingHelper;
+use J2Commerce\Component\J2commerce\Administrator\Helper\SampleDataHelper;
 use J2Commerce\Component\J2commerce\Administrator\Model\AnalyticsModel;
 use J2Commerce\Component\J2commerce\Administrator\Model\DashboardModel;
 use J2Commerce\Component\J2commerce\Administrator\SetupGuide\SetupGuideHelper;
@@ -71,6 +72,10 @@ class HtmlView extends BaseHtmlView
     // Onboarding wizard
     public bool $showOnboarding = false;
 
+    // Sample data state
+    public bool $hasProducts = false;
+    public bool $hasSampleData = false;
+
     public function display($tpl = null): void
     {
         $this->loadAdminAssets();
@@ -105,6 +110,16 @@ class HtmlView extends BaseHtmlView
         $this->customersCount = $model->getCustomersCount();
         $this->recentOrders   = $model->getRecentOrders(5);
         $this->liveUsers      = $model->getLiveUsers();
+
+        // Sample data state
+        $db = Factory::getContainer()->get(\Joomla\Database\DatabaseInterface::class);
+        $productCheckQuery = $db->getQuery(true)
+            ->select('1')
+            ->from($db->quoteName('#__j2commerce_products'))
+            ->where($db->quoteName('enabled') . ' = 1');
+        $db->setQuery($productCheckQuery, 0, 1);
+        $this->hasProducts  = (bool) $db->loadResult();
+        $this->hasSampleData = (new SampleDataHelper($db))->isLoaded();
 
         // All-time sales data for tabs
         $this->monthlySales = $model->getMonthlySales();
@@ -200,6 +215,90 @@ class HtmlView extends BaseHtmlView
                 'messageIds' => array_column($this->dashboardMessages, 'id'),
             ]);
         }
+
+        Text::script('COM_J2COMMERCE_DASHBOARD_SAMPLEDATA_LOADED');
+        Text::script('COM_J2COMMERCE_DASHBOARD_SAMPLEDATA_REMOVED');
+        Text::script('COM_J2COMMERCE_DASHBOARD_SAMPLEDATA_CONFIRM_REMOVE');
+        Text::script('COM_J2COMMERCE_LOADING');
+
+        // Sample data AJAX handlers
+        $wa->addInlineScript(<<<'JS'
+document.addEventListener('DOMContentLoaded', function () {
+    const loadBtn   = document.getElementById('j2c-load-sampledata');
+    const removeBtn = document.getElementById('j2c-remove-sampledata');
+    const tokenEl   = document.getElementById('dashboard-token');
+
+    if (!tokenEl) return;
+
+    function getToken() {
+        return tokenEl.value || '';
+    }
+
+    function reloadPage() {
+        window.location.href = window.location.pathname + '?option=com_j2commerce&view=dashboard';
+    }
+
+    if (loadBtn) {
+        loadBtn.addEventListener('click', async function () {
+            loadBtn.disabled = true;
+            const spinner = document.createElement('span');
+            spinner.className = 'spinner-border spinner-border-sm me-1';
+            spinner.setAttribute('role', 'status');
+            loadBtn.prepend(spinner);
+
+            const fd = new FormData();
+            fd.append(getToken(), '1');
+
+            try {
+                const res  = await fetch('index.php?option=com_j2commerce&task=dashboard.loadSampleData&format=json', { method: 'POST', body: fd });
+                const json = await res.json();
+                if (json.success) {
+                    Joomla.renderMessages({ success: [Joomla.Text._('COM_J2COMMERCE_DASHBOARD_SAMPLEDATA_LOADED')] });
+                    reloadPage();
+                } else {
+                    Joomla.renderMessages({ error: [json.message || Joomla.Text._('COM_J2COMMERCE_LOADING')] });
+                    loadBtn.disabled = false;
+                    spinner.remove();
+                }
+            } catch {
+                loadBtn.disabled = false;
+                spinner.remove();
+            }
+        });
+    }
+
+    if (removeBtn) {
+        removeBtn.addEventListener('click', async function () {
+            if (!window.confirm(Joomla.Text._('COM_J2COMMERCE_DASHBOARD_SAMPLEDATA_CONFIRM_REMOVE'))) return;
+
+            removeBtn.disabled = true;
+            const spinner = document.createElement('span');
+            spinner.className = 'spinner-border spinner-border-sm me-1';
+            spinner.setAttribute('role', 'status');
+            removeBtn.prepend(spinner);
+
+            const fd = new FormData();
+            fd.append(getToken(), '1');
+
+            try {
+                const res  = await fetch('index.php?option=com_j2commerce&task=dashboard.removeSampleData&format=json', { method: 'POST', body: fd });
+                const json = await res.json();
+                if (json.success) {
+                    Joomla.renderMessages({ success: [Joomla.Text._('COM_J2COMMERCE_DASHBOARD_SAMPLEDATA_REMOVED')] });
+                    reloadPage();
+                } else {
+                    Joomla.renderMessages({ error: [json.message || Joomla.Text._('COM_J2COMMERCE_LOADING')] });
+                    removeBtn.disabled = false;
+                    spinner.remove();
+                }
+            } catch {
+                removeBtn.disabled = false;
+                spinner.remove();
+            }
+        });
+    }
+});
+JS);
 
         Text::script('COM_J2COMMERCE_LIVE_USERS_JUST_NOW');
         Text::script('COM_J2COMMERCE_LIVE_USERS_MINUTES_AGO');
@@ -339,6 +438,8 @@ class HtmlView extends BaseHtmlView
             Text::script('COM_J2COMMERCE_ONBOARDING_PAYMENT_SELECT');
             Text::script('COM_J2COMMERCE_ONBOARDING_PAYPAL_HELP_TEXT');
             Text::script('COM_J2COMMERCE_ONBOARDING_PAYPAL_HELP_LINK');
+            Text::script('COM_J2COMMERCE_ONBOARDING_SAMPLEDATA_LOAD');
+            Text::script('COM_J2COMMERCE_ONBOARDING_SAMPLEDATA_SKIP');
         }
 
         $this->addToolbar();

--- a/administrator/components/com_j2commerce/tmpl/dashboard/default.php
+++ b/administrator/components/com_j2commerce/tmpl/dashboard/default.php
@@ -57,6 +57,31 @@ if($doc->countModules('j2commerce-dashboard-module-main-tab') && $doc->countModu
 <?php echo $this->navbar; ?>
 
 <div id="j2commerce-dashboard">
+    <?php if ($this->hasSampleData) : ?>
+    <div class="alert alert-purple d-flex align-items-center mb-4">
+        <span class="fa-solid fa-circle-info me-2"></span>
+        <span class="me-auto"><?php echo Text::_('COM_J2COMMERCE_DASHBOARD_SAMPLEDATA_ACTIVE'); ?></span>
+        <button type="button" class="btn btn-sm btn-primary" id="j2c-remove-sampledata">
+            <span class="fa-solid fa-trash me-1"></span>
+            <?php echo Text::_('COM_J2COMMERCE_DASHBOARD_REMOVE_SAMPLEDATA'); ?>
+        </button>
+    </div>
+    <?php endif; ?>
+
+    <?php if (!$this->hasProducts && !$this->hasSampleData) : ?>
+    <div class="card mb-4">
+        <div class="card-body text-center py-5">
+            <span class="fa-solid fa-box-open fa-3x text-muted d-block mb-3"></span>
+            <h5><?php echo Text::_('COM_J2COMMERCE_DASHBOARD_EMPTY_STORE_TITLE'); ?></h5>
+            <p class="text-muted"><?php echo Text::_('COM_J2COMMERCE_DASHBOARD_EMPTY_STORE_DESC'); ?></p>
+            <button type="button" class="btn btn-primary" id="j2c-load-sampledata">
+                <span class="fa-solid fa-database me-1"></span>
+                <?php echo Text::_('COM_J2COMMERCE_DASHBOARD_LOAD_SAMPLEDATA'); ?>
+            </button>
+        </div>
+    </div>
+    <?php endif; ?>
+
     <!-- Date Filter Bar -->
     <div class="row mb-4">
         <div class="col-12">

--- a/administrator/components/com_j2commerce/tmpl/dashboard/default_onboarding.php
+++ b/administrator/components/com_j2commerce/tmpl/dashboard/default_onboarding.php
@@ -693,6 +693,17 @@ $e = fn(string $s): string => htmlspecialchars($s, ENT_QUOTES, 'UTF-8');
             </div>
           </div>
 
+          <div id="ob-sampledata-prompt" class="text-center mt-4 d-none">
+            <p><?php echo Text::_('COM_J2COMMERCE_ONBOARDING_SAMPLEDATA_PROMPT'); ?></p>
+            <button type="button" class="btn btn-outline-primary me-2" data-action="load-sampledata">
+              <span class="fa-solid fa-database me-1"></span>
+              <?php echo Text::_('COM_J2COMMERCE_ONBOARDING_SAMPLEDATA_LOAD'); ?>
+            </button>
+            <button type="button" class="btn btn-link" data-action="skip-sampledata">
+              <?php echo Text::_('COM_J2COMMERCE_ONBOARDING_SAMPLEDATA_SKIP'); ?>
+            </button>
+          </div>
+
           <div class="row g-3 text-center">
             <div class="col-md-3">
               <button type="button" class="btn btn-outline-secondary w-100 shadow-none" data-action="back">

--- a/build/build_package.php
+++ b/build/build_package.php
@@ -86,6 +86,7 @@ $plugins = [
     ['group' => 'j2commerce', 'element' => 'shipping_free'],
     ['group' => 'j2commerce', 'element' => 'report_itemised'],
     ['group' => 'j2commerce', 'element' => 'report_products'],
+    ['group' => 'sampledata', 'element' => 'j2commerce'],
 ];
 
 $adminModules = [

--- a/build/script.pkg_j2commerce.php
+++ b/build/script.pkg_j2commerce.php
@@ -46,6 +46,7 @@ class Pkg_J2commerceInstallerScript extends InstallerScript
         ['j2commerce',  'shipping_free',        true],
         ['j2commerce',  'report_itemised',      true],
         ['j2commerce',  'report_products',      true],
+        ['sampledata',  'j2commerce',           true],
     ];
 
     /**

--- a/media/com_j2commerce/js/administrator/onboarding.js
+++ b/media/com_j2commerce/js/administrator/onboarding.js
@@ -457,6 +457,8 @@ document.addEventListener('DOMContentLoaded', () => {
             }
             case 6: {
                 buildSummary(data);
+                const sdPrompt = modal.querySelector('#ob-sampledata-prompt');
+                if (sdPrompt) sdPrompt.classList.remove('d-none');
                 break;
             }
         }
@@ -633,6 +635,46 @@ document.addEventListener('DOMContentLoaded', () => {
                 const defaults = options.defaults || {};
                 applyDefaults(defaults);
                 goToStep(2, 'forward');
+                break;
+            }
+            case 'load-sampledata': {
+                const btn = e.target.closest('[data-action="load-sampledata"]');
+                if (!btn) break;
+                btn.disabled = true;
+                const spinner = document.createElement('span');
+                spinner.className = 'spinner-border spinner-border-sm me-1';
+                spinner.setAttribute('role', 'status');
+                btn.prepend(spinner);
+
+                const fd = new FormData();
+                fd.append(token, '1');
+
+                try {
+                    const res  = await fetch('index.php?option=com_j2commerce&task=dashboard.loadSampleData&format=json', { method: 'POST', body: fd });
+                    const json = await res.json();
+                    const sdPrompt = modal.querySelector('#ob-sampledata-prompt');
+                    if (json.success) {
+                        if (sdPrompt) {
+                            const successAlert = document.createElement('div');
+                            successAlert.className = 'alert alert-success mt-3';
+                            successAlert.textContent = Joomla.Text._('COM_J2COMMERCE_DASHBOARD_SAMPLEDATA_LOADED');
+                            sdPrompt.replaceChildren(successAlert);
+                        }
+                    } else {
+                        btn.disabled = false;
+                        spinner.remove();
+                        showError(json.message || Joomla.Text._('COM_J2COMMERCE_ONBOARDING_ERR_SAVE'));
+                    }
+                } catch {
+                    btn.disabled = false;
+                    spinner.remove();
+                    showError(Joomla.Text._('COM_J2COMMERCE_ONBOARDING_ERR_SAVE'));
+                }
+                break;
+            }
+            case 'skip-sampledata': {
+                const sdPrompt = modal.querySelector('#ob-sampledata-prompt');
+                if (sdPrompt) sdPrompt.classList.add('d-none');
                 break;
             }
         }

--- a/media/plg_sampledata_j2commerce/images/books/1.svg
+++ b/media/plg_sampledata_j2commerce/images/books/1.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#7C3AED"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Books</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">1</text>
+</svg>

--- a/media/plg_sampledata_j2commerce/images/books/2.svg
+++ b/media/plg_sampledata_j2commerce/images/books/2.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#7C3AED"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Books</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">2</text>
+</svg>

--- a/media/plg_sampledata_j2commerce/images/books/3.svg
+++ b/media/plg_sampledata_j2commerce/images/books/3.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#7C3AED"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Books</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">3</text>
+</svg>

--- a/media/plg_sampledata_j2commerce/images/books/4.svg
+++ b/media/plg_sampledata_j2commerce/images/books/4.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#7C3AED"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Books</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">4</text>
+</svg>

--- a/media/plg_sampledata_j2commerce/images/books/5.svg
+++ b/media/plg_sampledata_j2commerce/images/books/5.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#7C3AED"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Books</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">5</text>
+</svg>

--- a/media/plg_sampledata_j2commerce/images/clothing/1.svg
+++ b/media/plg_sampledata_j2commerce/images/clothing/1.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#DB2777"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Clothing</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">1</text>
+</svg>

--- a/media/plg_sampledata_j2commerce/images/clothing/2.svg
+++ b/media/plg_sampledata_j2commerce/images/clothing/2.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#DB2777"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Clothing</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">2</text>
+</svg>

--- a/media/plg_sampledata_j2commerce/images/clothing/3.svg
+++ b/media/plg_sampledata_j2commerce/images/clothing/3.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#DB2777"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Clothing</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">3</text>
+</svg>

--- a/media/plg_sampledata_j2commerce/images/clothing/4.svg
+++ b/media/plg_sampledata_j2commerce/images/clothing/4.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#DB2777"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Clothing</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">4</text>
+</svg>

--- a/media/plg_sampledata_j2commerce/images/clothing/5.svg
+++ b/media/plg_sampledata_j2commerce/images/clothing/5.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#DB2777"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Clothing</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">5</text>
+</svg>

--- a/media/plg_sampledata_j2commerce/images/electronics/1.svg
+++ b/media/plg_sampledata_j2commerce/images/electronics/1.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#2563EB"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Electronics</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">1</text>
+</svg>

--- a/media/plg_sampledata_j2commerce/images/electronics/2.svg
+++ b/media/plg_sampledata_j2commerce/images/electronics/2.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#2563EB"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Electronics</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">2</text>
+</svg>

--- a/media/plg_sampledata_j2commerce/images/electronics/3.svg
+++ b/media/plg_sampledata_j2commerce/images/electronics/3.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#2563EB"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Electronics</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">3</text>
+</svg>

--- a/media/plg_sampledata_j2commerce/images/electronics/4.svg
+++ b/media/plg_sampledata_j2commerce/images/electronics/4.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#2563EB"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Electronics</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">4</text>
+</svg>

--- a/media/plg_sampledata_j2commerce/images/electronics/5.svg
+++ b/media/plg_sampledata_j2commerce/images/electronics/5.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#2563EB"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Electronics</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">5</text>
+</svg>

--- a/media/plg_sampledata_j2commerce/images/home/1.svg
+++ b/media/plg_sampledata_j2commerce/images/home/1.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#16A34A"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Home</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">1</text>
+</svg>

--- a/media/plg_sampledata_j2commerce/images/home/2.svg
+++ b/media/plg_sampledata_j2commerce/images/home/2.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#16A34A"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Home</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">2</text>
+</svg>

--- a/media/plg_sampledata_j2commerce/images/home/3.svg
+++ b/media/plg_sampledata_j2commerce/images/home/3.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#16A34A"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Home</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">3</text>
+</svg>

--- a/media/plg_sampledata_j2commerce/images/home/4.svg
+++ b/media/plg_sampledata_j2commerce/images/home/4.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#16A34A"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Home</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">4</text>
+</svg>

--- a/media/plg_sampledata_j2commerce/images/home/5.svg
+++ b/media/plg_sampledata_j2commerce/images/home/5.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#16A34A"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Home</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">5</text>
+</svg>

--- a/media/plg_sampledata_j2commerce/images/sporting/1.svg
+++ b/media/plg_sampledata_j2commerce/images/sporting/1.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#EA580C"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Sporting</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">1</text>
+</svg>

--- a/media/plg_sampledata_j2commerce/images/sporting/2.svg
+++ b/media/plg_sampledata_j2commerce/images/sporting/2.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#EA580C"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Sporting</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">2</text>
+</svg>

--- a/media/plg_sampledata_j2commerce/images/sporting/3.svg
+++ b/media/plg_sampledata_j2commerce/images/sporting/3.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#EA580C"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Sporting</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">3</text>
+</svg>

--- a/media/plg_sampledata_j2commerce/images/sporting/4.svg
+++ b/media/plg_sampledata_j2commerce/images/sporting/4.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#EA580C"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Sporting</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">4</text>
+</svg>

--- a/media/plg_sampledata_j2commerce/images/sporting/5.svg
+++ b/media/plg_sampledata_j2commerce/images/sporting/5.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#EA580C"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Sporting</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">5</text>
+</svg>

--- a/plugins/sampledata/j2commerce/j2commerce.xml
+++ b/plugins/sampledata/j2commerce/j2commerce.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extension type="plugin" group="sampledata" method="upgrade">
+    <name>plg_sampledata_j2commerce</name>
+    <author>J2Commerce, LLC</author>
+    <creationDate>2026-04</creationDate>
+    <copyright>(C)2024-2026 J2Commerce, LLC. All rights reserved.</copyright>
+    <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
+    <authorEmail>support@j2commerce.com</authorEmail>
+    <authorUrl>https://www.j2commerce.com</authorUrl>
+    <version>6.0.0</version>
+    <description>PLG_SAMPLEDATA_J2COMMERCE_XML_DESCRIPTION</description>
+    <namespace path="src">J2Commerce\Plugin\SampleData\J2Commerce</namespace>
+    <files>
+        <folder plugin="j2commerce">services</folder>
+        <folder>src</folder>
+    </files>
+    <media destination="plg_sampledata_j2commerce" folder="media">
+        <folder>images</folder>
+    </media>
+    <languages>
+        <language tag="en-GB">language/en-GB/plg_sampledata_j2commerce.ini</language>
+        <language tag="en-GB">language/en-GB/plg_sampledata_j2commerce.sys.ini</language>
+    </languages>
+    <config>
+        <fields name="params">
+        </fields>
+    </config>
+</extension>

--- a/plugins/sampledata/j2commerce/language/en-GB/plg_sampledata_j2commerce.ini
+++ b/plugins/sampledata/j2commerce/language/en-GB/plg_sampledata_j2commerce.ini
@@ -1,0 +1,15 @@
+; J2Commerce Sample Data Plugin
+; @package     J2Commerce
+; @copyright   (C)2024-2026 J2Commerce, LLC
+; @license     GNU General Public License version 2 or later
+
+PLG_SAMPLEDATA_J2COMMERCE_XML_DESCRIPTION="Loads sample products, orders, and customers into your J2Commerce store."
+
+PLG_SAMPLEDATA_J2COMMERCE_OVERVIEW_TITLE="J2Commerce Store"
+PLG_SAMPLEDATA_J2COMMERCE_OVERVIEW_DESC="Sample products with images, customer accounts, orders with status history, and discount coupons."
+
+PLG_SAMPLEDATA_J2COMMERCE_STEP1_SUCCESS="Step 1 complete: %d categories and %d manufacturers created."
+PLG_SAMPLEDATA_J2COMMERCE_STEP2_SUCCESS="Step 2 complete: %d products with %d images created."
+PLG_SAMPLEDATA_J2COMMERCE_STEP3_SUCCESS="Step 3 complete: %d customers and %d orders created."
+PLG_SAMPLEDATA_J2COMMERCE_STEP4_SUCCESS="Step 4 complete: %d coupons created. Sample data loaded successfully."
+PLG_SAMPLEDATA_J2COMMERCE_STEP_FAILED="Step %d failed: %s"

--- a/plugins/sampledata/j2commerce/language/en-GB/plg_sampledata_j2commerce.sys.ini
+++ b/plugins/sampledata/j2commerce/language/en-GB/plg_sampledata_j2commerce.sys.ini
@@ -1,0 +1,7 @@
+; J2Commerce Sample Data Plugin - System strings
+; @package     J2Commerce
+; @copyright   (C)2024-2026 J2Commerce, LLC
+; @license     GNU General Public License version 2 or later
+
+PLG_SAMPLEDATA_J2COMMERCE="Sample Data - J2Commerce"
+PLG_SAMPLEDATA_J2COMMERCE_XML_DESCRIPTION="Loads sample products, orders, and customers into your J2Commerce store."

--- a/plugins/sampledata/j2commerce/media/images/books/1.svg
+++ b/plugins/sampledata/j2commerce/media/images/books/1.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#7C3AED"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Books</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">1</text>
+</svg>

--- a/plugins/sampledata/j2commerce/media/images/books/2.svg
+++ b/plugins/sampledata/j2commerce/media/images/books/2.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#7C3AED"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Books</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">2</text>
+</svg>

--- a/plugins/sampledata/j2commerce/media/images/books/3.svg
+++ b/plugins/sampledata/j2commerce/media/images/books/3.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#7C3AED"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Books</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">3</text>
+</svg>

--- a/plugins/sampledata/j2commerce/media/images/books/4.svg
+++ b/plugins/sampledata/j2commerce/media/images/books/4.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#7C3AED"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Books</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">4</text>
+</svg>

--- a/plugins/sampledata/j2commerce/media/images/books/5.svg
+++ b/plugins/sampledata/j2commerce/media/images/books/5.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#7C3AED"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Books</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">5</text>
+</svg>

--- a/plugins/sampledata/j2commerce/media/images/clothing/1.svg
+++ b/plugins/sampledata/j2commerce/media/images/clothing/1.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#DB2777"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Clothing</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">1</text>
+</svg>

--- a/plugins/sampledata/j2commerce/media/images/clothing/2.svg
+++ b/plugins/sampledata/j2commerce/media/images/clothing/2.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#DB2777"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Clothing</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">2</text>
+</svg>

--- a/plugins/sampledata/j2commerce/media/images/clothing/3.svg
+++ b/plugins/sampledata/j2commerce/media/images/clothing/3.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#DB2777"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Clothing</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">3</text>
+</svg>

--- a/plugins/sampledata/j2commerce/media/images/clothing/4.svg
+++ b/plugins/sampledata/j2commerce/media/images/clothing/4.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#DB2777"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Clothing</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">4</text>
+</svg>

--- a/plugins/sampledata/j2commerce/media/images/clothing/5.svg
+++ b/plugins/sampledata/j2commerce/media/images/clothing/5.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#DB2777"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Clothing</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">5</text>
+</svg>

--- a/plugins/sampledata/j2commerce/media/images/electronics/1.svg
+++ b/plugins/sampledata/j2commerce/media/images/electronics/1.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#2563EB"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Electronics</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">1</text>
+</svg>

--- a/plugins/sampledata/j2commerce/media/images/electronics/2.svg
+++ b/plugins/sampledata/j2commerce/media/images/electronics/2.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#2563EB"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Electronics</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">2</text>
+</svg>

--- a/plugins/sampledata/j2commerce/media/images/electronics/3.svg
+++ b/plugins/sampledata/j2commerce/media/images/electronics/3.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#2563EB"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Electronics</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">3</text>
+</svg>

--- a/plugins/sampledata/j2commerce/media/images/electronics/4.svg
+++ b/plugins/sampledata/j2commerce/media/images/electronics/4.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#2563EB"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Electronics</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">4</text>
+</svg>

--- a/plugins/sampledata/j2commerce/media/images/electronics/5.svg
+++ b/plugins/sampledata/j2commerce/media/images/electronics/5.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#2563EB"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Electronics</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">5</text>
+</svg>

--- a/plugins/sampledata/j2commerce/media/images/home/1.svg
+++ b/plugins/sampledata/j2commerce/media/images/home/1.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#16A34A"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Home</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">1</text>
+</svg>

--- a/plugins/sampledata/j2commerce/media/images/home/2.svg
+++ b/plugins/sampledata/j2commerce/media/images/home/2.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#16A34A"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Home</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">2</text>
+</svg>

--- a/plugins/sampledata/j2commerce/media/images/home/3.svg
+++ b/plugins/sampledata/j2commerce/media/images/home/3.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#16A34A"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Home</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">3</text>
+</svg>

--- a/plugins/sampledata/j2commerce/media/images/home/4.svg
+++ b/plugins/sampledata/j2commerce/media/images/home/4.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#16A34A"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Home</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">4</text>
+</svg>

--- a/plugins/sampledata/j2commerce/media/images/home/5.svg
+++ b/plugins/sampledata/j2commerce/media/images/home/5.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#16A34A"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Home</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">5</text>
+</svg>

--- a/plugins/sampledata/j2commerce/media/images/sporting/1.svg
+++ b/plugins/sampledata/j2commerce/media/images/sporting/1.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#EA580C"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Sporting</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">1</text>
+</svg>

--- a/plugins/sampledata/j2commerce/media/images/sporting/2.svg
+++ b/plugins/sampledata/j2commerce/media/images/sporting/2.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#EA580C"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Sporting</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">2</text>
+</svg>

--- a/plugins/sampledata/j2commerce/media/images/sporting/3.svg
+++ b/plugins/sampledata/j2commerce/media/images/sporting/3.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#EA580C"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Sporting</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">3</text>
+</svg>

--- a/plugins/sampledata/j2commerce/media/images/sporting/4.svg
+++ b/plugins/sampledata/j2commerce/media/images/sporting/4.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#EA580C"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Sporting</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">4</text>
+</svg>

--- a/plugins/sampledata/j2commerce/media/images/sporting/5.svg
+++ b/plugins/sampledata/j2commerce/media/images/sporting/5.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800" viewBox="0 0 800 800">
+  <rect width="800" height="800" fill="#EA580C"/>
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Sporting</text>
+  <text x="400" y="460" font-family="Arial, sans-serif" font-size="120" font-weight="bold" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">5</text>
+</svg>

--- a/plugins/sampledata/j2commerce/services/provider.php
+++ b/plugins/sampledata/j2commerce/services/provider.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  plg_sampledata_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+\defined('_JEXEC') or die;
+
+use J2Commerce\Plugin\SampleData\J2Commerce\Extension\J2Commerce;
+use Joomla\CMS\Extension\PluginInterface;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\Database\DatabaseInterface;
+use Joomla\DI\Container;
+use Joomla\DI\ServiceProviderInterface;
+
+return new class () implements ServiceProviderInterface {
+    public function register(Container $container): void
+    {
+        $container->set(
+            PluginInterface::class,
+            function (Container $container) {
+                $plugin = new J2Commerce(
+                    (array) PluginHelper::getPlugin('sampledata', 'j2commerce')
+                );
+                $plugin->setApplication(Factory::getApplication());
+                $plugin->setDatabase($container->get(DatabaseInterface::class));
+
+                return $plugin;
+            }
+        );
+    }
+};

--- a/plugins/sampledata/j2commerce/src/Extension/J2Commerce.php
+++ b/plugins/sampledata/j2commerce/src/Extension/J2Commerce.php
@@ -1,0 +1,176 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  plg_sampledata_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Plugin\SampleData\J2Commerce\Extension;
+
+use J2Commerce\Component\J2commerce\Administrator\Helper\SampleDataHelper;
+use Joomla\CMS\Event\Plugin\AjaxEvent;
+use Joomla\CMS\Event\SampleData\GetOverviewEvent;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Plugin\CMSPlugin;
+use Joomla\CMS\Session\Session;
+use Joomla\Database\DatabaseAwareTrait;
+use Joomla\Event\SubscriberInterface;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+final class J2Commerce extends CMSPlugin implements SubscriberInterface
+{
+    use DatabaseAwareTrait;
+
+    protected $autoloadLanguage = true;
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            'onSampledataGetOverview'    => 'onSampledataGetOverview',
+            'onAjaxSampledataApplyStep1' => 'onAjaxSampledataApplyStep1',
+            'onAjaxSampledataApplyStep2' => 'onAjaxSampledataApplyStep2',
+            'onAjaxSampledataApplyStep3' => 'onAjaxSampledataApplyStep3',
+            'onAjaxSampledataApplyStep4' => 'onAjaxSampledataApplyStep4',
+        ];
+    }
+
+    public function onSampledataGetOverview(GetOverviewEvent $event): void
+    {
+        if (!$this->getApplication()->getIdentity()->authorise('core.manage', 'com_j2commerce')) {
+            return;
+        }
+
+        $data              = new \stdClass();
+        $data->name        = $this->_name;
+        $data->title       = Text::_('PLG_SAMPLEDATA_J2COMMERCE_OVERVIEW_TITLE');
+        $data->description = Text::_('PLG_SAMPLEDATA_J2COMMERCE_OVERVIEW_DESC');
+        $data->icon        = 'fa-solid fa-store';
+        $data->steps       = 4;
+
+        $event->addResult($data);
+    }
+
+    /**
+     * Step 1: Create categories and manufacturers.
+     */
+    public function onAjaxSampledataApplyStep1(AjaxEvent $event): void
+    {
+        if (!Session::checkToken('get') || $this->getApplication()->getInput()->get('type') !== $this->_name) {
+            return;
+        }
+
+        if (!$this->getApplication()->getIdentity()->authorise('core.manage', 'com_j2commerce')) {
+            $response            = [];
+            $response['success'] = false;
+            $response['message'] = Text::_('JERROR_ALERTNOAUTHOR');
+
+            $event->addResult($response);
+            return;
+        }
+
+        try {
+            $helper  = new SampleDataHelper($this->getDatabase());
+            $summary = $helper->load('standard');
+
+            // Store summary in user state for subsequent steps to reference
+            $this->getApplication()->setUserState('sampledata.j2commerce.loaded', true);
+            $this->getApplication()->setUserState('sampledata.j2commerce.summary', $summary);
+
+            $response            = [];
+            $response['success'] = true;
+            $response['message'] = Text::sprintf(
+                'PLG_SAMPLEDATA_J2COMMERCE_STEP1_SUCCESS',
+                (int) ($summary['categories'] ?? 0),
+                (int) ($summary['manufacturers'] ?? 0)
+            );
+
+            $event->addResult($response);
+        } catch (\Throwable $e) {
+            $response            = [];
+            $response['success'] = false;
+            $response['message'] = Text::sprintf('PLG_SAMPLEDATA_J2COMMERCE_STEP_FAILED', 1, $e->getMessage());
+
+            $event->addResult($response);
+        }
+    }
+
+    /**
+     * Step 2: Products and images were already created in step 1 (via load()).
+     * This step reports the product creation results.
+     */
+    public function onAjaxSampledataApplyStep2(AjaxEvent $event): void
+    {
+        if (!Session::checkToken('get') || $this->getApplication()->getInput()->get('type') !== $this->_name) {
+            return;
+        }
+
+        $summary = $this->getApplication()->getUserState('sampledata.j2commerce.summary', []);
+
+        $response            = [];
+        $response['success'] = true;
+        $response['message'] = Text::sprintf(
+            'PLG_SAMPLEDATA_J2COMMERCE_STEP2_SUCCESS',
+            (int) ($summary['products_simple'] ?? 0) + (int) ($summary['products_variable'] ?? 0),
+            (int) ($summary['product_images'] ?? 0)
+        );
+
+        $event->addResult($response);
+    }
+
+    /**
+     * Step 3: Customers and orders were already created in step 1 (via load()).
+     * This step reports the results.
+     */
+    public function onAjaxSampledataApplyStep3(AjaxEvent $event): void
+    {
+        if (!Session::checkToken('get') || $this->getApplication()->getInput()->get('type') !== $this->_name) {
+            return;
+        }
+
+        $summary = $this->getApplication()->getUserState('sampledata.j2commerce.summary', []);
+
+        $response            = [];
+        $response['success'] = true;
+        $response['message'] = Text::sprintf(
+            'PLG_SAMPLEDATA_J2COMMERCE_STEP3_SUCCESS',
+            (int) ($summary['customers'] ?? 0),
+            (int) ($summary['orders'] ?? 0)
+        );
+
+        $event->addResult($response);
+    }
+
+    /**
+     * Step 4: Coupons were already created in step 1 (via load()).
+     * This step reports the final results.
+     */
+    public function onAjaxSampledataApplyStep4(AjaxEvent $event): void
+    {
+        if (!Session::checkToken('get') || $this->getApplication()->getInput()->get('type') !== $this->_name) {
+            return;
+        }
+
+        $summary = $this->getApplication()->getUserState('sampledata.j2commerce.summary', []);
+
+        $response            = [];
+        $response['success'] = true;
+        $response['message'] = Text::sprintf(
+            'PLG_SAMPLEDATA_J2COMMERCE_STEP4_SUCCESS',
+            (int) ($summary['coupons'] ?? 0)
+        );
+
+        // Clear user state
+        $this->getApplication()->setUserState('sampledata.j2commerce.loaded', null);
+        $this->getApplication()->setUserState('sampledata.j2commerce.summary', null);
+
+        $event->addResult($response);
+    }
+}


### PR DESCRIPTION
## Summary
Fixes #347

New Joomla 6 sampledata plugin that loads sample products, categories, customers, orders, and coupons — accessible from the Joomla System > Sample Data UI, the J2Commerce dashboard, the onboarding wizard completion screen, or CLI.

## Changes

### New Plugin: `plugins/sampledata/j2commerce/`
- Joomla 6 native sampledata plugin ("Sample Data - J2Commerce")
- 4-step AJAX loading via `onSampledataGetOverview` + `onAjaxSampledataApplyStep1-4`
- Plugin manifest with media folder for placeholder images
- Language files (en-GB)
- Registered in `build/build_package.php` and `build/script.pkg_j2commerce.php` (enabled by default)

### SampleDataHelper Enhancements
- Product descriptions (intro + full text per category with HTML formatting)
- Product images via `#__j2commerce_productimages` using SVG placeholders from plugin media
- "Shop" parent category created as sibling of Uncategorised (not nested under it)
- Real order_id format: `timestamp + auto_increment_pk` (matches `OrderTable::generateOrderId()`)
- `invoice_prefix` from component config (default `INV-`)
- Store setup: auto-creates tax profile, enables shipping/payment if none exist
- Advanced pricing (sale prices + tier pricing) for "full" profile
- Complete cleanup in `remove()` including product images and advanced pricing
- `whereIn` with `ParameterType::STRING` for varchar order_id columns

### Dashboard Integration
- Empty store card with "Load Sample Data" button (shows when no products exist)
- "Sample data active" banner with "Remove Sample Data" button
- AJAX controller actions: `loadSampleData()` / `removeSampleData()`

### Onboarding Integration
- Sample data prompt after wizard completion (Step 6)

### CLI Enhancements
- Override options: `--categories`, `--products`, `--variable`, `--customers`, `--orders`

### 25 SVG Placeholder Images
- 5 categories × 5 images in `media/plg_sampledata_j2commerce/images/`
- Color-coded: electronics=blue, clothing=pink, home=green, sporting=orange, books=purple

## Testing
1. Navigate to J2Commerce dashboard with empty store → verify "Load Sample Data" card
2. Click Load → verify products, orders, customers created
3. Verify purple banner appears with Remove button
4. Click Remove → verify all sample data cleaned up
5. Test via Joomla System > Install > Sample Data → "Sample Data - J2Commerce"
6. Test CLI: `php cli/joomla.php j2commerce:load:sampledata --profile=standard --yes`

## Files Changed (65 files)
- `.gitignore` — whitelist sampledata plugin + media paths
- `administrator/.../Helper/SampleDataHelper.php` — descriptions, images, store setup, advanced pricing, order_id fix
- `administrator/.../Controller/DashboardController.php` — AJAX load/remove actions
- `administrator/.../View/Dashboard/HtmlView.php` — hasProducts/hasSampleData detection
- `administrator/.../tmpl/dashboard/default.php` — empty store card + active banner
- `administrator/.../tmpl/dashboard/default_onboarding.php` — completion prompt
- `administrator/.../CliCommands/LoadSampleDataCommand.php` — override options
- `media/com_j2commerce/js/administrator/onboarding.js` — sampledata prompt handlers
- `build/build_package.php` — added sampledata plugin
- `build/script.pkg_j2commerce.php` — added sampledata plugin config
- `plugins/sampledata/j2commerce/` — new plugin (manifest, provider, extension class, language, media)
- `media/plg_sampledata_j2commerce/images/` — 25 SVG placeholders