### PR TITLE
fix(phone-countries): show full country names and enable search by name/ISO2

### DIFF
--- a/administrator/components/com_j2commerce/src/Field/PhoneCountriesField.php
+++ b/administrator/components/com_j2commerce/src/Field/PhoneCountriesField.php
@@ -55,11 +55,17 @@ class PhoneCountriesField extends CheckboxesField
         $name         = $this->name;
         $id           = $this->id;
 
-        // Build name map from DB-enabled countries
-        $countries = PhoneHelper::getCountryListForDropdown();
-        $nameMap   = [];
-        foreach ($countries as $c) {
-            $nameMap[$c['iso2']] = $c['name'];
+        // Build name map from ALL countries in the DB (not just enabled) so that
+        // every country in the picker shows its full name and is searchable by name.
+        $db    = $this->getDatabase();
+        $query = $db->getQuery(true)
+            ->select($db->quoteName(['country_name', 'country_isocode_2']))
+            ->from($db->quoteName('#__j2commerce_countries'))
+            ->order($db->quoteName('country_name') . ' ASC');
+        $db->setQuery($query);
+        $nameMap = [];
+        foreach ($db->loadObjectList() as $row) {
+            $nameMap[$row->country_isocode_2] = $row->country_name;
         }
 
         // Build ISO2 → dial code map
@@ -153,7 +159,8 @@ class PhoneCountriesField extends CheckboxesField
 
                 $html .= '<div class="form-check j2c-phone-country-item" '
                     . 'data-name="' . $esc(strtolower($countryName)) . '" '
-                    . 'data-code="' . $esc($dialCode) . '">'
+                    . 'data-code="' . $esc($dialCode) . '" '
+                    . 'data-iso="' . $esc(strtolower($iso2)) . '">'
                     . '<input type="checkbox" class="form-check-input j2c-phone-country-check" '
                     . 'name="' . $esc($name) . '" '
                     . 'id="' . $esc($optId) . '" '
@@ -195,7 +202,7 @@ class PhoneCountriesField extends CheckboxesField
             picker.querySelectorAll('.j2c-phone-continent').forEach(function(cont) {
                 let anyVisible = false;
                 cont.querySelectorAll('.j2c-phone-country-item').forEach(function(item) {
-                    const match = !q || item.dataset.name.indexOf(q) !== -1 || item.dataset.code.indexOf(q) !== -1;
+                    const match = !q || item.dataset.name.indexOf(q) !== -1 || item.dataset.code.indexOf(q) !== -1 || item.dataset.iso.indexOf(q) !== -1;
                     item.style.display = match ? '' : 'none';
                     if (match) anyVisible = true;
                 });


### PR DESCRIPTION
## Summary
Fixes #530

The phone countries picker in the admin custom field editor was only loading country names for **enabled** countries. Any country not enabled in the J2Commerce countries table fell back to displaying its ISO2 code (e.g. "US" instead of "United States"), making it unsearchable by name.

## Changes
- Query **all** countries from the database for the name map (not just enabled ones)
- Added `data-iso` attribute to each country checkbox item
- Search now matches by country name, dial code, **and** ISO2 code

## Files Modified
| Type | Count |
|------|-------|
| PHP files | 1 |

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only (non-core excluded)

## Testing
1. Go to J2Commerce > Catalog > Custom Fields
2. Edit a telephone-type custom field
3. Set "Phone Country Mode" to "Selected"
4. In the country picker search box, type "United"
5. Verify: United States, United Kingdom, and UAE all appear with full names
6. Search "US" — verify United States appears
7. Search "44" — verify United Kingdom appears (dial code search)