### PR TITLE
fix(css): revert alert-info color scheme for admin backend

### DIFF
--- a/media/com_j2commerce/css/administrator/j2commerce_admin.css
+++ b/media/com_j2commerce/css/administrator/j2commerce_admin.css
@@ -103,6 +103,18 @@ body.com_j2commerce #content, #fieldset-j2commerce-product-settings, .j2commerce
         }
     }
 
+    .j-main-container > .alert-info {
+        color: var(--state-info-text)!important;
+        background-color: var(--state-info-bg)!important;
+        border-color: var(--state-info-border)!important;
+        .alert-link {color: var(--state-info-text)!important;}
+        .btn-info{
+            background-color: var(--state-info-text);
+            color: #fff;
+            text-decoration:none;
+        }
+    }
+
     .text-bg-warning {
         color: var(--warning)!important;
         background-color: var(--warning-bg-subtle)!important;


### PR DESCRIPTION
## Core Update

Fixes #21

### Changes
Revert the info message color scheme styling in the admin backend CSS. This change temporarily restores the previous styling for `.alert-info` elements in `.j-main-container`.

> **Note:** This change is being made to revert these info messages now and will revisit the overall color schema in a later update.

### Files Modified
| Type | Count |
|------|-------|
| CSS files | 1 |

### Pre-Flight
- [x] No PHP files changed (CSS only)
- [x] No secrets detected
- [x] Core files only