### PR TITLE
fix(invoicetemplates): remove unsupported template type filter options

### DIFF
--- a/administrator/components/com_j2commerce/forms/filter_invoicetemplates.xml
+++ b/administrator/components/com_j2commerce/forms/filter_invoicetemplates.xml
@@ -79,11 +79,8 @@
         >
             <option value="">COM_J2COMMERCE_SELECT_TEMPLATE_TYPE</option>
             <option value="invoice">COM_J2COMMERCE_INVOICETEMPLATE_TYPE_INVOICE</option>
-            <option value="quote">COM_J2COMMERCE_INVOICETEMPLATE_TYPE_QUOTE</option>
-            <option value="receipt">COM_J2COMMERCE_INVOICETEMPLATE_TYPE_RECEIPT</option>
-            <option value="credit_note">COM_J2COMMERCE_INVOICETEMPLATE_TYPE_CREDIT_NOTE</option>
-            <option value="proforma">COM_J2COMMERCE_INVOICETEMPLATE_TYPE_PROFORMA</option>
             <option value="packingslip">COM_J2COMMERCE_INVOICETEMPLATE_TYPE_PACKINGSLIP</option>
+            <option value="receipt">COM_J2COMMERCE_INVOICETEMPLATE_TYPE_RECEIPT</option>
         </field>
     </fields>
 


### PR DESCRIPTION
## Summary
Fixes #554

## Changes
- Removed Credit Note, Proforma Invoice, and Quote options from the invoice templates filter dropdown — these are not built-in types
- Alpha sorted remaining options (Invoice, Packing Slip, Receipt)
- No language file changes needed — strings for the removed types never existed

## Files Changed
- `administrator/components/com_j2commerce/forms/filter_invoicetemplates.xml` — removed 3 unsupported options, alpha sorted remainder

## Testing
1. Navigate to J2Commerce > Print Templates
2. Open the "Template Type" filter dropdown
3. Verify only 3 options shown: Invoice, Packing Slip, Receipt (alpha sorted)

## Pre-Flight
- [x] XML-only change, no PHP to lint
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only