### PR TITLE
fix(install): correct SQL file paths and package language dir entries

### DIFF
--- a/administrator/components/com_j2commerce/script.j2commerce.php
+++ b/administrator/components/com_j2commerce/script.j2commerce.php
@@ -269,7 +269,7 @@ class Com_J2commerceInstallerScript extends InstallerScript
             }
 
             if ($needsCountries) {
-                $this->executeSqlFile($installer->getPath('source') . '/administrator/components/com_j2commerce/sql/countries.sql');
+                $this->executeSqlFile($installer->getPath('source') . '/administrator/components/com_j2commerce/sql/install/mysql/countries.sql');
             }
         } catch (\Exception $e) {
             Log::add('Error installing countries: ' . $e->getMessage(), Log::WARNING, 'j2commerce');
@@ -288,7 +288,7 @@ class Com_J2commerceInstallerScript extends InstallerScript
             }
 
             if ($needsZones) {
-                $this->executeSqlFile($installer->getPath('source') . '/administrator/components/com_j2commerce/sql/zones.sql');
+                $this->executeSqlFile($installer->getPath('source') . '/administrator/components/com_j2commerce/sql/install/mysql/zones.sql');
             }
         } catch (\Exception $e) {
             Log::add('Error installing zones: ' . $e->getMessage(), Log::WARNING, 'j2commerce');
@@ -296,8 +296,8 @@ class Com_J2commerceInstallerScript extends InstallerScript
 
         // Install metrics (lengths and weights)
         try {
-            $this->executeSqlFile($installer->getPath('source') . '/administrator/components/com_j2commerce/sql/lengths.sql');
-            $this->executeSqlFile($installer->getPath('source') . '/administrator/components/com_j2commerce/sql/weights.sql');
+            $this->executeSqlFile($installer->getPath('source') . '/administrator/components/com_j2commerce/sql/install/mysql/lengths.sql');
+            $this->executeSqlFile($installer->getPath('source') . '/administrator/components/com_j2commerce/sql/install/mysql/weights.sql');
         } catch (\Exception $e) {
             Log::add('Error installing metrics: ' . $e->getMessage(), Log::WARNING, 'j2commerce');
         }

--- a/build/build_package.php
+++ b/build/build_package.php
@@ -538,7 +538,9 @@ if (file_exists($pkgScript)) {
     echo "  WARNING: Package script not found at {$pkgScript}\n";
 }
 
-// Package language file
+// Package language file (add directory entries so all extractors create the folder)
+$outerZip->addEmptyDir('language');
+$outerZip->addEmptyDir('language/en-GB');
 $pkgLang = $buildDir . '/language/en-GB/pkg_j2commerce.sys.ini';
 if (file_exists($pkgLang)) {
     $outerZip->addFile($pkgLang, 'language/en-GB/pkg_j2commerce.sys.ini');


### PR DESCRIPTION
## Summary
Fixes #382

- Fixed 4 localisation SQL paths in `script.j2commerce.php` from `sql/*.sql` to `sql/install/mysql/*.sql` (countries, zones, lengths, weights)
- Added explicit `language/` and `language/en-GB/` directory entries in the package zip to prevent extraction issues with `pkg_j2commerce.sys.ini`

## Changes
- `administrator/components/com_j2commerce/script.j2commerce.php` — corrected SQL file paths
- `build/build_package.php` — added empty dir entries for language folder in package zip

## Testing
1. Run `php build/build_package.php`
2. Install the resulting zip on a fresh Joomla 6 site
3. Verify no SQL "not found" errors in the install log
4. Verify no "File does not exist" error for `pkg_j2commerce.sys.ini`