### PR TITLE
Update voucher history title to remove 'CODE' from the language key

### DIFF
--- a/administrator/components/com_j2commerce/src/View/Voucher/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Voucher/HtmlView.php
@@ -121,7 +121,7 @@ class HtmlView extends BaseHtmlView
             if ($isEditLayout) {
                 ToolbarHelper::title(Text::sprintf('COM_J2COMMERCE_VOUCHER_EDIT', $this->item->j2commerce_voucher_id), 'fa-solid fa-money-check');
             } else {
-                ToolbarHelper::title(Text::sprintf('COM_J2COMMERCE_VOUCHER_HISTORY_CODE', $this->item->voucher_code), 'fa-solid fa-money-check');
+                ToolbarHelper::title(Text::sprintf('COM_J2COMMERCE_VOUCHER_HISTORY', $this->item->voucher_code), 'fa-solid fa-money-check');
             }
         }
 


### PR DESCRIPTION
<img width="1412" height="323" alt="image" src="https://github.com/user-attachments/assets/c56d78d4-fe8c-4e78-9bca-58f99961ab64" />
