### PR TITLE
fix(products): load existing master variant before save to prevent data loss

### DIFF
--- a/administrator/components/com_j2commerce/src/Model/Behavior/Simple.php
+++ b/administrator/components/com_j2commerce/src/Model/Behavior/Simple.php
@@ -226,12 +226,28 @@ class Simple
             return;
         }
 
-        // Save variant data
+        // Save variant data — load existing master variant first so store() does UPDATE not INSERT
         /** @var VariantTable $variant */
         $variant = $this->mvcFactory->createTable('Variant', 'Administrator');
         if (!$variant) {
             throw new \RuntimeException('Unable to create Variant table instance.');
         }
+
+        // Try to load existing master variant by product_id
+        $db = Factory::getContainer()->get(\Joomla\Database\DatabaseInterface::class);
+        $query = $db->getQuery(true)
+            ->select($db->quoteName('j2commerce_variant_id'))
+            ->from($db->quoteName('#__j2commerce_variants'))
+            ->where($db->quoteName('product_id') . ' = :productId')
+            ->where($db->quoteName('is_master') . ' = 1')
+            ->bind(':productId', $table->j2commerce_product_id, \Joomla\Database\ParameterType::INTEGER);
+        $db->setQuery($query);
+        $existingVariantId = (int) $db->loadResult();
+
+        if ($existingVariantId) {
+            $variant->load($existingVariantId);
+        }
+
         $variant->bind($this->_rawData);
         $variant->is_master  = 1;
         $variant->product_id = $table->j2commerce_product_id;


### PR DESCRIPTION
## Summary
Fixes #363

`Simple::onAfterSave()` was creating a fresh `VariantTable` instance and calling `bind()` + `store()` without first loading the existing master variant. When the raw data lacked `j2commerce_variant_id` (e.g., content plugin save flow, guided tour), `store()` attempted an INSERT with default values instead of UPDATE — silently losing SKU, price, shipping, and all other variant fields.

## Changes
- `administrator/.../Model/Behavior/Simple.php` — query for existing master variant by `product_id + is_master=1` and `load()` it before `bind()`/`store()`

## Testing
1. Create a new simple product via article editor
2. Set SKU, price, shipping — save
3. Reload article — verify all variant fields are persisted
4. Edit values and save again — verify update works
5. Create a product via guided tour, then edit — verify data saves