### PR TITLE
fix(a11y): add robust focus-visible styling to onboarding dashboard buttons (fixes #539)

### DIFF
--- a/media/com_j2commerce/css/administrator/category-wizard.css
+++ b/media/com_j2commerce/css/administrator/category-wizard.css
@@ -82,3 +82,13 @@
 #j2c-wizard-success-details .btn {
     justify-content: flex-start;
 }
+
+/* ---- Focus styling (a11y) ---- */
+.j2c-onboarding-footer .btn:focus-visible,
+.j2c-step .btn:focus-visible,
+.j2c-step a.btn:focus-visible,
+.j2c-step button:focus-visible {
+    outline: 2px solid var(--bs-primary, var(--primary, #0d6efd)) !important;
+    outline-offset: 2px !important;
+    box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25) !important;
+}

--- a/media/com_j2commerce/css/administrator/onboarding.css
+++ b/media/com_j2commerce/css/administrator/onboarding.css
@@ -183,9 +183,11 @@
 /* ---- Focus styling (a11y) ---- */
 .j2c-onboarding-footer .btn:focus-visible,
 .j2c-step .btn:focus-visible,
-.j2c-step a.btn:focus-visible {
-    outline: 2px solid var(--bs-primary);
-    outline-offset: 2px;
+.j2c-step a.btn:focus-visible,
+.j2c-step button:focus-visible {
+    outline: 2px solid var(--bs-primary, var(--primary, #0d6efd)) !important;
+    outline-offset: 2px !important;
+    box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25) !important;
 }
 
 /* ---- Shipping rate table (onboarding) ---- */


### PR DESCRIPTION
## Summary
Fixes #539

PR #555 attempted to add focus-visible styling for onboarding dashboard buttons, but the reporter confirmed it still doesn't work for the step 6 action buttons.

**Root cause:** Bootstrap's `.btn:focus-visible` sets `outline: 0` (using `box-shadow` instead), and Atum's `.modal .btn` overrides `box-shadow` with a decorative shadow. The `shadow-none` class on footer buttons removes `box-shadow` entirely. The original fix used `var(--bs-primary)` without a fallback — if the variable is undefined in some contexts, the entire `outline` declaration becomes invalid.

**Fix:**
- Added `!important` on `outline`, `outline-offset`, and `box-shadow` to guarantee visibility (valid accessibility use)
- Added CSS variable fallback chain: `var(--bs-primary, var(--primary, #0d6efd))` 
- Added `box-shadow` focus ring as belt-and-suspenders alongside `outline`
- Added `button:focus-visible` selector to explicitly target `<button>` elements
- Applied same fix to `category-wizard.css` for consistency

## Changes
- `media/com_j2commerce/css/administrator/onboarding.css` — Robust focus-visible selectors with fallbacks
- `media/com_j2commerce/css/administrator/category-wizard.css` — Matching focus-visible rules for consistency

## Testing
1. Open J2Commerce Dashboard → start onboarding wizard
2. Tab through footer buttons (Back, Skip, Continue) — verify blue outline + ring on each
3. Advance to step 6, tab through the 4 action buttons (Back, Add Product, Dashboard, Settings)
4. Verify each focused button shows a visible blue outline ring
5. Verify mouse click does NOT show the focus ring (keyboard-only)

## Files Changed
| Type | Count |
|------|-------|
| CSS assets | 2 |

## Pre-Flight
- [x] No PHP changes
- [x] No secrets detected
- [x] Core files only (non-core excluded)