### PR TITLE
fix(filters): use pluginstatus for payment methods, reports, and apps filters

### DIFF
--- a/administrator/components/com_j2commerce/forms/filter_apps.xml
+++ b/administrator/components/com_j2commerce/forms/filter_apps.xml
@@ -11,7 +11,7 @@
 
         <field
             name="enabled"
-            type="status"
+            type="pluginstatus"
             label="JOPTION_SELECT_PUBLISHED"
             optionsFilter="*,0,1"
             onchange="this.form.submit();"

--- a/administrator/components/com_j2commerce/forms/filter_paymentmethods.xml
+++ b/administrator/components/com_j2commerce/forms/filter_paymentmethods.xml
@@ -11,7 +11,7 @@
 
         <field
             name="enabled"
-            type="status"
+            type="pluginstatus"
             label="JSTATUS"
             description="JFIELD_ENABLED_DESC"
             onchange="this.form.submit();"

--- a/administrator/components/com_j2commerce/forms/filter_reports.xml
+++ b/administrator/components/com_j2commerce/forms/filter_reports.xml
@@ -11,7 +11,7 @@
 
         <field
             name="enabled"
-            type="status"
+            type="pluginstatus"
             label="JSTATUS"
             description="JFIELD_ENABLED_DESC"
             onchange="this.form.submit();"


### PR DESCRIPTION
## Summary
Fixes #564

Payment methods, reports, and apps list views used `type="status"` for their enabled filter, which shows Published/Unpublished/Archived/Trashed options. Plugins only have Enabled/Disabled states. Changed to `type="pluginstatus"` matching Joomla core `com_plugins` pattern (same fix as #545/#565 for shipping methods).

## Changes
- `filter_paymentmethods.xml` — `type="status"` → `type="pluginstatus"`
- `filter_reports.xml` — `type="status"` → `type="pluginstatus"`
- `filter_apps.xml` — `type="status"` → `type="pluginstatus"`

## Files Modified
| Type | Count |
|------|-------|
| XML/Config | 3 |

## Pre-Flight
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only

## Testing
1. Navigate to Payment Methods → Filter Options → verify status dropdown shows only Enabled/Disabled
2. Navigate to Reports → Filter Options → verify status dropdown shows only Enabled/Disabled
3. Navigate to Apps → Filter Options → verify status dropdown shows only Enabled/Disabled