### PR TITLE
fix(inventory): remove inconsistent sort options from dropdown

### DIFF
--- a/administrator/components/com_j2commerce/forms/filter_inventory.xml
+++ b/administrator/components/com_j2commerce/forms/filter_inventory.xml
@@ -64,10 +64,6 @@
             <option value="v.sku DESC">COM_J2COMMERCE_INVENTORY_SKU_DESC</option>
             <option value="pq.quantity ASC">COM_J2COMMERCE_INVENTORY_QUANTITY_ASC</option>
             <option value="pq.quantity DESC">COM_J2COMMERCE_INVENTORY_QUANTITY_DESC</option>
-            <option value="v.manage_stock ASC">COM_J2COMMERCE_INVENTORY_MANAGE_STOCK_ASC</option>
-            <option value="v.manage_stock DESC">COM_J2COMMERCE_INVENTORY_MANAGE_STOCK_DESC</option>
-            <option value="v.availability ASC">COM_J2COMMERCE_INVENTORY_STOCK_STATUS_ASC</option>
-            <option value="v.availability DESC">COM_J2COMMERCE_INVENTORY_STOCK_STATUS_DESC</option>
         </field>
 
         <field


### PR DESCRIPTION
## Summary
Fixes #419

## Changes
- Removed "Manage Stock" and "Stock Status" sort options from the inventory dropdown since those columns don't have clickable column header sorting (due to variant product complexity)
- Filters for Manage Stock and Stock Status still work — only the sort options are removed

## Testing
1. Navigate to J2Commerce → Inventory
2. Open the sort dropdown — no "Manage Stock" or "Stock Status" sort options
3. Verify ID, Name, SKU, Quantity sorts still work
4. Verify Manage Stock and Stock Status filter dropdowns still work

## Files Changed
- `administrator/components/com_j2commerce/forms/filter_inventory.xml` — removed 4 sort options