### PR TITLE
fix(a11y): remove empty sorted/filtered spans from Top Products caption (fixes #461)

### DIFF
--- a/administrator/components/com_j2commerce/tmpl/analytics/default.php
+++ b/administrator/components/com_j2commerce/tmpl/analytics/default.php
@@ -272,9 +272,7 @@ $changeHtml = function (array $change): string {
                     <div class="table-responsive">
                         <table class="table" id="analytics-products">
                             <caption class="visually-hidden">
-                                <?php echo Text::_('COM_J2COMMERCE_ANALYTICS_TOP_PRODUCTS'); ?>,
-                                <span id="orderedBy"><?php echo Text::_('JGLOBAL_SORTED_BY'); ?> </span>,
-                                <span id="filteredBy"><?php echo Text::_('JGLOBAL_FILTERED_BY'); ?></span>
+                                <?php echo Text::_('COM_J2COMMERCE_ANALYTICS_TOP_PRODUCTS'); ?>
                             </caption>
                             <thead>
                                 <tr>


### PR DESCRIPTION
## Summary
Fixes #461

The Top Products table in the admin analytics view used the standard sortable-list-view caption pattern with `#orderedBy` / `#filteredBy` spans. Joomla's grid JS updates these spans from sort-link clicks in real list views, but the Top Products table has no sortable headers or filters, so the spans stay empty and screen readers read: "Top Products, Sorted by , Filtered by" — meaningless and incomplete.

## Changes
- Remove the trailing comma and the two empty `#orderedBy` / `#filteredBy` spans from the `<caption>` of the Top Products table
- Caption now contains only the label (via `COM_J2COMMERCE_ANALYTICS_TOP_PRODUCTS`)

## Testing
1. Navigate to **Components → J2Commerce → Analytics**
2. Scroll to the **Top Products** card
3. Inspect the `<caption>` of `#analytics-products` via DevTools
4. Verify it now reads only "Top Products" with no trailing punctuation or empty "Sorted by" / "Filtered by" fragments

## Scope
Only `analytics/default.php`. Other files using the same span pattern (`apps/`, `countries/`, `coupons/`, `currencies/`, `customfields/`, etc.) are legitimate sortable list views where the spans ARE updated by Joomla's grid JS — those are left unchanged.

## Files Changed
| File | Change |
|---|---|
| `administrator/components/com_j2commerce/tmpl/analytics/default.php` | Remove unused `#orderedBy` / `#filteredBy` spans from Top Products caption |