### PR TITLE
fix(onboarding): use proper plugin language keys, wrap sample data in info alert

### DIFF
--- a/administrator/components/com_j2commerce/src/Controller/OnboardingController.php
+++ b/administrator/components/com_j2commerce/src/Controller/OnboardingController.php
@@ -635,8 +635,12 @@ class OnboardingController extends BaseController
             $params      = new \Joomla\Registry\Registry($plugin->params);
             $displayName = $params->get('display_name', '');
 
-            if ($displayName === '') {
-                $displayName = Text::_(strtoupper('PLG_J2COMMERCE_' . $plugin->element));
+            // Use proper plugin language key — ignore legacy _DEFAULT keys
+            $pluginLangKey = strtoupper('PLG_J2COMMERCE_' . $plugin->element);
+            if ($displayName === '' || str_ends_with(strtoupper($displayName), '_DEFAULT')) {
+                $displayName = Text::_($pluginLangKey);
+            } else {
+                $displayName = Text::_($displayName);
             }
 
             if ($plugin->element === $defaultPayment) {

--- a/administrator/components/com_j2commerce/tmpl/dashboard/default_onboarding.php
+++ b/administrator/components/com_j2commerce/tmpl/dashboard/default_onboarding.php
@@ -89,7 +89,14 @@ foreach ($allPaymentPlugins as $plugin) {
 
     $params = new \Joomla\Registry\Registry($plugin->params);
     $displayName = $params->get('display_name', '');
-    $plugin->display_name = $displayName ? Text::_($displayName) : Text::_(strtoupper('PLG_J2COMMERCE_' . $plugin->element));
+
+    // Use proper plugin language key — ignore legacy _DEFAULT keys
+    $pluginLangKey = strtoupper('PLG_J2COMMERCE_' . $plugin->element);
+    if ($displayName === '' || str_ends_with(strtoupper($displayName), '_DEFAULT')) {
+        $plugin->display_name = Text::_($pluginLangKey);
+    } else {
+        $plugin->display_name = Text::_($displayName);
+    }
 
     if ((int) $plugin->enabled === 1) {
         $paymentPlugins[] = $plugin;
@@ -693,15 +700,17 @@ $e = fn(string $s): string => htmlspecialchars($s, ENT_QUOTES, 'UTF-8');
             </div>
           </div>
 
-          <div id="ob-sampledata-prompt" class="text-center mt-4 d-none">
-            <p><?php echo Text::_('COM_J2COMMERCE_ONBOARDING_SAMPLEDATA_PROMPT'); ?></p>
-            <button type="button" class="btn btn-outline-primary me-2" data-action="load-sampledata">
-              <span class="fa-solid fa-database me-1"></span>
-              <?php echo Text::_('COM_J2COMMERCE_ONBOARDING_SAMPLEDATA_LOAD'); ?>
-            </button>
-            <button type="button" class="btn btn-link" data-action="skip-sampledata">
-              <?php echo Text::_('COM_J2COMMERCE_ONBOARDING_SAMPLEDATA_SKIP'); ?>
-            </button>
+          <div id="ob-sampledata-prompt" class="d-none">
+            <div class="alert alert-info text-center mb-0">
+              <p class="mb-2"><?php echo Text::_('COM_J2COMMERCE_ONBOARDING_SAMPLEDATA_PROMPT'); ?></p>
+              <button type="button" class="btn btn-outline-primary btn-sm me-2" data-action="load-sampledata">
+                <span class="fa-solid fa-database me-1"></span>
+                <?php echo Text::_('COM_J2COMMERCE_ONBOARDING_SAMPLEDATA_LOAD'); ?>
+              </button>
+              <button type="button" class="btn btn-link btn-sm" data-action="skip-sampledata">
+                <?php echo Text::_('COM_J2COMMERCE_ONBOARDING_SAMPLEDATA_SKIP'); ?>
+              </button>
+            </div>
           </div>
 
           <div class="row g-3 text-center">

--- a/plugins/j2commerce/payment_banktransfer/payment_banktransfer.xml
+++ b/plugins/j2commerce/payment_banktransfer/payment_banktransfer.xml
@@ -65,7 +65,7 @@
                     type="text"
                     label="COM_J2COMMERCE_PLUGIN_DISPLAY_NAME"
                     description="COM_J2COMMERCE_PLUGIN_DISPLAY_NAME_DESC"
-                    default="PLG_J2COMMERCE_PAYMENT_BANKTRANSFER_DEFAULT"
+                    default="PLG_J2COMMERCE_PAYMENT_BANKTRANSFER"
                 />
 
                 <field

--- a/plugins/j2commerce/payment_banktransfer/src/Extension/PaymentBanktransfer.php
+++ b/plugins/j2commerce/payment_banktransfer/src/Extension/PaymentBanktransfer.php
@@ -143,7 +143,7 @@ final class PaymentBanktransfer extends CMSPlugin implements SubscriberInterface
         $result = $event->getArgument('result', []);
         $result[] = [
             'element' => $this->_element,
-            'name'    => Text::_($this->params->get('display_name', 'PLG_J2COMMERCE_PAYMENT_BANKTRANSFER_DEFAULT')),
+            'name'    => Text::_($this->params->get('display_name', 'PLG_J2COMMERCE_PAYMENT_BANKTRANSFER')),
             'image'   => $this->params->get('display_image', ''),
         ];
         $event->setArgument('result', $result);
@@ -217,7 +217,7 @@ final class PaymentBanktransfer extends CMSPlugin implements SubscriberInterface
         $vars->orderpayment_type = $this->_element;
         $vars->bank_information = $this->params->get('bank_details', '');
 
-        $vars->display_name = Text::_($this->params->get('display_name', 'PLG_J2COMMERCE_PAYMENT_BANKTRANSFER_DEFAULT'));
+        $vars->display_name = Text::_($this->params->get('display_name', 'PLG_J2COMMERCE_PAYMENT_BANKTRANSFER'));
         $vars->onbeforepayment_text = $this->params->get('onbeforepayment', '');
         $vars->button_text = $this->params->get('button_text', Text::_('COM_J2COMMERCE_PLACE_ORDER'));
 

--- a/plugins/j2commerce/payment_cash/payment_cash.xml
+++ b/plugins/j2commerce/payment_cash/payment_cash.xml
@@ -65,7 +65,7 @@
                     type="text"
                     label="COM_J2COMMERCE_PLUGIN_DISPLAY_NAME"
                     description="COM_J2COMMERCE_PLUGIN_DISPLAY_NAME_DESC"
-                    default="PLG_J2COMMERCE_PAYMENT_CASH_DEFAULT"
+                    default="PLG_J2COMMERCE_PAYMENT_CASH"
                 />
 
                 <field

--- a/plugins/j2commerce/payment_cash/src/Extension/PaymentCash.php
+++ b/plugins/j2commerce/payment_cash/src/Extension/PaymentCash.php
@@ -162,7 +162,7 @@ final class PaymentCash extends CMSPlugin implements SubscriberInterface
         $result = $event->getArgument('result', []);
         $result[] = [
             'element' => $this->_name,
-            'name'    => Text::_($this->params->get('display_name', 'PLG_J2COMMERCE_PAYMENT_CASH_DEFAULT')),
+            'name'    => Text::_($this->params->get('display_name', 'PLG_J2COMMERCE_PAYMENT_CASH')),
             'image'   => $this->params->get('display_image', ''),
         ];
         $event->setArgument('result', $result);
@@ -277,7 +277,7 @@ final class PaymentCash extends CMSPlugin implements SubscriberInterface
         $vars->orderpayment_amount = $data['orderpayment_amount'];
         $vars->orderpayment_type = $this->_name;
 
-        $vars->display_name = Text::_($this->params->get('display_name', 'PLG_J2COMMERCE_PAYMENT_CASH_DEFAULT'));
+        $vars->display_name = Text::_($this->params->get('display_name', 'PLG_J2COMMERCE_PAYMENT_CASH'));
         $vars->display_image = $this->params->get('display_image', '');
         $vars->onbeforepayment_text = $this->params->get('onbeforepayment', '');
         $vars->button_text = $this->params->get('button_text', Text::_('COM_J2COMMERCE_PLACE_ORDER'));

--- a/plugins/j2commerce/payment_moneyorder/payment_moneyorder.xml
+++ b/plugins/j2commerce/payment_moneyorder/payment_moneyorder.xml
@@ -65,7 +65,7 @@
                     type="text"
                     label="COM_J2COMMERCE_PLUGIN_DISPLAY_NAME"
                     description="COM_J2COMMERCE_PLUGIN_DISPLAY_NAME_DESC"
-                    default="PLG_J2COMMERCE_PAYMENT_MONEYORDER_DEFAULT"
+                    default="PLG_J2COMMERCE_PAYMENT_MONEYORDER"
                 />
 
                 <field

--- a/plugins/j2commerce/payment_moneyorder/src/Extension/PaymentMoneyorder.php
+++ b/plugins/j2commerce/payment_moneyorder/src/Extension/PaymentMoneyorder.php
@@ -197,7 +197,7 @@ final class PaymentMoneyorder extends CMSPlugin implements SubscriberInterface
         $result = $event->getArgument('result', []);
         $result[] = [
             'element' => $this->_name,
-            'name'    => Text::_($this->params->get('display_name', 'PLG_J2COMMERCE_PAYMENT_MONEYORDER_DEFAULT')),
+            'name'    => Text::_($this->params->get('display_name', 'PLG_J2COMMERCE_PAYMENT_MONEYORDER')),
             'image'   => $this->params->get('display_image', ''),
         ];
         $event->setArgument('result', $result);
@@ -290,7 +290,7 @@ final class PaymentMoneyorder extends CMSPlugin implements SubscriberInterface
         $vars->orderpayment_amount = $data['orderpayment_amount'];
         $vars->orderpayment_type = $this->_name;
 
-        $vars->display_name = Text::_($this->params->get('display_name', 'PLG_J2COMMERCE_PAYMENT_MONEYORDER_DEFAULT'));
+        $vars->display_name = Text::_($this->params->get('display_name', 'PLG_J2COMMERCE_PAYMENT_MONEYORDER'));
         $vars->display_image = $this->params->get('display_image', '');
         $vars->onbeforepayment_text = $this->params->get('onbeforepayment', '');
         $vars->moneyorder_information = $this->params->get('moneyorder_information', '');

--- a/plugins/j2commerce/payment_paypal/payment_paypal.xml
+++ b/plugins/j2commerce/payment_paypal/payment_paypal.xml
@@ -66,7 +66,7 @@
                     type="text"
                     label="COM_J2COMMERCE_PLUGIN_DISPLAY_NAME"
                     description="COM_J2COMMERCE_PLUGIN_DISPLAY_NAME_DESC"
-                    default="PLG_J2COMMERCE_PAYMENT_PAYPAL_DEFAULT"
+                    default="PLG_J2COMMERCE_PAYMENT_PAYPAL"
                 />
                 <field
                     name="display_image"

--- a/plugins/j2commerce/payment_paypal/src/Extension/PaymentPaypal.php
+++ b/plugins/j2commerce/payment_paypal/src/Extension/PaymentPaypal.php
@@ -229,7 +229,7 @@ final class PaymentPaypal extends CMSPlugin implements SubscriberInterface
         $result = $event->getArgument('result', []);
         $result[] = [
             'element' => $this->_name,
-            'name'    => Text::_($this->params->get('display_name', 'PLG_J2COMMERCE_PAYMENT_PAYPAL_DEFAULT')),
+            'name'    => Text::_($this->params->get('display_name', 'PLG_J2COMMERCE_PAYMENT_PAYPAL')),
             'image'   => $this->params->get('display_image', ''),
         ];
         $event->setArgument('result', $result);
@@ -455,7 +455,7 @@ final class PaymentPaypal extends CMSPlugin implements SubscriberInterface
         $vars->orderpayment_amount = $data['orderpayment_amount'];
         $vars->orderpayment_type = $this->_name;
 
-        $vars->display_name = Text::_($this->params->get('display_name', 'PLG_J2COMMERCE_PAYMENT_PAYPAL_DEFAULT'));
+        $vars->display_name = Text::_($this->params->get('display_name', 'PLG_J2COMMERCE_PAYMENT_PAYPAL'));
         $vars->display_image = $this->params->get('display_image', '');
         $vars->onbeforepayment_text = $this->params->get('onbeforepayment', '');
 

--- a/plugins/j2commerce/shipping_free/shipping_free.xml
+++ b/plugins/j2commerce/shipping_free/shipping_free.xml
@@ -60,7 +60,7 @@
                     type="text"
                     label="PLG_J2COMMERCE_SHIPPING_FREE_DISPLAY_NAME"
                     description="PLG_J2COMMERCE_SHIPPING_FREE_DISPLAY_NAME_DESC"
-                    default="PLG_J2COMMERCE_SHIPPING_FREE_DEFAULT"
+                    default="PLG_J2COMMERCE_SHIPPING_FREE"
                 />
 
                 <field

--- a/plugins/j2commerce/shipping_free/src/Extension/ShippingFree.php
+++ b/plugins/j2commerce/shipping_free/src/Extension/ShippingFree.php
@@ -115,7 +115,7 @@ final class ShippingFree extends CMSPlugin implements SubscriberInterface
         $result   = $event->getArgument('result', []);
         $result[] = [
             'element' => $this->_name,
-            'name'    => Text::_($this->params->get('display_name', 'PLG_J2COMMERCE_SHIPPING_FREE_DEFAULT')),
+            'name'    => Text::_($this->params->get('display_name', 'PLG_J2COMMERCE_SHIPPING_FREE')),
             'code'    => '',
             'price'   => 0,
             'tax'     => 0,


### PR DESCRIPTION
## Core Update

### Changes
- Replace all legacy `_DEFAULT` language key references with proper `PLG_J2COMMERCE_{ELEMENT}` keys across payment and shipping plugins
- Update `OnboardingController::getPaymentSummary()` and onboarding template `display_name` resolution to detect and ignore legacy `_DEFAULT` keys
- Wrap onboarding sample data prompt in `alert-info` box to visually separate from the 4 action buttons

### Files Modified
| Type | Count |
|------|-------|
| PHP files | 7 |
| XML manifests | 5 |

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only (non-core excluded)