### PR TITLE
fix(core): bypass GD processing for SVG images in ImageProcessorHelper

### DIFF
--- a/administrator/components/com_j2commerce/src/Helper/ImageProcessorHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/ImageProcessorHelper.php
@@ -65,6 +65,10 @@ class ImageProcessorHelper
         int $height
     ): bool {
         try {
+            if (strtolower(pathinfo($sourcePath, PATHINFO_EXTENSION)) === 'svg') {
+                return copy($sourcePath, $thumbPath);
+            }
+
             $image = new Image($sourcePath);
 
             $originalWidth  = $image->getWidth();
@@ -91,6 +95,10 @@ class ImageProcessorHelper
     /** Resize and convert main image to WebP. Returns WebP data or false on failure. */
     public function processMainImage(string $sourcePath, int $maxDimension, bool $maintainRatio): string|false
     {
+        if (strtolower(pathinfo($sourcePath, PATHINFO_EXTENSION)) === 'svg') {
+            return file_get_contents($sourcePath);
+        }
+
         if (!\function_exists('imagewebp') || $maxDimension < 1) {
             return false;
         }
@@ -163,6 +171,10 @@ class ImageProcessorHelper
 
     public function validateImage(string $data): bool
     {
+        if (str_starts_with(trim($data), '<svg')) {
+            return true;
+        }
+
         $imageInfo = @getimagesizefromstring($data);
 
         if ($imageInfo === false) {


### PR DESCRIPTION
## Core Update

### Changes
- Bypass GD image processing for SVG files in `ImageProcessorHelper` to prevent "corrupt or unsupported format" errors.
- SVGs are now copied directly to target directories as they are natively scalable.

### Files Modified
| Type | Count |
|------|-------|
| PHP files | 1 |
| JS/CSS assets | 0 |
| Language files | 0 |
| XML/Config | 0 |

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Code style (php-cs-fixer) passed
- [x] Core files only (non-core excluded)