### PR TITLE
fix(fields): correct GeoZone field type casing for Linux (fixes #580)

### DIFF
--- a/administrator/components/com_j2commerce/forms/taxrate.xml
+++ b/administrator/components/com_j2commerce/forms/taxrate.xml
@@ -31,7 +31,7 @@
 
         <field
             name="geozone_id"
-            type="geozone"
+            type="GeoZone"
             label="COM_J2COMMERCE_FIELD_GEOZONE"
             description="COM_J2COMMERCE_FIELD_GEOZONE_DESC"
             required="true"

--- a/plugins/j2commerce/payment_banktransfer/payment_banktransfer.xml
+++ b/plugins/j2commerce/payment_banktransfer/payment_banktransfer.xml
@@ -157,7 +157,7 @@
 
                 <field
                     name="geozone_id"
-                    type="geozone"
+                    type="GeoZone"
                     default=""
                     label="COM_J2COMMERCE_GEOZONE_RESTRICTION"
                     description="COM_J2COMMERCE_GEOZONE_RESTRICTION_DESC"

--- a/plugins/j2commerce/payment_cash/payment_cash.xml
+++ b/plugins/j2commerce/payment_cash/payment_cash.xml
@@ -156,7 +156,7 @@
 
                 <field
                     name="geozone_id"
-                    type="geozone"
+                    type="GeoZone"
                     default=""
                     label="COM_J2COMMERCE_GEOZONE_RESTRICTION"
                     description="COM_J2COMMERCE_GEOZONE_RESTRICTION_DESC"

--- a/plugins/j2commerce/payment_moneyorder/payment_moneyorder.xml
+++ b/plugins/j2commerce/payment_moneyorder/payment_moneyorder.xml
@@ -159,7 +159,7 @@
 
                 <field
                     name="geozone_id"
-                    type="geozone"
+                    type="GeoZone"
                     default=""
                     label="COM_J2COMMERCE_GEOZONE_RESTRICTION"
                     description="COM_J2COMMERCE_GEOZONE_RESTRICTION_DESC"

--- a/plugins/j2commerce/payment_paypal/payment_paypal.xml
+++ b/plugins/j2commerce/payment_paypal/payment_paypal.xml
@@ -201,7 +201,7 @@
 
                 <field
                     name="geozone_id"
-                    type="geozone"
+                    type="GeoZone"
                     default=""
                     label="COM_J2COMMERCE_GEOZONE_RESTRICTION"
                     description="COM_J2COMMERCE_GEOZONE_RESTRICTION_DESC"


### PR DESCRIPTION
## Summary
Fixes #580

`type="geozone"` in XML form fields resolves to class `GeozoneField` via Joomla's `FormHelper::loadClass()`. The actual file is `GeoZoneField.php` (capital Z). This works on Windows (case-insensitive) but silently fails on Linux (case-sensitive), causing the GeoZone dropdown to not render on live servers.

## Changes
- `administrator/components/com_j2commerce/forms/taxrate.xml` — `type="GeoZone"`
- `plugins/j2commerce/payment_banktransfer/payment_banktransfer.xml` — `type="GeoZone"`
- `plugins/j2commerce/payment_cash/payment_cash.xml` — `type="GeoZone"`
- `plugins/j2commerce/payment_moneyorder/payment_moneyorder.xml` — `type="GeoZone"`
- `plugins/j2commerce/payment_paypal/payment_paypal.xml` — `type="GeoZone"`

Reference: `shipping_free.xml` already had the correct `type="GeoZone"` casing.

## Testing
1. Deploy to a Linux server
2. Navigate to J2Commerce > Tax Rates > Edit — verify GeoZone dropdown renders
3. Check payment plugin settings (Bank Transfer, Cash, Money Order, PayPal) — verify GeoZone Restriction field renders

## Pre-Flight
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only