### PR TITLE
fix(library): add missing vendor/ and csvexport/ to XML manifest

### DIFF
--- a/libraries/j2commerce/j2commerce.xml
+++ b/libraries/j2commerce/j2commerce.xml
@@ -13,10 +13,12 @@
 	<namespace path="src">J2Commerce\Library\J2Commerce</namespace>
     <scriptfile>script.php</scriptfile>
     <files>
+        <folder>csvexport</folder>
         <folder>layouts</folder>
-		<folder>src</folder>
-		<filename>README.md</filename>
-	</files>
+        <folder>src</folder>
+        <folder>vendor</folder>
+        <filename>README.md</filename>
+    </files>
     <languages folder="language">
         <language tag="en-US">en-US/lib_j2commerce.ini</language>
         <language tag="en-US">en-US/lib_j2commerce.sys.ini</language>


### PR DESCRIPTION
## Summary
Fixes #569

The `libraries/j2commerce/j2commerce.xml` `<files>` section was missing `vendor/` and `csvexport/` folders. These directories are included in the generated zip but Joomla's installer never deploys them because they aren't listed in the manifest.

## Changes
- Added `<folder>csvexport</folder>` to `<files>` section
- Added `<folder>vendor</folder>` to `<files>` section
- Normalized indentation (tabs → spaces to match surrounding XML)

**Why these folders matter:**
- `vendor/` — Contains `dvdoug/boxpacker` (used by `ShipperHelper.php` for shipping calculations) and Amazon Pay SDK
- `csvexport/` — Contains `ExportCsv` class for CSV report exports

## Files Modified
| Type | Count |
|------|-------|
| XML/Config | 1 |

## Pre-Flight
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only (non-core excluded)

## Testing
1. Run `php build/build_package.php` and inspect `lib_j2commerce.zip`
2. Install on a test site
3. Verify `libraries/j2commerce/vendor/` and `libraries/j2commerce/csvexport/` exist after installation