### PR TITLE
fix(shipping-troubleshooter): add ID column, deep-link to shipping tab, exclude downloadable products

### DIFF
--- a/administrator/components/com_j2commerce/src/Model/ShippingtroublesModel.php
+++ b/administrator/components/com_j2commerce/src/Model/ShippingtroublesModel.php
@@ -109,6 +109,7 @@ class ShippingtroublesModel extends ListModel
             'v.sku AS product_sku',
             'p.enabled',
             'p.product_source_id',
+            'p.product_type',
             'v.shipping',
             'v.weight',
             'v.length',
@@ -123,6 +124,9 @@ class ShippingtroublesModel extends ListModel
 
         // Exclude products where product_type contains "variable" AND is_master = 1
         $query->where('NOT (' . $db->quoteName('p.product_type') . ' LIKE ' . $db->quote('%variable%') . ' AND ' . $db->quoteName('v.is_master') . ' = 1)');
+
+        // Exclude downloadable products — they cannot be shipped
+        $query->where($db->quoteName('p.product_type') . ' != ' . $db->quote('downloadable'));
 
         // Filter by search in product name or SKU
         $search = $this->getState('filter.search');
@@ -499,7 +503,8 @@ class ShippingtroublesModel extends ListModel
             ])
             ->from($db->quoteName('#__j2commerce_products', 'p'))
             ->leftJoin($db->quoteName('#__j2commerce_variants', 'v') . ' ON p.j2commerce_product_id = v.product_id AND v.is_master = 1')
-            ->where($db->quoteName('p.enabled') . ' = 1');
+            ->where($db->quoteName('p.enabled') . ' = 1')
+            ->where($db->quoteName('p.product_type') . ' != ' . $db->quote('downloadable'));
 
             $db->setQuery($query);
             $products = $db->loadObjectList();

--- a/administrator/components/com_j2commerce/tmpl/product/form.php
+++ b/administrator/components/com_j2commerce/tmpl/product/form.php
@@ -457,7 +457,22 @@ document.addEventListener('DOMContentLoaded', function() {
 
     if (typeof customElements !== 'undefined' && customElements.whenDefined) {
         customElements.whenDefined('joomla-tab').then(function() {
-            setTimeout(function() { initNestedTabs(false); }, 50);
+            setTimeout(function() {
+                initNestedTabs(false);
+
+                // Deep-link to a specific sub-tab via sessionStorage
+                var targetTab = sessionStorage.getItem('j2ctab');
+                if (targetTab) {
+                    sessionStorage.removeItem('j2ctab');
+                    var tabEl = document.getElementById(targetTab);
+                    if (tabEl) {
+                        var joomlaTab = tabEl.closest('joomla-tab');
+                        if (joomlaTab && typeof joomlaTab.activateTab === 'function') {
+                            joomlaTab.activateTab(tabEl);
+                        }
+                    }
+                }
+            }, 50);
         });
     }
 

--- a/administrator/components/com_j2commerce/tmpl/shippingtroubles/default_shipping_product.php
+++ b/administrator/components/com_j2commerce/tmpl/shippingtroubles/default_shipping_product.php
@@ -182,6 +182,9 @@ function getProductStatusBadge($status) {
                     <table class="table" id="productList">
                         <thead>
                             <tr>
+                                <th scope="col" class="w-1 text-center">
+                                    <?php echo HTMLHelper::_('searchtools.sort', 'JGRID_HEADING_ID', 'p.j2commerce_product_id', $listDirn, $listOrder); ?>
+                                </th>
                                 <th scope="col">
                                     <?php echo HTMLHelper::_('searchtools.sort', 'COM_J2COMMERCE_PRODUCT_NAME', 'p.product_source_id', $listDirn, $listOrder); ?>
                                 </th>
@@ -201,9 +204,12 @@ function getProductStatusBadge($status) {
                         </thead>
                         <tbody>
                             <?php foreach ($products as $product):
-                                $contentEditLink = Route::_('index.php?option=com_content&task=article.edit&id=' . (int) $product->product_source_id);
+                                $contentEditLink = Route::_('index.php?option=com_content&task=article.edit&id=' . (int) $product->product_source_id) . '#attrib-j2commerce';
                                 ?>
                                 <tr>
+                                    <td class="text-center">
+                                        <?php echo (int) $product->j2commerce_product_id; ?>
+                                    </td>
                                     <td>
                                         <strong><?php echo $this->escape($product->product_name); ?></strong>
                                         <?php if (!empty($product->shipping_issues) || !empty($product->shipping_warnings)): ?>
@@ -258,7 +264,8 @@ function getProductStatusBadge($status) {
                                     <td class="text-center">
                                         <a href="<?php echo $contentEditLink; ?>"
                                            class="btn btn-sm btn-link"
-                                           title="<?php echo Text::_('JACTION_EDIT'); ?>">
+                                           title="<?php echo Text::_('JACTION_EDIT'); ?>"
+                                           onclick="sessionStorage.setItem('j2ctab', 'shippingTab')">
                                             <span class="fa-solid fa-edit" aria-hidden="true"></span>
                                         </a>
                                     </td>


### PR DESCRIPTION
## Summary
Fixes #531

Three improvements to the Shipping Troubleshooter products list:

1. **Added ID column** — sortable, matches the existing sort-by-ID filter option
2. **Deep-link to shipping sub-tab** — edit action now opens article editor with J2Commerce tab active and shipping sub-tab selected (via sessionStorage)
3. **Excluded downloadable products** — they cannot be shipped, so they no longer appear in the list or statistics

## Changes
- `ShippingtroublesModel.php` — Added `product_type != 'downloadable'` filter to `getListQuery()` and `getProductsShippingStatistics()`
- `default_shipping_product.php` — Added ID column (header + body), edit link with `#attrib-j2commerce` hash and `sessionStorage` onclick for sub-tab targeting
- `form.php` — Added JS to read `sessionStorage.j2ctab` and activate the target sub-tab via `joomla-tab.activateTab()`

## Files Modified
| Type | Count |
|------|-------|
| PHP files | 3 |

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only (non-core excluded)

## Testing
1. Navigate to admin → Shipping Troubleshooter → Check Products
2. Verify ID column is visible and sortable
3. Verify no downloadable products appear
4. Click edit on a product — article editor opens with J2Commerce tab active AND shipping sub-tab selected
5. Open any article normally — tabs work as before