### PR TITLE
fix(filters): reorder admin list view filters to match column order (fixes #544)

### DIFF
--- a/administrator/components/com_j2commerce/forms/filter_emailtemplates.xml
+++ b/administrator/components/com_j2commerce/forms/filter_emailtemplates.xml
@@ -11,6 +11,8 @@
             class="form-control"
         />
 
+        <!-- Column-matched filters (in column order: Status, Language, Order Status, Group, Email Type) -->
+
         <field
             name="enabled"
             type="list"
@@ -26,15 +28,15 @@
         </field>
 
         <field
-            name="email_type"
-            type="EmailtypeList"
-            label="COM_J2COMMERCE_EMAILTEMPLATE_EMAIL_TYPE"
-            description="COM_J2COMMERCE_EMAILTEMPLATE_EMAIL_TYPE_DESC"
-            addfieldprefix="J2Commerce\Component\J2commerce\Administrator\Field"
+            name="language"
+            type="contentlanguage"
+            label="JFIELD_LANGUAGE_LABEL"
+            description="COM_J2COMMERCE_FILTER_LANGUAGE_DESC"
             onchange="this.form.submit();"
             class="form-select"
         >
-            <option value="">COM_J2COMMERCE_EMAILTYPE_ALL</option>
+            <option value="">JOPTION_SELECT_LANGUAGE</option>
+            <option value="*">JALL</option>
         </field>
 
         <field
@@ -61,6 +63,20 @@
         </field>
 
         <field
+            name="email_type"
+            type="EmailtypeList"
+            label="COM_J2COMMERCE_EMAILTEMPLATE_EMAIL_TYPE"
+            description="COM_J2COMMERCE_EMAILTEMPLATE_EMAIL_TYPE_DESC"
+            addfieldprefix="J2Commerce\Component\J2commerce\Administrator\Field"
+            onchange="this.form.submit();"
+            class="form-select"
+        >
+            <option value="">COM_J2COMMERCE_EMAILTYPE_ALL</option>
+        </field>
+
+        <!-- Non-column filters -->
+
+        <field
             name="paymentmethod"
             type="PaymentMethods"
             label="COM_J2COMMERCE_EMAILTEMPLATE_PAYMENTMETHOD"
@@ -70,18 +86,6 @@
             class="form-select"
         >
             <option value="">COM_J2COMMERCE_SELECT_PAYMENT_METHOD</option>
-        </field>
-
-        <field
-            name="language"
-            type="contentlanguage"
-            label="JFIELD_LANGUAGE_LABEL"
-            description="COM_J2COMMERCE_FILTER_LANGUAGE_DESC"
-            onchange="this.form.submit();"
-            class="form-select"
-        >
-            <option value="">JOPTION_SELECT_LANGUAGE</option>
-            <option value="*">JALL</option>
         </field>
     </fields>
 

--- a/administrator/components/com_j2commerce/forms/filter_invoicetemplates.xml
+++ b/administrator/components/com_j2commerce/forms/filter_invoicetemplates.xml
@@ -23,6 +23,33 @@
             <option value="0">JUNPUBLISHED</option>
         </field>
 
+        <!-- Column-matched filters (in column order: Type, Language, Order Status, Group, Payment Method) -->
+
+        <field
+            name="invoice_type"
+            type="list"
+            label="COM_J2COMMERCE_INVOICETEMPLATE_TYPE"
+            onchange="this.form.submit();"
+            class="form-select"
+        >
+            <option value="">COM_J2COMMERCE_SELECT_TEMPLATE_TYPE</option>
+            <option value="invoice">COM_J2COMMERCE_INVOICETEMPLATE_TYPE_INVOICE</option>
+            <option value="packingslip">COM_J2COMMERCE_INVOICETEMPLATE_TYPE_PACKINGSLIP</option>
+            <option value="receipt">COM_J2COMMERCE_INVOICETEMPLATE_TYPE_RECEIPT</option>
+        </field>
+
+        <field
+            name="language"
+            type="contentlanguage"
+            label="JFIELD_LANGUAGE_LABEL"
+            description="JFIELD_LANGUAGE_DESC"
+            onchange="this.form.submit();"
+            class="form-select"
+        >
+            <option value="">JOPTION_SELECT_LANGUAGE</option>
+            <option value="*">JALL</option>
+        </field>
+
         <field
             name="orderstatus_id"
             type="OrderStatus"
@@ -56,31 +83,6 @@
             class="form-select"
         >
             <option value="">COM_J2COMMERCE_SELECT_PAYMENT_METHOD</option>
-        </field>
-
-        <field
-            name="language"
-            type="contentlanguage"
-            label="JFIELD_LANGUAGE_LABEL"
-            description="JFIELD_LANGUAGE_DESC"
-            onchange="this.form.submit();"
-            class="form-select"
-        >
-            <option value="">JOPTION_SELECT_LANGUAGE</option>
-            <option value="*">JALL</option>
-        </field>
-
-        <field
-            name="invoice_type"
-            type="list"
-            label="COM_J2COMMERCE_INVOICETEMPLATE_TYPE"
-            onchange="this.form.submit();"
-            class="form-select"
-        >
-            <option value="">COM_J2COMMERCE_SELECT_TEMPLATE_TYPE</option>
-            <option value="invoice">COM_J2COMMERCE_INVOICETEMPLATE_TYPE_INVOICE</option>
-            <option value="packingslip">COM_J2COMMERCE_INVOICETEMPLATE_TYPE_PACKINGSLIP</option>
-            <option value="receipt">COM_J2COMMERCE_INVOICETEMPLATE_TYPE_RECEIPT</option>
         </field>
     </fields>
 

--- a/administrator/components/com_j2commerce/forms/filter_orders.xml
+++ b/administrator/components/com_j2commerce/forms/filter_orders.xml
@@ -10,60 +10,7 @@
             hint="JSEARCH_FILTER"
         />
 
-        <field
-            name="order_state_id"
-            type="sql"
-            query="SELECT j2commerce_orderstatus_id AS value, orderstatus_name AS text FROM #__j2commerce_orderstatuses WHERE enabled = 1 ORDER BY ordering ASC"
-            key_field="value"
-            value_field="text"
-            translate="true"
-            header="COM_J2COMMERCE_SELECT_ORDER_STATUS"
-            onchange="this.form.submit();"
-        />
-
-        <field
-            name="payment_type"
-            type="sql"
-            query="SELECT element AS value, name AS text FROM #__extensions WHERE type = &apos;plugin&apos; AND folder = &apos;j2commerce&apos; AND element LIKE &apos;payment_%&apos; AND enabled = 1 ORDER BY name"
-            key_field="value"
-            value_field="text"
-            translate="true"
-            header="COM_J2COMMERCE_SELECT_PAYMENT_METHOD"
-            onchange="this.form.submit();"
-        />
-
-        <field
-            name="user_id"
-            type="user"
-            label="COM_J2COMMERCE_FILTER_USER"
-            hint="COM_J2COMMERCE_FILTER_SELECT_USER"
-            onchange="this.form.submit();"
-        />
-
-        <field
-            name="coupon_code"
-            type="text"
-            label="COM_J2COMMERCE_FILTER_COUPON_CODE"
-            hint="COM_J2COMMERCE_FILTER_COUPON_CODE_HINT"
-        />
-
-        <field
-            name="amount_from"
-            type="number"
-            label="COM_J2COMMERCE_FILTER_AMOUNT_FROM"
-            hint="COM_J2COMMERCE_FILTER_AMOUNT_FROM_HINT"
-            step="0.01"
-            min="0"
-        />
-
-        <field
-            name="amount_to"
-            type="number"
-            label="COM_J2COMMERCE_FILTER_AMOUNT_TO"
-            hint="COM_J2COMMERCE_FILTER_AMOUNT_TO_HINT"
-            step="0.01"
-            min="0"
-        />
+        <!-- Column-matched filters (in column order: Order, Date, Customer, Total, Payment, Status) -->
 
         <field
             name="from_order_id"
@@ -99,6 +46,63 @@
             hint="COM_J2COMMERCE_FILTER_DATE_TO"
             format="%Y-%m-%d"
             showtime="false"
+        />
+
+        <field
+            name="user_id"
+            type="user"
+            label="COM_J2COMMERCE_FILTER_USER"
+            hint="COM_J2COMMERCE_FILTER_SELECT_USER"
+            onchange="this.form.submit();"
+        />
+
+        <field
+            name="amount_from"
+            type="number"
+            label="COM_J2COMMERCE_FILTER_AMOUNT_FROM"
+            hint="COM_J2COMMERCE_FILTER_AMOUNT_FROM_HINT"
+            step="0.01"
+            min="0"
+        />
+
+        <field
+            name="amount_to"
+            type="number"
+            label="COM_J2COMMERCE_FILTER_AMOUNT_TO"
+            hint="COM_J2COMMERCE_FILTER_AMOUNT_TO_HINT"
+            step="0.01"
+            min="0"
+        />
+
+        <field
+            name="payment_type"
+            type="sql"
+            query="SELECT element AS value, name AS text FROM #__extensions WHERE type = &apos;plugin&apos; AND folder = &apos;j2commerce&apos; AND element LIKE &apos;payment_%&apos; AND enabled = 1 ORDER BY name"
+            key_field="value"
+            value_field="text"
+            translate="true"
+            header="COM_J2COMMERCE_SELECT_PAYMENT_METHOD"
+            onchange="this.form.submit();"
+        />
+
+        <field
+            name="order_state_id"
+            type="sql"
+            query="SELECT j2commerce_orderstatus_id AS value, orderstatus_name AS text FROM #__j2commerce_orderstatuses WHERE enabled = 1 ORDER BY ordering ASC"
+            key_field="value"
+            value_field="text"
+            translate="true"
+            header="COM_J2COMMERCE_SELECT_ORDER_STATUS"
+            onchange="this.form.submit();"
+        />
+
+        <!-- Non-column filters -->
+
+        <field
+            name="coupon_code"
+            type="text"
+            label="COM_J2COMMERCE_FILTER_COUPON_CODE"
+            hint="COM_J2COMMERCE_FILTER_COUPON_CODE_HINT"
         />
     </fields>
 

--- a/administrator/components/com_j2commerce/forms/filter_products.xml
+++ b/administrator/components/com_j2commerce/forms/filter_products.xml
@@ -10,6 +10,26 @@
             inputmode="search"
         />
 
+        <!-- Column-matched filters (in column order: Product ID, Product Type, Price, Visibility) -->
+
+        <field
+            name="product_id_from"
+            type="text"
+            label="COM_J2COMMERCE_FILTER_PRODUCT_ID_FROM"
+            hint="COM_J2COMMERCE_FILTER_PRODUCT_ID_FROM"
+            inputmode="numeric"
+            onchange="this.form.submit();"
+        />
+
+        <field
+            name="product_id_to"
+            type="text"
+            label="COM_J2COMMERCE_FILTER_PRODUCT_ID_TO"
+            hint="COM_J2COMMERCE_FILTER_PRODUCT_ID_TO"
+            inputmode="numeric"
+            onchange="this.form.submit();"
+        />
+
         <field
             name="product_type"
             type="ProductType"
@@ -19,6 +39,37 @@
         >
             <option value="">COM_J2COMMERCE_FILTER_SELECT_PRODUCT_TYPE</option>
         </field>
+
+        <field
+            name="price_from"
+            type="text"
+            label="COM_J2COMMERCE_FILTER_PRICE_FROM"
+            hint="COM_J2COMMERCE_FILTER_PRICE_FROM"
+            inputmode="decimal"
+            onchange="this.form.submit();"
+        />
+
+        <field
+            name="price_to"
+            type="text"
+            label="COM_J2COMMERCE_FILTER_PRICE_TO"
+            hint="COM_J2COMMERCE_FILTER_PRICE_TO"
+            inputmode="decimal"
+            onchange="this.form.submit();"
+        />
+
+        <field
+            name="visibility"
+            type="list"
+            label="COM_J2COMMERCE_FILTER_VISIBILITY"
+            onchange="this.form.submit();"
+        >
+            <option value="">COM_J2COMMERCE_FILTER_SELECT_VISIBILITY</option>
+            <option value="1">JYES</option>
+            <option value="0">JNO</option>
+        </field>
+
+        <!-- Non-column filters -->
 
         <field
             name="manufacturer_id"
@@ -62,17 +113,6 @@
         </field>
 
         <field
-            name="visibility"
-            type="list"
-            label="COM_J2COMMERCE_FILTER_VISIBILITY"
-            onchange="this.form.submit();"
-        >
-            <option value="">COM_J2COMMERCE_FILTER_SELECT_VISIBILITY</option>
-            <option value="1">JYES</option>
-            <option value="0">JNO</option>
-        </field>
-
-        <field
             name="date_from"
             type="calendar"
             label="COM_J2COMMERCE_FILTER_DATE_FROM"
@@ -89,42 +129,6 @@
             hint="COM_J2COMMERCE_FILTER_DATE_TO"
             format="%Y-%m-%d"
             showtime="false"
-            onchange="this.form.submit();"
-        />
-
-        <field
-            name="product_id_from"
-            type="text"
-            label="COM_J2COMMERCE_FILTER_PRODUCT_ID_FROM"
-            hint="COM_J2COMMERCE_FILTER_PRODUCT_ID_FROM"
-            inputmode="numeric"
-            onchange="this.form.submit();"
-        />
-
-        <field
-            name="product_id_to"
-            type="text"
-            label="COM_J2COMMERCE_FILTER_PRODUCT_ID_TO"
-            hint="COM_J2COMMERCE_FILTER_PRODUCT_ID_TO"
-            inputmode="numeric"
-            onchange="this.form.submit();"
-        />
-
-        <field
-            name="price_from"
-            type="text"
-            label="COM_J2COMMERCE_FILTER_PRICE_FROM"
-            hint="COM_J2COMMERCE_FILTER_PRICE_FROM"
-            inputmode="decimal"
-            onchange="this.form.submit();"
-        />
-
-        <field
-            name="price_to"
-            type="text"
-            label="COM_J2COMMERCE_FILTER_PRICE_TO"
-            hint="COM_J2COMMERCE_FILTER_PRICE_TO"
-            inputmode="decimal"
             onchange="this.form.submit();"
         />
     </fields>

--- a/administrator/components/com_j2commerce/forms/filter_queuelogs.xml
+++ b/administrator/components/com_j2commerce/forms/filter_queuelogs.xml
@@ -10,14 +10,7 @@
             inputmode="search"
         />
 
-        <field
-            name="queue_type"
-            type="sql"
-            label="COM_J2COMMERCE_HEADING_QUEUE_TYPE"
-            query="SELECT DISTINCT queue_type AS value, queue_type AS text FROM #__j2commerce_queue_logs ORDER BY queue_type ASC"
-            class="js-select-submit-on-change"
-            header="COM_J2COMMERCE_FILTER_SELECT_QUEUE_TYPE"
-        />
+        <!-- Column-matched filters (in column order: Status, Queue Type) -->
 
         <field
             name="status"
@@ -30,6 +23,15 @@
             <option value="completed">COM_J2COMMERCE_QUEUE_STATUS_COMPLETED</option>
             <option value="error">COM_J2COMMERCE_QUEUE_LOG_STATUS_ERROR</option>
         </field>
+
+        <field
+            name="queue_type"
+            type="sql"
+            label="COM_J2COMMERCE_HEADING_QUEUE_TYPE"
+            query="SELECT DISTINCT queue_type AS value, queue_type AS text FROM #__j2commerce_queue_logs ORDER BY queue_type ASC"
+            class="js-select-submit-on-change"
+            header="COM_J2COMMERCE_FILTER_SELECT_QUEUE_TYPE"
+        />
     </fields>
 
     <fields name="list">


### PR DESCRIPTION
## Summary
Fixes #544

Reorders filter fields in admin list view XML files so they follow the same order as the table columns, per Joomla core convention. Filters without a matching column are placed after all column-matched filters.

## Changes
- **filter_products.xml** — Product ID range → Product Type → Price range → Visibility → [non-column: Manufacturer, Vendor, Tax Profile, Category, Date range]
- **filter_orders.xml** — Order ID range → Date range → Customer → Amount range → Payment → Status → [non-column: Coupon Code]
- **filter_emailtemplates.xml** — Status → Language → Order Status → Group → Email Type → [non-column: Payment Method]
- **filter_invoicetemplates.xml** — Status → Type → Language → Order Status → Group → Payment Method
- **filter_queuelogs.xml** — Status → Queue Type (was reversed)

## Files Modified
| Type | Count |
|------|-------|
| XML filter forms | 5 |

## Testing
1. Open each admin list view (Products, Orders, Email Templates, Invoice Templates, Queue Logs)
2. Expand the filter bar
3. Verify filters appear in the same order as the table columns

## Pre-Flight
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only (no non-core files)