### PR TITLE
fix(a11y): make category wizard keyboard-navigable (fixes #588)

### DIFF
--- a/administrator/components/com_j2commerce/tmpl/dashboard/default_categorywizard.php
+++ b/administrator/components/com_j2commerce/tmpl/dashboard/default_categorywizard.php
@@ -90,7 +90,7 @@ $sefRewrite = (bool) $app->get('sef_rewrite', false);
                 </div>
 
                 <!-- Step 2a: Single product name -->
-                <div class="j2c-wizard-step d-none" data-step="2a">
+                <div class="j2c-wizard-step d-none" inert data-step="2a">
                     <h5 class="mb-4"><?php echo Text::_('COM_J2COMMERCE_WIZARD_PRODUCT_NAME'); ?></h5>
                     <div class="mb-3">
                         <input type="text" class="form-control form-control-lg" id="j2c-product-name"
@@ -101,7 +101,7 @@ $sefRewrite = (bool) $app->get('sef_rewrite', false);
                 </div>
 
                 <!-- Step 3a: Product type -->
-                <div class="j2c-wizard-step d-none" data-step="3a">
+                <div class="j2c-wizard-step d-none" inert data-step="3a">
                     <h5 class="mb-4"><?php echo Text::_('COM_J2COMMERCE_WIZARD_PRODUCT_TYPE'); ?></h5>
                     <div class="row g-3">
                         <div class="col-12">
@@ -150,7 +150,7 @@ $sefRewrite = (bool) $app->get('sef_rewrite', false);
                 </div>
 
                 <!-- Step 3b: Define option titles -->
-                <div class="j2c-wizard-step d-none" data-step="3b">
+                <div class="j2c-wizard-step d-none" inert data-step="3b">
                     <h5 class="mb-4"><?php echo Text::_('COM_J2COMMERCE_WIZARD_OPTIONS_TITLE'); ?></h5>
                     <div id="j2c-option-titles-list">
                         <div class="j2c-option-title-row mb-3 d-flex gap-2 align-items-center">
@@ -166,7 +166,7 @@ $sefRewrite = (bool) $app->get('sef_rewrite', false);
                 </div>
 
                 <!-- Step 3c: Add option values -->
-                <div class="j2c-wizard-step d-none" data-step="3c">
+                <div class="j2c-wizard-step d-none" inert data-step="3c">
                     <h5 class="mb-4"><?php echo Text::_('COM_J2COMMERCE_WIZARD_OPTION_VALUES_TITLE'); ?></h5>
                     <div id="j2c-option-values-container">
                         <!-- Populated dynamically by JS based on option titles -->
@@ -174,7 +174,7 @@ $sefRewrite = (bool) $app->get('sef_rewrite', false);
                 </div>
 
                 <!-- Step 2b: Category count (multi) -->
-                <div class="j2c-wizard-step d-none" data-step="2b">
+                <div class="j2c-wizard-step d-none" inert data-step="2b">
                     <h5 class="mb-4"><?php echo Text::_('COM_J2COMMERCE_WIZARD_CATEGORY_COUNT'); ?></h5>
                     <div class="row g-3">
                         <div class="col-12 col-md-6">
@@ -214,7 +214,7 @@ $sefRewrite = (bool) $app->get('sef_rewrite', false);
                 </div>
 
                 <!-- Step: Category source (existing vs new) -->
-                <div class="j2c-wizard-step d-none" data-step="category-source">
+                <div class="j2c-wizard-step d-none" inert data-step="category-source">
                     <h5 class="mb-4"><?php echo Text::_('COM_J2COMMERCE_WIZARD_CATEGORY_SOURCE_TITLE'); ?></h5>
                     <div class="row g-3">
                         <div class="col-12">
@@ -249,7 +249,7 @@ $sefRewrite = (bool) $app->get('sef_rewrite', false);
                 </div>
 
                 <!-- Step: Select existing categories (fancy-select) -->
-                <div class="j2c-wizard-step d-none" data-step="category-select">
+                <div class="j2c-wizard-step d-none" inert data-step="category-select">
                     <h5 class="mb-4"><?php echo Text::_('COM_J2COMMERCE_WIZARD_CATEGORY_SELECT_TITLE'); ?></h5>
                     <p class="text-muted"><?php echo Text::_('COM_J2COMMERCE_WIZARD_CATEGORY_SELECT_DESC'); ?></p>
                     <div id="j2c-category-select-container">
@@ -258,7 +258,7 @@ $sefRewrite = (bool) $app->get('sef_rewrite', false);
                 </div>
 
                 <!-- Step 3b-multi: Display settings (>1 category) -->
-                <div class="j2c-wizard-step d-none" data-step="3b-multi">
+                <div class="j2c-wizard-step d-none" inert data-step="3b-multi">
                     <h5 class="mb-4"><?php echo Text::_('COM_J2COMMERCE_WIZARD_DISPLAY_SETTINGS'); ?></h5>
                     <div class="row g-3">
                         <div class="col-12">
@@ -283,7 +283,7 @@ $sefRewrite = (bool) $app->get('sef_rewrite', false);
                 </div>
 
                 <!-- Step: Category naming -->
-                <div class="j2c-wizard-step d-none" data-step="category-naming">
+                <div class="j2c-wizard-step d-none" inert data-step="category-naming">
                     <h5 class="mb-4 j2c-cat-naming-title"><?php echo Text::_('COM_J2COMMERCE_WIZARD_CATEGORY_NAME'); ?></h5>
                     <div id="j2c-category-names-container">
                         <!-- Populated by JS based on category count selection -->
@@ -295,7 +295,7 @@ $sefRewrite = (bool) $app->get('sef_rewrite', false);
                 </div>
 
                 <!-- Step: Template detection (shown only if YOOtheme + UIkit available) -->
-                <div class="j2c-wizard-step d-none" data-step="template">
+                <div class="j2c-wizard-step d-none" inert data-step="template">
                     <div class="alert alert-info">
                         <span class="fa-solid fa-circle-info me-2" aria-hidden="true"></span>
                         <?php echo Text::_('COM_J2COMMERCE_WIZARD_TEMPLATE_YOOTHEME'); ?>
@@ -322,7 +322,7 @@ $sefRewrite = (bool) $app->get('sef_rewrite', false);
                 </div>
 
                 <!-- Step: Confirmation -->
-                <div class="j2c-wizard-step d-none" data-step="confirm">
+                <div class="j2c-wizard-step d-none" inert data-step="confirm">
                     <h6 class="mb-3"><?php echo Text::_('COM_J2COMMERCE_WIZARD_CONFIRM_TITLE'); ?></h6>
                     <ul class="list-unstyled" id="j2c-wizard-summary">
                         <!-- Populated by JS -->
@@ -330,7 +330,7 @@ $sefRewrite = (bool) $app->get('sef_rewrite', false);
                 </div>
 
                 <!-- Step: Success -->
-                <div class="j2c-wizard-step d-none" data-step="success">
+                <div class="j2c-wizard-step d-none" inert data-step="success">
                     <div class="text-center py-3">
                         <span class="fa-solid fa-circle-check fa-4x text-success mb-3 d-block" aria-hidden="true"></span>
                         <h4><?php echo Text::_('COM_J2COMMERCE_WIZARD_SUCCESS_TITLE'); ?></h4>

--- a/media/com_j2commerce/css/administrator/category-wizard.css
+++ b/media/com_j2commerce/css/administrator/category-wizard.css
@@ -40,6 +40,17 @@
     box-shadow: 0 0 0 0.15rem rgba(13, 110, 253, 0.2);
 }
 
