### PR TITLE
fix(bs5): prevent j2commerce_bs5.css from loading in admin

### DIFF
--- a/plugins/j2commerce/app_bootstrap5/src/Extension/AppBootstrap5.php
+++ b/plugins/j2commerce/app_bootstrap5/src/Extension/AppBootstrap5.php
@@ -119,6 +119,10 @@ final class AppBootstrap5 extends CMSPlugin implements SubscriberInterface
 
     public function onAfterAddCSS(Event $event): void
     {
+        if (!Factory::getApplication()->isClient('site')) {
+            return;
+        }
+
         $wa = Factory::getApplication()->getDocument()->getWebAssetManager();
         $wa->registerAndUseStyle(
             'com_j2commerce.bs5.css',


### PR DESCRIPTION
## Summary
The `onJ2CommerceAfterAddCSS` event fires for both admin and frontend, causing `j2commerce_bs5.css` (a frontend-only stylesheet) to load in the admin backend.

## Changes
- Added `isClient('site')` guard to `AppBootstrap5::onAfterAddCSS()` so the CSS only loads on the frontend
- The UIkit plugin doesn't have this issue because it loads CSS directly in its template files which only render on the frontend

## Files Changed
- `plugins/j2commerce/app_bootstrap5/src/Extension/AppBootstrap5.php` — added frontend-only guard