### PR TITLE
fix(filters): use pluginstatus for shipping methods and fix troubleshooter no-results message

### DIFF
--- a/administrator/components/com_j2commerce/forms/filter_shippingmethods.xml
+++ b/administrator/components/com_j2commerce/forms/filter_shippingmethods.xml
@@ -11,7 +11,7 @@
 
         <field
             name="enabled"
-            type="status"
+            type="pluginstatus"
             label="JSTATUS"
             description="JFIELD_ENABLED_DESC"
             onchange="this.form.submit();"

--- a/administrator/components/com_j2commerce/tmpl/shippingtroubles/default_shipping_product.php
+++ b/administrator/components/com_j2commerce/tmpl/shippingtroubles/default_shipping_product.php
@@ -154,13 +154,20 @@ function getProductStatusBadge($status) {
             <?php echo LayoutHelper::render('joomla.searchtools.default', ['view' => $this]); ?>
 
             <?php if (empty($products)): ?>
-                <div class="alert alert-info" role="alert">
-                    <span class="fa-solid fa-info-circle me-2" aria-hidden="true"></span>
-                    <?php echo Text::_('COM_J2COMMERCE_SHIPPING_TROUBLESHOOTER_NO_PRODUCTS'); ?>
-                </div>
-                <a href="<?php echo Route::_('index.php?option=com_j2commerce&view=products'); ?>" class="btn btn-primary">
-                    <?php echo Text::_('COM_J2COMMERCE_ADD_PRODUCTS'); ?>
-                </a>
+                <?php if (!empty($this->activeFilters)): ?>
+                    <div class="alert alert-info" role="alert">
+                        <span class="fa-solid fa-info-circle me-2" aria-hidden="true"></span>
+                        <?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
+                    </div>
+                <?php else: ?>
+                    <div class="alert alert-info" role="alert">
+                        <span class="fa-solid fa-info-circle me-2" aria-hidden="true"></span>
+                        <?php echo Text::_('COM_J2COMMERCE_SHIPPING_TROUBLESHOOTER_NO_PRODUCTS'); ?>
+                    </div>
+                    <a href="<?php echo Route::_('index.php?option=com_j2commerce&view=products'); ?>" class="btn btn-primary">
+                        <?php echo Text::_('COM_J2COMMERCE_ADD_PRODUCTS'); ?>
+                    </a>
+                <?php endif; ?>
             <?php else: ?>
                 <div class="my-3">
                     <div class="row">


### PR DESCRIPTION
## Summary
Fixes #545

- Shipping methods status filter used `type="status"` (Published/Unpublished/Archived/Trashed) but plugins only have Enabled/Disabled states. Changed to `type="pluginstatus"` matching Joomla core `com_plugins` pattern.
- Shipping troubleshooter products view showed "No enabled products found. Add products to your store first." even when filters were active and narrowed results to zero. Now shows standard "No Matching Results" when filters are active.

## Files Modified
| Type | Count |
|------|-------|
| XML/Config | 1 |
| PHP template | 1 |

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] Core files only

## Testing
1. Navigate to J2Commerce → Setup → Shipping Methods
2. Click Filter Options → open status dropdown
3. Verify only "Enabled" and "Disabled" appear (no Archived/Trashed)
4. Navigate to Shipping Troubleshooter → Products step
5. Apply a shipping status filter that returns no results
6. Verify "No Matching Results" appears (not "No enabled products found")