### PR TITLE
fix(core): standardize helper class references to J2CommerceHelper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,255 @@
+# Joomla 6 + J2Commerce - GitHub Repository
+# Strategy: Only track custom J2Commerce code, ignore ALL Joomla core
+
+# ===========================================================================
+# IGNORE ALL JOOMLA CORE - We only want J2Commerce custom code
+# ===========================================================================
+*
+*/
+
+# ===========================================================================
+# EXPLICITLY INCLUDE - Only our custom J2Commerce files
+# ===========================================================================
+
+# Root level files
+!.gitignore
+!LICENSE.txt
+
+# Build scripts (package builder + install script)
+!build/
+!build/**
+
+# ===========================================================================
+# J2Commerce component files
+# Must un-ignore parent directories in order for negation to work
+# ===========================================================================
+
+# Admin component
+!administrator/
+!administrator/components/
+!administrator/components/com_j2commerce/
+!administrator/components/com_j2commerce/**
+
+# J2Commerce admin modules (explicit — no wildcards)
+!administrator/modules/
+!administrator/modules/mod_j2commerce_menu/
+!administrator/modules/mod_j2commerce_menu/**
+!administrator/modules/mod_j2commerce_orders/
+!administrator/modules/mod_j2commerce_orders/**
+!administrator/modules/mod_j2commerce_quickicons/
+!administrator/modules/mod_j2commerce_quickicons/**
+!administrator/modules/mod_j2commerce_stats/
+!administrator/modules/mod_j2commerce_stats/**
+
+# Site component
+!components/
+!components/com_j2commerce/
+!components/com_j2commerce/**
+
+# J2Commerce core plugins (only those in the package skill)
+!plugins/
+!plugins/j2commerce/
+!plugins/j2commerce/app_bootstrap5/
+!plugins/j2commerce/app_bootstrap5/**
+!plugins/j2commerce/app_flexivariable/
+!plugins/j2commerce/app_flexivariable/**
+!plugins/j2commerce/app_diagnostics/
+!plugins/j2commerce/app_diagnostics/**
+!plugins/j2commerce/app_localization_data/
+!plugins/j2commerce/app_localization_data/**
+!plugins/j2commerce/app_currencyupdater/
+!plugins/j2commerce/app_currencyupdater/**
+!plugins/j2commerce/app_uikit/
+!plugins/j2commerce/app_uikit/**
+!plugins/j2commerce/payment_cash/
+!plugins/j2commerce/payment_cash/**
+!plugins/j2commerce/payment_moneyorder/
+!plugins/j2commerce/payment_moneyorder/**
+!plugins/j2commerce/payment_banktransfer/
+!plugins/j2commerce/payment_banktransfer/**
+!plugins/j2commerce/payment_paypal/
+!plugins/j2commerce/payment_paypal/**
+!plugins/j2commerce/shipping_standard/
+!plugins/j2commerce/shipping_standard/**
+!plugins/j2commerce/shipping_free/
+!plugins/j2commerce/shipping_free/**
+!plugins/j2commerce/report_itemised/
+!plugins/j2commerce/report_itemised/**
+!plugins/j2commerce/report_products/
+!plugins/j2commerce/report_products/**
+!plugins/console/
+!plugins/console/j2commerce/
+!plugins/console/j2commerce/**
+!plugins/system/
+!plugins/system/j2commerce/
+!plugins/system/j2commerce/**
+!plugins/system/ecommerceschema/
+!plugins/system/ecommerceschema/**
+!plugins/user/
+!plugins/user/j2commerce/
+!plugins/user/j2commerce/**
+!plugins/content/
+!plugins/content/j2commerce/
+!plugins/content/j2commerce/**
+!plugins/finder/
+!plugins/finder/j2commerce/
+!plugins/finder/j2commerce/**
+!plugins/schemaorg/
+!plugins/schemaorg/ecommerce/
+!plugins/schemaorg/ecommerce/**
+!plugins/actionlog/
+!plugins/actionlog/j2commerce/
+!plugins/actionlog/j2commerce/**
+!plugins/task/
+!plugins/task/j2commerce/
+!plugins/task/j2commerce/**
+!plugins/webservices/
+!plugins/webservices/j2commerce/
+!plugins/webservices/j2commerce/**
+!plugins/sampledata/
+!plugins/sampledata/j2commerce/
+!plugins/sampledata/j2commerce/**
+
+# J2Commerce core frontend modules (only those in the package skill)
+!modules/
+!modules/mod_j2commerce_cart/
+!modules/mod_j2commerce_cart/**
+!modules/mod_j2commerce_currency/
+!modules/mod_j2commerce_currency/**
+!modules/mod_j2commerce_products/
+!modules/mod_j2commerce_products/**
+!modules/mod_j2commerce_relatedproducts/
+!modules/mod_j2commerce_relatedproducts/**
+
+# Media files
+!media/
+!media/com_j2commerce/
+!media/com_j2commerce/**
+!media/plg_sampledata_j2commerce/
+!media/plg_sampledata_j2commerce/**
+!media/lib_j2commerce/
+!media/lib_j2commerce/**
+
+# J2Commerce library
+!libraries/
+!libraries/j2commerce/
+!libraries/j2commerce/**
+
+# ===========================================================================
+# ALWAYS IGNORE - Even if paths match above
+# ===========================================================================
+.mcp.json
+configuration.php
+language/
+!build/language/
+!build/language/**
+# Re-allow language dirs inside core J2Commerce component
+!administrator/components/com_j2commerce/language/
+!administrator/components/com_j2commerce/language/**
+!components/com_j2commerce/language/
+!components/com_j2commerce/language/**
+# Re-allow language dirs inside core J2Commerce plugins
+!plugins/j2commerce/*/language/
+!plugins/j2commerce/*/language/**
+!plugins/console/j2commerce/language/
+!plugins/console/j2commerce/language/**
+!plugins/system/j2commerce/language/
+!plugins/system/j2commerce/language/**
+!plugins/system/ecommerceschema/language/
+!plugins/system/ecommerceschema/language/**
+!plugins/user/j2commerce/language/
+!plugins/user/j2commerce/language/**
+!plugins/content/j2commerce/language/
+!plugins/content/j2commerce/language/**
+!plugins/finder/j2commerce/language/
+!plugins/finder/j2commerce/language/**
+!plugins/schemaorg/ecommerce/language/
+!plugins/schemaorg/ecommerce/language/**
+!plugins/task/j2commerce/language/
+!plugins/task/j2commerce/language/**
+!plugins/webservices/j2commerce/language/
+!plugins/webservices/j2commerce/language/**
+!plugins/actionlog/j2commerce/language/
+!plugins/actionlog/j2commerce/language/**
+# Re-allow language dirs inside core J2Commerce modules
+!modules/mod_j2commerce_*/language/
+!modules/mod_j2commerce_*/language/**
+!administrator/modules/mod_j2commerce_*/language/
+!administrator/modules/mod_j2commerce_*/language/**
+.env
+*.log
+cache/
+tmp/
+logs/
+node_modules/
+vendor/
+!libraries/j2commerce/vendor/
+!libraries/j2commerce/vendor/**
+!administrator/components/com_j2commerce/src/View/Vendor/
+!administrator/components/com_j2commerce/src/View/Vendor/**
+!administrator/components/com_j2commerce/tmpl/vendor/
+!administrator/components/com_j2commerce/tmpl/vendor/**
+!media/com_j2commerce/vendor/
+!media/com_j2commerce/vendor/**
+*.bak
+
+# Ignore SQL dumps but allow J2Commerce schema files
+*.sql
+!administrator/components/com_j2commerce/**/*.sql
+
+# Claude Code temp files
+tmpclaude-*
+
+# ===========================================================================
+# SEPARATE EXTENSIONS — belong in j2commerce6extensions repo, NOT here
+# ===========================================================================
+# Chatbot
+administrator/components/com_j2commerce_chatbot/
+plugins/j2commerce_chat/
+modules/mod_j2commerce_chatbot/
+# Non-core j2commerce plugins (belong in j2commerce6extensions repo)
+plugins/j2commerce/app_acymailing/
+plugins/j2commerce/app_addressautocomplete/
+plugins/j2commerce/app_affiliatetracker/
+plugins/j2commerce/app_boxbuilderproduct/
+plugins/j2commerce/app_bulkdiscount/
+plugins/j2commerce/app_bundleproduct/
+plugins/j2commerce/app_calculatorsortbyprice/
+plugins/j2commerce/app_changepasswords/
+plugins/j2commerce/app_customaccordions/
+plugins/j2commerce/app_customtabs/
+plugins/j2commerce/app_edi/
+plugins/j2commerce/app_faker/
+plugins/j2commerce/app_giftcertificate/
+plugins/j2commerce/app_giftwrapping/
+plugins/j2commerce/app_printify/
+plugins/j2commerce/app_reorder/
+plugins/j2commerce/app_storemapper/
+plugins/j2commerce/payment_authorizenet/
+plugins/j2commerce/payment_paytrace/
+plugins/j2commerce/shipping_atoship/
+plugins/j2commerce/shipping_ups/
+# Non-core system plugins
+plugins/system/j2commercemcp/
+plugins/system/j2commerce_advancedcart/
+plugins/system/j2commerce_migration_tool/
+# Non-core fields plugins
+plugins/fields/j2commercecountry/
+plugins/fields/j2commerceregion/
+# Non-core modules
+modules/mod_j2commerce_advancedcart_toggle/
+modules/mod_j2commerce_categories/
+modules/mod_j2commerce_tags/
+# Non-core Behavior files (inserted by 3rd-party plugins, not part of core install)
+administrator/components/com_j2commerce/src/Model/Behavior/Bundleproduct.php
+administrator/components/com_j2commerce/src/Model/Behavior/Boxbuilderproduct.php
+administrator/components/com_j2commerce/src/Model/Behavior/CartBoxbuilderproduct.php
+administrator/components/com_j2commerce/src/Model/Behavior/CartBundleproduct.php
+administrator/components/com_j2commerce/src/Model/Behavior/Guidedbuilder.php
+# Non-core admin templates (inserted by 3rd-party plugins)
+administrator/components/com_j2commerce/tmpl/product/form_guidedbuilder.php
+# Non-core site layouts (inserted by 3rd-party plugins)
+components/com_j2commerce/layouts/app_bootstrap5/list/category/item_guidedbuilder.php
+components/com_j2commerce/layouts/app_bootstrap5/list/tag/item_guidedbuilder.php
+# Non-core site templates (created by plugins on install — do NOT whitelist)
+components/com_j2commerce/tmpl/vendorapply/

