### PR TITLE
chore(core): reorder shortcodes fieldset, default to Bootstrap 5

### DIFF
--- a/plugins/content/j2commerce/j2commerce.xml
+++ b/plugins/content/j2commerce/j2commerce.xml
@@ -3,7 +3,7 @@
     <name>plg_content_j2commerce</name>
     <author>J2Commerce, LLC</author>
     <creationDate>2026-01</creationDate>
-    <copyright>(C)2024-2026 J2Commerce, LLC. All rights reserved.</copyright>
+    <copyright>(C)2024–2026 J2Commerce, LLC. All rights reserved.</copyright>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>support@j2commerce.com</authorEmail>
     <authorUrl>https://www.j2commerce.com</authorUrl>
@@ -153,51 +153,6 @@
                 />
             </fieldset>
 
-            <fieldset name="shortcodes" label="PLG_CONTENT_J2COMMERCE_SHORTCODES_FIELDSET_LABEL">
-                <field
-                    name="shortcode_subtemplate"
-                    type="list"
-                    label="PLG_CONTENT_J2COMMERCE_SHORTCODE_SUBTEMPLATE_LABEL"
-                    description="PLG_CONTENT_J2COMMERCE_SHORTCODE_SUBTEMPLATE_DESC"
-                    default=""
-                >
-                    <option value="">JUSE_GLOBAL</option>
-                    <option value="app_bootstrap5">Bootstrap 5</option>
-                    <option value="app_uikit">UIkit 3</option>
-                </field>
-                <field
-                    name="shortcode_image_width"
-                    type="number"
-                    label="PLG_CONTENT_J2COMMERCE_SHORTCODE_IMAGE_WIDTH_LABEL"
-                    description="PLG_CONTENT_J2COMMERCE_SHORTCODE_IMAGE_WIDTH_DESC"
-                    default="300"
-                    min="50"
-                    max="2000"
-                />
-                <field
-                    name="shortcode_show_cart_options"
-                    type="radio"
-                    layout="joomla.form.field.radio.switcher"
-                    label="PLG_CONTENT_J2COMMERCE_SHORTCODE_SHOW_CART_OPTIONS_LABEL"
-                    description="PLG_CONTENT_J2COMMERCE_SHORTCODE_SHOW_CART_OPTIONS_DESC"
-                    default="1"
-                >
-                    <option value="0">JNO</option>
-                    <option value="1">JYES</option>
-                </field>
-                <field
-                    name="shortcode_strip_in_finder"
-                    type="radio"
-                    layout="joomla.form.field.radio.switcher"
-                    label="PLG_CONTENT_J2COMMERCE_SHORTCODE_STRIP_IN_FINDER_LABEL"
-                    description="PLG_CONTENT_J2COMMERCE_SHORTCODE_STRIP_IN_FINDER_DESC"
-                    default="1"
-                >
-                    <option value="0">JNO</option>
-                    <option value="1">JYES</option>
-                </field>
-            </fieldset>
-
             <fieldset name="itemview" label="PLG_CONTENT_J2COMMERCE_FIELDSET_ITEM_VIEW">
                 <field
                     name="item_product_block_position"
@@ -273,6 +228,50 @@
                     min="50"
                     max="800"
                 />
+            </fieldset>
+            <fieldset name="shortcodes" label="PLG_CONTENT_J2COMMERCE_SHORTCODES_FIELDSET_LABEL">
+                <field
+                    name="shortcode_subtemplate"
+                    type="list"
+                    label="PLG_CONTENT_J2COMMERCE_SHORTCODE_SUBTEMPLATE_LABEL"
+                    description="PLG_CONTENT_J2COMMERCE_SHORTCODE_SUBTEMPLATE_DESC"
+                    default="app_bootstrap5"
+                >
+                    <option value="">JUSE_GLOBAL</option>
+                    <option value="app_bootstrap5">Bootstrap 5</option>
+                    <option value="app_uikit">UIkit 3</option>
+                </field>
+                <field
+                    name="shortcode_image_width"
+                    type="number"
+                    label="PLG_CONTENT_J2COMMERCE_SHORTCODE_IMAGE_WIDTH_LABEL"
+                    description="PLG_CONTENT_J2COMMERCE_SHORTCODE_IMAGE_WIDTH_DESC"
+                    default="300"
+                    min="50"
+                    max="2000"
+                />
+                <field
+                    name="shortcode_show_cart_options"
+                    type="radio"
+                    layout="joomla.form.field.radio.switcher"
+                    label="PLG_CONTENT_J2COMMERCE_SHORTCODE_SHOW_CART_OPTIONS_LABEL"
+                    description="PLG_CONTENT_J2COMMERCE_SHORTCODE_SHOW_CART_OPTIONS_DESC"
+                    default="1"
+                >
+                    <option value="0">JNO</option>
+                    <option value="1">JYES</option>
+                </field>
+                <field
+                    name="shortcode_strip_in_finder"
+                    type="radio"
+                    layout="joomla.form.field.radio.switcher"
+                    label="PLG_CONTENT_J2COMMERCE_SHORTCODE_STRIP_IN_FINDER_LABEL"
+                    description="PLG_CONTENT_J2COMMERCE_SHORTCODE_STRIP_IN_FINDER_DESC"
+                    default="1"
+                >
+                    <option value="0">JNO</option>
+                    <option value="1">JYES</option>
+                </field>
             </fieldset>
         </fields>
     </config>


### PR DESCRIPTION
## Core Update

### Changes
- Move the Shortcodes fieldset to appear after `itemview` in `plg_content_j2commerce` settings
- Set `shortcode_subtemplate` default to `app_bootstrap5` for out-of-the-box rendering

### Files Modified
| Type | Count |
|------|-------|
| XML/Config | 1 |

### Pre-Flight
- [x] No secrets detected
- [x] Core files only (non-core excluded)