### PR TITLE
fix(ui): consistent action cards across plugin list views (fixes #520)

### DIFF
--- a/administrator/components/com_j2commerce/language/en-GB/com_j2commerce.ini
+++ b/administrator/components/com_j2commerce/language/en-GB/com_j2commerce.ini
@@ -1475,6 +1475,15 @@ COM_J2COMMERCE_REPORT_LAYOUT_CARDS_ADD_TITLE="Add Reporting Tools"
 COM_J2COMMERCE_REPORT_LAYOUT_CARDS_ADD_DESC="Install reporting plugins for sales analytics, customer insights, and performance metrics."
 COM_J2COMMERCE_REPORT_LAYOUT_CARDS_ADD_BTN1_TITLE="Browse Reporting Plugins"
 
+; Apps Layout Cards
+COM_J2COMMERCE_APP_LAYOUT_CARDS_HELP_TITLE="Need Help?"
+COM_J2COMMERCE_APP_LAYOUT_CARDS_HELP_DESC="Learn how to install and configure apps to extend your store functionality."
+COM_J2COMMERCE_APP_LAYOUT_CARDS_HELP_BTN1_TITLE="Documentation"
+COM_J2COMMERCE_APP_LAYOUT_CARDS_HELP_BTN2_TITLE="Get Support"
+COM_J2COMMERCE_APP_LAYOUT_CARDS_ADD_TITLE="Boost Sales & Productivity"
+COM_J2COMMERCE_APP_LAYOUT_CARDS_ADD_DESC="Discover apps to boost your sales, increase conversions, improve customer engagement, and more."
+COM_J2COMMERCE_APP_LAYOUT_CARDS_ADD_BTN1_TITLE="Visit the App Store"
+
 ; ===========================================
 ; Coupons View - List Headings
 ; ===========================================

--- a/administrator/components/com_j2commerce/language/en-US/com_j2commerce.ini
+++ b/administrator/components/com_j2commerce/language/en-US/com_j2commerce.ini
@@ -1483,6 +1483,15 @@ COM_J2COMMERCE_REPORT_LAYOUT_CARDS_ADD_TITLE="Add Reporting Tools"
 COM_J2COMMERCE_REPORT_LAYOUT_CARDS_ADD_DESC="Install reporting plugins for sales analytics, customer insights, and performance metrics."
 COM_J2COMMERCE_REPORT_LAYOUT_CARDS_ADD_BTN1_TITLE="Browse Reporting Plugins"
 
+; Apps Layout Cards
+COM_J2COMMERCE_APP_LAYOUT_CARDS_HELP_TITLE="Need Help?"
+COM_J2COMMERCE_APP_LAYOUT_CARDS_HELP_DESC="Learn how to install and configure apps to extend your store functionality."
+COM_J2COMMERCE_APP_LAYOUT_CARDS_HELP_BTN1_TITLE="Documentation"
+COM_J2COMMERCE_APP_LAYOUT_CARDS_HELP_BTN2_TITLE="Get Support"
+COM_J2COMMERCE_APP_LAYOUT_CARDS_ADD_TITLE="Boost Sales & Productivity"
+COM_J2COMMERCE_APP_LAYOUT_CARDS_ADD_DESC="Discover apps to boost your sales, increase conversions, improve customer engagement, and more."
+COM_J2COMMERCE_APP_LAYOUT_CARDS_ADD_BTN1_TITLE="Visit the App Store"
+
 ;creditcard form
 COM_J2COMMERCE_CREDITCARD_TYPE="Credit Card Type"
 COM_J2COMMERCE_CREDITCARD="Credit Card"

--- a/administrator/components/com_j2commerce/layouts/app/default.php
+++ b/administrator/components/com_j2commerce/layouts/app/default.php
@@ -31,7 +31,8 @@ $is_pro = $versionHelper->isPro();
 
 ?>
 
-<div class="j2commerce-shipping-container inline-content my-3">
+
+<div class="j2commerce-app-container inline-content my-3">
     <div class="row">
         <div class="col-md-6 align-self-stretch mb-3 mb-lg-0">
             <div class="card">
@@ -39,12 +40,12 @@ $is_pro = $versionHelper->isPro();
                     <div class="d-flex flex-column text-center h-100 pt-3">
                         <div class="mt-auto">
                             <span class="fa-4x mb-2 fa-solid fa-circle-info" aria-hidden="true"></span>
-                            <h2 class="fs-1 fw-bold"><?php echo Text::_('COM_J2COMMERCE_SHIPPING_LAYOUT_CARDS_HELP_TITLE');?></h2>
-                            <p class="text-muted mb-5"><?php echo Text::_('COM_J2COMMERCE_SHIPPING_LAYOUT_CARDS_HELP_DESC');?></p>
+                            <h2 class="fs-1 fw-bold"><?php echo Text::_('COM_J2COMMERCE_APP_LAYOUT_CARDS_HELP_TITLE');?></h2>
+                            <p class="text-muted mb-5"><?php echo Text::_('COM_J2COMMERCE_APP_LAYOUT_CARDS_HELP_DESC');?></p>
                         </div>
                         <div class="text-center mt-auto mb-4">
-                            <a class="btn btn-outline-primary app-button-open" href="https://docs.j2commerce.com/v6/shipping-methods" target="_blank" title="<?php echo Text::_('COM_J2COMMERCE_SHIPPING_LAYOUT_CARDS_HELP_BTN1_TITLE');?>"><span class="ps-1"><?php echo Text::_('COM_J2COMMERCE_SHIPPING_LAYOUT_CARDS_HELP_BTN1_TITLE');?></span></a>
-                            <a class="btn btn-primary app-button-open" href="<?php echo Route::_('index.php?option=com_j2commerce&view=shippingtroubles');?>" title="<?php echo Text::_('COM_J2COMMERCE_SHIPPING_TROUBLESHOOTER');?>"><span class="ps-1"><?php echo Text::_('COM_J2COMMERCE_SHIPPING_TROUBLESHOOTER');?></span></a>
+                            <a class="btn btn-outline-primary app-button-open" href="https://www.j2commerce.com/support/technical-support" target="_blank" title="<?php echo Text::_('COM_J2COMMERCE_APP_LAYOUT_CARDS_HELP_BTN2_TITLE');?>"><span class="ps-1"><?php echo Text::_('COM_J2COMMERCE_APP_LAYOUT_CARDS_HELP_BTN2_TITLE');?></span></a>
+                            <a class="btn btn-primary app-button-open" href="https://docs.j2commerce.com/v6/apps-and-extensions" target="_blank" title="<?php echo Text::_('COM_J2COMMERCE_APP_LAYOUT_CARDS_HELP_BTN1_TITLE');?>"><span class="ps-1"><?php echo Text::_('COM_J2COMMERCE_APP_LAYOUT_CARDS_HELP_BTN1_TITLE');?></span></a>
                         </div>
                     </div>
                 </div>
@@ -55,12 +56,12 @@ $is_pro = $versionHelper->isPro();
                 <div class="card-body">
                     <div class="d-flex flex-column text-center h-100 pt-3">
                         <div class="mt-auto">
-                            <span class="fa-4x mb-2 fa-solid fa-truck-plane" aria-hidden="true"></span>
-                            <h2 class="fs-1 fw-bold"><?php echo Text::_('COM_J2COMMERCE_SHIPPING_LAYOUT_CARDS_ADD_TITLE');?></h2>
-                            <p class="text-muted mb-5"><?php echo Text::_('COM_J2COMMERCE_SHIPPING_LAYOUT_CARDS_ADD_DESC');?></p>
+                            <span class="fa-4x mb-2 fa-solid fa-cart-arrow-down" aria-hidden="true"></span>
+                            <h2 class="fs-1 fw-bold"><?php echo Text::_('COM_J2COMMERCE_APP_LAYOUT_CARDS_ADD_TITLE');?></h2>
+                            <p class="text-muted mb-5"><?php echo Text::_('COM_J2COMMERCE_APP_LAYOUT_CARDS_ADD_DESC');?></p>
                         </div>
                         <div class="text-center mt-auto mb-4">
-                            <a class="btn btn-primary app-button-open" href="https://www.j2commerce.com/extensions/shipping-plugins" target="_blank" title="<?php echo Text::_('COM_J2COMMERCE_SHIPPING_LAYOUT_CARDS_ADD_BTN1_TITLE');?>"><span class="ps-1"><?php echo Text::_('COM_J2COMMERCE_SHIPPING_LAYOUT_CARDS_ADD_BTN1_TITLE');?></span></a>
+                            <a class="btn btn-primary app-button-open" href="https://www.j2commerce.com/extensions/apps" target="_blank" title="<?php echo Text::_('COM_J2COMMERCE_APP_LAYOUT_CARDS_ADD_BTN1_TITLE');?>"><span class="ps-1"><?php echo Text::_('COM_J2COMMERCE_APP_LAYOUT_CARDS_ADD_BTN1_TITLE');?></span></a>
                         </div>
                     </div>
                 </div>
@@ -68,4 +69,3 @@ $is_pro = $versionHelper->isPro();
         </div>
     </div>
 </div>
-

--- a/administrator/components/com_j2commerce/layouts/payment/default.php
+++ b/administrator/components/com_j2commerce/layouts/payment/default.php
@@ -37,11 +37,11 @@ $is_pro = $versionHelper->isPro();
         <div class="col-md-6 align-self-stretch mb-3 mb-lg-0">
             <div class="card">
                 <div class="card-body">
-                    <div class="d-flex flex-column text-center h-100">
+                    <div class="d-flex flex-column text-center h-100 pt-3">
                         <div class="mt-auto">
-                            <span class="fa-4x mb-2 fa-solid fas fa-circle-info" aria-hidden="true"></span>
+                            <span class="fa-4x mb-2 fa-solid fa-circle-info" aria-hidden="true"></span>
                             <h2 class="fs-1 fw-bold"><?php echo Text::_('COM_J2COMMERCE_PAYMENT_LAYOUT_CARDS_HELP_TITLE');?></h2>
-                            <p class="fs-3 text-muted mb-5"><?php echo Text::_('COM_J2COMMERCE_PAYMENT_LAYOUT_CARDS_HELP_DESC');?></p>
+                            <p class="text-muted mb-5"><?php echo Text::_('COM_J2COMMERCE_PAYMENT_LAYOUT_CARDS_HELP_DESC');?></p>
                         </div>
                         <div class="text-center mt-auto mb-4">
                             <a class="btn btn-outline-primary app-button-open" href="https://www.j2commerce.com/support/technical-support" target="_blank" title="<?php echo Text::_('COM_J2COMMERCE_PAYMENT_LAYOUT_CARDS_HELP_BTN2_TITLE');?>"><span class="ps-1"><?php echo Text::_('COM_J2COMMERCE_PAYMENT_LAYOUT_CARDS_HELP_BTN2_TITLE');?></span></a>
@@ -54,11 +54,11 @@ $is_pro = $versionHelper->isPro();
         <div class="col-md-6 align-self-stretch">
             <div class="card">
                 <div class="card-body">
-                    <div class="d-flex flex-column text-center h-100">
+                    <div class="d-flex flex-column text-center h-100 pt-3">
                         <div class="mt-auto">
-                            <span class="fa-4x mb-2 fa-solid fas fa-credit-card" aria-hidden="true"></span>
+                            <span class="fa-4x mb-2 fa-solid fa-credit-card" aria-hidden="true"></span>
                             <h2 class="fs-1 fw-bold"><?php echo Text::_('COM_J2COMMERCE_PAYMENT_LAYOUT_CARDS_ADD_TITLE');?></h2>
-                            <p class="fs-3 text-muted mb-5"><?php echo Text::_('COM_J2COMMERCE_PAYMENT_LAYOUT_CARDS_ADD_DESC');?></p>
+                            <p class="text-muted mb-5"><?php echo Text::_('COM_J2COMMERCE_PAYMENT_LAYOUT_CARDS_ADD_DESC');?></p>
                         </div>
                         <div class="text-center mt-auto mb-4">
                             <a class="btn btn-primary app-button-open" href="https://www.j2commerce.com/extensions/payment-plugins" target="_blank" title="<?php echo Text::_('COM_J2COMMERCE_PAYMENT_LAYOUT_CARDS_ADD_BTN1_TITLE');?>"><span class="ps-1"><?php echo Text::_('COM_J2COMMERCE_PAYMENT_LAYOUT_CARDS_ADD_BTN1_TITLE');?></span></a>

--- a/administrator/components/com_j2commerce/layouts/report/default.php
+++ b/administrator/components/com_j2commerce/layouts/report/default.php
@@ -37,15 +37,15 @@ $is_pro = $versionHelper->isPro();
         <div class="col-md-6 align-self-stretch mb-3 mb-lg-0">
             <div class="card">
                 <div class="card-body">
-                    <div class="d-flex flex-column text-center h-100">
+                    <div class="d-flex flex-column text-center h-100 pt-3">
                         <div class="mt-auto">
-                            <span class="fa-4x mb-2 fa-solid fas fa-circle-info" aria-hidden="true"></span>
+                            <span class="fa-4x mb-2 fa-solid fa-circle-info" aria-hidden="true"></span>
                             <h2 class="fs-1 fw-bold"><?php echo Text::_('COM_J2COMMERCE_REPORT_LAYOUT_CARDS_HELP_TITLE');?></h2>
-                            <p class="fs-3 text-muted mb-5"><?php echo Text::_('COM_J2COMMERCE_REPORT_LAYOUT_CARDS_HELP_DESC');?></p>
+                            <p class="text-muted mb-5"><?php echo Text::_('COM_J2COMMERCE_REPORT_LAYOUT_CARDS_HELP_DESC');?></p>
                         </div>
                         <div class="text-center mt-auto mb-4">
                             <a class="btn btn-outline-primary app-button-open" href="https://www.j2commerce.com/support/technical-support" target="_blank" title="<?php echo Text::_('COM_J2COMMERCE_REPORT_LAYOUT_CARDS_HELP_BTN2_TITLE');?>"><span class="ps-1"><?php echo Text::_('COM_J2COMMERCE_REPORT_LAYOUT_CARDS_HELP_BTN2_TITLE');?></span></a>
-                            <a class="btn btn-primary app-button-open" href="https://docs.j2commerce.com/report-sales" target="_blank" title="<?php echo Text::_('COM_J2COMMERCE_REPORT_LAYOUT_CARDS_HELP_BTN1_TITLE');?>"><span class="ps-1"><?php echo Text::_('COM_J2COMMERCE_REPORT_LAYOUT_CARDS_HELP_BTN1_TITLE');?></span></a>
+                            <a class="btn btn-primary app-button-open" href="https://docs.j2commerce.com/v6/reports" target="_blank" title="<?php echo Text::_('COM_J2COMMERCE_REPORT_LAYOUT_CARDS_HELP_BTN1_TITLE');?>"><span class="ps-1"><?php echo Text::_('COM_J2COMMERCE_REPORT_LAYOUT_CARDS_HELP_BTN1_TITLE');?></span></a>
                         </div>
                     </div>
                 </div>
@@ -54,11 +54,11 @@ $is_pro = $versionHelper->isPro();
         <div class="col-md-6 align-self-stretch">
             <div class="card">
                 <div class="card-body">
-                    <div class="d-flex flex-column text-center h-100">
+                    <div class="d-flex flex-column text-center h-100 pt-3">
                         <div class="mt-auto">
-                            <span class="fa-4x mb-2 fa-solid fas fa-chart-line" aria-hidden="true"></span>
+                            <span class="fa-4x mb-2 fa-solid fa-chart-bar" aria-hidden="true"></span>
                             <h2 class="fs-1 fw-bold"><?php echo Text::_('COM_J2COMMERCE_REPORT_LAYOUT_CARDS_ADD_TITLE');?></h2>
-                            <p class="fs-3 text-muted mb-5"><?php echo Text::_('COM_J2COMMERCE_REPORT_LAYOUT_CARDS_ADD_DESC');?></p>
+                            <p class="text-muted mb-5"><?php echo Text::_('COM_J2COMMERCE_REPORT_LAYOUT_CARDS_ADD_DESC');?></p>
                         </div>
                         <div class="text-center mt-auto mb-4">
                             <a class="btn btn-primary app-button-open" href="https://www.j2commerce.com/extensions/reporting-plugins" target="_blank" title="<?php echo Text::_('COM_J2COMMERCE_REPORT_LAYOUT_CARDS_ADD_BTN1_TITLE');?>"><span class="ps-1"><?php echo Text::_('COM_J2COMMERCE_REPORT_LAYOUT_CARDS_ADD_BTN1_TITLE');?></span></a>

--- a/administrator/components/com_j2commerce/src/View/Apps/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Apps/HtmlView.php
@@ -44,6 +44,7 @@ class HtmlView extends BaseHtmlView
         $this->loadAppPluginLanguages();
 
         $this->navbar = $this->getNavbar();
+        $this->appCards = $this->getAppCards();
 
         $model = $this->getModel();
         $this->items = $model->getItems();
@@ -64,6 +65,13 @@ class HtmlView extends BaseHtmlView
         $this->addToolbar();
 
         parent::display($tpl);
+    }
+
+    protected function getAppCards(): string
+    {
+        $displayData = [];
+
+        return LayoutHelper::render('app.default', $displayData, JPATH_COMPONENT_ADMINISTRATOR . '/layouts');
     }
 
     protected function getNavbar(): string

