### PR TITLE
fix(products): load existing variant before save in Downloadable and Configurable

### DIFF
--- a/administrator/components/com_j2commerce/src/Model/Behavior/Configurable.php
+++ b/administrator/components/com_j2commerce/src/Model/Behavior/Configurable.php
@@ -185,11 +185,28 @@ class Configurable
             return;
         }
 
+        // Save variant data — load existing master variant first so store() does UPDATE not INSERT
         /** @var VariantTable $variant */
         $variant = $this->mvcFactory->createTable('Variant', 'Administrator');
         if (!$variant) {
             throw new \RuntimeException('Unable to create Variant table instance.');
         }
+
+        // Try to load existing master variant by product_id
+        $db = Factory::getContainer()->get(\Joomla\Database\DatabaseInterface::class);
+        $query = $db->getQuery(true)
+            ->select($db->quoteName('j2commerce_variant_id'))
+            ->from($db->quoteName('#__j2commerce_variants'))
+            ->where($db->quoteName('product_id') . ' = :productId')
+            ->where($db->quoteName('is_master') . ' = 1')
+            ->bind(':productId', $table->j2commerce_product_id, \Joomla\Database\ParameterType::INTEGER);
+        $db->setQuery($query);
+        $existingVariantId = (int) $db->loadResult();
+
+        if ($existingVariantId) {
+            $variant->load($existingVariantId);
+        }
+
         $variant->bind($this->_rawData);
         $variant->is_master = 1;
         $variant->product_id = $table->j2commerce_product_id;

--- a/administrator/components/com_j2commerce/src/Model/Behavior/Downloadable.php
+++ b/administrator/components/com_j2commerce/src/Model/Behavior/Downloadable.php
@@ -273,12 +273,28 @@ class Downloadable
             return;
         }
 
-        // Save variant data
+        // Save variant data — load existing master variant first so store() does UPDATE not INSERT
         /** @var VariantTable $variant */
         $variant = $this->mvcFactory->createTable('Variant', 'Administrator');
         if (!$variant) {
             throw new \RuntimeException('Unable to create Variant table instance.');
         }
+
+        // Try to load existing master variant by product_id
+        $db = Factory::getContainer()->get(\Joomla\Database\DatabaseInterface::class);
+        $query = $db->getQuery(true)
+            ->select($db->quoteName('j2commerce_variant_id'))
+            ->from($db->quoteName('#__j2commerce_variants'))
+            ->where($db->quoteName('product_id') . ' = :productId')
+            ->where($db->quoteName('is_master') . ' = 1')
+            ->bind(':productId', $table->j2commerce_product_id, \Joomla\Database\ParameterType::INTEGER);
+        $db->setQuery($query);
+        $existingVariantId = (int) $db->loadResult();
+
+        if ($existingVariantId) {
+            $variant->load($existingVariantId);
+        }
+
         $variant->bind($this->_rawData);
         $variant->is_master = 1;
         $variant->product_id = $table->j2commerce_product_id;


### PR DESCRIPTION
## Summary
Follow-up to #401 (fixes #363) — same variant save bug in two more product types.

Audited all behavior classes:

| Behavior | Had bug? | Status |
|----------|----------|--------|
| Simple | Yes | Fixed in #401 |
| **Downloadable** | **Yes** | **Fixed here** |
| **Configurable** | **Yes** | **Fixed here** |
| Variable | No (already loads) | OK |
| Flexivariable | No (already loads) | OK |
| Bundleproduct | No (already loads) | OK |
| Boxbuilderproduct | No (already loads) | OK |
| Guidedbuilder | No (already loads) | OK |

## Changes
- `administrator/.../Model/Behavior/Downloadable.php` — load existing master variant before bind/store
- `administrator/.../Model/Behavior/Configurable.php` — load existing master variant before bind/store

## Testing
1. Create a downloadable product — set SKU, price — save and reload — verify persisted
2. Create a configurable product — set SKU, price — save and reload — verify persisted