### PR TITLE
fix(cart-module): hide links when empty, AJAX update, auto-detect menu items (fixes #552)

### DIFF
--- a/media/com_j2commerce/js/site/j2commerce.js
+++ b/media/com_j2commerce/js/site/j2commerce.js
@@ -107,11 +107,6 @@ const J2Commerce = {
                 return;
             }
 
-            if (json.redirect) {
-                window.location.href = json.redirect;
-                return;
-            }
-
             if (json.success) {
                 button.classList.remove('loading');
                 button.classList.add('added');
@@ -119,6 +114,11 @@ const J2Commerce = {
                 if (complete) complete.style.display = 'block';
                 this.dispatchEvent('afterAddingToCart', { button, response: json, type: 'link' });
                 this.dispatchEvent('cart:updated', { type: 'add' });
+            }
+
+            if (json.redirect) {
+                window.location.href = json.redirect;
+                return;
             }
         } catch (error) {
             console.error('Cart error:', error);
@@ -206,11 +206,6 @@ const J2Commerce = {
                 return;
             }
 
-            if (json.redirect) {
-                window.location.href = json.redirect;
-                return;
-            }
-
             if (json.success) {
                 setTimeout(() => {
                     if (submitBtn) { if (submitBtn.tagName === 'BUTTON') submitBtn.textContent = actionDone; else submitBtn.value = actionDone; }
@@ -225,6 +220,11 @@ const J2Commerce = {
 
                 this.dispatchEvent('afterAddingToCart', { form, response: json, type: 'normal' });
                 this.dispatchEvent('cart:updated', { type: 'add' });
+            }
+
+            if (json.redirect) {
+                window.location.href = json.redirect;
+                return;
             }
         } catch (error) {
             console.error('Cart form error:', error);

--- a/modules/mod_j2commerce_cart/src/Dispatcher/Dispatcher.php
+++ b/modules/mod_j2commerce_cart/src/Dispatcher/Dispatcher.php
@@ -23,15 +23,39 @@ use Joomla\CMS\Router\Route;
 
 class Dispatcher extends AbstractModuleDispatcher
 {
+    /**
+     * Find a published menu item by its link.
+     *
+     * @param  string  $link  The menu item link to search for (e.g. 'index.php?option=com_j2commerce&view=carts')
+     *
+     * @return int  The menu item ID, or 0 if not found
+     */
+    private function findMenuItemId(string $link): int
+    {
+        $menu  = Factory::getApplication()->getMenu();
+        $items = $menu->getItems('link', $link);
+
+        foreach ($items as $item) {
+            if ((int) ($item->published ?? 0) === 1) {
+                return (int) $item->id;
+            }
+        }
+
+        return 0;
+    }
+
     protected function getLayoutData(): array
     {
         $data   = parent::getLayoutData();
         $params = $data['params'];
         $app    = Factory::getApplication();
 
-        // Load language files
+        // Load language files — load from component's own directory as fallback
+        // to ensure COM_J2COMMERCE_* strings are available even when the root
+        // language/ directory doesn't have com_j2commerce.ini
         $language = $app->getLanguage();
         $language->load('com_j2commerce', JPATH_SITE);
+        $language->load('com_j2commerce', JPATH_SITE . '/components/com_j2commerce');
         $language->load('mod_j2commerce_cart', JPATH_SITE . '/modules/mod_j2commerce_cart');
 
         // Safe defaults
@@ -84,14 +108,25 @@ class Dispatcher extends AbstractModuleDispatcher
             // Format the total
             $formattedTotal = CurrencyHelper::format($total);
 
-            // Build URLs — use menu item params if set, fallback to RouteHelper
+            // Build URLs — use menu item params if set, auto-detect matching
+            // menu item, or fallback to RouteHelper
             $cartMenuItemId     = (int) $params->get('cart_menu_item', 0);
             $checkoutMenuItemId = (int) $params->get('checkout_menu_item', 0);
+
+            // Auto-detect cart menu item when not manually configured
+            if ($cartMenuItemId < 1) {
+                $cartMenuItemId = $this->findMenuItemId('index.php?option=com_j2commerce&view=carts');
+            }
 
             if ($cartMenuItemId > 0) {
                 $cartUrl = Route::_('index.php?option=com_j2commerce&view=carts&Itemid=' . $cartMenuItemId);
             } else {
                 $cartUrl = Route::_(RouteHelper::getCartRoute());
+            }
+
+            // Auto-detect checkout menu item when not manually configured
+            if ($checkoutMenuItemId < 1) {
+                $checkoutMenuItemId = $this->findMenuItemId('index.php?option=com_j2commerce&view=checkout');
             }
 
             if ($checkoutMenuItemId > 0) {

--- a/modules/mod_j2commerce_cart/tmpl/default.php
+++ b/modules/mod_j2commerce_cart/tmpl/default.php
@@ -217,31 +217,31 @@ try {
         <span class="j2commerce-cart-empty"><?php echo Text::_('MOD_J2COMMERCE_CART_EMPTY'); ?></span>
     <?php endif; ?>
 
-    <!-- Footer buttons -->
-    <?php if ($showCheckout || $showViewCart) : ?>
-        <div class="j2commerce-minicart-button d-flex gap-2 mt-2">
-            <?php if ($showCheckout && $productCount > 0) : ?>
-                <a class="btn btn-success flex-fill"
+    <!-- Footer buttons (only when cart has items) -->
+    <?php if ($productCount > 0 && ($showCheckout || $showViewCart)) : ?>
+        <div class="j2commerce-minicart-button d-grid gap-2 mt-2">
+            <?php if ($showCheckout) : ?>
+                <a class="btn btn-success"
                    href="<?php echo htmlspecialchars($checkoutUrl, ENT_QUOTES, 'UTF-8'); ?>">
                     <?php echo Text::_('MOD_J2COMMERCE_CART_CHECKOUT'); ?>
                 </a>
             <?php endif; ?>
             <?php if ($showViewCart) : ?>
                 <?php if ($linkType === 'link') : ?>
-                    <a class="j2commerce-view-cart-link"
+                    <a class="j2commerce-view-cart-link text-center"
                        href="<?php echo htmlspecialchars($cartUrl, ENT_QUOTES, 'UTF-8'); ?>">
                         <?php echo Text::_('MOD_J2COMMERCE_CART_VIEW_CART'); ?>
                     </a>
                 <?php else : ?>
-                    <a class="btn btn-outline-secondary flex-fill"
+                    <a class="btn btn-outline-secondary"
                        href="<?php echo htmlspecialchars($cartUrl, ENT_QUOTES, 'UTF-8'); ?>">
                         <?php echo Text::_('MOD_J2COMMERCE_CART_VIEW_CART'); ?>
                     </a>
                 <?php endif; ?>
             <?php endif; ?>
         </div>
-    <?php elseif ($productCount > 0 || !((int) $params->get('check_empty', 0) === 1)) : ?>
-        <!-- Fallback: always show View Cart if no button params configured -->
+    <?php elseif ($productCount > 0) : ?>
+        <!-- Fallback: show View Cart if no button params configured but cart has items -->
         <div class="j2commerce-minicart-button mt-2">
             <?php if ($linkType === 'link') : ?>
                 <a class="j2commerce-view-cart-link"

--- a/modules/mod_j2commerce_cart/tmpl/default_uikit.php
+++ b/modules/mod_j2commerce_cart/tmpl/default_uikit.php
@@ -185,29 +185,29 @@ try {
         <span class="j2commerce-cart-empty"><?php echo Text::_('MOD_J2COMMERCE_CART_EMPTY'); ?></span>
     <?php endif; ?>
 
-    <?php if ($showCheckout || $showViewCart) : ?>
-        <div class="j2commerce-minicart-button uk-flex uk-grid-small uk-margin-small-top" uk-grid>
-            <?php if ($showCheckout && $productCount > 0) : ?>
-                <a class="uk-button uk-button-primary uk-width-expand"
+    <?php if ($productCount > 0 && ($showCheckout || $showViewCart)) : ?>
+        <div class="j2commerce-minicart-button uk-margin-small-top">
+            <?php if ($showCheckout) : ?>
+                <a class="uk-button uk-button-primary uk-width-1-1"
                    href="<?php echo htmlspecialchars($checkoutUrl, ENT_QUOTES, 'UTF-8'); ?>">
                     <?php echo Text::_('MOD_J2COMMERCE_CART_CHECKOUT'); ?>
                 </a>
             <?php endif; ?>
             <?php if ($showViewCart) : ?>
                 <?php if ($linkType === 'link') : ?>
-                    <a class="j2commerce-view-cart-link"
+                    <a class="j2commerce-view-cart-link uk-display-block uk-text-center uk-margin-small-top"
                        href="<?php echo htmlspecialchars($cartUrl, ENT_QUOTES, 'UTF-8'); ?>">
                         <?php echo Text::_('MOD_J2COMMERCE_CART_VIEW_CART'); ?>
                     </a>
                 <?php else : ?>
-                    <a class="uk-button uk-button-default uk-width-expand"
+                    <a class="uk-button uk-button-default uk-width-1-1 uk-margin-small-top"
                        href="<?php echo htmlspecialchars($cartUrl, ENT_QUOTES, 'UTF-8'); ?>">
                         <?php echo Text::_('MOD_J2COMMERCE_CART_VIEW_CART'); ?>
                     </a>
                 <?php endif; ?>
             <?php endif; ?>
         </div>
-    <?php elseif ($productCount > 0 || !((int) $params->get('check_empty', 0) === 1)) : ?>
+    <?php elseif ($productCount > 0) : ?>
         <div class="j2commerce-minicart-button uk-margin-small-top">
             <?php if ($linkType === 'link') : ?>
                 <a class="j2commerce-view-cart-link"

--- a/modules/mod_j2commerce_cart/tmpl/detailcartonhover.php
+++ b/modules/mod_j2commerce_cart/tmpl/detailcartonhover.php
@@ -76,9 +76,11 @@ $panelId = 'j2commerce-cart-detail-' . $moduleId;
                 <span class="j2commerce-cart-text">
                     <?php echo htmlspecialchars(Text::sprintf('MOD_J2COMMERCE_CART_TOTAL', $productCount, $formattedTotal), ENT_QUOTES, 'UTF-8'); ?>
                 </span>
-                <a class="j2commerce-view-cart-link ms-2" href="<?php echo htmlspecialchars($cartUrl, ENT_QUOTES, 'UTF-8'); ?>">
-                    <?php echo Text::_('MOD_J2COMMERCE_CART_VIEW_CART'); ?>
-                </a>
+                <?php if (!empty($cartUrl)) : ?>
+                    <a class="j2commerce-view-cart-link ms-2" href="<?php echo htmlspecialchars($cartUrl, ENT_QUOTES, 'UTF-8'); ?>">
+                        <?php echo Text::_('MOD_J2COMMERCE_CART_VIEW_CART'); ?>
+                    </a>
+                <?php endif; ?>
             <?php else : ?>
                 <span class="j2commerce-cart-empty"><?php echo Text::_('MOD_J2COMMERCE_CART_EMPTY'); ?></span>
             <?php endif; ?>
@@ -95,9 +97,11 @@ $panelId = 'j2commerce-cart-detail-' . $moduleId;
                         <?php echo Text::_('MOD_J2COMMERCE_CART_EMPTY'); ?>
                     <?php endif; ?>
                 </div>
-                <a class="text-decoration-none" href="<?php echo htmlspecialchars($cartUrl, ENT_QUOTES, 'UTF-8'); ?>">
-                    <?php echo Text::_('MOD_J2COMMERCE_CART_VIEW_CART'); ?>
-                </a>
+                <?php if ($productCount > 0) : ?>
+                    <a class="text-decoration-none" href="<?php echo htmlspecialchars($cartUrl, ENT_QUOTES, 'UTF-8'); ?>">
+                        <?php echo Text::_('MOD_J2COMMERCE_CART_VIEW_CART'); ?>
+                    </a>
+                <?php endif; ?>
             </div>
 
             <?php if ($productCount > 0 && !empty($items)) : ?>
@@ -166,14 +170,14 @@ $panelId = 'j2commerce-cart-detail-' . $moduleId;
 
             <?php if ($showCheckout || $showViewCart) : ?>
             <!-- Footer buttons -->
-            <div class="card-footer d-flex gap-2">
+            <div class="card-footer d-grid gap-2">
                 <?php if ($showCheckout) : ?>
-                    <a class="btn btn-success flex-fill" href="<?php echo htmlspecialchars($checkoutUrl, ENT_QUOTES, 'UTF-8'); ?>">
+                    <a class="btn btn-success" href="<?php echo htmlspecialchars($checkoutUrl, ENT_QUOTES, 'UTF-8'); ?>">
                         <?php echo Text::_('MOD_J2COMMERCE_CART_CHECKOUT'); ?>
                     </a>
                 <?php endif; ?>
                 <?php if ($showViewCart) : ?>
-                    <a class="btn btn-outline-secondary flex-fill" href="<?php echo htmlspecialchars($cartUrl, ENT_QUOTES, 'UTF-8'); ?>">
+                    <a class="btn btn-outline-secondary" href="<?php echo htmlspecialchars($cartUrl, ENT_QUOTES, 'UTF-8'); ?>">
                         <?php echo Text::_('MOD_J2COMMERCE_CART_VIEW_CART'); ?>
                     </a>
                 <?php endif; ?>

--- a/modules/mod_j2commerce_cart/tmpl/detailcartonhover_uikit.php
+++ b/modules/mod_j2commerce_cart/tmpl/detailcartonhover_uikit.php
@@ -73,9 +73,11 @@ $panelId = 'j2commerce-cart-detail-' . $moduleId;
                 <span class="j2commerce-cart-text">
                     <?php echo htmlspecialchars(Text::sprintf('MOD_J2COMMERCE_CART_TOTAL', $productCount, $formattedTotal), ENT_QUOTES, 'UTF-8'); ?>
                 </span>
-                <a class="j2commerce-view-cart-link uk-margin-small-left" href="<?php echo htmlspecialchars($cartUrl, ENT_QUOTES, 'UTF-8'); ?>">
-                    <?php echo Text::_('MOD_J2COMMERCE_CART_VIEW_CART'); ?>
-                </a>
+                <?php if (!empty($cartUrl)) : ?>
+                    <a class="j2commerce-view-cart-link uk-margin-small-left" href="<?php echo htmlspecialchars($cartUrl, ENT_QUOTES, 'UTF-8'); ?>">
+                        <?php echo Text::_('MOD_J2COMMERCE_CART_VIEW_CART'); ?>
+                    </a>
+                <?php endif; ?>
             <?php else : ?>
                 <span class="j2commerce-cart-empty"><?php echo Text::_('MOD_J2COMMERCE_CART_EMPTY'); ?></span>
             <?php endif; ?>
@@ -92,9 +94,11 @@ $panelId = 'j2commerce-cart-detail-' . $moduleId;
                         <?php echo Text::_('MOD_J2COMMERCE_CART_EMPTY'); ?>
                     <?php endif; ?>
                 </div>
-                <a href="<?php echo htmlspecialchars($cartUrl, ENT_QUOTES, 'UTF-8'); ?>">
-                    <?php echo Text::_('MOD_J2COMMERCE_CART_VIEW_CART'); ?>
-                </a>
+                <?php if ($productCount > 0) : ?>
+                    <a href="<?php echo htmlspecialchars($cartUrl, ENT_QUOTES, 'UTF-8'); ?>">
+                        <?php echo Text::_('MOD_J2COMMERCE_CART_VIEW_CART'); ?>
+                    </a>
+                <?php endif; ?>
             </div>
 
             <?php if ($productCount > 0 && !empty($items)) : ?>
@@ -163,14 +167,14 @@ $panelId = 'j2commerce-cart-detail-' . $moduleId;
 
             <?php if ($showCheckout || $showViewCart) : ?>
             <!-- Footer buttons -->
-            <div class="uk-card-footer uk-flex uk-grid-small" uk-grid>
+            <div class="uk-card-footer">
                 <?php if ($showCheckout) : ?>
-                    <a class="uk-button uk-button-primary uk-width-expand" href="<?php echo htmlspecialchars($checkoutUrl, ENT_QUOTES, 'UTF-8'); ?>">
+                    <a class="uk-button uk-button-primary uk-width-1-1" href="<?php echo htmlspecialchars($checkoutUrl, ENT_QUOTES, 'UTF-8'); ?>">
                         <?php echo Text::_('MOD_J2COMMERCE_CART_CHECKOUT'); ?>
                     </a>
                 <?php endif; ?>
                 <?php if ($showViewCart) : ?>
-                    <a class="uk-button uk-button-default uk-width-expand" href="<?php echo htmlspecialchars($cartUrl, ENT_QUOTES, 'UTF-8'); ?>">
+                    <a class="uk-button uk-button-default uk-width-1-1 uk-margin-small-top" href="<?php echo htmlspecialchars($cartUrl, ENT_QUOTES, 'UTF-8'); ?>">
                         <?php echo Text::_('MOD_J2COMMERCE_CART_VIEW_CART'); ?>
                     </a>
                 <?php endif; ?>

--- a/modules/mod_j2commerce_cart/tmpl/minicart.php
+++ b/modules/mod_j2commerce_cart/tmpl/minicart.php
@@ -37,15 +37,21 @@ if (!empty($customCss)) {
 
 <?php if (!$hide) : ?>
     <div class="j2commerce-minicart">
-        <a class="j2commerce-minicart-link position-relative d-inline-block"
-           href="<?php echo htmlspecialchars($cartUrl, ENT_QUOTES, 'UTF-8'); ?>"
-           aria-label="<?php echo htmlspecialchars(\Joomla\CMS\Language\Text::_('MOD_J2COMMERCE_CART_VIEW_CART'), ENT_QUOTES, 'UTF-8'); ?>">
-            <i class="<?php echo $iconClass; ?>" aria-hidden="true"></i>
-            <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger j2commerce-cart-badge">
-                <?php echo $productCount; ?>
-                <span class="visually-hidden"><?php echo \Joomla\CMS\Language\Text::_('MOD_J2COMMERCE_CART_VIEW_CART'); ?></span>
+        <?php if ($productCount > 0) : ?>
+            <a class="j2commerce-minicart-link position-relative d-inline-block"
+               href="<?php echo htmlspecialchars($cartUrl, ENT_QUOTES, 'UTF-8'); ?>"
+               aria-label="<?php echo htmlspecialchars(\Joomla\CMS\Language\Text::_('MOD_J2COMMERCE_CART_VIEW_CART'), ENT_QUOTES, 'UTF-8'); ?>">
+                <i class="<?php echo $iconClass; ?>" aria-hidden="true"></i>
+                <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger j2commerce-cart-badge">
+                    <?php echo $productCount; ?>
+                    <span class="visually-hidden"><?php echo \Joomla\CMS\Language\Text::_('MOD_J2COMMERCE_CART_VIEW_CART'); ?></span>
+                </span>
+            </a>
+        <?php else : ?>
+            <span class="j2commerce-minicart-link position-relative d-inline-block">
+                <i class="<?php echo $iconClass; ?>" aria-hidden="true"></i>
             </span>
-        </a>
+        <?php endif; ?>
     </div>
 <?php endif; ?>
 

--- a/modules/mod_j2commerce_cart/tmpl/minicart_uikit.php
+++ b/modules/mod_j2commerce_cart/tmpl/minicart_uikit.php
@@ -34,16 +34,22 @@ if (!empty($customCss)) {
 
 <?php if (!$hide) : ?>
     <div class="j2commerce-minicart">
-        <a class="j2commerce-minicart-link uk-position-relative uk-display-inline-block"
-           href="<?php echo htmlspecialchars($cartUrl, ENT_QUOTES, 'UTF-8'); ?>"
-           aria-label="<?php echo htmlspecialchars(\Joomla\CMS\Language\Text::_('MOD_J2COMMERCE_CART_VIEW_CART'), ENT_QUOTES, 'UTF-8'); ?>">
-            <i class="<?php echo $iconClass; ?>" aria-hidden="true"></i>
-            <span class="uk-badge j2commerce-cart-badge"
-                  style="position:absolute;top:-8px;right:-12px;font-size:0.65rem;">
-                <?php echo $productCount; ?>
-                <span class="uk-hidden"><?php echo \Joomla\CMS\Language\Text::_('MOD_J2COMMERCE_CART_VIEW_CART'); ?></span>
+        <?php if ($productCount > 0) : ?>
+            <a class="j2commerce-minicart-link uk-position-relative uk-display-inline-block"
+               href="<?php echo htmlspecialchars($cartUrl, ENT_QUOTES, 'UTF-8'); ?>"
+               aria-label="<?php echo htmlspecialchars(\Joomla\CMS\Language\Text::_('MOD_J2COMMERCE_CART_VIEW_CART'), ENT_QUOTES, 'UTF-8'); ?>">
+                <i class="<?php echo $iconClass; ?>" aria-hidden="true"></i>
+                <span class="uk-badge j2commerce-cart-badge"
+                      style="position:absolute;top:-8px;right:-12px;font-size:0.65rem;">
+                    <?php echo $productCount; ?>
+                    <span class="uk-hidden"><?php echo \Joomla\CMS\Language\Text::_('MOD_J2COMMERCE_CART_VIEW_CART'); ?></span>
+                </span>
+            </a>
+        <?php else : ?>
+            <span class="j2commerce-minicart-link uk-position-relative uk-display-inline-block">
+                <i class="<?php echo $iconClass; ?>" aria-hidden="true"></i>
             </span>
-        </a>
+        <?php endif; ?>
     </div>
 <?php endif; ?>
 


### PR DESCRIPTION
## Summary
Fixes #552

- **Empty cart = no link:** When the basket is empty, View Cart/Checkout links and buttons are hidden across all 6 module templates (minicart, default, detailcartonhover + UIkit variants). Minicart shows icon only without badge or link.
- **AJAX update on add-to-cart:** Reordered JS in `j2commerce.js` so `cart:updated` event fires on success *before* checking for redirect. Previously, when `addtocart_action=3` (redirect, the default), the redirect happened first and the event never fired.
- **Auto-detect cart menu item:** Dispatcher now auto-detects published menu items for cart/checkout views when not manually configured, ensuring correct breadcrumbs.
- **Language string fix:** Added fallback language load from component directory to fix untranslated `COM_J2COMMERCE_CART_SUBTOTAL` / `COM_J2COMMERCE_CART_GRANDTOTAL` strings.
- **Stacked buttons:** Checkout and View Cart buttons now display full-width and stacked vertically instead of inline.

## Changes
| Type | Count |
|------|-------|
| PHP files | 7 |
| JS assets | 1 |

## Files Modified
- `modules/mod_j2commerce_cart/src/Dispatcher/Dispatcher.php` — findMenuItemId(), language fallback, auto-detect menu items
- `media/com_j2commerce/js/site/j2commerce.js` — fire cart:updated before redirect in addToCartButton + addToCartForm
- `modules/mod_j2commerce_cart/tmpl/minicart.php` — icon-only when empty
- `modules/mod_j2commerce_cart/tmpl/minicart_uikit.php` — same
- `modules/mod_j2commerce_cart/tmpl/default.php` — hide buttons when empty, stacked layout
- `modules/mod_j2commerce_cart/tmpl/default_uikit.php` — same
- `modules/mod_j2commerce_cart/tmpl/detailcartonhover.php` — hide links when empty, stacked layout
- `modules/mod_j2commerce_cart/tmpl/detailcartonhover_uikit.php` — same

## Testing
1. With empty cart: verify no View Cart link/button in any layout
2. Add a product (inline mode): verify module updates via AJAX without page refresh
3. Add a product (redirect mode): verify cart:updated fires before redirect
4. Create a cart menu item: verify breadcrumbs are correct
5. Check totals show "Subtotal" / "Total" (not raw language keys)
6. Verify buttons are full-width and stacked vertically

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only (0 non-core excluded)