### PR TITLE
fix(customer): move Address Type field to Address Information tab (fixes #463)

### DIFF
--- a/administrator/components/com_j2commerce/tmpl/customer/edit.php
+++ b/administrator/components/com_j2commerce/tmpl/customer/edit.php
@@ -47,9 +47,8 @@ $wa->useScript('keepalive')
                 </fieldset>
             </div>
             <div class="col-lg-3">
-                <fieldset id="fieldset-type" class="options-form">
-                    <legend><?php echo Text::_('COM_J2COMMERCE_FIELDSET_ADDRESS_TYPE'); ?></legend>
-                    <?php echo $this->form->renderField('type'); ?>
+                <fieldset id="fieldset-user" class="options-form">
+                    <legend><?php echo Text::_('COM_J2COMMERCE_FIELD_USER'); ?></legend>
                     <?php echo $this->form->renderField('user_id'); ?>
                 </fieldset>
             </div>
@@ -82,6 +81,10 @@ $wa->useScript('keepalive')
                 </fieldset>
             </div>
             <div class="col-lg-3">
+                <fieldset id="fieldset-type" class="options-form">
+                    <legend><?php echo Text::_('COM_J2COMMERCE_FIELDSET_ADDRESS_TYPE'); ?></legend>
+                    <?php echo $this->form->renderField('type'); ?>
+                </fieldset>
                 <fieldset id="fieldset-tax" class="options-form">
                     <legend><?php echo Text::_('COM_J2COMMERCE_FIELDSET_TAX_INFO'); ?></legend>
                     <?php echo $this->form->renderField('tax_number'); ?>


### PR DESCRIPTION
## Summary
Fixes #463

The Address Type select (billing/shipping) was rendered in the **Customer Details** tab sidebar of the customer/address edit form. Since the field describes a property of the address row itself (not the customer), users could not tell what the field was for or why it lived under Customer Details. Move it to the **Address Information** tab sidebar, next to Tax Information, where all other address-scoped settings live.

## Changes
- Remove the `type` field rendering from the Details tab sidebar
- Add a new `fieldset-type` on the Address tab sidebar above the existing `fieldset-tax`
- Rename the Details tab sidebar fieldset legend from `COM_J2COMMERCE_FIELDSET_ADDRESS_TYPE` ("Address Type") to `COM_J2COMMERCE_FIELD_USER` ("User") so the remaining `user_id` field is correctly labelled
- Rename the Details tab sidebar fieldset id from `fieldset-type` to `fieldset-user`

No form XML, model, controller, or database changes. No new language keys. The `type` field retains its existing form definition, validation, and persistence behavior.

## Testing
1. Navigate to **Components → J2Commerce → Customers**
2. Open any customer address record to edit
3. **Details** tab: verify sidebar now shows a **User** fieldset with the linked-user field only (no Address Type field)
4. **Address** tab: verify the sidebar now has two fieldsets — **Address Type** (new) above **Tax Information**
5. Change the Address Type value to Shipping, click **Save & Close**
6. Reopen the record — verify the type persisted correctly

## Files Changed
| File | Change |
|---|---|
| `administrator/components/com_j2commerce/tmpl/customer/edit.php` | Move `type` field from Details tab sidebar to Address tab sidebar, relabel Details sidebar |