### PR TITLE
fix(schemaorg): encode image URL spaces and resolve brand from manufacturer

### DIFF
--- a/plugins/schemaorg/ecommerce/src/Helper/J2CommerceSchemaHelper.php
+++ b/plugins/schemaorg/ecommerce/src/Helper/J2CommerceSchemaHelper.php
@@ -405,9 +405,14 @@ class J2CommerceSchemaHelper
     public function getManufacturer(int $manufacturerId): ?object
     {
         $query = $this->db->getQuery(true)
-            ->select('*')
-            ->from($this->db->quoteName('#__j2commerce_manufacturers'))
-            ->where($this->db->quoteName('j2commerce_manufacturer_id') . ' = :manufacturerId')
+            ->select('m.*, a.company')
+            ->from($this->db->quoteName('#__j2commerce_manufacturers', 'm'))
+            ->join(
+                'LEFT',
+                $this->db->quoteName('#__j2commerce_addresses', 'a')
+                . ' ON ' . $this->db->quoteName('m.address_id') . ' = ' . $this->db->quoteName('a.j2commerce_address_id')
+            )
+            ->where($this->db->quoteName('m.j2commerce_manufacturer_id') . ' = :manufacturerId')
             ->bind(':manufacturerId', $manufacturerId, ParameterType::INTEGER);
 
         $this->db->setQuery($query);
@@ -554,14 +559,14 @@ class J2CommerceSchemaHelper
             return '';
         }
 
-        // If already a full URL, return as-is
+        // If already a full URL, encode spaces and return
         if (strpos($imagePath, 'http://') === 0 || strpos($imagePath, 'https://') === 0) {
-            return $imagePath;
+            return str_replace(' ', '%20', $imagePath);
         }
 
         $imagePath = ltrim($imagePath, '/');
 
-        return Uri::root() . $imagePath;
+        return Uri::root() . str_replace(' ', '%20', $imagePath);
     }
 
     /**

--- a/plugins/schemaorg/ecommerce/src/Schema/ProductSchemaBuilder.php
+++ b/plugins/schemaorg/ecommerce/src/Schema/ProductSchemaBuilder.php
@@ -366,12 +366,12 @@ class ProductSchemaBuilder
             return '';
         }
 
-        // Already absolute
+        // Already absolute — encode spaces
         if (strpos($imagePath, 'http://') === 0 || strpos($imagePath, 'https://') === 0) {
-            return $imagePath;
+            return str_replace(' ', '%20', $imagePath);
         }
 
-        return Uri::root() . ltrim($imagePath, '/');
+        return Uri::root() . str_replace(' ', '%20', ltrim($imagePath, '/'));
     }
 
     /**
@@ -402,8 +402,12 @@ class ProductSchemaBuilder
             ];
         }
 
-        // Use default from params
+        // Use default from params, fall back to store name
         $defaultBrand = $this->params->get('default_brand', '');
+
+        if (empty($defaultBrand)) {
+            $defaultBrand = $this->helper->getStoreName();
+        }
 
         if (!empty($defaultBrand)) {
             return [


### PR DESCRIPTION
## Summary
Fixes #418

## Changes
- **Image URLs**: `getImageUrl()` and `prepareImageUrl()` now encode spaces as `%20` in image paths for valid JSON-LD output
- **Brand resolution**: `getManufacturer()` JOINs the addresses table to retrieve the `company` field (brand name) — previously the manufacturer object had no `company` column
- **Brand fallback**: When no manufacturer is assigned and no `default_brand` param is set, falls back to the store name instead of returning null

## Testing
1. View a product page that has an image with spaces in the filename
2. View page source, find the `<script type="application/ld+json">` tag
3. Verify: image URL has `%20` instead of spaces
4. Verify: `brand.name` shows the actual manufacturer name, or store name as fallback

## Files Changed
- `plugins/schemaorg/ecommerce/src/Helper/J2CommerceSchemaHelper.php` — JOIN addresses for manufacturer brand name; encode spaces in image URLs
- `plugins/schemaorg/ecommerce/src/Schema/ProductSchemaBuilder.php` — encode spaces in override image URLs; store name fallback for brand

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only