--- a/components/com_j2commerce/language/en-US/com_j2commerce.sys.ini
+++ b/components/com_j2commerce/language/en-US/com_j2commerce.sys.ini
@@ -1,0 +1,70 @@
+; J2Commerce Site System Language Strings
+; These strings are used by menu item parameters in the admin backend
+; Copyright (C) 2024-2026 J2Commerce, LLC. All rights reserved.
+; License GNU General Public License version 2 or later; see LICENSE.txt
+
+COM_J2COMMERCE="J2Commerce"
+COM_J2COMMERCE_DESCRIPTION="J2Commerce ecommerce component for Joomla"
+
+; Menu Item Layout Titles and Descriptions
+COM_J2COMMERCE_PRODUCTS_VIEW_DEFAULT_TITLE="Product Category List View"
+COM_J2COMMERCE_PRODUCTS_VIEW_DEFAULT_OPTION="Product Category List View"
+COM_J2COMMERCE_PRODUCTS_VIEW_DEFAULT_DESC="Displays a list of products from a selected category."
+COM_J2COMMERCE_PRODUCT_VIEW_DEFAULT_TITLE="Single Product View"
+COM_J2COMMERCE_PRODUCT_VIEW_DEFAULT_OPTION="Single Product View"
+COM_J2COMMERCE_PRODUCT_VIEW_DEFAULT_DESC="Displays a single product detail page."
+COM_J2COMMERCE_CATEGORIES_VIEW_DEFAULT_TITLE="Product Categories View"
+COM_J2COMMERCE_CATEGORIES_VIEW_DEFAULT_OPTION="Product Categories View"
+COM_J2COMMERCE_CATEGORIES_VIEW_DEFAULT_DESC="Displays product categories with optional products."
+COM_J2COMMERCE_PRODUCTTAGS_VIEW_DEFAULT_TITLE="Product Tag List View"
+COM_J2COMMERCE_PRODUCTTAGS_VIEW_DEFAULT_OPTION="Product Tag List View"
+COM_J2COMMERCE_PRODUCTTAGS_VIEW_DEFAULT_DESC="Displays a list of products filtered by selected tags."
+
+; Filter Display Options (used in menu item dropdowns)
+COM_J2COMMERCE_TOGGLE_HIDE="Hide Toggle"
+COM_J2COMMERCE_TOGGLE_ALWAYS_CLOSED="Always Closed"
+COM_J2COMMERCE_TOGGLE_ALWAYS_OPENED="Always Opened"
+COM_J2COMMERCE_FILTER_SELECTED_ONLY="Selected Products Only"
+COM_J2COMMERCE_FILTER_SHOW_ALL="Show All"
+COM_J2COMMERCE_FILTER_LOGIC_OR="OR (any match)"
+COM_J2COMMERCE_FILTER_LOGIC_AND="AND (all must match)"
+
+; Menu Item Filter Settings
+COM_J2COMMERCE_PRODUCT_LIST_FILTER_CATEGORY_TOGGLE="Category Filter Toggle"
+COM_J2COMMERCE_PRODUCT_LIST_FILTER_CATEGORY_TOGGLE_DESC="Control how the category filter section is displayed - hidden, always closed, or always opened."
+COM_J2COMMERCE_PRODUCT_LIST_FILTER_CATEGORY_ALL="Show 'All Categories' Option"
+COM_J2COMMERCE_PRODUCT_LIST_FILTER_CATEGORY_ALL_DESC="Show an 'All Categories' option in the category filter."
+COM_J2COMMERCE_PRODUCT_LIST_FILTER_SELECTED_CATEGORIES="Filter by Selected Categories"
+COM_J2COMMERCE_PRODUCT_LIST_FILTER_SELECTED_CATEGORIES_DESC="Limit the category filter to show only selected categories."
+COM_J2COMMERCE_PRODUCT_LIST_FILTER_PRICE_ROUND="Price Filter Rounding"
+COM_J2COMMERCE_PRODUCT_LIST_FILTER_PRICE_ROUND_DESC="Round price filter values to this digit (10, 100, or 1000)."
+COM_J2COMMERCE_PRODUCT_LIST_FILTER_PRODUCT="Show Product Filter"
+COM_J2COMMERCE_PRODUCT_LIST_FILTER_PRODUCT_DESC="Show the product attribute filter in the sidebar."
+COM_J2COMMERCE_PRODUCT_LIST_FILTER_PRODUCT_LIST_TYPE="Product Filter Display"
+COM_J2COMMERCE_PRODUCT_LIST_FILTER_PRODUCT_LIST_TYPE_DESC="Show only selected product filters or all available filters."
+COM_J2COMMERCE_PRODUCT_LIST_FILTER_SEARCH_LOGIC="Product Filter Logic"
+COM_J2COMMERCE_PRODUCT_LIST_FILTER_SEARCH_LOGIC_DESC="Use AND (all filters must match) or OR (any filter can match) logic for product filters."
+COM_J2COMMERCE_PRODUCT_LIST_FILTER_PRODUCT_TOGGLE="Product Filter Toggle"
+COM_J2COMMERCE_PRODUCT_LIST_FILTER_PRODUCT_TOGGLE_DESC="Control how the product filter section is displayed - hidden, always closed, or always opened."
+COM_J2COMMERCE_PRODUCT_LIST_FILTER_MANUFACTURER_LIST_TYPE="Manufacturer Filter Display"
+COM_J2COMMERCE_PRODUCT_LIST_FILTER_MANUFACTURER_LIST_TYPE_DESC="Show only selected manufacturers or all available manufacturers."
+COM_J2COMMERCE_PRODUCT_LIST_FILTER_VENDOR_LIST_TYPE="Vendor Filter Display"
+COM_J2COMMERCE_PRODUCT_LIST_FILTER_VENDOR_LIST_TYPE_DESC="Show only selected vendors or all available vendors."
+
+COM_J2COMMERCE_SELECT_OPTION="- Select -"
+COM_J2COMMERCE_ERROR_LOADING_MENU_ITEMS="Error loading menu items: %s"
+
+; Checkout View
+COM_J2COMMERCE_CHECKOUT_VIEW_DEFAULT_TITLE="Checkout View"
+COM_J2COMMERCE_CHECKOUT_VIEW_DEFAULT_DESC="Displays the checkout process"
+COM_J2COMMERCE_CHECKOUT_VIEW_DEFAULT_OPTION="Default"
+
+; Confirmation View
+COM_J2COMMERCE_CONFIRMATION_VIEW_DEFAULT_TITLE="Order Confirmation/Thank You View"
+COM_J2COMMERCE_CONFIRMATION_VIEW_DEFAULT_DESC="Displays the order confirmation page after a successful or failed order."
+COM_J2COMMERCE_CONFIRMATION_VIEW_DEFAULT_OPTION="Order Confirmation/Thank You View"
+
+; Cart View
+COM_J2COMMERCE_CARTS_VIEW_DEFAULT_TITLE="Shopping Cart"
+COM_J2COMMERCE_CARTS_VIEW_DEFAULT_DESC="Displays the shopping cart"
+COM_J2COMMERCE_CARTS_VIEW_DEFAULT_OPTION="Default"

