### PR TITLE
fix(a11y): theme-aware text-muted override for WCAG AAA (fixes #495)

### DIFF
--- a/media/com_j2commerce/css/administrator/j2commerce_admin.css
+++ b/media/com_j2commerce/css/administrator/j2commerce_admin.css
@@ -1,6 +1,3 @@
-.text-muted {
-    color: #495057 !important;
-}
 
 :root {
     --j2c-error: #dc3545;
@@ -210,6 +207,28 @@ body.com_j2commerce #content, #fieldset-j2commerce-product-settings, .j2commerce
     .j2commerce-variant-inventory .form-check {padding-block-start: 3px;}
     #dashboardModuleTabs nav.quick-icons {padding:0!important;}
 
+
+
+}
+
+html[data-bs-theme="light"] body.com_j2commerce {
+    .text-muted {
+        --text-muted-color:#495057;
+        color: var(--text-muted-color)!important;
+        opacity:1!important;
+    }
+}
+
+
+html[data-bs-theme="dark"] body.com_j2commerce {
+    .btn-outline-primary {
+        --btn-color: var(--btn-active-color)!important;
+        border: var(--btn-primary-border-hvr);
+    }
+    .btn-outline-primary:hover, .btn-outline-primary:focus, .btn-outline-primary:active {
+        background-color: var(--btn-primary-bg-hvr);
+        border: var(--btn-primary-border-hvr);
+    }
 }
 
 .j2commerce-social-share a[target="_blank"]:before {display:none;}

--- a/media/com_j2commerce/css/administrator/listview.css
+++ b/media/com_j2commerce/css/administrator/listview.css
@@ -1,1 +1,0 @@
-/* listview admin styles */

--- a/media/com_j2commerce/css/site/j2commerce.css
+++ b/media/com_j2commerce/css/site/j2commerce.css
@@ -1,7 +1,3 @@
-.text-muted {
-    color: #495057 !important;
-}
-
 .j2commerce {
     --primary: #112855;
     --success: #0d9347;
@@ -870,5 +866,13 @@
     .j2commerce-confirmation .j2c-confirmation-main {
         border-right: none !important;
         padding-right: 0 !important;
+    }
+}
+
+html[data-bs-theme="light"] .j2commerce {
+    .text-muted {
+        --text-muted-color:#495057;
+        color: var(--text-muted-color)!important;
+        opacity:1!important;
     }
 }


### PR DESCRIPTION
Replace naive .text-muted override with theme-aware CSS using html[data-bs-theme="light"] scoping and CSS custom properties. Admin: scoped to body.com_j2commerce, also adds dark mode btn-outline-primary fix. Frontend: scoped to .j2commerce wrapper. Single CSS override avoids updating ~170 files.