### PR TITLE
Hide menu links when 'hidemainmenu' input is true or no items exist

### DIFF
--- a/administrator/modules/mod_j2commerce_menu/tmpl/default.php
+++ b/administrator/modules/mod_j2commerce_menu/tmpl/default.php
@@ -12,7 +12,9 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
-if (empty($menuItems)) {
+$hideLinks = $app->getInput()->getBool('hidemainmenu');
+
+if ($hideLinks || $menuItems < 1) {
     return;
 }
 


### PR DESCRIPTION
Usually the modules in the status position are not displayed in an edit view - this prevents you leaving an article open and checked out for example. But the j2commerce admin menu module is present on all views - this PR changes that

<img width="1661" height="89" alt="Image" src="https://github.com/user-attachments/assets/7d7deccb-77ec-4af2-8674-bbf4bca379c1" />

### Before
<img width="1924" height="139" alt="Image" src="https://github.com/user-attachments/assets/ea2b1ca0-3961-41e1-82e7-f9462b0ac614" />

### After
<img width="1916" height="110" alt="image" src="https://github.com/user-attachments/assets/8704df15-0772-4d8a-ace0-8fd8e3ce3a61" />