--- a/components/com_j2commerce/layouts/app_uikit/list/category/item_boxbuilderproduct.php
+++ b/components/com_j2commerce/layouts/app_uikit/list/category/item_boxbuilderproduct.php
@@ -12,9 +12,10 @@ declare(strict_types=1);
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 
 $images = $this->loadTemplate('images');
-J2Commerce::plugin()->event('BeforeDisplayImages', [&$images, $this, 'com_j2commerce.products.list.uikit']);
+J2CommerceHelper::plugin()->event('BeforeDisplayImages', [&$images, $this, 'com_j2commerce.products.list.uikit']);
 echo $images;
 ?>
 <?php echo $this->loadTemplate('title'); ?>
@@ -34,7 +35,7 @@ echo $images;
     <?php echo $this->loadTemplate('sku'); ?>
 <?php endif; ?>
 
-<?php if ($this->params->get('list_show_product_stock', 1) && J2Commerce::product()->managing_stock($this->product->variant)): ?>
+<?php if ($this->params->get('list_show_product_stock', 1) && J2CommerceHelper::product()->managing_stock($this->product->variant)): ?>
     <?php echo $this->loadTemplate('stock'); ?>
 <?php endif; ?>
 

--- a/components/com_j2commerce/layouts/app_uikit/list/tag/item_boxbuilderproduct.php
+++ b/components/com_j2commerce/layouts/app_uikit/list/tag/item_boxbuilderproduct.php
@@ -12,9 +12,10 @@ declare(strict_types=1);
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 
 $images = $this->loadTemplate('images');
