### PR TITLE
fix(build): email template SQL install and package language file

### DIFF
--- a/administrator/components/com_j2commerce/script.j2commerce.php
+++ b/administrator/components/com_j2commerce/script.j2commerce.php
@@ -318,7 +318,7 @@ class Com_J2commerceInstallerScript extends InstallerScript
             }
 
             if ($needsEmails) {
-                $this->executeSqlFile($installer->getPath('source') . '/administrator/components/com_j2commerce/sql/install/mysql/emailtemplates.sql');
+                $this->executeSqlFileDirect($installer->getPath('source') . '/administrator/components/com_j2commerce/sql/install/mysql/emailtemplates.sql');
             }
         } catch (\Exception $e) {
             $this->debugLog("LOCALISATION: email templates error: " . $e->getMessage());
@@ -338,7 +338,7 @@ class Com_J2commerceInstallerScript extends InstallerScript
             }
 
             if ($needsInvoices) {
-                $this->executeSqlFile($installer->getPath('source') . '/administrator/components/com_j2commerce/sql/install/mysql/invoicetemplates.sql');
+                $this->executeSqlFileDirect($installer->getPath('source') . '/administrator/components/com_j2commerce/sql/install/mysql/invoicetemplates.sql');
             }
         } catch (\Exception $e) {
             $this->debugLog("LOCALISATION: invoice templates error: " . $e->getMessage());

--- a/build/build_package.php
+++ b/build/build_package.php
@@ -593,6 +593,9 @@ $outerZip->addEmptyDir('language/en-GB');
 $pkgLang = $buildDir . '/language/en-GB/pkg_j2commerce.sys.ini';
 if (file_exists($pkgLang)) {
     $outerZip->addFile($pkgLang, 'language/en-GB/pkg_j2commerce.sys.ini');
+    // Also add at root en-GB/ for Joomla 6 package installer compatibility
+    $outerZip->addEmptyDir('en-GB');
+    $outerZip->addFile($pkgLang, 'en-GB/pkg_j2commerce.sys.ini');
 } else {
     echo "  WARNING: Package language file not found at {$pkgLang}\n";
 }


### PR DESCRIPTION
## Summary
Fixes #408

## Changes
- Switch `emailtemplates.sql` and `invoicetemplates.sql` from `executeSqlFile()` to `executeSqlFileDirect()` — `DatabaseDriver::splitSql()` was breaking on CSS semicolons inside HTML template bodies, fragmenting the single INSERT into invalid SQL queries
- Add `en-GB/pkg_j2commerce.sys.ini` at zip root level for Joomla 6 package installer compatibility (was only under `language/en-GB/`)

## Testing
1. Run `php build/build_package.php` — verify no language file warning
2. Install the resulting zip on a clean Joomla 6 site
3. Verify no `pkg_j2commerce.sys.ini` error in install log
4. Verify email templates populate in admin (Design > Email Templates)

## Files Changed
- `administrator/components/com_j2commerce/script.j2commerce.php` — use `executeSqlFileDirect()` for template SQL files
- `build/build_package.php` — add language file at zip root level