### PR TITLE
fix(calendar): use core Joomla calendar on Dashboard and Analytics

### DIFF
--- a/administrator/components/com_j2commerce/tmpl/analytics/default.php
+++ b/administrator/components/com_j2commerce/tmpl/analytics/default.php
@@ -55,11 +55,11 @@ $changeHtml = function (array $change): string {
                 <div class="card-body d-flex flex-wrap align-items-center gap-3">
                     <div class="d-flex align-items-center gap-2">
                         <label for="analytics-from" class="form-label mb-0 fw-bold"><?php echo Text::_('COM_J2COMMERCE_ANALYTICS_DATE_FROM'); ?></label>
-                        <input type="date" id="analytics-from" class="form-control form-control-sm" style="width:160px" value="<?php echo $this->escape($this->fromDate); ?>">
+                        <?php echo HTMLHelper::_('calendar', $this->escape($this->fromDate), 'analytics-from', 'analytics-from', '%Y-%m-%d', ['class' => 'form-control-sm', 'style' => 'width:160px']); ?>
                     </div>
                     <div class="d-flex align-items-center gap-2">
                         <label for="analytics-to" class="form-label mb-0 fw-bold"><?php echo Text::_('COM_J2COMMERCE_ANALYTICS_DATE_TO'); ?></label>
-                        <input type="date" id="analytics-to" class="form-control form-control-sm" style="width:160px" value="<?php echo $this->escape($this->toDate); ?>">
+                        <?php echo HTMLHelper::_('calendar', $this->escape($this->toDate), 'analytics-to', 'analytics-to', '%Y-%m-%d', ['class' => 'form-control-sm', 'style' => 'width:160px']); ?>
                     </div>
                     <button type="button" id="analytics-refresh" class="btn btn-primary btn-sm">
                         <span class="icon-loop"></span> <?php echo Text::_('COM_J2COMMERCE_ANALYTICS_REFRESH'); ?>

--- a/administrator/components/com_j2commerce/tmpl/dashboard/default.php
+++ b/administrator/components/com_j2commerce/tmpl/dashboard/default.php
@@ -89,11 +89,11 @@ if($doc->countModules('j2commerce-dashboard-module-main-tab') && $doc->countModu
                 <div class="card-body d-flex flex-wrap align-items-center gap-3">
                     <div class="d-flex align-items-center gap-2">
                         <label for="dashboard-from" class="form-label mb-0 fw-bold"><?php echo Text::_('COM_J2COMMERCE_ANALYTICS_DATE_FROM'); ?></label>
-                        <input type="date" id="dashboard-from" class="form-control form-control-sm" style="width:160px" value="<?php echo $this->escape($this->fromDate); ?>">
+                        <?php echo HTMLHelper::_('calendar', $this->escape($this->fromDate), 'dashboard-from', 'dashboard-from', '%Y-%m-%d', ['class' => 'form-control-sm', 'style' => 'width:160px']); ?>
                     </div>
                     <div class="d-flex align-items-center gap-2">
                         <label for="dashboard-to" class="form-label mb-0 fw-bold"><?php echo Text::_('COM_J2COMMERCE_ANALYTICS_DATE_TO'); ?></label>
-                        <input type="date" id="dashboard-to" class="form-control form-control-sm" style="width:160px" value="<?php echo $this->escape($this->toDate); ?>">
+                        <?php echo HTMLHelper::_('calendar', $this->escape($this->toDate), 'dashboard-to', 'dashboard-to', '%Y-%m-%d', ['class' => 'form-control-sm', 'style' => 'width:160px']); ?>
                     </div>
                     <button type="button" id="dashboard-refresh" class="btn btn-primary btn-sm">
                         <span class="icon-loop"></span> <?php echo Text::_('COM_J2COMMERCE_ANALYTICS_REFRESH'); ?>


### PR DESCRIPTION
## Summary
Fixes #379

## Changes
- Replaced 4 HTML5 `<input type="date">` fields with `HTMLHelper::_('calendar', ...)` on:
  - **Dashboard** date filter bar (from/to fields)
  - **Analytics** date filter bar (from/to fields)
- Uses `%Y-%m-%d` format to maintain AJAX JS compatibility
- Calendar popup provides localized month/day names, first-day-of-week, and non-Gregorian calendar support (e.g., Jalali)

## Files Changed
- `administrator/components/com_j2commerce/tmpl/dashboard/default.php` — replaced 2 date inputs
- `administrator/components/com_j2commerce/tmpl/analytics/default.php` — replaced 2 date inputs

## Testing
1. Open J2Commerce Dashboard — verify Joomla calendar widgets appear
2. Click preset buttons (1d, 7d, 30d, 90d) — dates update, AJAX refresh works
3. Click calendar icon — popup shows localized month/day names
4. Open Analytics page — same calendar behavior
5. Verify preset buttons and manual date selection trigger AJAX data refresh

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] Core files only