### PR TITLE
fix(build): track pkg_j2commerce.sys.ini language file in repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,6 +156,8 @@
 .mcp.json
 configuration.php
 language/
+!build/language/
+!build/language/**
 .env
 *.log
 cache/

--- a/build/language/en-GB/pkg_j2commerce.sys.ini
+++ b/build/language/en-GB/pkg_j2commerce.sys.ini
@@ -1,0 +1,2 @@
+PKG_J2COMMERCE="J2Commerce"
+PKG_J2COMMERCE_DESCRIPTION="J2Commerce e-commerce suite for Joomla 6. Includes the J2Commerce component, library, system plugins, payment plugins, shipping plugins, app plugins, report plugins, and frontend/admin modules."


### PR DESCRIPTION
## Summary
Fixes #413

## Changes
- Add `!build/language/` and `!build/language/**` negation rules in `.gitignore` — the blanket `language/` rule was preventing `build/language/` from being committed
- `build/language/en-GB/pkg_j2commerce.sys.ini` is now tracked so collaborators get it on clone and package builds succeed without the "Package language file not found" warning

## Testing
1. Clone fresh from the repo
2. Verify `build/language/en-GB/pkg_j2commerce.sys.ini` exists
3. Run `php build/build_package.php` — no language file warning

## Files Changed
- `.gitignore` — add negation for `build/language/`
- `build/language/en-GB/pkg_j2commerce.sys.ini` — newly tracked file