### PR TITLE
fix(a11y): add sr-only text to dashboard trend icons (fixes #452)

### DIFF
--- a/administrator/components/com_j2commerce/tmpl/analytics/default.php
+++ b/administrator/components/com_j2commerce/tmpl/analytics/default.php
@@ -41,8 +41,9 @@ $changeHtml = function (array $change): string {
         return '';
     }
     $icon  = $change['dir'] === 'up' ? 'fa-arrow-up' : 'fa-arrow-down';
+    $dirText = $change['dir'] === 'up' ? 'Up' : 'Down';
 
-    return '<span><span class="fa-solid ' . $icon . '" aria-hidden="true"></span> ' . $change['pct'] . '%</span>';
+    return '<span><span class="fa-solid ' . $icon . '" aria-hidden="true"></span><span class="visually-hidden">' . $dirText . '</span> ' . $change['pct'] . '%</span>';
 };
 ?>
 

--- a/administrator/components/com_j2commerce/tmpl/dashboard/default.php
+++ b/administrator/components/com_j2commerce/tmpl/dashboard/default.php
@@ -45,7 +45,8 @@ $changeHtml = function (array $change): string {
         return '';
     }
     $icon = $change['dir'] === 'up' ? 'fa-arrow-up' : 'fa-arrow-down';
-    return '<span><span class="fa-solid ' . $icon . '" aria-hidden="true"></span> ' . $change['pct'] . '%</span>';
+    $dirText = $change['dir'] === 'up' ? 'Up' : 'Down';
+    return '<span><span class="fa-solid ' . $icon . '" aria-hidden="true"></span><span class="visually-hidden">' . $dirText . '</span> ' . $change['pct'] . '%</span>';
 };
 if($doc->countModules('j2commerce-dashboard-module-main-tab') && $doc->countModules('j2commerce-dashboard-module-side-tab')){
     $colClass = 'col-lg-6';


### PR DESCRIPTION
## Summary
Fixes #452

Adds screen reader-only text for "Up" or "Down" direction indicators in dashboard and analytics KPI cards. The icons already had `aria-hidden="true"` (added upstream), but screen readers had no way to know whether the percentage change was up or down.

## Changes
- Add `$dirText` variable for direction text
- Add `<span class="visually-hidden">` with "Up" or "Down" for screen readers
- Files: `dashboard/default.php`, `analytics/default.php`

## Testing
1. Navigate to **Components → J2Commerce Dashboard**
2. Use browser DevTools or a screen reader
3. Inspect the percentage change indicators (arrows with %)
4. Verify: icons have `aria-hidden="true"` and adjacent `<span class="visually-hidden">Up</span>` (or Down)

## Files Changed
| Type | Count |
|------|-------|
| PHP templates | 2 |