### PR TITLE
fix(wizard): add missing ParameterType import in CategorywizardController (fixes #590)

### DIFF
--- a/administrator/components/com_j2commerce/src/Controller/CategorywizardController.php
+++ b/administrator/components/com_j2commerce/src/Controller/CategorywizardController.php
@@ -21,6 +21,7 @@ use Joomla\CMS\MVC\Controller\BaseController;
 use Joomla\CMS\Response\JsonResponse;
 use Joomla\CMS\Session\Session;
 use Joomla\Database\DatabaseInterface;
+use Joomla\Database\ParameterType;
 
 class CategorywizardController extends BaseController
 {


### PR DESCRIPTION
## Summary
Fixes #590

## Changes
- Added missing `use Joomla\Database\ParameterType;` import to `CategorywizardController.php`

The `createMultiProduct()` method uses `ParameterType::INTEGER` on line 300 but the class was never imported, causing a fatal error when the multi-product wizard flow processes existing category IDs. This only manifests after sample data is installed (which creates the categories users can select).

## Files Changed
- `administrator/components/com_j2commerce/src/Controller/CategorywizardController.php` — added missing import

## Testing
1. Install sample data from the J2Commerce dashboard
2. Open the Category Shop Wizard
3. Choose "2-10 products" → "2-5 categories" → "Use existing categories"
4. Select 2+ existing categories → choose display settings → confirm
5. Click "Create" — should succeed without error
6. Verify categories and menu items were created

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only