### PR TITLE
fix(phone): auto-strip trunk prefix 0 and increase GB max length

### DIFF
--- a/administrator/components/com_j2commerce/src/Helper/PhoneHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/PhoneHelper.php
@@ -185,7 +185,7 @@ class PhoneHelper
         'UG' => ['code' => '256',  'min' => 9,  'max' => 9],
         'UA' => ['code' => '380',  'min' => 9,  'max' => 9],
         'AE' => ['code' => '971',  'min' => 8,  'max' => 9],
-        'GB' => ['code' => '44',   'min' => 7,  'max' => 10],
+        'GB' => ['code' => '44',   'min' => 7,  'max' => 11],
         'US' => ['code' => '1',    'min' => 10, 'max' => 10],
         'UY' => ['code' => '598',  'min' => 4,  'max' => 11],
         'UZ' => ['code' => '998',  'min' => 9,  'max' => 9],

--- a/media/com_j2commerce/js/site/telephone-field.js
+++ b/media/com_j2commerce/js/site/telephone-field.js
@@ -131,8 +131,14 @@
         nationalInput.addEventListener('input', function() {
             nationalInput.value = nationalInput.value.replace(/\D/g, '');
             var country = findCountry(selectedIso);
-            if (country && nationalInput.value.length > country.max) {
-                nationalInput.value = nationalInput.value.slice(0, country.max);
+            if (country) {
+                // Auto-strip trunk prefix 0 for non-NANP countries
+                if (country.code !== '1' && nationalInput.value.charAt(0) === '0') {
+                    nationalInput.value = nationalInput.value.substring(1);
+                }
+                if (nationalInput.value.length > country.max) {
+                    nationalInput.value = nationalInput.value.slice(0, country.max);
+                }
             }
             updateHiddenValue();
             validateLength();
@@ -241,6 +247,10 @@
 
         nationalInput.addEventListener('input', function() {
             nationalInput.value = nationalInput.value.replace(/\D/g, '');
+            // Auto-strip trunk prefix 0 for non-NANP countries
+            if (country.code !== '1' && nationalInput.value.charAt(0) === '0') {
+                nationalInput.value = nationalInput.value.substring(1);
+            }
             if (nationalInput.value.length > country.max) {
                 nationalInput.value = nationalInput.value.slice(0, country.max);
             }


### PR DESCRIPTION
## Summary
Fixes #529

UK phone numbers entered with a leading 0 (e.g. 07700900000) were silently truncated to 10 digits, corrupting the stored number. The phone widget already shows the +44 dial code, so the trunk prefix 0 is redundant — but many users include it out of habit.

## Changes
- **PhoneHelper.php** — Increased GB national number max length from 10 to 11 as a safety net
- **telephone-field.js** — Auto-strip leading trunk prefix `0` on input for non-NANP countries (both multi-country dropdown and single-country modes)

## Files Modified
| Type | Count |
|------|-------|
| PHP files | 1 |
| JS assets | 1 |

## Testing
1. Go to checkout or any address form with a phone field
2. Select GB (+44) as phone country
3. Type `07700900000` (11 digits with leading 0)
4. Verify: leading 0 is auto-stripped, field shows `7700900000`, stored as `+447700900000`
5. Switch to US (+1) and type `0555` — verify 0 is NOT stripped (NANP keeps it)

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only (non-core excluded)