### PR TITLE
fix(sampledata): use correct payment plugin element name

### DIFF
--- a/administrator/components/com_j2commerce/src/Helper/SampleDataHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/SampleDataHelper.php
@@ -1543,7 +1543,7 @@ final class SampleDataHelper
             $order->order_refund           = 0.0;
             $order->order_surcharge        = 0.0;
             $order->order_fees             = 0.0;
-            $order->orderpayment_type      = 'plg_j2commerce_payment_cod';
+            $order->orderpayment_type      = 'payment_cash';
             $order->transaction_id         = 'TXN-SAMPLE-' . ($i + 1);
             $order->transaction_status     = 'success';
             $order->transaction_details    = '';


### PR DESCRIPTION
## Summary
Fixes #422

## Changes
- Changed sample data `orderpayment_type` from `'plg_j2commerce_payment_cod'` (wrong plugin name, wrong format) to `'payment_cash'` (correct plugin element, matches real checkout format)
- The OrdersModel JOIN on `#__extensions` can now resolve the payment plugin name, so the orders list displays "Cash on Delivery" instead of the raw string

## Testing
1. Reset sample data or load new sample orders
2. Navigate to J2Commerce → Orders
3. Verify payment column shows "Cash on Delivery" instead of "plg_j2commerce_payment_cod"

## Files Changed
- `administrator/components/com_j2commerce/src/Helper/SampleDataHelper.php` — fixed orderpayment_type value