+/* Keyboard focus ring on card when hidden radio receives focus */
+.j2c-wizard-card:focus-within {
+    border-color: var(--bs-primary, #0d6efd);
+    box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25);
+}
+
+/* Remove focus ring when radio loses focus (mouse click selects differently) */
+.j2c-wizard-card input[type="radio"]:focus:not(:focus-visible) + .j2c-wizard-card-body {
+    box-shadow: none;
+}
+
 .j2c-wizard-card-body {
     padding: 0.875rem 1rem;
 }

--- a/media/com_j2commerce/js/administrator/category-wizard.js
+++ b/media/com_j2commerce/js/administrator/category-wizard.js
@@ -191,11 +191,13 @@ class CategoryWizard {
     showStep(stepKey) {
         this.el.querySelectorAll('.j2c-wizard-step').forEach((el) => {
             el.classList.add('d-none');
+            el.setAttribute('inert', '');
         });
 
         const stepEl = this.el.querySelector(`[data-step="${stepKey}"]`);
         if (stepEl) {
             stepEl.classList.remove('d-none');
+            stepEl.removeAttribute('inert');
         }
 
         this.currentStepKey = stepKey;


### PR DESCRIPTION
## Summary
Fixes #588

The category wizard modal was completely inaccessible via keyboard. Radio inputs inside wizard cards used `visually-hidden` which hides them visually but keeps them focusable — yet there was no visual focus indicator on the parent card. Additionally, hidden steps (using `d-none`) could still intercept tab focus, causing the keyboard focus to jump unpredictably.

### Changes
- **CSS**: Added `:focus-within` rule on `.j2c-wizard-card` to show a visible blue focus ring when the hidden radio receives keyboard focus
- **CSS**: Added `:focus:not(:focus-visible)` rule to suppress focus ring artifacts from mouse clicks
- **HTML**: Added `inert` attribute to all hidden wizard step divs so they cannot receive keyboard focus
- **JS**: Added `setAttribute('inert', '')` / `removeAttribute('inert')` in `showStep()` to keep inert state in sync during step transitions

### Files Modified
| Type | File |
|------|------|
| PHP | `administrator/components/com_j2commerce/tmpl/dashboard/default_categorywizard.php` |
| CSS | `media/com_j2commerce/css/administrator/category-wizard.css` |
| JS | `media/com_j2commerce/js/administrator/category-wizard.js` |

### Testing
1. Open J2Commerce Dashboard in admin
2. Open the Category Wizard modal
3. Press Tab — verify a blue focus ring appears on each wizard card sequentially
4. Press Enter/Space when a card has focus — verify it selects the option
5. Tab through the entire modal — verify focus stays within the visible step only (cannot tab into hidden steps)

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only