### PR TITLE
fix(orders): resolve payment method display using sys.ini language files

### DIFF
--- a/administrator/components/com_j2commerce/src/Model/OrdersModel.php
+++ b/administrator/components/com_j2commerce/src/Model/OrdersModel.php
@@ -197,11 +197,13 @@ class OrdersModel extends ListModel
         );
 
         // Join extensions for payment plugin display name
+        // Handle both new format (payment_cash) and legacy J2Store format (plg_j2commerce_payment_cash)
         $query->select($db->quoteName('ext.name', 'payment_plugin_name'));
         $query->join(
             'LEFT',
             $db->quoteName('#__extensions', 'ext') .
-            ' ON ' . $db->quoteName('ext.element') . ' = ' . $db->quoteName('a.orderpayment_type') .
+            ' ON ' . $db->quoteName('ext.element') .
+            ' = REPLACE(' . $db->quoteName('a.orderpayment_type') . ', ' . $db->quote('plg_j2commerce_') . ', ' . $db->quote('') . ')' .
             ' AND ' . $db->quoteName('ext.folder') . ' = ' . $db->quote('j2commerce') .
             ' AND ' . $db->quoteName('ext.type') . ' = ' . $db->quote('plugin')
         );

--- a/administrator/components/com_j2commerce/src/View/Orders/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Orders/HtmlView.php
@@ -185,8 +185,11 @@ class HtmlView extends BaseHtmlView
         $db->setQuery($query);
 
         foreach ($db->loadColumn() ?: [] as $element) {
-            $lang->load('plg_j2commerce_' . $element, JPATH_ADMINISTRATOR);
-            $lang->load('plg_j2commerce_' . $element, JPATH_PLUGINS . '/j2commerce/' . $element);
+            $ext = 'plg_j2commerce_' . $element;
+            $lang->load($ext . '.sys', JPATH_ADMINISTRATOR)
+                || $lang->load($ext . '.sys', JPATH_PLUGINS . '/j2commerce/' . $element);
+            $lang->load($ext, JPATH_ADMINISTRATOR)
+                || $lang->load($ext, JPATH_PLUGINS . '/j2commerce/' . $element);
         }
     }
 


### PR DESCRIPTION
## Summary
Fixes #372

## Changes
- **OrdersModel.php** — SQL JOIN uses `REPLACE()` to strip `plg_j2commerce_` prefix from `orderpayment_type` so both legacy J2Store format (`plg_j2commerce_payment_cod`) and new format (`payment_cash`) match `#__extensions.element`
- **Orders/HtmlView.php** — `loadPaymentPluginLanguages()` now loads `.sys.ini` files (where plugin display names like "Cash on Delivery" are defined), matching the pattern used in onboarding and payment-methods views

## Files Changed
- `administrator/.../src/Model/OrdersModel.php` — REPLACE in JOIN condition
- `administrator/.../src/View/Orders/HtmlView.php` — load .sys.ini + .ini

## Testing
1. Open J2Commerce → Orders
2. Payment method column shows translated names ("Cash on Delivery" not "PLG_J2COMMERCE_PAYMENT_CASH")
3. Migrated orders with old-format types resolve correctly
4. Uninstalled plugins show raw value as-is