--- a/administrator/components/com_j2commerce/tmpl/apps/default.php
+++ b/administrator/components/com_j2commerce/tmpl/apps/default.php
@@ -204,4 +204,6 @@ $return = rawurlencode($encodedReturn);
     </div>
 </form>
 
+<?php echo $this->appCards; ?>
+
 <?php echo $this->footer ?? ''; ?>

--- a/administrator/components/com_j2commerce/tmpl/reports/default.php
+++ b/administrator/components/com_j2commerce/tmpl/reports/default.php
@@ -225,8 +225,6 @@ HTMLHelper::_('bootstrap.tooltip', '[data-bs-toggle="tooltip"]', ['placement' =>
 
                 <?php endif; ?>
 
-                <?php echo $this->reportCards;?>
-
                 <input type="hidden" name="task" value="" />
                 <input type="hidden" name="boxchecked" value="0" />
                 <?php echo HTMLHelper::_('form.token'); ?>
@@ -234,5 +232,7 @@ HTMLHelper::_('bootstrap.tooltip', '[data-bs-toggle="tooltip"]', ['placement' =>
         </div>
     </div>
 </form>
+
+<?php echo $this->reportCards; ?>
 
 <?php echo $this->footer ?? ''; ?>

--- a/administrator/components/com_j2commerce/tmpl/shippingmethods/default.php
+++ b/administrator/components/com_j2commerce/tmpl/shippingmethods/default.php
@@ -47,8 +47,6 @@ HTMLHelper::_('bootstrap.tooltip', '[data-bs-toggle="tooltip"]', ['placement' =>
 
 <?php echo $this->navbar; ?>
 
-<?php echo $this->shippingCards; ?>
-
 <form action="<?php echo Route::_('index.php?option=com_j2commerce&view=shippingmethods'); ?>" method="post" name="adminForm" id="adminForm">
     <div class="row">
         <div class="col-md-12">
@@ -225,4 +223,7 @@ HTMLHelper::_('bootstrap.tooltip', '[data-bs-toggle="tooltip"]', ['placement' =>
         </div>
     </div>
 </form>
+
+<?php echo $this->shippingCards; ?>
+
 <?php echo $this->footer ?? ''; ?>

--- a/plugins/content/j2commerce/src/Extension/J2Commerce.php
+++ b/plugins/content/j2commerce/src/Extension/J2Commerce.php
@@ -635,7 +635,7 @@ final class J2Commerce extends CMSPlugin implements SubscriberInterface
         if ($variant) {
             // Price display
             $html .= '<div class="j2commerce-product-price">';
-            $html .= $this->formatPrice($variant->price ?? 0);
+            $html .= $this->formatPrice((float) ($variant->price ?? 0));
             $html .= '</div>';
 
             // Add to cart button
@@ -1311,7 +1311,7 @@ final class J2Commerce extends CMSPlugin implements SubscriberInterface
             ->from($db->quoteName('#__j2commerce_productimages'))
             ->where($db->quoteName('product_id') . ' = :productId')
             ->bind(':productId', $productId, ParameterType::INTEGER)
-            ->order($db->quoteName('ordering') . ' ASC');
+            ->order($db->quoteName('j2commerce_productimage_id') . ' ASC');
 
         $db->setQuery($query);
         $images = $db->loadObjectList() ?: [];


### PR DESCRIPTION
## Core Update

Fixes #520

### Changes
- All 4 plugin list views (Payment, Shipping, Reports, Apps) now render action cards **below** the list, outside the form — consistent with the Payment Methods pattern
- **Apps view**: added new `layouts/app/default.php` card layout with App Store link (`fa-cart-arrow-down` icon)
- **Apps HtmlView**: added `getAppCards()` method and `$this->appCards` property
- Removed `.fs-3` class from all card `<p>` elements for better small-screen readability
- Removed legacy `fas` class from all card icons (Font Awesome 6 uses `fa-solid` only)
- Added `.pt-3` padding to all card flex containers
- Updated report Documentation link from `report-sales` to `v6/reports`
- Updated shipping icon to `fa-truck-plane`, report icon to `fa-chart-bar`
- Added 8 new `COM_J2COMMERCE_APP_LAYOUT_CARDS_*` language strings to en-GB and en-US

### Files Modified
| Type | Count |
|------|-------|
| PHP templates/layouts | 7 |
| PHP View class | 1 |
| Language files | 2 |

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only (non-core excluded)

### Testing
1. Visit Payment Methods — cards below list, no `.fs-3`
2. Visit Shipping Methods — cards now below list (were above)
3. Visit Reports — cards now below form (were inside)
4. Visit Apps — new cards visible below list
5. Verify all links work (docs, support, extension store)