### PR TITLE
fix(checkout): hash password with User::bind() so registration auto-login works

### DIFF
--- a/components/com_j2commerce/src/Controller/CheckoutController.php
+++ b/components/com_j2commerce/src/Controller/CheckoutController.php
@@ -399,18 +399,33 @@ class CheckoutController extends BaseController
         $guestSessionId = $session->getId();
 
         try {
-            $user                 = new \Joomla\CMS\User\User();
-            $user->name           = $name;
-            $user->username       = $email;
-            $user->email          = $email;
-            $user->password_clear = $password;
-
             // Get default user group from Joomla global config
             $params       = \Joomla\CMS\Component\ComponentHelper::getParams('com_users');
             $defaultGroup = $params->get('new_usertype', 2);
-            $user->groups = [$defaultGroup];
 
-            $user->block        = 0;
+            // Use bind() so the password is properly hashed before save.
+            // Setting properties directly (e.g. password_clear) skips the
+            // hashing logic inside User::bind(), leaving the DB hash NULL
+            // and causing the subsequent auto-login to fail silently.
+            $userData = [
+                'name'      => $name,
+                'username'  => $email,
+                'email'     => $email,
+                'password'  => $password,
+                'password2' => $password,
+                'groups'    => [$defaultGroup],
+                'block'     => 0,
+            ];
+
+            $user = new \Joomla\CMS\User\User();
+
+            if (!$user->bind($userData)) {
+                $json['error']['warning'] = $user->getError() ?: Text::_('COM_J2COMMERCE_CHECKOUT_REGISTER_ERROR');
+                $this->jsonResponse($json);
+
+                return;
+            }
+
             $user->registerDate = Factory::getDate()->toSql();
 
             if (!$user->save()) {
@@ -422,8 +437,17 @@ class CheckoutController extends BaseController
 
             // Auto-login the new user
             $credentials = ['username' => $email, 'password' => $password];
-            $this->app->login($credentials);
+            $result      = $this->app->login($credentials);
 
+            if ($result !== true) {
+                $json['error']['warning'] = Text::_('COM_J2COMMERCE_CHECKOUT_ERROR_LOGIN');
+                $this->jsonResponse($json);
+
+                return;
+            }
+
+            // Re-acquire session after fork (login regenerates session ID)
+            $session    = $this->app->getSession();
             $loggedUser = $this->app->getIdentity();
 
             // Merge guest cart items
@@ -455,7 +479,7 @@ class CheckoutController extends BaseController
             $session->clear('guest', 'j2commerce');
             $session->clear('payment_method', 'j2commerce');
             $session->clear('payment_methods', 'j2commerce');
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $json['error']['warning'] = $e->getMessage();
             $this->jsonResponse($json);
 

--- a/components/com_j2commerce/tmpl/checkout/default.php
+++ b/components/com_j2commerce/tmpl/checkout/default.php
@@ -467,8 +467,21 @@ document.addEventListener('DOMContentLoaded', function() {
         }
 
         // Country change → reload zones
-        countrySelect.addEventListener('change', function() {
-            loadZones(this.value, 0);
+        // Support for zone ID passed via CustomEvent detail or dataset (used by address autocomplete)
+        countrySelect.addEventListener('change', function(e) {
+            // Skip zone reload when autocomplete already fetched and set zones directly
+            if (e instanceof CustomEvent && e.detail && e.detail.fromAutocomplete) {
+                syncZoneRequired();
+                return;
+            }
+            var zoneId = 0;
+            if (e instanceof CustomEvent && e.detail && e.detail.zoneId) {
+                zoneId = e.detail.zoneId;
+            } else if (this.dataset.zoneId) {
+                zoneId = this.dataset.zoneId;
+                delete this.dataset.zoneId;
+            }
+            loadZones(this.value, zoneId);
         });
     }
 
@@ -592,6 +605,32 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }
 
+    // Map step IDs to their fetch-task names so the "Change" link can
+    // re-fetch fresh content from the server instead of showing stale DOM.
+    var stepTaskMap = {
+        'billing-address': function() { return billingTask || 'billingAddress'; },
+        'shipping-address': function() { return 'shippingAddress'; }
+    };
+
+    // Open a checkout step, re-fetching its content when a task is mapped.
+    function openStep(stepId, linkToRemove) {
+        var taskFn = stepTaskMap[stepId];
+        hideAllContents();
+
+        if (taskFn) {
+            var content = getContent(stepId);
+            if (content) content.setAttribute('aria-busy', 'true');
+            slideDown(content);
+            fetchStep(taskFn(), stepId).then(function() {
+                initCountryZoneFields(getContent(stepId));
+            });
+        } else {
+            slideDown(getContent(stepId));
+        }
+
+        if (linkToRemove) linkToRemove.remove();
+    }
+
     // Heading edit link clicks - open that step
     document.addEventListener('click', function(e) {
         var link = e.target.closest('.checkout-heading a');
@@ -599,11 +638,7 @@ document.addEventListener('DOMContentLoaded', function() {
         e.preventDefault();
         var step = link.closest('[id]');
         if (!step) return;
-        hideAllContents();
-        slideDown(getContent(step.id));
-        // Remove the edit link from the step we just navigated to —
-        // being ON a step means its own "Change" link is redundant.
-        link.remove();
+        openStep(step.id, link);
     });
 
     // Keyboard accessibility for edit links (Enter/Space)
@@ -614,9 +649,7 @@ document.addEventListener('DOMContentLoaded', function() {
         e.preventDefault();
         var step = link.closest('[id]');
         if (!step) return;
-        hideAllContents();
-        slideDown(getContent(step.id));
-        link.remove();
+        openStep(step.id, link);
     });
 
     // Toggle existing/new address form visibility (billing)
@@ -631,8 +664,9 @@ document.addEventListener('DOMContentLoaded', function() {
     });
 
     // Toggle existing/new address form visibility (shipping)
+    // Note: Only match radio buttons, not the "same as billing" checkbox (issue #528)
     document.addEventListener('change', function(e) {
-        if (!e.target.matches('input[name="shipping_address"]')) return;
+        if (!e.target.matches('input[type="radio"][name="shipping_address"]')) return;
         var newForm = document.getElementById('shipping-new-address-form');
         if (newForm) {
             newForm.style.display = e.target.value === 'new' ? 'block' : 'none';
@@ -730,6 +764,10 @@ document.addEventListener('DOMContentLoaded', function() {
                     }
                 });
             } else {
+                // After successful registration the user is now logged in,
+                // so switch to the billingAddress task which loads saved
+                // addresses instead of re-rendering the empty register form.
+                billingTask = 'billingAddress';
                 advanceFromBilling();
             }
         });


### PR DESCRIPTION
Closes #528

## Summary

- **Root cause:** Checkout registration created users with a NULL password hash because `User::bind()` was never called — properties were set directly on the User object, skipping the password hashing logic inside `bind()`. The subsequent `$this->app->login()` failed silently (return value was unchecked), leaving the user as a guest with `user_id=0`.
- Billing address was saved with `user_id=0` (orphaned), and re-visiting the billing step showed empty fields because the form was never refetched from the server.

## Changes

### `CheckoutController.php` (3 fixes)
1. **Use `User::bind($userData)` instead of setting properties directly** — ensures the password is hashed via `UserHelper::hashPassword()` before save
2. **Check `$this->app->login()` return value** — if login fails, return an error to the user instead of silently continuing with a guest session
3. **Re-acquire `$session` after login** — `session_fork()` regenerates the session ID; re-acquiring ensures subsequent `$session->set()` calls target the forked session

### `default.php` (2 fixes)
4. **Set `billingTask = 'billingAddress'` after successful registration** — so `advanceFromBilling()` refetches the billing form (with saved address dropdown) instead of the empty register form
5. **Add `openStep()` with `stepTaskMap`** — the "Change" link now refetches step content from the server via `fetchStep()` instead of just toggling stale DOM visibility. Applies to both billing and shipping steps.

## Files Modified

| Type | Count |
|------|-------|
| PHP (Controller) | 1 |
| PHP (Template) | 1 |

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only (non-core excluded)

## Test Plan
- [ ] Add item to cart → Checkout → select "Register Account" → Continue
- [ ] Fill billing info (name, address, etc.), set password, uncheck "same as billing" → Continue
- [ ] Verify shipping address step appears and user is logged in
- [ ] Click "Change" next to Account & Billing Details → verify saved address appears in dropdown
- [ ] Refresh page → verify user remains logged in (not redirected to login form)
- [ ] Verify new user appears in Joomla Users with a valid password hash (not NULL)