### PR TITLE
fix(install): enable PayPal plugin on fresh install

### DIFF
--- a/build/script.pkg_j2commerce.php
+++ b/build/script.pkg_j2commerce.php
@@ -41,7 +41,7 @@ class Pkg_J2commerceInstallerScript extends InstallerScript
         ['j2commerce',  'payment_cash',         true],
         ['j2commerce',  'payment_moneyorder',   true],
         ['j2commerce',  'payment_banktransfer', true],
-        ['j2commerce',  'payment_paypal',       false],
+        ['j2commerce',  'payment_paypal',       true],
         ['j2commerce',  'shipping_standard',    true],
         ['j2commerce',  'shipping_free',        true],
         ['j2commerce',  'report_itemised',      true],


### PR DESCRIPTION
## Summary
Fixes #365

- Changes PayPal plugin `enableOnFreshInstall` from `false` to `true` in the package install script
- PayPal will now appear in the onboarding payment method list alongside Cash, Money Order, and Bank Transfer

## Changes
- `build/script.pkg_j2commerce.php` — changed `payment_paypal` auto-enable flag to `true`

## Testing
1. Fresh install J2Commerce package
2. Verify PayPal plugin is enabled in Extensions > Plugins
3. Open Setup Guide / Onboarding
4. Verify PayPal appears in the payment methods list