### PR TITLE
fix(inventory): add SKU search and fix emptystate on failed search

### DIFF
--- a/administrator/components/com_j2commerce/src/Model/InventoryModel.php
+++ b/administrator/components/com_j2commerce/src/Model/InventoryModel.php
@@ -156,8 +156,10 @@ class InventoryModel extends ListModel
             } else {
                 $search = '%' . str_replace(' ', '%', $db->escape(trim($search), true)) . '%';
                 $query->where('(' . $db->quoteName('a.title') . ' LIKE :search OR ' .
+                    $db->quoteName('v.sku') . ' LIKE :searchSku OR ' .
                     $db->quoteName('p.j2commerce_product_id') . ' LIKE :searchId)')
                     ->bind(':search', $search)
+                    ->bind(':searchSku', $search)
                     ->bind(':searchId', $search);
             }
         }
@@ -693,7 +695,8 @@ class InventoryModel extends ListModel
     public function getIsEmptyState(): bool
     {
         $filters = $this->getActiveFilters();
+        $search = $this->getState('filter.search');
 
-        return empty($filters);
+        return empty($filters) && empty($search);
     }
 }


### PR DESCRIPTION
## Summary
Fixes #546

Three sub-bugs reported:
1. **SKU search doesn't work** — search only checked product name and ID, not SKU
2. **Clear filters stuck** — after a failed search, emptystate layout rendered with no search form
3. **Emptystate on failed search** — `getIsEmptyState()` didn't account for the search text filter

## Changes
- Added `v.sku LIKE :searchSku` to the inventory search WHERE clause
- Fixed `getIsEmptyState()` to also check `filter.search` state before returning true

## Files Changed
- `administrator/components/com_j2commerce/src/Model/InventoryModel.php`

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only

## Test plan
- [ ] Search by a known SKU — should find the product
- [ ] Search for nonsense "xyz123" — should show "no items" alert (NOT emptystate)
- [ ] Click Clear after a search — should reset to full listing