### PR TITLE
fix(inventory): retain selected filter values after page reload (fixes #542)

### DIFF
--- a/administrator/components/com_j2commerce/src/Model/InventoryModel.php
+++ b/administrator/components/com_j2commerce/src/Model/InventoryModel.php
@@ -15,7 +15,6 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\MVC\Model\ListModel;
 use Joomla\Database\ParameterType;
-use Joomla\Registry\Registry;
 
 /**
  * Inventory Model
@@ -412,36 +411,6 @@ class InventoryModel extends ListModel
         }
 
         return $form;
-    }
-
-    /**
-     * Method to get the data that should be injected in the form.
-     *
-     * @return  mixed  The data for the form.
-     *
-     * @since   6.0.0
-     */
-    protected function loadFormData()
-    {
-        // Check the session for previously entered form data.
-        $app = Factory::getApplication();
-        $data = $app->getUserState('com_j2commerce.edit.inventory.data', []);
-
-        if (empty($data)) {
-            $data = $this->getItem();
-        }
-
-        // Ensure data is in the correct format for forms
-        if ($data instanceof \stdClass) {
-            $data = (array) $data;
-        }
-
-        // Convert data to Registry object for form compatibility
-        if (is_array($data)) {
-            $data = new Registry($data);
-        }
-
-        return $data;
     }
 
     /**


### PR DESCRIPTION
## Summary
Fixes #542

InventoryModel::loadFormData() was overriding the parent ListModel::loadFormData() with edit-form logic (reading from `com_j2commerce.edit.inventory.data`). This meant the filter form never received the current filter state from the session, causing all filter dropdowns to reset to their default placeholder after page reload — even though the data was correctly filtered.

## Changes
- Removed incorrect `loadFormData()` override from `InventoryModel` so the parent `ListModel::loadFormData()` correctly reads filter state from the session
- Removed unused `Registry` import

## Files Modified
| Type | Count |
|------|-------|
| PHP files | 1 |

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only (non-core excluded)

## Testing
1. Navigate to J2Commerce → Inventory
2. Select "Out of Stock" from the availability filter
3. Page reloads — verify dropdown shows "Out of Stock" (not default placeholder)
4. Test manage_stock and product_type filters retain their selection too