### PR TITLE
fix(coupons): allow NULL dates and fix expiry validation variable typo

### DIFF
--- a/administrator/components/com_j2commerce/sql/updates/mysql/6.1.5.sql
+++ b/administrator/components/com_j2commerce/sql/updates/mysql/6.1.5.sql
@@ -1,0 +1,15 @@
+-- Fix coupon date columns: allow NULL instead of storing 0000-00-00 00:00:00
+ALTER TABLE `#__j2commerce_coupons`
+    MODIFY `valid_from` datetime DEFAULT NULL/** CAN FAIL **/;
+
+ALTER TABLE `#__j2commerce_coupons`
+    MODIFY `valid_to` datetime DEFAULT NULL/** CAN FAIL **/;
+
+-- Clean up existing zero-date records
+UPDATE `#__j2commerce_coupons`
+SET `valid_from` = NULL
+WHERE `valid_from` = '0000-00-00 00:00:00'/** CAN FAIL **/;
+
+UPDATE `#__j2commerce_coupons`
+SET `valid_to` = NULL
+WHERE `valid_to` = '0000-00-00 00:00:00'/** CAN FAIL **/;

--- a/administrator/components/com_j2commerce/src/Model/CouponModel.php
+++ b/administrator/components/com_j2commerce/src/Model/CouponModel.php
@@ -935,8 +935,8 @@ class CouponModel extends AdminModel
         $validFrom = $this->coupon->valid_from;
         $validTo = $this->coupon->valid_to;
 
-        $isValidFrom = (empty($valid_from) || $validFrom === $nullDate || Factory::getDate($valid_from)->toSql() <= $now);
-        $isValidTo = (empty($valid_to) || $validTo === $nullDate || Factory::getDate($valid_to)->toSql() >= $now);
+        $isValidFrom = (empty($validFrom) || $validFrom === $nullDate || Factory::getDate($validFrom)->toSql() <= $now);
+        $isValidTo = (empty($validTo) || $validTo === $nullDate || Factory::getDate($validTo)->toSql() >= $now);
 
         if (!$isValidFrom || !$isValidTo) {
             throw new Exception(Text::_('COM_J2COMMERCE_COUPON_HAS_EXPIRED'));


### PR DESCRIPTION
## Summary
Fixes #374

## Changes
- **SQL migration (6.1.5.sql):** ALTER `valid_from`/`valid_to` columns on `j2commerce_coupons` to `datetime DEFAULT NULL` (were `NOT NULL`), and UPDATE existing `0000-00-00 00:00:00` records to `NULL`
- **CouponModel.php:** Fix undefined variable typo in `validateExpiryDate()` — `$valid_from`/`$valid_to` → `$validFrom`/`$validTo`

## Root Cause
The coupon date columns were `NOT NULL` on existing installs. When PHP set empty dates to `null`, MySQL stored `0000-00-00 00:00:00`. The install SQL was already correct (`DEFAULT NULL`) but no ALTER was issued for upgrades. Additionally, `validateExpiryDate()` used undefined snake_case variables instead of the camelCase ones assigned two lines above.

## Files Changed
- `administrator/.../sql/updates/mysql/6.1.5.sql` — new migration
- `administrator/.../src/Model/CouponModel.php` — fix variable names on lines 938-939

## Testing
1. Create a coupon with empty date fields → saves without error
2. View coupons list → empty dates show as "—" not `0000-00-00 00:00:00`
3. Edit coupon → calendar fields are empty, not showing zero dates
4. Apply a dateless coupon at checkout → no false expiry error

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] Core files only