### PR TITLE
fix(phone): country sync + legacy data normalization (fixes #464)

### DIFF
--- a/administrator/components/com_j2commerce/forms/customer.xml
+++ b/administrator/components/com_j2commerce/forms/customer.xml
@@ -39,20 +39,6 @@
         />
 
         <field
-            name="phone_1"
-            type="tel"
-            label="COM_J2COMMERCE_FIELD_PHONE_1"
-            maxlength="255"
-        />
-
-        <field
-            name="phone_2"
-            type="tel"
-            label="COM_J2COMMERCE_FIELD_PHONE_2"
-            maxlength="255"
-        />
-
-        <field
             name="type"
             type="list"
             label="COM_J2COMMERCE_FIELD_ADDRESS_TYPE"
@@ -113,6 +99,18 @@
             label="COM_J2COMMERCE_FIELD_ZONE"
             country_field="country_id"
             addfieldprefix="J2Commerce\Component\J2commerce\Administrator\Field"
+        />
+
+        <field
+            name="phone_1"
+            type="phone"
+            label="COM_J2COMMERCE_FIELD_PHONE_1"
+        />
+
+        <field
+            name="phone_2"
+            type="phone"
+            label="COM_J2COMMERCE_FIELD_PHONE_2"
         />
 
         <field

--- a/administrator/components/com_j2commerce/src/Field/PhoneField.php
+++ b/administrator/components/com_j2commerce/src/Field/PhoneField.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Administrator\Field;
+
+\defined('_JEXEC') or die;
+
+use Joomla\CMS\Form\FormField;
+use J2Commerce\Component\J2commerce\Administrator\Helper\CustomFieldHelper;
+
+/**
+ * Admin form field that renders the same telephone widget used on the frontend
+ * (country flag dropdown + dial code + national number) so admin-saved values
+ * stay consistent with frontend-edited values.
+ *
+ * XML usage:
+ *   <field name="phone_1" type="phone" label="COM_J2COMMERCE_FIELD_PHONE_1" />
+ *
+ * Optional XML attributes:
+ *   mode="all|selected|none"          default: all
+ *   countries="US,GB,FR"              (comma-separated ISO2, used when mode=selected)
+ *   default_iso="US"                  override the default country
+ *   autocomplete="tel-national"
+ *   placeholder="COM_J2COMMERCE_PHONE_NATIONAL_NUMBER"
+ *
+ * @since 6.1.5
+ */
+class PhoneField extends FormField
+{
+    protected $type = 'Phone';
+
+    protected function getInput(): string
+    {
+        $mode = (string) ($this->element['mode'] ?? 'all');
+
+        $allowedIso2 = null;
+        $countriesAttr = (string) ($this->element['countries'] ?? '');
+        if ($countriesAttr !== '') {
+            $allowedIso2 = array_values(array_filter(array_map('trim', explode(',', $countriesAttr))));
+        }
+
+        $opts = [
+            'required'     => (bool) $this->required,
+            'autocomplete' => (string) ($this->element['autocomplete'] ?? 'tel-national'),
+            'mode'         => $mode,
+            'allowedIso2'  => $allowedIso2,
+            'defaultIso'   => (string) ($this->element['default_iso'] ?? ''),
+            'extraClass'   => (string) ($this->class ?? ''),
+        ];
+
+        $placeholder = (string) ($this->element['placeholder'] ?? '');
+        if ($placeholder !== '') {
+            $opts['placeholder'] = \Joomla\CMS\Language\Text::_($placeholder);
+        }
+
+        return CustomFieldHelper::renderPhoneWidget(
+            (string) $this->value,
+            $this->id,
+            $this->name,
+            $opts
+        );
+    }
+}

--- a/administrator/components/com_j2commerce/src/Helper/CustomFieldHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/CustomFieldHelper.php
@@ -14,6 +14,7 @@ namespace J2Commerce\Component\J2commerce\Administrator\Helper;
 \defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
+use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Session\Session;
 use Joomla\CMS\Uri\Uri;
@@ -412,9 +413,13 @@ class CustomFieldHelper
             }
 
             if ($field->field_type === 'telephone' && trim($value) !== '') {
-                $parsed   = PhoneHelper::parseE164($value);
-                $national = $parsed['national'];
-                $iso      = $parsed['iso2'];
+                // Normalize separators (space, dash, paren, dot) before
+                // validating so legacy values entered via admin forms don't
+                // trip digit-only checks.
+                $normalized = PhoneHelper::normalize((string) $value);
+                $parsed     = PhoneHelper::parseE164($normalized);
+                $national   = $parsed['national'];
+                $iso        = $parsed['iso2'];
 
                 if (!preg_match('/^\d+$/', $national)) {
                     $errors[$namekey] = Text::sprintf('COM_J2COMMERCE_ERR_PHONE_DIGITS_ONLY', $label);
@@ -477,7 +482,7 @@ class CustomFieldHelper
 
             // Hidden input already contains the assembled E.164 value
             if ($field->field_type === 'telephone') {
-                $data[$namekey] = $formData[$namekey] ?? '';
+                $data[$namekey] = PhoneHelper::normalize((string) ($formData[$namekey] ?? ''));
                 continue;
             }
 
@@ -493,6 +498,163 @@ class CustomFieldHelper
         return $data;
     }
 
+    /**
+     * Register telephone widget assets, Bootstrap dropdown, and the
+     * country_id -> ISO2 script map. Safe to call multiple times per request.
+     */
+    public static function ensureTelephoneAssets(): void
+    {
+        $wa = Factory::getApplication()->getDocument()->getWebAssetManager();
+        $wa->registerAndUseStyle('com_j2commerce.telephone.css', 'media/com_j2commerce/css/site/telephone-field.css');
+        $wa->registerAndUseScript('com_j2commerce.telephone', 'media/com_j2commerce/js/site/telephone-field.js', [], ['defer' => true]);
+
+        // Ensure Bootstrap dropdown is initialized so the country-code
+        // dropdown opens. Some views (e.g. frontend edit address, admin
+        // customer edit) don't call bootstrap.dropdown otherwise.
+        HTMLHelper::_('bootstrap.dropdown', '.j2c-phone-country-btn', ['autoclose' => true]);
+
+        // Emit country_id -> ISO2 map once per request so JS can sync the
+        // phone country flag when the address country_id field changes.
+        self::registerPhoneCountryMap();
+    }
+
+    /**
+     * Render the standalone phone widget (hidden input + country selector +
+     * national number input) with no label or form-group wrapper. Shared by
+     * the frontend custom-field renderer and the admin Phone form field so
+     * both render identical markup and share all assets/behavior.
+     *
+     * @param  string  $value  Stored value (E.164 "+xxx..." or digits, may be empty).
+     * @param  string  $id     DOM id for the hidden input.
+     * @param  string  $name   Form input name (e.g. "jform[phone_1]" in admin).
+     * @param  array   $opts   Optional: required (bool), autocomplete (string),
+     *                         placeholder (string), mode ('all'|'selected'|'none'),
+     *                         allowedIso2 (string[]), extraClass (string),
+     *                         defaultIso (string — overrides config default).
+     */
+    public static function renderPhoneWidget(string $value, string $id, string $name, array $opts = []): string
+    {
+        self::ensureTelephoneAssets();
+
+        $required     = !empty($opts['required']);
+        $requiredAttr = $required ? ' required' : '';
+        $autocomplete = (string) ($opts['autocomplete'] ?? 'tel-national');
+        $placeholder  = (string) ($opts['placeholder'] ?? Text::_('COM_J2COMMERCE_PHONE_NATIONAL_NUMBER'));
+        $phoneMode    = (string) ($opts['mode'] ?? 'all');
+        $allowedIso2  = $opts['allowedIso2'] ?? null;
+        $extraClass   = (string) ($opts['extraClass'] ?? '');
+        $defaultIso   = (string) ($opts['defaultIso'] ?? '');
+
+        if ($defaultIso === '') {
+            $defaultCountry = J2CommerceHelper::config()->get('default_country', '223');
+            $defaultIso     = self::getCountryIso2((int) $defaultCountry) ?: 'US';
+        }
+
+        $parsed        = PhoneHelper::parseE164($value, $defaultIso);
+        $selectedIso   = $parsed['iso2'];
+        $nationalValue = $parsed['national'];
+        $dialCode      = $parsed['code'];
+
+        $escapedValue = htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+        $escapedAc    = htmlspecialchars($autocomplete, ENT_QUOTES, 'UTF-8');
+        $escapedPh    = htmlspecialchars($placeholder, ENT_QUOTES, 'UTF-8');
+
+        // "none" mode: plain tel input, no country dropdown / no widget
+        if ($phoneMode === 'none') {
+            return '<input type="tel" class="form-control" '
+                . 'name="' . $name . '" id="' . $id . '" '
+                . 'value="' . $escapedValue . '" '
+                . 'autocomplete="' . $escapedAc . '" '
+                . 'placeholder="' . $escapedPh . '" '
+                . 'data-mode="none"'
+                . $requiredAttr . '>';
+        }
+
+        if ($phoneMode === 'selected' && !empty($allowedIso2)) {
+            $countries = PhoneHelper::getCountryListForDropdown((array) $allowedIso2);
+        } else {
+            $countries = PhoneHelper::getCountryListForDropdown(null);
+        }
+
+        // Fallback: if filter yielded nothing, show all enabled countries
+        if (empty($countries)) {
+            $countries = PhoneHelper::getCountryListForDropdown(null);
+        }
+
+        $escapedIso  = htmlspecialchars($selectedIso, ENT_QUOTES, 'UTF-8');
+        $escapedCode = htmlspecialchars($dialCode, ENT_QUOTES, 'UTF-8');
+        $escapedNat  = htmlspecialchars($nationalValue, ENT_QUOTES, 'UTF-8');
+        $flagUrl     = PhoneHelper::getFlagUrl($selectedIso);
+        $flagHtml    = $flagUrl
+            ? '<img src="' . htmlspecialchars($flagUrl, ENT_QUOTES, 'UTF-8') . '" alt="' . $escapedIso . '" class="j2c-phone-flag">'
+            : '<span class="j2c-phone-flag">' . $escapedIso . '</span>';
+
+        $isSingleCountry = \count($countries) === 1;
+
+        if ($isSingleCountry) {
+            $singleCountry = $countries[0];
+            $singleFlagUrl = htmlspecialchars($singleCountry['flagUrl'] ?? '', ENT_QUOTES, 'UTF-8');
+            $singleIso     = htmlspecialchars($singleCountry['iso2'], ENT_QUOTES, 'UTF-8');
+            $singleCode    = htmlspecialchars($singleCountry['code'], ENT_QUOTES, 'UTF-8');
+            $singleFlag    = $singleFlagUrl
+                ? '<img src="' . $singleFlagUrl . '" alt="' . $singleIso . '" class="j2c-phone-flag">'
+                : '<span class="j2c-phone-flag">' . $singleIso . '</span>';
+
+            $countryPrefix = '<span class="input-group-text j2c-phone-static-prefix">'
+                . $singleFlag . ' '
+                . '<span class="j2c-phone-code">+' . $singleCode . '</span>'
+                . '</span>';
+
+            $maxLen = (int) $singleCountry['max'];
+            $nationalInput = '<input type="tel" class="form-control j2c-phone-national" '
+                . 'value="' . $escapedNat . '" '
+                . 'inputmode="numeric" pattern="[0-9]*" '
+                . 'maxlength="' . $maxLen . '" '
+                . 'autocomplete="' . $escapedAc . '" '
+                . 'placeholder="' . $escapedPh . '" '
+                . 'aria-label="' . $escapedPh . '" '
+                . 'data-dial-code="' . htmlspecialchars($singleCountry['code'], ENT_QUOTES, 'UTF-8') . '" '
+                . 'data-hidden-target="' . $id . '">';
+        } else {
+            $countryPrefix = '<button type="button" class="btn btn-outline-secondary dropdown-toggle j2c-phone-country-btn" '
+                . 'data-bs-toggle="dropdown" aria-expanded="false" '
+                . 'aria-label="' . Text::_('COM_J2COMMERCE_PHONE_SELECT_COUNTRY') . '">'
+                . $flagHtml . ' '
+                . '<span class="j2c-phone-code">+' . $escapedCode . '</span>'
+                . '</button>'
+                . '<ul class="dropdown-menu j2c-phone-country-dropdown" style="max-height:300px;overflow-y:auto;">'
+                . '<li class="px-2 py-1 sticky-top bg-body">'
+                . '<input type="text" class="form-control form-control-sm j2c-phone-search" '
+                . 'placeholder="' . Text::_('COM_J2COMMERCE_PHONE_SEARCH_COUNTRY') . '" autocomplete="off">'
+                . '</li>'
+                . '</ul>';
+
+            $nationalInput = '<input type="tel" class="form-control j2c-phone-national" '
+                . 'value="' . $escapedNat . '" '
+                . 'inputmode="numeric" pattern="[0-9]*" '
+                . 'autocomplete="' . $escapedAc . '" '
+                . 'placeholder="' . $escapedPh . '" '
+                . 'aria-label="' . $escapedPh . '">';
+        }
+
+        $countriesJson = htmlspecialchars(json_encode($countries, JSON_UNESCAPED_UNICODE), ENT_QUOTES, 'UTF-8');
+        $hiddenInput   = '<input type="hidden" name="' . $name . '" id="' . $id . '" '
+            . 'value="' . $escapedValue . '"' . $requiredAttr . '>';
+
+        $groupAttrs = ' data-field-id="' . $id . '" data-default-iso="' . $escapedIso . '" data-countries="' . $countriesJson . '"';
+        if ($isSingleCountry) {
+            $groupAttrs .= ' data-single-country="1"';
+        }
+
+        $cls = 'j2c-telephone-field input-group' . ($extraClass !== '' ? ' ' . $extraClass : '');
+
+        return '<div class="' . $cls . '"' . $groupAttrs . '>'
+            . $hiddenInput
+            . $countryPrefix
+            . $nationalInput
+            . '</div>';
+    }
+
     private static function renderTelephoneField(
         object $field,
         string $value,
@@ -504,10 +666,7 @@ class CustomFieldHelper
         string $extraClass,
         string $autocompleteAttr
     ): string {
-        // Register telephone field assets once per request
-        $wa = Factory::getApplication()->getDocument()->getWebAssetManager();
-        $wa->registerAndUseStyle('com_j2commerce.telephone.css', 'media/com_j2commerce/css/site/telephone-field.css');
-        $wa->registerAndUseScript('com_j2commerce.telephone', 'media/com_j2commerce/js/site/telephone-field.js', [], ['defer' => true]);
+        self::ensureTelephoneAssets();
 
         $defaultCountry = J2CommerceHelper::config()->get('default_country', '223');
         $defaultIso     = self::getCountryIso2((int) $defaultCountry) ?: 'US';
@@ -663,6 +822,40 @@ class CustomFieldHelper
             . $nationalInput
             . '</div>'
             . '</div>';
+    }
+
+    /**
+     * Emit a script option mapping country_id (DB primary key) to its ISO2 code
+     * so the telephone-field JS can sync the phone country when the address
+     * country_id select changes. Runs at most once per request.
+     */
+    private static function registerPhoneCountryMap(): void
+    {
+        static $registered = false;
+
+        if ($registered) {
+            return;
+        }
+        $registered = true;
+
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
+        $query = $db->getQuery(true)
+            ->select($db->quoteName(['j2commerce_country_id', 'country_isocode_2']))
+            ->from($db->quoteName('#__j2commerce_countries'))
+            ->where($db->quoteName('enabled') . ' = 1');
+
+        $db->setQuery($query);
+        $rows = $db->loadObjectList() ?: [];
+
+        $map = [];
+        foreach ($rows as $row) {
+            $iso = strtoupper((string) $row->country_isocode_2);
+            if ($iso !== '') {
+                $map[(int) $row->j2commerce_country_id] = $iso;
+            }
+        }
+
+        Factory::getApplication()->getDocument()->addScriptOptions('com_j2commerce.phoneCountryMap', $map);
     }
 
     private static function renderMultiuploaderField(

--- a/administrator/components/com_j2commerce/src/Helper/PhoneHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/PhoneHelper.php
@@ -272,11 +272,42 @@ class PhoneHelper
         return '+' . $code . preg_replace('/\D/', '', $national);
     }
 
+    /**
+     * Normalize a raw phone string by stripping common separators (space, dash,
+     * paren, dot, non-breaking space) while preserving a leading + if present.
+     *
+     * Does NOT force E.164 formatting: legacy values entered without a country
+     * code (e.g. "555-555-0000" or "0113 2667042") are preserved as clean
+     * digit strings so the frontend parser can handle them with the correct
+     * address-country context.
+     */
+    public static function normalize(string $raw): string
+    {
+        $raw = trim($raw);
+        if ($raw === '') {
+            return '';
+        }
+
+        $hasPlus = str_starts_with($raw, '+');
+        $digits  = preg_replace('/\D/', '', $raw);
+
+        if ($digits === '') {
+            return '';
+        }
+
+        return $hasPlus ? '+' . $digits : $digits;
+    }
+
     public static function parseE164(string $e164, string $preferredIso = 'US'): array
     {
         $preferredIso = strtoupper($preferredIso);
 
         if (!str_starts_with($e164, '+')) {
+            // Legacy value (typically saved from admin with separators). Strip
+            // non-digits and treat as a national number under the preferred
+            // country. Caller is responsible for passing the address's
+            // country_id ISO2 as $preferredIso so the number is interpreted
+            // correctly.
             return [
                 'iso2'     => $preferredIso,
                 'code'     => self::DIAL_DATA[$preferredIso]['code'] ?? '1',

--- a/administrator/components/com_j2commerce/src/Table/AddressTable.php
+++ b/administrator/components/com_j2commerce/src/Table/AddressTable.php
@@ -13,6 +13,7 @@ namespace J2Commerce\Component\J2commerce\Administrator\Table;
 
 \defined('_JEXEC') or die;
 
+use J2Commerce\Component\J2commerce\Administrator\Helper\PhoneHelper;
 use Joomla\CMS\Table\Table;
 use Joomla\Database\DatabaseDriver;
 
@@ -43,6 +44,17 @@ class AddressTable extends Table
         foreach ($defaults as $field) {
             if (!isset($this->$field)) {
                 $this->$field = '';
+            }
+        }
+
+        // Strip common separators (space, dash, paren, dot) from phone fields
+        // so admin and frontend agree on storage format. The frontend widget
+        // expects digits-only (optionally prefixed with +); admin saves from a
+        // plain <field type="tel"> with no filter. Normalizing here keeps
+        // editing round-trips safe on both sides.
+        foreach (['phone_1', 'phone_2', 'fax'] as $phoneField) {
+            if (!empty($this->$phoneField)) {
+                $this->$phoneField = PhoneHelper::normalize((string) $this->$phoneField);
             }
         }
 

--- a/administrator/components/com_j2commerce/tmpl/customer/edit.php
+++ b/administrator/components/com_j2commerce/tmpl/customer/edit.php
@@ -42,8 +42,6 @@ $wa->useScript('keepalive')
                     </div>
                     <?php echo $this->form->renderField('email'); ?>
                     <?php echo $this->form->renderField('company'); ?>
-                    <?php echo $this->form->renderField('phone_1'); ?>
-                    <?php echo $this->form->renderField('phone_2'); ?>
                 </fieldset>
             </div>
             <div class="col-lg-3">
@@ -78,6 +76,8 @@ $wa->useScript('keepalive')
                             <?php echo $this->form->renderField('zone_id'); ?>
                         </div>
                     </div>
+                    <?php echo $this->form->renderField('phone_1'); ?>
+                    <?php echo $this->form->renderField('phone_2'); ?>
                 </fieldset>
             </div>
             <div class="col-lg-3">

--- a/components/com_j2commerce/tmpl/checkout/default.php
+++ b/components/com_j2commerce/tmpl/checkout/default.php
@@ -11,6 +11,7 @@
 \defined('_JEXEC') or die;
 // phpcs:enable PSR1.Files.SideEffects
 
+use J2Commerce\Component\J2commerce\Administrator\Helper\CustomFieldHelper;
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
@@ -29,8 +30,13 @@ $wa->useScript('bootstrap.collapse');
 $wa->useScript('bootstrap.dropdown');
 
 $wa->registerAndUseStyle('checkout.style', 'media/com_j2commerce/css/site/checkout.css', [], [], []);
-$wa->registerAndUseStyle('com_j2commerce.telephone.css', 'media/com_j2commerce/css/site/telephone-field.css');
-$wa->registerAndUseScript('com_j2commerce.telephone', 'media/com_j2commerce/js/site/telephone-field.js', [], ['defer' => true]);
+
+// Register telephone widget assets + script options on initial page render.
+// The billing/shipping forms (which actually render the telephone widget) are
+// often loaded via AJAX, so calling this from renderTelephoneField() alone is
+// too late — addScriptOptions during an AJAX response doesn't reach the main
+// page's <joomla-script-options> block.
+CustomFieldHelper::ensureTelephoneAssets();
 
 // Grand total for mobile toggle button
 $grandTotal = '';

--- a/media/com_j2commerce/js/site/telephone-field.js
+++ b/media/com_j2commerce/js/site/telephone-field.js
@@ -82,14 +82,34 @@
         var selectedIso        = container.dataset.defaultIso || 'US';
         var userChangedCountry = false;
 
+        // Strip separators from any legacy stored value (e.g. "555-555-0000"
+        // saved by an older admin form) so we display clean digits. Do NOT
+        // truncate to the country max-length here — that corrupts numbers
+        // whose stored country differs from the rendered default.
+        nationalInput.value = (nationalInput.value || '').replace(/\D/g, '');
+
         populateDropdown(dropdown, countries, selectedIso);
         applyMaxLength();
+
+        // Initial sync: if an address country_id select already has a value
+        // on page load (e.g. in an Edit Address form), align the phone
+        // country flag to it. Otherwise the user would see a mismatched flag
+        // until they re-select the country.
+        syncFromCountryId();
 
         dropdown.addEventListener('click', function(e) {
             var item = e.target.closest('[data-iso]');
             if (!item) return;
             selectCountry(item.dataset.iso);
             userChangedCountry = true;
+            // Truncate only on an explicit user-triggered country change so
+            // the new country's max-length is respected.
+            var c = findCountry(selectedIso);
+            if (c && nationalInput.value.length > c.max) {
+                nationalInput.value = nationalInput.value.slice(0, c.max);
+                updateHiddenValue();
+                validateLength();
+            }
             var dd = bootstrap.Dropdown.getInstance(countryBtn);
             if (dd) dd.hide();
         });
@@ -118,16 +138,20 @@
             validateLength();
         });
 
-        // Sync phone country when billing country_id changes
+        // Sync phone country when billing/shipping country_id changes
         document.addEventListener('change', function(e) {
             if (userChangedCountry) return;
             var sel = e.target.closest('[name="country_id"], #country_id');
-            if (!sel) return;
+            if (!sel || !sel.value) return;
             var countryMap = (typeof Joomla !== 'undefined' && Joomla.getOptions)
                 ? Joomla.getOptions('com_j2commerce.phoneCountryMap') || {}
                 : {};
             var iso = countryMap[sel.value];
-            if (iso) selectCountry(iso);
+            if (!iso) return;
+            // If the ISO isn't in this widget's allowed countries list, skip
+            // silently — the widget may be restricted to a subset.
+            if (!findCountry(iso)) return;
+            selectCountry(iso);
         });
 
         function findCountry(iso) {
@@ -175,9 +199,21 @@
             var country = findCountry(selectedIso);
             if (country) {
                 nationalInput.maxLength = country.max;
-                if (nationalInput.value.length > country.max) {
-                    nationalInput.value = nationalInput.value.slice(0, country.max);
-                }
+            }
+        }
+
+        function syncFromCountryId() {
+            var countryMap = (typeof Joomla !== 'undefined' && Joomla.getOptions)
+                ? Joomla.getOptions('com_j2commerce.phoneCountryMap') || {}
+                : {};
+            // Only look inside the same form as the phone field to avoid
+            // picking up an unrelated country_id on the page.
+            var form = container.closest('form') || document;
+            var sel  = form.querySelector('[name="country_id"], #country_id');
+            if (!sel || !sel.value) return;
+            var iso = countryMap[sel.value];
+            if (iso && iso !== selectedIso) {
+                selectCountry(iso);
             }
         }
 
@@ -198,6 +234,10 @@
 
     function initSingleCountry(container, hiddenInput, nationalInput, country) {
         var dialCode = nationalInput.dataset.dialCode || country.code;
+
+        // Strip separators from any legacy stored value so the single-country
+        // widget displays clean digits without truncation.
+        nationalInput.value = (nationalInput.value || '').replace(/\D/g, '');
 
         nationalInput.addEventListener('input', function() {
             nationalInput.value = nationalInput.value.replace(/\D/g, '');


### PR DESCRIPTION
## Summary

Fixes #464 (telephone field bugs reported by @brianteeman). Verified live.

## Root cause fixed

The country-id → phone-country sync never worked on the frontend checkout
because:

1. The `com_j2commerce.phoneCountryMap` script option was only emitted
   when `renderTelephoneField()` was called. On the checkout the
   billing/shipping fields are loaded via AJAX, and `addScriptOptions()`
   during an AJAX response never reaches the main page's
   `<joomla-script-options>` block.
2. `HTMLHelper::_('bootstrap.dropdown', ...)` was never registered for
   the country-code dropdown button, so the dropdown wouldn't open on
   views that didn't otherwise initialize it (e.g. frontend Edit Address).
3. The JS silently truncated the initial rendered national number to the
   default country's max-length, corrupting legacy values stored without
   a country code prefix (e.g. UK `0113 2667042` truncated to 10 digits).
4. Admin saved raw `type="tel"` strings with separators (`555-555-000`);
   frontend widget required digits-only and could not round-trip them.

## Changes

### New shared infrastructure
- `CustomFieldHelper::ensureTelephoneAssets()` — registers CSS/JS + bootstrap.dropdown + phoneCountryMap. Idempotent per request.
- `CustomFieldHelper::renderPhoneWidget()` — standalone input-group renderer used by both the frontend custom field path and the new admin Phone form field.
- `CustomFieldHelper::registerPhoneCountryMap()` — emits `com_j2commerce.phoneCountryMap` (country_id → ISO2).
- `PhoneHelper::normalize()` — strips common separators while preserving a leading +.
- New admin form field: `type="phone"` via `J2Commerce\...\Administrator\Field\PhoneField`.

### Wire-ups
- `components/com_j2commerce/tmpl/checkout/default.php` calls `ensureTelephoneAssets()` on initial page render so the script map is available when AJAX later inserts the billing form.
- `administrator/components/com_j2commerce/forms/customer.xml` uses `type="phone"` for `phone_1` / `phone_2`, moved into the address fieldset with country_id / zone_id.
- `administrator/components/com_j2commerce/tmpl/customer/edit.php` renders phone fields on the Address tab (right after country/zone).
- `administrator/components/com_j2commerce/src/Table/AddressTable.php` normalizes `phone_1` / `phone_2` / `fax` on save.
- `CustomFieldHelper::validateFields()` / `collectAddressData()` normalize separators before validating / storing telephone values.

### JS fixes (`telephone-field.js`)
- Initial rendered value no longer truncated to default-country max-length — only user input / explicit country change truncate.

## Notes on Brian's 4 reported bugs

- **[A] Admin/frontend validation mismatch** — fixed. Admin save normalizes separators; frontend parses and displays legacy values without truncation; admin customer form now uses the same widget.
- **[B] country → phone sync not working** — fixed. Root cause was the script map never reaching the page.
- **[C] Can't change country code on Edit Address** — fixed. bootstrap.dropdown now registered via the shared asset helper.
- **[D] Cramped 2-column checkout layout** — deferred to merchant configuration. Merchants can set `field_width` to `col-12` on the phone custom field record if their chosen country set makes the widget overflow.

Fixes #464