### PR TITLE
fix(a11y): override text-muted color for WCAG AAA compliance (fixes #495)

### DIFF
--- a/media/com_j2commerce/css/administrator/j2commerce_admin.css
+++ b/media/com_j2commerce/css/administrator/j2commerce_admin.css
@@ -1,3 +1,7 @@
+.text-muted {
+    color: #495057 !important;
+}
+
 :root {
     --j2c-error: #dc3545;
     --j2c-success: #33b36b;

--- a/media/com_j2commerce/css/site/j2commerce.css
+++ b/media/com_j2commerce/css/site/j2commerce.css
@@ -1,3 +1,7 @@
+.text-muted {
+    color: #495057 !important;
+}
+
 .j2commerce {
     --primary: #112855;
     --success: #0d9347;


### PR DESCRIPTION
## Summary
Fixes #495

Overrides `.text-muted` to `#495057` (Bootstrap gray-700) in both admin and frontend CSS, achieving **WCAG AAA compliance** with an **8.18:1 contrast ratio** against white.

The default `text-muted` color `rgba(33,37,41,.749)` renders as `#595C5F` on white — contrast ratio 6.73:1, which passes **WCAG AA but fails AAA**.

A single CSS override was chosen instead of updating ~170 files (316 occurrences) that use the `text-muted` class across core component, plugins, modules, and JS assets. Full usage inventory documented in `docs/reports/text-muted-alternatives.md`.

## Changes
- `media/com_j2commerce/css/administrator/j2commerce_admin.css` — added `.text-muted` override
- `media/com_j2commerce/css/site/j2commerce.css` — added `.text-muted` override

## Files Modified
| Type | Count |
|------|-------|
| CSS assets | 2 |

## Pre-Flight
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only (non-core excluded)

## Testing
1. Open any J2Commerce admin page with gray secondary text
2. Inspect a `.text-muted` element → computed color should be `#495057`
3. Check frontend storefront pages similarly
4. Verify text still looks visually muted but with improved contrast