### PR TITLE
fix(i18n): add missing Text::script() calls for category wizard Choices.js (fixes #589)

### DIFF
--- a/administrator/components/com_j2commerce/src/View/Dashboard/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Dashboard/HtmlView.php
@@ -359,6 +359,10 @@ JS);
         Text::script('COM_J2COMMERCE_WIZARD_ERR_SELECT_CATEGORIES');
         Text::script('COM_J2COMMERCE_ERR_GENERIC');
 
+        // Joomla core strings for Choices.js select in the category wizard
+        Text::script('JGLOBAL_TYPE_OR_SELECT_SOME_OPTIONS');
+        Text::script('JGLOBAL_SELECT_NO_RESULTS_MATCH');
+
         if (!SetupGuideHelper::isComplete()) {
             HTMLHelper::_('bootstrap.offcanvas', '#j2commerce-setup-guide');
             $wa->registerAndUseScript('com_j2commerce.setup-guide', 'media/com_j2commerce/js/administrator/setup-guide.js', [], ['defer' => true]);


### PR DESCRIPTION
## Summary
Fixes #589

The Product Category Shop Wizard's Choices.js multi-select dropdown was displaying raw language keys (`JGLOBAL_TYPE_OR_SELECT_SOME_OPTIONS`, `JGLOBAL_SELECT_NO_RESULTS_MATCH`) instead of translated text because these Joomla core strings were never loaded into the JavaScript text dictionary via `Text::script()`.

## Changes
- `HtmlView.php`: Added `Text::script('JGLOBAL_TYPE_OR_SELECT_SOME_OPTIONS')` and `Text::script('JGLOBAL_SELECT_NO_RESULTS_MATCH')` to the category wizard Text::script() block

## Testing
1. Open J2Commerce dashboard
2. Open the Category Wizard (Setup Guide → Configure Menu, or any wizard trigger)
3. Select "2–10 products" → proceed through the wizard
4. When reaching the "Select your store categories" step, verify:
   - The Choices.js search placeholder shows "Type or select some options" (not the raw key)
   - Empty results show "No results found" (not `JGLOBAL_SELECT_NO_RESULTS_MATCH`)

## Files Changed
- `administrator/components/com_j2commerce/src/View/Dashboard/HtmlView.php` — Added 2 Text::script() calls for Joomla core strings used by Choices.js