### PR TITLE
fix(css): add visible outline to frontend search reset button (fixes #549)

### DIFF
--- a/components/com_j2commerce/tmpl/products/default_sortfilter.php
+++ b/components/com_j2commerce/tmpl/products/default_sortfilter.php
@@ -58,7 +58,7 @@ $currentSefPath = Uri::getInstance()->getPath();
                     <button type="submit" class="btn btn-primary" title="<?php echo Text::_('COM_J2COMMERCE_FILTER_GO'); ?>">
                         <span class="fa-solid fa-search" aria-hidden="true"></span>
                     </button>
-                    <button type="button" class="btn btn-light text-danger" id="j2commerce-filter-reset" title="<?php echo Text::_('COM_J2COMMERCE_FILTER_RESET'); ?>">
+                    <button type="button" class="btn btn-outline-secondary" id="j2commerce-filter-reset" title="<?php echo Text::_('COM_J2COMMERCE_FILTER_RESET'); ?>">
                         <span class="fa-solid fa-close" aria-hidden="true"></span>
                     </button>
                 </div>

--- a/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/default_sortfilter.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/default_sortfilter.php
@@ -58,7 +58,7 @@ $currentSefPath = Uri::getInstance()->getPath();
                     <button type="submit" class="btn btn-primary" title="<?php echo Text::_('COM_J2COMMERCE_FILTER_GO'); ?>">
                         <span class="fa-solid fa-search" aria-hidden="true"></span>
                     </button>
-                    <button type="button" class="btn btn-light text-danger" id="j2commerce-filter-reset" title="<?php echo Text::_('COM_J2COMMERCE_FILTER_RESET'); ?>">
+                    <button type="button" class="btn btn-outline-secondary" id="j2commerce-filter-reset" title="<?php echo Text::_('COM_J2COMMERCE_FILTER_RESET'); ?>">
                         <span class="fa-solid fa-close" aria-hidden="true"></span>
                     </button>
                 </div>

--- a/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/default_sortfilter.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/default_sortfilter.php
@@ -53,7 +53,7 @@ $currentSefPath = Uri::getInstance()->getPath();
                     <button type="submit" class="btn btn-primary" title="<?php echo Text::_('COM_J2COMMERCE_FILTER_GO'); ?>">
                         <span class="fa-solid fa-search" aria-hidden="true"></span>
                     </button>
-                    <button type="button" class="btn btn-light text-danger" id="j2commerce-filter-reset" title="<?php echo Text::_('COM_J2COMMERCE_FILTER_RESET'); ?>">
+                    <button type="button" class="btn btn-outline-secondary" id="j2commerce-filter-reset" title="<?php echo Text::_('COM_J2COMMERCE_FILTER_RESET'); ?>">
                         <span class="fa-solid fa-close" aria-hidden="true"></span>
                     </button>
                 </div>


### PR DESCRIPTION
## Summary
Fixes #549

## Changes
- Changed `#j2commerce-filter-reset` button class from `btn btn-light text-danger` to `btn btn-outline-secondary` across all Bootstrap 5 sortfilter templates so the reset button has a visible border outline in its default state

## Testing
1. Visit a frontend category product listing page
2. Visit a frontend tag product listing page
3. Verify the reset (X) button now has a visible gray outline in its default state
4. Verify button still functions correctly to clear search/filters

## Files Changed
- `components/com_j2commerce/tmpl/products/default_sortfilter.php` — button class change
- `plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/default_sortfilter.php` — button class change
- `plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/default_sortfilter.php` — button class change

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] Core files only (no non-core excluded)