### PR TITLE
fix(myprofile): null-safe orders and pagination access

### DIFF
--- a/components/com_j2commerce/tmpl/myprofile/default_orders.php
+++ b/components/com_j2commerce/tmpl/myprofile/default_orders.php
@@ -19,11 +19,11 @@ use Joomla\CMS\Router\Route;
 
 /** @var \J2Commerce\Component\J2commerce\Site\View\Myprofile\HtmlView $this */
 
-$orders     = $this->orders;
+$orders     = $this->orders ?? [];
 $params     = $this->params;
 $dateFormat = $params->get('date_format', 'Y-m-d');
-$total      = $this->pagination ? $this->pagination->total : \count($orders);
-$limit      = $this->pagination ? $this->pagination->limit : 20;
+$total      = isset($this->pagination) ? $this->pagination->total : \count($orders);
+$limit      = isset($this->pagination) ? $this->pagination->limit : 20;
 ?>
 
 <div id="j2c-orders-container">


### PR DESCRIPTION
## Summary
Prevent errors when the orders tab renders before orders/pagination are populated.

## Changes
- `$this->orders ?? []` — default to empty array when null
- `isset($this->pagination)` — safe check before accessing pagination properties

## Files Changed
| Type | Count |
|------|-------|
| PHP files | 1 |

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only