### PR TITLE
fix(a11y): add focus-visible styling to onboarding dashboard buttons

### DIFF
--- a/media/com_j2commerce/css/administrator/onboarding.css
+++ b/media/com_j2commerce/css/administrator/onboarding.css
@@ -180,6 +180,14 @@
     padding: 1rem 2rem;
 }
 
+/* ---- Focus styling (a11y) ---- */
+.j2c-onboarding-footer .btn:focus-visible,
+.j2c-step .btn:focus-visible,
+.j2c-step a.btn:focus-visible {
+    outline: 2px solid var(--bs-primary);
+    outline-offset: 2px;
+}
+
 /* ---- Shipping rate table (onboarding) ---- */
 .j2c-onboarding-body .ob-rates-table th,
 .j2c-onboarding-body .ob-rates-table td {


### PR DESCRIPTION
## Summary
Fixes #539

Onboarding wizard buttons (footer and final step) had no visible focus indicator when navigating with keyboard. The `shadow-none` Bootstrap class suppresses the default focus box-shadow, and no custom focus styles were defined.

## Changes
- Added `:focus-visible` outline styles for `.btn` elements inside `.j2c-onboarding-footer` and `.j2c-step` containers

## Files Modified
| Type | Count |
|------|-------|
| CSS assets | 1 |

## Testing
1. Open J2Commerce Dashboard → start onboarding wizard
2. Tab through footer buttons (Back, Skip, Continue)
3. Advance to final step, tab through the 4 action buttons
4. Verify each focused button shows a visible blue outline ring

## Pre-Flight
- [x] No PHP changes
- [x] No secrets detected
- [x] Core files only