### PR TITLE
fix(checkout): render field errors below telephone widget + fix icon position

### DIFF
--- a/components/com_j2commerce/tmpl/checkout/default.php
+++ b/components/com_j2commerce/tmpl/checkout/default.php
@@ -332,7 +332,10 @@ document.addEventListener('DOMContentLoaded', function() {
             span.id = fieldId + '-error';
             span.setAttribute('role', 'alert');
             span.textContent = message;
-            field.parentNode.insertBefore(span, field.nextSibling);
+            // Anchor after the telephone wrapper (if any) so the error
+            // renders below the full widget, not inside its flex row.
+            var anchor = field.closest('.j2c-telephone-field') || field;
+            anchor.parentNode.insertBefore(span, anchor.nextSibling);
         }
     }
 

--- a/media/com_j2commerce/css/site/checkout.css
+++ b/media/com_j2commerce/css/site/checkout.css
@@ -61,11 +61,11 @@
     padding-inline-end: calc(1.5em + 0.75rem);
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='%23dc3545' viewBox='0 0 16 16'%3E%3Cpath d='M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0M8 4a.905.905 0 0 0-.9.995l.35 3.507a.553.553 0 0 0 1.1 0l.35-3.507A.905.905 0 0 0 8 4m.002 6a1 1 0 1 0 0 2 1 1 0 0 0 0-2'/%3E%3C/svg%3E");
     background-repeat: no-repeat;
-    background-position: inline-end calc(0.375em + 0.1875rem) center;
+    background-position: right calc(0.375em + 0.1875rem) center;
     background-size: calc(0.75em + 0.375rem) calc(0.75em + 0.375rem);
 }
 .j2commerce.checkout select.j2-invalid {
-    background-position: inline-end calc(0.375em + 1.5rem) center;
+    background-position: right calc(0.375em + 1.5rem) center;
 }
 .j2commerce.checkout .wait {
     display: inline-block;


### PR DESCRIPTION
## Summary

Fixes #474

Two related checkout validation-display bugs:

1. **`.j2error` rendered inline next to the telephone national input** instead of below the full widget, because `showFieldError()` used `field.parentNode.insertBefore(...)` — and for telephone fields the parent is the `.input-group` flex row, so the error became a flex sibling.
2. **The `.j2-invalid` alert icon rendered in the top-left corner** instead of the right-centered edge, because the CSS used `inline-end` inside the `background-position` shorthand. That keyword is only valid on `background-position-x`/`-y` (or via logical properties), not in the shorthand — so the declaration was discarded and the browser fell back to `0% 0%`.

## Changes

- **`components/com_j2commerce/tmpl/checkout/default.php`** — `showFieldError()` now anchors the `.j2error` span after the closest `.j2c-telephone-field` wrapper (if present), else keeps current behaviour for every other field type.
- **`media/com_j2commerce/css/site/checkout.css`** — replace `inline-end` with `right` in both `.j2-invalid` and `select.j2-invalid` background-position rules (3-value shorthand: edge + offset + centered vertical).

## Testing

1. Clear browser cache (CSS change) and open checkout with a product in cart.
2. Leave Mobile and City empty → click Continue.
3. Verify:
   - Red alert icon sits on the **right edge** of each invalid input, vertically centered.
   - "Mobile is required" renders **below the full telephone widget** (country-code button + input), full-width.
   - Other field errors (City, Zip) still render directly below the input as before.
4. Fill the required fields → submit → errors clear (existing `clearErrors()` finds `.j2error` by class, unchanged).

## Files Changed

- `components/com_j2commerce/tmpl/checkout/default.php` — 4 lines touched in `showFieldError()`.
- `media/com_j2commerce/css/site/checkout.css` — 2 lines touched (`inline-end` → `right`).