### PR TITLE
Update spelling from "e-commerce" to "ecommerce" in language files

### DIFF
--- a/build/language/en-GB/pkg_j2commerce.sys.ini
+++ b/build/language/en-GB/pkg_j2commerce.sys.ini
@@ -1,2 +1,2 @@
 PKG_J2COMMERCE="J2Commerce"
-PKG_J2COMMERCE_DESCRIPTION="J2Commerce e-commerce suite for Joomla 6. Includes the J2Commerce component, library, system plugins, payment plugins, shipping plugins, app plugins, report plugins, and frontend/admin modules."
+PKG_J2COMMERCE_DESCRIPTION="J2Commerce ecommerce suite for Joomla 6. Includes the J2Commerce component, library, system plugins, payment plugins, shipping plugins, app plugins, report plugins, and frontend/admin modules."

--- a/build/language/us_to_gb_dictionary.php
+++ b/build/language/us_to_gb_dictionary.php
@@ -8,7 +8,7 @@
  */
 return [
     'exact' => [
-        // E-commerce terms (customer-facing)
+        // Ecommerce terms (customer-facing)
         'Shopping Cart'     => 'Shopping Basket',
         'shopping cart'     => 'shopping basket',
         'Add to Cart'       => 'Add to Basket',


### PR DESCRIPTION
in a previous PR it was decided to standardise on this spelling