-J2Commerce::plugin()->event('BeforeDisplayImages', [&$images, $this, 'com_j2commerce.products.list.uikit']);
+J2CommerceHelper::plugin()->event('BeforeDisplayImages', [&$images, $this, 'com_j2commerce.products.list.uikit']);
 echo $images;
 ?>
 <?php echo $this->loadTemplate('title'); ?>
@@ -34,7 +35,7 @@ echo $images;
     <?php echo $this->loadTemplate('sku'); ?>
 <?php endif; ?>
 
-<?php if ($this->params->get('list_show_product_stock', 1) && J2Commerce::product()->managing_stock($this->product->variant)): ?>
+<?php if ($this->params->get('list_show_product_stock', 1) && J2CommerceHelper::product()->managing_stock($this->product->variant)): ?>
     <?php echo $this->loadTemplate('stock'); ?>
 <?php endif; ?>
 

--- a/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/cart.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/cart.php
@@ -18,7 +18,7 @@ $product = $this->singleton_product;
 $params = $this->singleton_params;
 $action = 'index.php?option=com_j2commerce&view=carts&task=carts.addItem&product_id=' . (int) $product->j2commerce_product_id;
 ?>
-<?php echo J2CommerceHelper::plugin()->eventWithHtml('BeforeAddToCartButton', array($product, J2Store::utilities()->getContext('cart')))->getArgument('html', ''); ?>
+<?php echo J2CommerceHelper::plugin()->eventWithHtml('BeforeAddToCartButton', array($product, J2CommerceHelper::utilities()->getContext('cart')))->getArgument('html', ''); ?>
 <div class="cart-action-complete" style="display:none;">
 		<p class="text-success">
 			<?php echo JText::_('COM_J2COMMERCE_ITEM_ADDED_TO_CART');?>
@@ -32,4 +32,4 @@ href="<?php echo JRoute::_($action); ?>" data-quantity="1" data-product_id="<?ph
 rel="nofollow">
 <?php echo $this->singleton_cartext; ?>
 </a>
-<?php echo J2CommerceHelper::plugin()->eventWithHtml('AfterAddToCartButton', array($product, J2Store::utilities()->getContext('cart')))->getArgument('html', ''); ?>
+<?php echo J2CommerceHelper::plugin()->eventWithHtml('AfterAddToCartButton', array($product, J2CommerceHelper::utilities()->getContext('cart')))->getArgument('html', ''); ?>

--- a/plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_boxbuilder_cart.php
+++ b/plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_boxbuilder_cart.php
@@ -17,6 +17,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Uri\Uri;
 use Joomla\Registry\Registry;
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 
 $plugin = PluginHelper::getPlugin('j2commerce', 'app_boxbuilderproduct');
 $params = new Registry($plugin->params);
@@ -39,13 +40,13 @@ if (!empty($this->product->addtocart_text)) {
     }
 }
 
-$show          = J2Commerce::product()->validateVariableProduct($this->product);
-$manageStock   = J2Commerce::product()->managing_stock($this->product->variant);
+$show          = J2CommerceHelper::product()->validateVariableProduct($this->product);
+$manageStock   = J2CommerceHelper::product()->managing_stock($this->product->variant);
 $is_available  = $this->product->variant->availability;
 $is_out_of_stock = ($manageStock === true && $is_available === 0);
 $disabled      = $is_out_of_stock ? ' disabled' : '';
 ?>
-<?php echo J2Commerce::plugin()->eventWithHtml('BeforeAddToCartButton', [$this->product, J2Commerce::utilities()->getContext('view_cart')]); ?>
+<?php echo J2CommerceHelper::plugin()->eventWithHtml('BeforeAddToCartButton', [$this->product, J2CommerceHelper::utilities()->getContext('view_cart')]); ?>
 <?php if ($show): ?>
     <div class="cart-action-complete uk-hidden" style="display:none;">
         <p class="uk-text-success">
@@ -62,7 +63,7 @@ $disabled      = $is_out_of_stock ? ' disabled' : '';
 
     <div id="add-to-cart-<?php echo $this->product->j2commerce_product_id; ?>" class="j2commerce-add-to-cart uk-flex uk-flex-wrap uk-flex-between uk-margin-top uk-margin-bottom">
         <?php if ($show_qty_btn): ?>
-            <?php echo J2Commerce::product()->displayQuantity('com_j2commerce.product.uikit', $this->product, $this->params, ['class' => 'uk-input']); ?>
+            <?php echo J2CommerceHelper::product()->displayQuantity('com_j2commerce.product.uikit', $this->product, $this->params, ['class' => 'uk-input']); ?>
         <?php else: ?>
             <input type="hidden" name="product_qty" value="1" />
         <?php endif; ?>
@@ -80,11 +81,11 @@ $disabled      = $is_out_of_stock ? ' disabled' : '';
             <span class="uk-text-capitalize boxbuilder-btn-text"><?php echo $cart_text; ?></span>
         </button>
 
-        <?php echo J2Commerce::plugin()->eventWithHtml('AfterAddToCartButton', [$this->product, J2Commerce::utilities()->getContext('view_cart')]); ?>
+        <?php echo J2CommerceHelper::plugin()->eventWithHtml('AfterAddToCartButton', [$this->product, J2CommerceHelper::utilities()->getContext('view_cart')]); ?>
     </div>
 <?php else: ?>
     <div class="uk-margin AfterAddToCartButton">
