### PR TITLE
fix(orders): use div.small.text-break for email in order list

### DIFF
--- a/administrator/components/com_j2commerce/tmpl/orders/default.php
+++ b/administrator/components/com_j2commerce/tmpl/orders/default.php
@@ -116,9 +116,9 @@ $dateFormat = ComponentHelper::getParams('com_j2commerce')->get('date_format', '
                                     <small><?php echo HTMLHelper::_('date', $item->created_on, $dateFormat); ?></small>
                                 </td>
                                 <td>
-                                    <small><?php echo $this->escape($customerName); ?></small>
+                                    <strong class="small"><?php echo $this->escape($customerName); ?></strong>
                                     <?php if (!empty($item->user_email) && $customerName !== $item->user_email) : ?>
-                                        <small class="text-muted">(<?php echo $this->escape($item->user_email); ?>)</small>
+                                        <div class="small text-break"><?php echo $this->escape($item->user_email); ?></div>
                                     <?php endif; ?>
                                     <?php if (!empty($item->discount_code)) : ?>
                                         <span class="clickTooltip ms-1" role="button" tabindex="0" style="cursor:pointer;" data-bs-toggle="tooltip" data-bs-trigger="click" data-bs-placement="top" title="<?php echo $this->escape(Text::_('COM_J2COMMERCE_COUPON_CODE') . ': ' . $item->discount_code); ?>">


### PR DESCRIPTION
## Summary
Fixes #371

- Moves email address to its own line below the customer name using `<div class="small text-break">`
- Bolds the customer name with `<strong>` for better visual hierarchy
- Uses Bootstrap 5 `text-break` utility to prevent long emails from breaking the table layout

## Changes
- `administrator/components/com_j2commerce/tmpl/orders/default.php` — changed email from inline `<small class="text-muted">` to block `<div class="small text-break">`, bolded customer name

## Testing
1. Go to J2Commerce > Orders in admin
2. Verify email appears below customer name on its own line
3. Verify long email addresses wrap properly without breaking the table