### PR TITLE
fix(sampledata): remove workflow_associations orphans on sample data removal

### DIFF
--- a/administrator/components/com_j2commerce/src/Helper/SampleDataHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/SampleDataHelper.php
@@ -574,6 +574,15 @@ final class SampleDataHelper
                 $counts['customers'] = $db->getAffectedRows();
             }
 
+            // Remove workflow associations for sample articles before deleting them
+            $db->setQuery(
+                $db->getQuery(true)
+                    ->delete($db->quoteName('#__workflow_associations'))
+                    ->whereIn($db->quoteName('item_id'), $articleIds)
+                    ->where($db->quoteName('extension') . ' = ' . $db->quote('com_content.article'))
+            );
+            $db->execute();
+
             $db->setQuery(
                 $db->getQuery(true)
                     ->delete($db->quoteName('#__content'))


### PR DESCRIPTION
## Summary
Fixes #599

When removing sample data, the `#__workflow_associations` table rows for sample articles were not deleted, leaving orphan records.

## Changes
- Added DELETE from `#__workflow_associations` for sample article IDs (with `extension = 'com_content.article'`) before deleting articles from `#__content`

## Testing
1. Load sample data via J2Commerce dashboard
2. Remove sample data via dashboard
3. Check DB: `SELECT * FROM #__workflow_associations WHERE extension = 'com_content.article'`
4. Verify: no orphan rows remain for the deleted sample article IDs

## Files Changed
- `administrator/components/com_j2commerce/src/Helper/SampleDataHelper.php` — added workflow_associations cleanup before article deletion

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] Core files only