-        <?php echo J2Commerce::plugin()->eventWithHtml('AfterAddToCartButton', [$this->product, J2Commerce::utilities()->getContext('view_cart')]); ?>
+        <?php echo J2CommerceHelper::plugin()->eventWithHtml('AfterAddToCartButton', [$this->product, J2CommerceHelper::utilities()->getContext('view_cart')]); ?>
     </div>
 <?php endif; ?>
 
@@ -115,10 +116,10 @@ $disabled      = $is_out_of_stock ? ' disabled' : '';
 
 <div id="AfterProductCartGrid">
     <div class="uk-flex uk-flex-wrap" style="gap:1rem;">
-        <?php echo J2Commerce::plugin()->eventWithHtml('AfterProductCartGrid', [$this->product, J2Commerce::utilities()->getContext('view_cart')]); ?>
+        <?php echo J2CommerceHelper::plugin()->eventWithHtml('AfterProductCartGrid', [$this->product, J2CommerceHelper::utilities()->getContext('view_cart')]); ?>
     </div>
 </div>
 
 <div id="AfterProductCart" class="uk-margin">
-    <?php echo J2Commerce::plugin()->eventWithHtml('AfterProductCart', [$this->product, J2Commerce::utilities()->getContext('view_cart')]); ?>
+    <?php echo J2CommerceHelper::plugin()->eventWithHtml('AfterProductCart', [$this->product, J2CommerceHelper::utilities()->getContext('view_cart')]); ?>
 </div>

--- a/plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_boxbuilder_general.php
+++ b/plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_boxbuilder_general.php
@@ -12,29 +12,30 @@ declare(strict_types=1);
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 ?>
 
 <div class="boxbuilder-general">
-    <?php echo J2Commerce::plugin()->eventWithHtml('BeforeProductTitle', [$this->product, J2Commerce::utilities()->getContext('title')]); ?>
+    <?php echo J2CommerceHelper::plugin()->eventWithHtml('BeforeProductTitle', [$this->product, J2CommerceHelper::utilities()->getContext('title')]); ?>
     <?php if ($this->params->get('item_show_title', 1)): ?>
         <h<?php echo $this->params->get('item_title_headertag', '2'); ?> class="product-title uk-text-capitalize uk-margin-bottom">
             <?php echo $this->escape($this->product->product_name); ?>
         </h<?php echo $this->params->get('item_title_headertag', '2'); ?>>
     <?php endif; ?>
-    <?php echo J2Commerce::plugin()->eventWithHtml('AfterProductTitle', [$this->product, J2Commerce::utilities()->getContext('title')]); ?>
+    <?php echo J2CommerceHelper::plugin()->eventWithHtml('AfterProductTitle', [$this->product, J2CommerceHelper::utilities()->getContext('title')]); ?>
     <?php if (isset($this->product->source->event->afterDisplayTitle)): ?>
         <?php echo $this->product->source->event->afterDisplayTitle; ?>
     <?php endif; ?>
-    <?php if (J2Commerce::product()->canShowSku($this->params)): ?>
+    <?php if (J2CommerceHelper::product()->canShowSku($this->params)): ?>
         <?php echo $this->loadTemplate('sku'); ?>
     <?php endif; ?>
     <?php echo $this->loadTemplate('sdesc'); ?>
 
     <div class="uk-flex uk-flex-wrap uk-flex-middle uk-margin-bottom">
-        <?php if (J2Commerce::product()->canShowprice($this->params)): ?>
+        <?php if (J2CommerceHelper::product()->canShowprice($this->params)): ?>
             <?php echo $this->loadTemplate('price'); ?>
         <?php endif; ?>
-        <?php if ($this->params->get('item_show_product_stock', 1) && J2Commerce::product()->managing_stock($this->product->variant)): ?>
+        <?php if ($this->params->get('item_show_product_stock', 1) && J2CommerceHelper::product()->managing_stock($this->product->variant)): ?>
             <?php echo $this->loadTemplate('stock'); ?>
         <?php endif; ?>
     </div>

--- a/plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_boxbuilderprice.php
+++ b/plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_boxbuilderprice.php
@@ -12,29 +12,30 @@ declare(strict_types=1);
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 
 $boxbuilderproducts     = (array) $this->product->params->get('boxbuilderproduct', []);
-$totalBoxBuilderPrice   = J2Commerce::getBoxBuilderProductTotal($boxbuilderproducts);
+$totalBoxBuilderPrice   = J2CommerceHelper::getBoxBuilderProductTotal($boxbuilderproducts);
 ?>
 
-<?php echo J2Commerce::plugin()->eventWithHtml('BeforeRenderingProductPrice', [$this->product]); ?>
+<?php echo J2CommerceHelper::plugin()->eventWithHtml('BeforeRenderingProductPrice', [$this->product]); ?>
 
 <div class="product-price-container uk-flex uk-flex-middle uk-margin-remove uk-margin-right">
     <span class="sale-price uk-text-large uk-text-bold">
         <?php if (isset($this->product->pricing->price)): ?>
-            <?php echo J2Commerce::product()->displayPrice($this->product->pricing->price, $this->product, $this->params); ?>
+            <?php echo J2CommerceHelper::product()->displayPrice($this->product->pricing->price, $this->product, $this->params); ?>
         <?php endif; ?>
     </span>
     <?php if (($this->product->pricing->price !== $totalBoxBuilderPrice) && ($this->product->pricing->price < $totalBoxBuilderPrice)): ?>
         <?php $class = isset($this->product->pricing->is_discount_pricing_available) ? 'strike' : ''; ?>
-        <?php $base_price = J2Commerce::product()->displayPrice($totalBoxBuilderPrice, $this->product, $this->params); ?>
+        <?php $base_price = J2CommerceHelper::product()->displayPrice($totalBoxBuilderPrice, $this->product, $this->params); ?>
         <del class="uk-text-small uk-text-muted uk-margin-small-left base-price <?php echo $class; ?>"><?php echo $base_price; ?></del>
     <?php endif; ?>
     <?php if ($this->params->get('display_price_with_tax_info', 0)): ?>
         <div class="tax-text">
-            <?php echo J2Commerce::product()->get_tax_text(); ?>
+            <?php echo J2CommerceHelper::product()->get_tax_text(); ?>
         </div>
     <?php endif; ?>
 </div>
 
