### PR TITLE
feat(sampledata): add sample vendors to sample data generation

### DIFF
--- a/administrator/components/com_j2commerce/src/Helper/SampleDataHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/SampleDataHelper.php
@@ -41,6 +41,7 @@ final class SampleDataHelper
             'orders'        => 10,
             'options'       => 2,
             'manufacturers' => 2,
+            'vendors'       => 2,
             'coupons'       => 2,
             'vouchers'      => 2,
             'date_range_days' => 30,
@@ -56,6 +57,7 @@ final class SampleDataHelper
             'orders'        => 50,
             'options'       => 5,
             'manufacturers' => 5,
+            'vendors'       => 3,
             'coupons'       => 5,
             'vouchers'      => 3,
             'date_range_days' => 90,
@@ -71,6 +73,7 @@ final class SampleDataHelper
             'orders'        => 500,
             'options'       => 10,
             'manufacturers' => 15,
+            'vendors'       => 8,
             'coupons'       => 15,
             'vouchers'      => 5,
             'date_range_days' => 365,
@@ -175,6 +178,11 @@ final class SampleDataHelper
         'TechNova', 'StyleCraft', 'EcoHome', 'ActivePro', 'ReadWell Publishing',
         'GadgetPrime', 'UrbanWear', 'GreenNest', 'SportMax', 'MediaHouse',
         'InnoTech', 'FashionForward', 'HomeEssentials', 'FitLife', 'BookWorld',
+    ];
+
+    private const VENDOR_NAMES = [
+        'GlobalTrade Co.', 'PrimeSellers', 'MarketEdge', 'DirectGoods', 'ValueLine Supply',
+        'SwiftShip Wholesale', 'TruSource Partners', 'AllStock Distributors',
     ];
 
     private const ADDRESS_DATA = [
@@ -304,6 +312,10 @@ final class SampleDataHelper
         $mfgIds  = $this->createManufacturers((int) $cfg['manufacturers'], $now);
         $summary['manufacturers'] = count($mfgIds);
 
+        // 2b. Create vendors
+        $vendorIds = $this->createVendors((int) ($cfg['vendors'] ?? 0), $now);
+        $summary['vendors'] = count($vendorIds);
+
         // 3. Create options
         $optionIds = $this->createOptions((int) $cfg['options']);
         $summary['options'] = count($optionIds);
@@ -311,28 +323,28 @@ final class SampleDataHelper
         // 4. Create products
         $productIds = [];
 
-        $simpleIds = $this->createSimpleProducts((int) $cfg['simple'], $catIds, $mfgIds, $now);
+        $simpleIds = $this->createSimpleProducts((int) $cfg['simple'], $catIds, $mfgIds, $vendorIds, $now);
         $productIds = array_merge($productIds, $simpleIds);
         $summary['products_simple'] = count($simpleIds);
 
-        $varIds = $this->createVariableProducts((int) $cfg['variable'], $catIds, $mfgIds, $optionIds, $now);
+        $varIds = $this->createVariableProducts((int) $cfg['variable'], $catIds, $mfgIds, $vendorIds, $optionIds, $now);
         $productIds = array_merge($productIds, $varIds);
         $summary['products_variable'] = count($varIds);
 
         if (!empty($cfg['configurable'])) {
-            $cfgIds = $this->createSimpleProducts((int) $cfg['configurable'], $catIds, $mfgIds, $now, 'configurable');
+            $cfgIds = $this->createSimpleProducts((int) $cfg['configurable'], $catIds, $mfgIds, $vendorIds, $now, 'configurable');
             $productIds = array_merge($productIds, $cfgIds);
             $summary['products_configurable'] = count($cfgIds);
         }
 
         if (!empty($cfg['bundle'])) {
-            $bundleIds = $this->createSimpleProducts((int) $cfg['bundle'], $catIds, $mfgIds, $now, 'bundle');
+            $bundleIds = $this->createSimpleProducts((int) $cfg['bundle'], $catIds, $mfgIds, $vendorIds, $now, 'bundle');
             $productIds = array_merge($productIds, $bundleIds);
             $summary['products_bundle'] = count($bundleIds);
         }
 
         if (!empty($cfg['downloadable'])) {
-            $dlIds = $this->createSimpleProducts((int) $cfg['downloadable'], $catIds, $mfgIds, $now, 'downloadable');
+            $dlIds = $this->createSimpleProducts((int) $cfg['downloadable'], $catIds, $mfgIds, $vendorIds, $now, 'downloadable');
             $productIds = array_merge($productIds, $dlIds);
             $summary['products_downloadable'] = count($dlIds);
         }
@@ -659,6 +671,14 @@ final class SampleDataHelper
 
             $db->setQuery(
                 $db->getQuery(true)
+                    ->delete($db->quoteName('#__j2commerce_vendors'))
+                    ->whereIn($db->quoteName('address_id'), $sampleAddrIds)
+            );
+            $db->execute();
+            $counts['vendors'] = $db->getAffectedRows();
+
+            $db->setQuery(
+                $db->getQuery(true)
                     ->delete($db->quoteName('#__j2commerce_addresses'))
                     ->whereIn($db->quoteName('j2commerce_address_id'), $sampleAddrIds)
             );
@@ -819,6 +839,58 @@ final class SampleDataHelper
         return $mfgIds;
     }
 
