### PR TITLE
fix(checkout): lift zone_id required when country has no zones

### DIFF
--- a/components/com_j2commerce/tmpl/checkout/default.php
+++ b/components/com_j2commerce/tmpl/checkout/default.php
@@ -386,6 +386,28 @@ document.addEventListener('DOMContentLoaded', function() {
         var savedCountryId = countrySelect.value || '';
         var savedZoneId = zoneSelect ? (zoneSelect.value || '') : '';
 
+        // Remember whether the zone field was originally marked required so we
+        // can restore that state when the selected country has zones, and lift
+        // it when the country has none — otherwise checkout is blocked for
+        // shoppers from countries with no zones (see issue #472).
+        var zoneWasRequired = zoneSelect ? zoneSelect.required : false;
+
+        function syncZoneRequired() {
+            if (!zoneSelect) return;
+            var hasRealZones = zoneSelect.querySelector('option[value]:not([value=""])') !== null;
+            if (hasRealZones) {
+                if (zoneWasRequired) {
+                    zoneSelect.setAttribute('required', 'required');
+                } else {
+                    zoneSelect.removeAttribute('required');
+                }
+                zoneSelect.disabled = false;
+            } else {
+                zoneSelect.removeAttribute('required');
+                zoneSelect.disabled = true;
+            }
+        }
+
         // Fetch and populate countries, restoring saved selection
         var countryUrl = baseUrl + '?option=com_j2commerce&task=ajax.getCountries';
         if (savedCountryId) countryUrl += '&country_id=' + savedCountryId;
@@ -413,6 +435,7 @@ document.addEventListener('DOMContentLoaded', function() {
             if (!countryId || countryId === '0' || countryId === '') {
                 zoneSelect.innerHTML = '<option value=""><?php echo $selectZoneJs; ?></option>';
                 zoneSelect.disabled = false;
+                syncZoneRequired();
                 return;
             }
 
@@ -424,11 +447,13 @@ document.addEventListener('DOMContentLoaded', function() {
                 .then(function(html) {
                     zoneSelect.innerHTML = html;
                     zoneSelect.disabled = false;
+                    syncZoneRequired();
                 })
                 .catch(function(err) {
                     console.error('Error loading zones:', err);
                     zoneSelect.innerHTML = '<option value=""><?php echo $selectZoneJs; ?></option>';
                     zoneSelect.disabled = false;
+                    syncZoneRequired();
                 });
         }
 


### PR DESCRIPTION
## Summary

Fixes #472

Shoppers from countries with zero zones in `#__j2commerce_zones` (e.g. Virgin Islands (British)) could not complete checkout — the zone dropdown was rendered required server-side, but the AJAX cascade returned no selectable options. Form validation blocked submit with no way for the shopper to resolve it.

## Changes

- Capture the original server-rendered `required` state of `zone_id` once, at init, as `zoneWasRequired`.
- Add `syncZoneRequired()` helper that inspects `zone_id`'s options after every repopulation:
  - If real options exist → restore original `required` state, enable field.
  - If no options exist → remove `required`, disable field (so it is excluded from form submission).
- Call `syncZoneRequired()` from all three zone-population paths: empty-country short-circuit, successful AJAX, AJAX failure.

## Testing

1. Add a product to cart and proceed to checkout.
2. At the billing address step, change country to **Virgin Islands (British)** (or any country with no rows in `#__j2commerce_zones`).
3. Zone dropdown shows the placeholder only and becomes disabled. Submit advances the step.
4. Change country to **United States** → zones repopulate, `required` restored, field enabled.
5. Change back to a no-zone country → `required` lifts, field disables again.
6. Load an address whose country has no zones on initial render → zone is NOT flagged required.

## Files Changed

- `components/com_j2commerce/tmpl/checkout/default.php` — JS-only patch inside `initCountryZoneFields()` and `loadZones()`.