-<?php echo J2Commerce::plugin()->eventWithHtml('AfterRenderingProductPrice', [$this->product]); ?>
+<?php echo J2CommerceHelper::plugin()->eventWithHtml('AfterRenderingProductPrice', [$this->product]); ?>

--- a/plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_boxbuilderproduct.php
+++ b/plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_boxbuilderproduct.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Uri\Uri;
 use Joomla\Registry\Registry;
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 
 $productParams = $this->product->params;
 if (!$productParams instanceof Registry) {
@@ -30,7 +31,7 @@ if (!empty($boxbuilderProducts)) {
     $this->availableProducts    = [];
     $this->boxSize              = $boxSize;
     $this->boxPrice             = $this->product->pricing->price ?? 0;
-    $this->boxPriceFormatted    = J2Commerce::currency()->format($this->boxPrice);
+    $this->boxPriceFormatted    = J2CommerceHelper::currency()->format($this->boxPrice);
     $this->addToCartButtonText  = $productParams->get('add_to_cart_button_text', Text::_('COM_J2COMMERCE_ADD_TO_CART'));
     $this->productDisplay       = $productDisplay;
 
@@ -42,12 +43,12 @@ if (!empty($boxbuilderProducts)) {
             continue;
         }
 
-        $product = J2Commerce::product()->setId($productId)->getProduct();
+        $product = J2CommerceHelper::product()->setId($productId)->getProduct();
         if (!$product) {
             continue;
         }
 
-        J2Commerce::product()->runBehaviorFlag(true)->getProduct($product);
+        J2CommerceHelper::product()->runBehaviorFlag(true)->getProduct($product);
 
         $productImage = '';
         if (!empty($product->thumb_image)) {
@@ -57,8 +58,8 @@ if (!empty($boxbuilderProducts)) {
         }
 
         $isOutOfStock = false;
-        if (J2Commerce::product()->managing_stock($product->variant)) {
-            $isOutOfStock = !J2Commerce::product()->check_stock_status($product->variant, 1);
+        if (J2CommerceHelper::product()->managing_stock($product->variant)) {
+            $isOutOfStock = !J2CommerceHelper::product()->check_stock_status($product->variant, 1);
         }
 
         $articleOrdering = 0;
@@ -127,7 +128,7 @@ if (!empty($boxbuilderProducts)) {
     <div class="uk-container">
         <div class="uk-grid" uk-grid>
             <div class="uk-width-1-1">
-                <?php if (J2Commerce::product()->canShowCart($this->params)): ?>
+                <?php if (J2CommerceHelper::product()->canShowCart($this->params)): ?>
                     <?php if (!empty($this->availableProducts)): ?>
                         <?php echo $this->loadTemplate('boxbuilder_interactive'); ?>
                     <?php endif; ?>
@@ -146,7 +147,7 @@ if (!empty($boxbuilderProducts)) {
 </section>
 
 <?php if ($this->params->get('item_use_tabs', 1)): ?>
-    <?php echo J2Commerce::plugin()->eventWithHtml('DisplayBoxBuilderDetails', [$this->product]); ?>
+    <?php echo J2CommerceHelper::plugin()->eventWithHtml('DisplayBoxBuilderDetails', [$this->product]); ?>
 <?php endif; ?>
 
 <?php if ($this->params->get('item_use_tabs', 1)): ?>
@@ -165,4 +166,4 @@ if (!empty($boxbuilderProducts)) {
     <?php echo $this->product->source->event->afterDisplayContent; ?>
 <?php endif; ?>
 
-<?php echo J2Commerce::plugin()->eventWithHtml('afterDisplayProductPage', [$this->product]); ?>
+<?php echo J2CommerceHelper::plugin()->eventWithHtml('afterDisplayProductPage', [$this->product]); ?>

--- a/plugins/j2commerce/app_uikit/tmpl/uikit/view_boxbuilder_cart.php
+++ b/plugins/j2commerce/app_uikit/tmpl/uikit/view_boxbuilder_cart.php
@@ -17,6 +17,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Uri\Uri;
 use Joomla\Registry\Registry;
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 
 $plugin = PluginHelper::getPlugin('j2commerce', 'app_boxbuilderproduct');
 $params = new Registry($plugin->params);
@@ -39,13 +40,13 @@ if (!empty($this->product->addtocart_text)) {
     }
 }
 
-$show          = J2Commerce::product()->validateVariableProduct($this->product);
-$manageStock   = J2Commerce::product()->managing_stock($this->product->variant);
+$show          = J2CommerceHelper::product()->validateVariableProduct($this->product);
+$manageStock   = J2CommerceHelper::product()->managing_stock($this->product->variant);
 $is_available  = $this->product->variant->availability;
 $is_out_of_stock = ($manageStock === true && $is_available === 0);
 $disabled      = $is_out_of_stock ? ' disabled' : '';
 ?>
-<?php echo J2Commerce::plugin()->eventWithHtml('BeforeAddToCartButton', [$this->product, J2Commerce::utilities()->getContext('view_cart')]); ?>
+<?php echo J2CommerceHelper::plugin()->eventWithHtml('BeforeAddToCartButton', [$this->product, J2CommerceHelper::utilities()->getContext('view_cart')]); ?>
 <?php if ($show): ?>
     <div class="cart-action-complete uk-hidden" style="display:none;">
         <p class="uk-text-success">
@@ -62,7 +63,7 @@ $disabled      = $is_out_of_stock ? ' disabled' : '';
 
     <div id="add-to-cart-<?php echo $this->product->j2commerce_product_id; ?>" class="j2commerce-add-to-cart uk-flex uk-flex-wrap uk-flex-between uk-margin-top uk-margin-bottom">
         <?php if ($show_qty_btn): ?>
-            <?php echo J2Commerce::product()->displayQuantity('com_j2commerce.product.uikit', $this->product, $this->params, ['class' => 'uk-input']); ?>
+            <?php echo J2CommerceHelper::product()->displayQuantity('com_j2commerce.product.uikit', $this->product, $this->params, ['class' => 'uk-input']); ?>
         <?php else: ?>
             <input type="hidden" name="product_qty" value="1" />
         <?php endif; ?>
@@ -80,11 +81,11 @@ $disabled      = $is_out_of_stock ? ' disabled' : '';
             <span class="uk-text-capitalize boxbuilder-btn-text"><?php echo $cart_text; ?></span>
         </button>
 
-        <?php echo J2Commerce::plugin()->eventWithHtml('AfterAddToCartButton', [$this->product, J2Commerce::utilities()->getContext('view_cart')]); ?>
+        <?php echo J2CommerceHelper::plugin()->eventWithHtml('AfterAddToCartButton', [$this->product, J2CommerceHelper::utilities()->getContext('view_cart')]); ?>
     </div>
 <?php else: ?>
     <div class="uk-margin AfterAddToCartButton">
-        <?php echo J2Commerce::plugin()->eventWithHtml('AfterAddToCartButton', [$this->product, J2Commerce::utilities()->getContext('view_cart')]); ?>
+        <?php echo J2CommerceHelper::plugin()->eventWithHtml('AfterAddToCartButton', [$this->product, J2CommerceHelper::utilities()->getContext('view_cart')]); ?>
     </div>
 <?php endif; ?>
 
@@ -115,10 +116,10 @@ $disabled      = $is_out_of_stock ? ' disabled' : '';
 
 <div id="AfterProductCartGrid">
     <div class="uk-flex uk-flex-wrap" style="gap:1rem;">
-        <?php echo J2Commerce::plugin()->eventWithHtml('AfterProductCartGrid', [$this->product, J2Commerce::utilities()->getContext('view_cart')]); ?>
+        <?php echo J2CommerceHelper::plugin()->eventWithHtml('AfterProductCartGrid', [$this->product, J2CommerceHelper::utilities()->getContext('view_cart')]); ?>
     </div>
 </div>
 
 <div id="AfterProductCart" class="uk-margin">
-    <?php echo J2Commerce::plugin()->eventWithHtml('AfterProductCart', [$this->product, J2Commerce::utilities()->getContext('view_cart')]); ?>
+    <?php echo J2CommerceHelper::plugin()->eventWithHtml('AfterProductCart', [$this->product, J2CommerceHelper::utilities()->getContext('view_cart')]); ?>
 </div>

--- a/plugins/j2commerce/app_uikit/tmpl/uikit/view_boxbuilder_general.php
+++ b/plugins/j2commerce/app_uikit/tmpl/uikit/view_boxbuilder_general.php
@@ -12,29 +12,30 @@ declare(strict_types=1);
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 ?>
 
 <div class="boxbuilder-general">
-    <?php echo J2Commerce::plugin()->eventWithHtml('BeforeProductTitle', [$this->product, J2Commerce::utilities()->getContext('title')]); ?>
+    <?php echo J2CommerceHelper::plugin()->eventWithHtml('BeforeProductTitle', [$this->product, J2CommerceHelper::utilities()->getContext('title')]); ?>
     <?php if ($this->params->get('item_show_title', 1)): ?>
         <h<?php echo $this->params->get('item_title_headertag', '2'); ?> class="product-title uk-text-capitalize uk-margin-bottom">
             <?php echo $this->escape($this->product->product_name); ?>
         </h<?php echo $this->params->get('item_title_headertag', '2'); ?>>
     <?php endif; ?>
-    <?php echo J2Commerce::plugin()->eventWithHtml('AfterProductTitle', [$this->product, J2Commerce::utilities()->getContext('title')]); ?>
+    <?php echo J2CommerceHelper::plugin()->eventWithHtml('AfterProductTitle', [$this->product, J2CommerceHelper::utilities()->getContext('title')]); ?>
     <?php if (isset($this->product->source->event->afterDisplayTitle)): ?>
         <?php echo $this->product->source->event->afterDisplayTitle; ?>
     <?php endif; ?>
-    <?php if (J2Commerce::product()->canShowSku($this->params)): ?>
+    <?php if (J2CommerceHelper::product()->canShowSku($this->params)): ?>
         <?php echo $this->loadTemplate('sku'); ?>
     <?php endif; ?>
     <?php echo $this->loadTemplate('sdesc'); ?>
 
     <div class="uk-flex uk-flex-wrap uk-flex-middle uk-margin-bottom">
-        <?php if (J2Commerce::product()->canShowprice($this->params)): ?>
+        <?php if (J2CommerceHelper::product()->canShowprice($this->params)): ?>
             <?php echo $this->loadTemplate('price'); ?>
         <?php endif; ?>
-        <?php if ($this->params->get('item_show_product_stock', 1) && J2Commerce::product()->managing_stock($this->product->variant)): ?>
+        <?php if ($this->params->get('item_show_product_stock', 1) && J2CommerceHelper::product()->managing_stock($this->product->variant)): ?>
             <?php echo $this->loadTemplate('stock'); ?>
         <?php endif; ?>
     </div>

--- a/plugins/j2commerce/app_uikit/tmpl/uikit/view_boxbuilderprice.php
+++ b/plugins/j2commerce/app_uikit/tmpl/uikit/view_boxbuilderprice.php
@@ -12,29 +12,30 @@ declare(strict_types=1);
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 
 $boxbuilderproducts     = (array) $this->product->params->get('boxbuilderproduct', []);
-$totalBoxBuilderPrice   = J2Commerce::getBoxBuilderProductTotal($boxbuilderproducts);
+$totalBoxBuilderPrice   = J2CommerceHelper::getBoxBuilderProductTotal($boxbuilderproducts);
 ?>
 
-<?php echo J2Commerce::plugin()->eventWithHtml('BeforeRenderingProductPrice', [$this->product]); ?>
+<?php echo J2CommerceHelper::plugin()->eventWithHtml('BeforeRenderingProductPrice', [$this->product]); ?>
 
 <div class="product-price-container uk-flex uk-flex-middle uk-margin-remove uk-margin-right">
     <span class="sale-price uk-text-large uk-text-bold">
         <?php if (isset($this->product->pricing->price)): ?>
-            <?php echo J2Commerce::product()->displayPrice($this->product->pricing->price, $this->product, $this->params); ?>
+            <?php echo J2CommerceHelper::product()->displayPrice($this->product->pricing->price, $this->product, $this->params); ?>
         <?php endif; ?>
     </span>
     <?php if (($this->product->pricing->price !== $totalBoxBuilderPrice) && ($this->product->pricing->price < $totalBoxBuilderPrice)): ?>
         <?php $class = isset($this->product->pricing->is_discount_pricing_available) ? 'strike' : ''; ?>
-        <?php $base_price = J2Commerce::product()->displayPrice($totalBoxBuilderPrice, $this->product, $this->params); ?>
+        <?php $base_price = J2CommerceHelper::product()->displayPrice($totalBoxBuilderPrice, $this->product, $this->params); ?>
         <del class="uk-text-small uk-text-muted uk-margin-small-left base-price <?php echo $class; ?>"><?php echo $base_price; ?></del>
     <?php endif; ?>
     <?php if ($this->params->get('display_price_with_tax_info', 0)): ?>
         <div class="tax-text">
-            <?php echo J2Commerce::product()->get_tax_text(); ?>
+            <?php echo J2CommerceHelper::product()->get_tax_text(); ?>
         </div>
     <?php endif; ?>
 </div>
 
-<?php echo J2Commerce::plugin()->eventWithHtml('AfterRenderingProductPrice', [$this->product]); ?>
+<?php echo J2CommerceHelper::plugin()->eventWithHtml('AfterRenderingProductPrice', [$this->product]); ?>

--- a/plugins/j2commerce/app_uikit/tmpl/uikit/view_boxbuilderproduct.php
+++ b/plugins/j2commerce/app_uikit/tmpl/uikit/view_boxbuilderproduct.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Uri\Uri;
 use Joomla\Registry\Registry;
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 
 $productParams = $this->product->params;
 if (!$productParams instanceof Registry) {
@@ -30,7 +31,7 @@ if (!empty($boxbuilderProducts)) {
     $this->availableProducts    = [];
     $this->boxSize              = $boxSize;
     $this->boxPrice             = $this->product->pricing->price ?? 0;
-    $this->boxPriceFormatted    = J2Commerce::currency()->format($this->boxPrice);
+    $this->boxPriceFormatted    = J2CommerceHelper::currency()->format($this->boxPrice);
     $this->addToCartButtonText  = $productParams->get('add_to_cart_button_text', Text::_('COM_J2COMMERCE_ADD_TO_CART'));
     $this->productDisplay       = $productDisplay;
 
@@ -42,12 +43,12 @@ if (!empty($boxbuilderProducts)) {
             continue;
         }
 
-        $product = J2Commerce::product()->setId($productId)->getProduct();
+        $product = J2CommerceHelper::product()->setId($productId)->getProduct();
         if (!$product) {
             continue;
         }
 
-        J2Commerce::product()->runBehaviorFlag(true)->getProduct($product);
+        J2CommerceHelper::product()->runBehaviorFlag(true)->getProduct($product);
 
         $productImage = '';
         if (!empty($product->thumb_image)) {
@@ -57,8 +58,8 @@ if (!empty($boxbuilderProducts)) {
         }
 
         $isOutOfStock = false;
-        if (J2Commerce::product()->managing_stock($product->variant)) {
-            $isOutOfStock = !J2Commerce::product()->check_stock_status($product->variant, 1);
+        if (J2CommerceHelper::product()->managing_stock($product->variant)) {
+            $isOutOfStock = !J2CommerceHelper::product()->check_stock_status($product->variant, 1);
         }
 
         $articleOrdering = 0;
@@ -127,7 +128,7 @@ if (!empty($boxbuilderProducts)) {
     <div class="uk-container">
         <div class="uk-grid" uk-grid>
             <div class="uk-width-1-1">
-                <?php if (J2Commerce::product()->canShowCart($this->params)): ?>
+                <?php if (J2CommerceHelper::product()->canShowCart($this->params)): ?>
                     <?php if (!empty($this->availableProducts)): ?>
                         <?php echo $this->loadTemplate('boxbuilder_interactive'); ?>
                     <?php endif; ?>
@@ -146,7 +147,7 @@ if (!empty($boxbuilderProducts)) {
 </section>
 
 <?php if ($this->params->get('item_use_tabs', 1)): ?>
-    <?php echo J2Commerce::plugin()->eventWithHtml('DisplayBoxBuilderDetails', [$this->product]); ?>
+    <?php echo J2CommerceHelper::plugin()->eventWithHtml('DisplayBoxBuilderDetails', [$this->product]); ?>
 <?php endif; ?>
 
 <?php if ($this->params->get('item_use_tabs', 1)): ?>
@@ -165,4 +166,4 @@ if (!empty($boxbuilderProducts)) {
     <?php echo $this->product->source->event->afterDisplayContent; ?>
 <?php endif; ?>
 
-<?php echo J2Commerce::plugin()->eventWithHtml('afterDisplayProductPage', [$this->product]); ?>
+<?php echo J2CommerceHelper::plugin()->eventWithHtml('afterDisplayProductPage', [$this->product]); ?>


### PR DESCRIPTION
## Summary

Fixes #509

Standardizes inconsistent static helper class references across J2Commerce core extensions.

## Changes

Replaces:
- `J2Store::utilities()` → `J2CommerceHelper::utilities()`
- `J2Commerce::utilities()` → `J2CommerceHelper::utilities()`
- `J2Commerce::plugin()` → `J2CommerceHelper::plugin()`
- `J2Commerce::product()` → `J2CommerceHelper::product()`

Adds use statement where missing:
```php
use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
```

## Files Changed

| Extension | Files | Instances Fixed |
|-----------|-------|-----------------|
| app_bootstrap5 | 1 | 2 (`J2Store::`) |
| app_uikit (uikit/) | 4 | 25 |
| app_uikit (tag_uikit/) | 4 | 25 |
| com_j2commerce layouts | 2 | 4 |
| **Total** | **11** | **56** |

## Testing

1. Load any product page using app_uikit or app_bootstrap5 template
2. Verify add-to-cart functionality works
3. Verify event hooks fire correctly (BeforeAddToCartButton, AfterAddToCartButton, etc.)
4. No PHP errors in logs

## Pre-Flight

- [x] PHP syntax check passed (all 11 files)
- [x] No remaining `J2Store::` or `J2Commerce::` in core files
- [x] All use statements added correctly