### PR TITLE
fix(inventory): fix variant save 404 and bind-by-reference error

### DIFF
--- a/administrator/components/com_j2commerce/src/Model/InventoryModel.php
+++ b/administrator/components/com_j2commerce/src/Model/InventoryModel.php
@@ -285,12 +285,13 @@ class InventoryModel extends ListModel
                 } else {
                     // Insert new record
                     $query = $db->getQuery(true);
+                    $emptyAttributes = '';
                     $query->insert($db->quoteName('#__j2commerce_productquantities'))
                         ->columns($db->quoteName(['variant_id', 'quantity', 'on_hold', 'sold', 'product_attributes']))
                         ->values(':variantId, :quantity, 0, 0, :productAttributes')
                         ->bind(':variantId', $variantId, ParameterType::INTEGER)
                         ->bind(':quantity', $quantity, ParameterType::INTEGER)
-                        ->bind(':productAttributes', '');
+                        ->bind(':productAttributes', $emptyAttributes);
                 }
 
                 $db->setQuery($query);

--- a/administrator/components/com_j2commerce/tmpl/inventory/default.php
+++ b/administrator/components/com_j2commerce/tmpl/inventory/default.php
@@ -153,7 +153,7 @@ document.addEventListener("DOMContentLoaded", function() {
     };
 
     // AJAX save for individual variant items
-    window.saveVariantItem = function(variantId) {
+    window.saveVariantItem = function(variantId, productId) {
         const row = document.getElementById("variant-row-" + variantId);
         if (!row) return;
         const quantity = getFieldValue(row, ".quantity-input, input[name*=quantity]");
@@ -165,13 +165,14 @@ document.addEventListener("DOMContentLoaded", function() {
         setBtnState(saveBtn, "saving", originalText);
 
         const body = new URLSearchParams();
+        body.set("product_id", productId);
         body.set("variant_id", variantId);
         body.set("quantity", quantity);
         body.set("manage_stock", manageStock);
         body.set("availability", availability);
         body.set(csrfToken, "1");
 
-        fetch("index.php?option=com_j2commerce&task=variants.saveVariant", {
+        fetch("index.php?option=com_j2commerce&task=inventory.saveItem", {
             method: "POST",
             headers: { "Content-Type": "application/x-www-form-urlencoded", "Accept": "application/json" },
             body: body.toString()
@@ -478,7 +479,7 @@ document.addEventListener("DOMContentLoaded", function() {
                                                     <div class="col-md-2 text-end">
                                                         <button type="button"
                                                                 class="btn btn-sm btn-primary save-btn"
-                                                                onclick="saveVariantItem(<?php echo $variant->j2commerce_variant_id; ?>)">
+                                                                onclick="saveVariantItem(<?php echo $variant->j2commerce_variant_id; ?>, <?php echo (int) $variant->product_id; ?>)">
                                                             <?php echo Text::_('COM_J2COMMERCE_SAVE'); ?>
                                                         </button>
                                                     </div>


### PR DESCRIPTION
## Summary
Fixes two bugs in the inventory view's individual variant save button:

1. **404 error** — `saveVariantItem()` called `task=variants.saveVariant` which routes to a non-existent `VariantsController`. Changed to `task=inventory.saveItem` (the existing `InventoryController::saveItem()` method).
2. **500 error** — `InventoryModel.php:293` passed a string literal `''` to `bind()`, which requires a variable reference. Assigned to a variable first.

Also added the missing `product_id` parameter to the variant save POST body (required by `saveItem()`).

## Changes
- `administrator/.../tmpl/inventory/default.php` — fixed task URL, added `productId` param to function and onclick
- `administrator/.../Model/InventoryModel.php` — fixed bind-by-reference error with `$emptyAttributes` variable

## Testing
1. Go to J2Commerce > Inventory
2. Expand a product with multiple variants (click the variant count badge)
3. Edit a variant's quantity or stock settings
4. Click Save on the variant row
5. Verify success message appears (no 404 or 500 errors)