### PR TITLE
fix(filters): add circle outline to accordion icons and focus-visible a11y

### DIFF
--- a/components/com_j2commerce/tmpl/products/default_filters.php
+++ b/components/com_j2commerce/tmpl/products/default_filters.php
@@ -57,13 +57,13 @@ HTMLHelper::_('bootstrap.collapse');
 <div id="j2commerce-product-loading" class="j2commerce-loading-overlay" style="display:none;"></div>
 
 <style>
-    .filter-accordion :focus {box-shadow:none;}
     .filter-accordion label {cursor:pointer;}
     .filter-accordion .accordion-button {padding: .75rem 0; }
     .filter-accordion .accordion-button:not(.collapsed) { background: transparent; box-shadow: none; }
-    .filter-accordion .accordion-button::after { content: '\2212'; background-image: none; font-size: 1.25rem; line-height: 1; width: auto; height: auto; flex-shrink: 0; transition: none; transform: none; }
+    .filter-accordion .accordion-button::after { content: '\2212'; background-image: none; font-size: .875rem; line-height: 1; width: 1.25rem; height: 1.25rem; flex-shrink: 0; display: inline-flex; align-items: center; justify-content: center; border: 1px solid var(--bs-border-color, #dee2e6); border-radius: 50%; transition: none; transform: none; }
     .filter-accordion .accordion-button.collapsed::after { content: '+'; }
-    .filter-accordion .accordion-button:focus, .filter-accordion .accordion-button:active {box-shadow:none;}
+    .filter-accordion .accordion-button:focus-visible { outline: 2px solid var(--bs-primary, #0d6efd); outline-offset: 2px; box-shadow: none; }
+    .filter-accordion .accordion-button:focus:not(:focus-visible) { box-shadow: none; }
     .filter-accordion .accordion-body { padding: .5rem 0 .75rem; }
     .filter-chip .btn-close { font-size: .5rem; }
 

--- a/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/default_filters.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/default_filters.php
@@ -57,13 +57,13 @@ HTMLHelper::_('bootstrap.collapse');
 <div id="j2commerce-product-loading" class="j2commerce-loading-overlay" style="display:none;"></div>
 
 <style>
-    .filter-accordion :focus {box-shadow:none;}
     .filter-accordion label {cursor:pointer;}
     .filter-accordion .accordion-button {padding: .75rem 0; }
     .filter-accordion .accordion-button:not(.collapsed) { background: transparent; box-shadow: none; }
-    .filter-accordion .accordion-button::after { content: '\2212'; background-image: none; font-size: 1.25rem; line-height: 1; width: auto; height: auto; flex-shrink: 0; transition: none; transform: none; }
+    .filter-accordion .accordion-button::after { content: '\2212'; background-image: none; font-size: .875rem; line-height: 1; width: 1.25rem; height: 1.25rem; flex-shrink: 0; display: inline-flex; align-items: center; justify-content: center; border: 1px solid var(--bs-border-color, #dee2e6); border-radius: 50%; transition: none; transform: none; }
     .filter-accordion .accordion-button.collapsed::after { content: '+'; }
-    .filter-accordion .accordion-button:focus, .filter-accordion .accordion-button:active {box-shadow:none;}
+    .filter-accordion .accordion-button:focus-visible { outline: 2px solid var(--bs-primary, #0d6efd); outline-offset: 2px; box-shadow: none; }
+    .filter-accordion .accordion-button:focus:not(:focus-visible) { box-shadow: none; }
     .filter-accordion .accordion-body { padding: .5rem 0 .75rem; }
     .filter-chip .btn-close { font-size: .5rem; }
 

--- a/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/default_filters.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/default_filters.php
@@ -57,13 +57,13 @@ HTMLHelper::_('bootstrap.collapse');
 <div id="j2commerce-product-loading" class="j2commerce-loading-overlay" style="display:none;"></div>
 
 <style>
-    .filter-accordion :focus {box-shadow:none;}
     .filter-accordion label {cursor:pointer;}
     .filter-accordion .accordion-button {padding: .75rem 0; }
     .filter-accordion .accordion-button:not(.collapsed) { background: transparent; box-shadow: none; }
-    .filter-accordion .accordion-button::after { content: '\2212'; background-image: none; font-size: 1.25rem; line-height: 1; width: auto; height: auto; flex-shrink: 0; transition: none; transform: none; }
+    .filter-accordion .accordion-button::after { content: '\2212'; background-image: none; font-size: .875rem; line-height: 1; width: 1.25rem; height: 1.25rem; flex-shrink: 0; display: inline-flex; align-items: center; justify-content: center; border: 1px solid var(--bs-border-color, #dee2e6); border-radius: 50%; transition: none; transform: none; }
     .filter-accordion .accordion-button.collapsed::after { content: '+'; }
-    .filter-accordion .accordion-button:focus, .filter-accordion .accordion-button:active {box-shadow:none;}
+    .filter-accordion .accordion-button:focus-visible { outline: 2px solid var(--bs-primary, #0d6efd); outline-offset: 2px; box-shadow: none; }
+    .filter-accordion .accordion-button:focus:not(:focus-visible) { box-shadow: none; }
     .filter-accordion .accordion-body { padding: .5rem 0 .75rem; }
     .filter-chip .btn-close { font-size: .5rem; }
 


### PR DESCRIPTION
## Summary
Fixes #551

## Changes
- Added fixed `width: 1.25rem; height: 1.25rem` on `.accordion-button::after` with `border-radius: 50%` and `border: 1px solid var(--bs-border-color)` to create a circular outline around +/− icons
- Centered icons using `display: inline-flex; align-items: center; justify-content: center`
- Replaced blanket `:focus {box-shadow:none}` with proper `:focus-visible` outline for keyboard accessibility
- Mouse clicks suppress the outline via `:focus:not(:focus-visible)`

## Testing
1. Navigate to a product list page with sidebar filters
2. Verify +/− icons have a circular border and are centered
3. Tab through accordion buttons — a blue focus ring should appear
4. Click with mouse — no focus ring should appear
5. Test both collapsed (+) and expanded (−) states
6. Test mobile offcanvas filter view

## Files Changed
- `components/com_j2commerce/tmpl/products/default_filters.php` — CSS update
- `plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/default_filters.php` — CSS update
- `plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/default_filters.php` — CSS update

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] Core files only