+    private function createVendors(int $count, string $now): array
+    {
+        if ($count <= 0) {
+            return [];
+        }
+
+        $db        = $this->db;
+        $vendorIds = [];
+        $names     = array_slice(self::VENDOR_NAMES, 0, $count);
+
+        foreach ($names as $i => $vendorName) {
+            $addr          = new \stdClass();
+            $addr->user_id = 0;
+            $addr->first_name  = $vendorName;
+            $addr->last_name   = '';
+            $addr->email       = strtolower(str_replace([' ', '.'], '', $vendorName)) . '@example.com';
+            $addr->address_1   = (($i + 1) * 200) . ' Vendor Blvd';
+            $addr->address_2   = '';
+            $addr->city        = 'Sample City';
+            $addr->zip         = '00000';
+            $addr->zone_id     = '0';
+            $addr->country_id  = '223';
+            $addr->phone_1     = '+1-555-000-0000';
+            $addr->phone_2     = '';
+            $addr->type        = 'vendor';
+            $addr->company     = '[SAMPLE] ' . $vendorName;
+            $addr->tax_number  = '';
+
+            $db->insertObject('#__j2commerce_addresses', $addr);
+            $addrId = (int) $db->insertid();
+
+            if ($addrId <= 0) {
+                continue;
+            }
+
+            $vendor                    = new \stdClass();
+            $vendor->j2commerce_user_id = 0;
+            $vendor->address_id        = $addrId;
+            $vendor->enabled           = 1;
+            $vendor->ordering          = $i + 1;
+
+            $db->insertObject('#__j2commerce_vendors', $vendor);
+            $vendorId = (int) $db->insertid();
+
+            if ($vendorId > 0) {
+                $vendorIds[] = $vendorId;
+            }
+        }
+
+        return $vendorIds;
+    }
+
     private function createOptions(int $count): array
     {
         $db        = $this->db;
@@ -857,7 +929,7 @@ final class SampleDataHelper
         return $optionIds;
     }
 
-    private function createSimpleProducts(int $count, array $catIds, array $mfgIds, string $now, string $type = 'simple'): array
+    private function createSimpleProducts(int $count, array $catIds, array $mfgIds, array $vendorIds, string $now, string $type = 'simple'): array
     {
         if ($count <= 0 || empty($catIds)) {
             return [];
@@ -940,7 +1012,7 @@ final class SampleDataHelper
             $product->main_tag         = '';
             $product->taxprofile_id    = 0;
             $product->manufacturer_id  = $mfgId;
-            $product->vendor_id        = 0;
+            $product->vendor_id        = !empty($vendorIds) ? $vendorIds[array_rand($vendorIds)] : 0;
             $product->has_options      = 0;
             $product->addtocart_text   = '';
             $product->enabled          = 1;
@@ -984,7 +1056,7 @@ final class SampleDataHelper
         return $productIds;
     }
 
-    private function createVariableProducts(int $count, array $catIds, array $mfgIds, array $optionIds, string $now): array
+    private function createVariableProducts(int $count, array $catIds, array $mfgIds, array $vendorIds, array $optionIds, string $now): array
     {
         if ($count <= 0 || empty($catIds)) {
             return [];
@@ -1074,7 +1146,7 @@ final class SampleDataHelper
             $product->main_tag          = '';
             $product->taxprofile_id     = 0;
             $product->manufacturer_id   = $mfgId;
-            $product->vendor_id         = 0;
+            $product->vendor_id         = !empty($vendorIds) ? $vendorIds[array_rand($vendorIds)] : 0;
             $product->has_options       = 1;
             $product->addtocart_text    = '';
             $product->enabled           = 1;


### PR DESCRIPTION
## Summary
Fixes #369

## Changes
- Added `VENDOR_NAMES` constant with 8 vendor company names
- Added `createVendors()` method (same pattern as `createManufacturers()` — creates address + vendor record with `[SAMPLE]` prefix)
- Added vendor counts to all 3 presets: minimal (2), standard (3), full (8)
- Updated `createSimpleProducts()` and `createVariableProducts()` to assign random vendor_id to products
- Added vendor cleanup in `removeSampleData()` (deletes from `#__j2commerce_vendors` by sample address IDs)

## Files Changed
- `administrator/.../src/Helper/SampleDataHelper.php` — all changes

## Testing
1. Remove existing sample data if loaded
2. Load sample data (any preset)
3. Check J2Commerce → Vendors — should have sample entries
4. Check products — should have vendor_id assigned
5. Remove sample data — vendors cleaned up