### PR TITLE
fix(orders-module): remove email address from latest orders module

### DIFF
--- a/administrator/modules/mod_j2commerce_orders/tmpl/default.php
+++ b/administrator/modules/mod_j2commerce_orders/tmpl/default.php
@@ -55,9 +55,6 @@ if (empty($orders)) {
                 </td>
                 <td>
                     <small><?php echo htmlspecialchars($customerName, ENT_QUOTES, 'UTF-8'); ?></small>
-                    <?php if (!empty($order->user_email) && $customerName !== $order->user_email) : ?>
-                        <small class="text-muted">(<?php echo htmlspecialchars($order->user_email, ENT_QUOTES, 'UTF-8'); ?>)</small>
-                    <?php endif; ?>
                 </td>
                 <td class="text-center">
                     <span class="order-status-badge <?php echo htmlspecialchars($order->orderstatus_cssclass ?? 'badge text-bg-secondary', ENT_QUOTES, 'UTF-8'); ?>">


### PR DESCRIPTION
## Summary
Fixes #378

- Removes the email address displayed in parentheses next to customer names in the Latest Orders admin dashboard module
- Guest orders with no name still show email as the customer name (existing fallback on line 43)

## Changes
- `administrator/modules/mod_j2commerce_orders/tmpl/default.php` — removed email display block (lines 58-60)

## Testing
1. Open J2Commerce Dashboard in admin
2. Check the Latest Orders module
3. Verify no email shown in parentheses next to customer names
4. Verify date column has proper width now
5. Verify guest orders with no name still show email as customer name