### PR TITLE
fix(i18n): add en-US language strings for setup wizard menu titles

### DIFF
--- a/administrator/components/com_j2commerce/language/en-US/com_j2commerce.ini
+++ b/administrator/components/com_j2commerce/language/en-US/com_j2commerce.ini
@@ -4080,6 +4080,12 @@ COM_J2COMMERCE_SETUP_GUIDE_CHECK_MYPROFILE_PAGE_DESC="A published menu item poin
 COM_J2COMMERCE_SETUP_GUIDE_CHECK_CONFIRMATION_PAGE="Order Confirmation Page"
 COM_J2COMMERCE_SETUP_GUIDE_CHECK_CONFIRMATION_PAGE_DESC="A published menu item pointing to the order confirmation view is required to display the thank-you page after a successful purchase."
 
+; Setup Guide — Menu item titles (used when wizard creates menu items)
+COM_J2COMMERCE_SETUP_GUIDE_MENU_TITLE_CART="Shopping Cart"
+COM_J2COMMERCE_SETUP_GUIDE_MENU_TITLE_CHECKOUT="Checkout"
+COM_J2COMMERCE_SETUP_GUIDE_MENU_TITLE_CONFIRMATION="Order Confirmation"
+COM_J2COMMERCE_SETUP_GUIDE_MENU_TITLE_MYPROFILE="My Account"
+
 ; Setup Guide — Category / shop menu
 COM_J2COMMERCE_SETUP_GUIDE_CHECK_CATEGORY_MENU="Shop / Category Menu Item"
 COM_J2COMMERCE_SETUP_GUIDE_CHECK_CATEGORY_MENU_DESC="At least one published menu item pointing to your shop categories, products, or product tags is required so customers can browse your store."


### PR DESCRIPTION
## Summary
Adds en-US language strings for the setup wizard menu title keys introduced in PR #556 (refs #553).

## Changes
- Added 4 new `COM_J2COMMERCE_SETUP_GUIDE_MENU_TITLE_*` keys to `en-US/com_j2commerce.ini`
- Uses American English variants (e.g. "Shopping Cart" vs en-GB "Shopping Basket")

## Files Modified
| Type | Count |
|------|-------|
| Language files | 1 |

### Pre-Flight
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only

## Test plan
- [ ] Verify en-US language strings load correctly in the setup wizard