### PR TITLE
fix(install): add vendor folder to component manifest media section

### DIFF
--- a/administrator/components/com_j2commerce/j2commerce.xml
+++ b/administrator/components/com_j2commerce/j2commerce.xml
@@ -33,6 +33,7 @@
         <folder>css</folder>
         <folder>js</folder>
         <folder>images</folder>
+        <folder>vendor</folder>
         <filename>joomla.asset.json</filename>
     </media>
 


### PR DESCRIPTION
## Core Update

### Changes
PR #450 moved 8 vendor libraries (Chart.js, Swiper, Fancybox, Leaflet, Zoom-Vanilla, Dual-Listbox, GrapesJS, Uppy) into `media/com_j2commerce/vendor/` but did not update the component manifest. Joomla's installer only copies folders explicitly listed in `<media>`, so the `vendor/` folder was never deployed on install/update — causing 404s on `chart.umd.min.js` and breaking the Dashboard with `Uncaught ReferenceError: Chart is not defined` on fresh installs.

Adding `<folder>vendor</folder>` to the media section ensures Joomla copies the `vendor/` subtree during component installation.

### Files Modified
| Type | Count |
|------|-------|
| XML/Config | 1 |

`administrator/components/com_j2commerce/j2commerce.xml` — added `<folder>vendor</folder>` to the `<media>` section.

### Pre-Flight
- [x] XML syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only (non-core excluded)
- [x] Verified fix on joomla-test-6: Chart.js loads and Dashboard renders correctly after deploying vendor/ subtree