### PR TITLE
fix(finder): prevent linked articles in Smart Search index (fixes #593)

### DIFF
--- a/administrator/components/com_j2commerce/j2commerce.xml
+++ b/administrator/components/com_j2commerce/j2commerce.xml
@@ -6,7 +6,7 @@
     <copyright>(C)2024–2026 J2Commerce, LLC. All rights reserved.</copyright>
     <authorEmail>support@j2commerce.com</authorEmail>
     <authorUrl>https://www.j2commerce.com</authorUrl>
-    <version>6.1.6</version>
+    <version>6.2.0</version>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <description>COM_J2COMMERCE_DESCRIPTION</description>
     <namespace path="src">J2Commerce\Component\J2commerce</namespace>

--- a/administrator/components/com_j2commerce/script.j2commerce.php
+++ b/administrator/components/com_j2commerce/script.j2commerce.php
@@ -160,7 +160,37 @@ class Com_J2commerceInstallerScript extends InstallerScript
             @unlink($cacheFile);
         }
 
+        // Ensure plg_finder_j2commerce runs after all other finder plugins
+        // so purgeLinkedArticlesFromIndex() catches articles indexed in the same batch
+        $this->setFinderPluginOrdering();
+
         $this->debugLog("=== POSTFLIGHT END ===");
+    }
+
+    // ── Finder plugin ordering ─────────────────────────────────────────────────
+
+    /**
+     * Set plg_finder_j2commerce ordering to 99 so it runs after all other
+     * finder plugins. This ensures purgeLinkedArticlesFromIndex() catches
+     * content articles indexed in the same batch request.
+     */
+    private function setFinderPluginOrdering(): void
+    {
+        try {
+            $db = Factory::getContainer()->get(DatabaseInterface::class);
+
+            $query = $db->getQuery(true)
+                ->update($db->quoteName('#__extensions'))
+                ->set($db->quoteName('ordering') . ' = 99')
+                ->where($db->quoteName('type') . ' = ' . $db->quote('plugin'))
+                ->where($db->quoteName('folder') . ' = ' . $db->quote('finder'))
+                ->where($db->quoteName('element') . ' = ' . $db->quote('j2commerce'));
+
+            $db->setQuery($query);
+            $db->execute();
+        } catch (\Throwable $e) {
+            $this->debugLog('setFinderPluginOrdering failed: ' . $e->getMessage());
+        }
     }
 
     // ── Default component params on fresh install ──────────────────────────────

--- a/plugins/finder/j2commerce/src/Extension/J2commerce.php
+++ b/plugins/finder/j2commerce/src/Extension/J2commerce.php
@@ -115,7 +115,6 @@ final class J2commerce extends Adapter implements SubscriberInterface
             'onFinderAfterDelete'         => 'onFinderAfterDelete',
             'onFinderBeforeSave'          => 'onFinderBeforeSave',
             'onFinderAfterSave'           => 'onFinderAfterSave',
-            'onFinderIndexAfterIndex'     => 'onFinderIndexAfterIndex',
         ]);
     }
 
@@ -369,54 +368,77 @@ final class J2commerce extends Adapter implements SubscriberInterface
     }
 
     /**
-     * Method called after an item has been indexed by Smart Search.
+     * Method to index a batch of content items.
      *
-     * This is triggered for ALL items indexed, not just J2Commerce items.
-     * We use this to detect when plg_finder_content indexes an article
-     * that has an associated J2Commerce product, and remove the duplicate
-     * article entry from the index.
+     * After each batch, removes any com_content article entries from
+     * the finder index when they have an associated J2Commerce product.
+     * This prevents duplicate search results (article AND product).
      *
-     * @param   \Joomla\Event\Event  $event  The event object containing item and linkId.
-     *
-     * @return  void
+     * @return  boolean  True on success.
      *
      * @since   6.0.0
      */
-    public function onFinderIndexAfterIndex(\Joomla\Event\Event $event): void
+    public function onBuildIndex()
     {
-        // Only process if exclusion is enabled
-        if (!$this->params->get('exclude_linked_articles', 1)) {
-            return;
+        // Purge BEFORE parent so it runs on every batch request, even after
+        // J2Commerce items are fully indexed (parent returns early at offset==total).
+        // This catches articles indexed by plg_finder_content in any prior batch.
+        if ($this->params->get('exclude_linked_articles', 1)) {
+            $this->purgeLinkedArticlesFromIndex();
         }
 
-        // Extract arguments from the event
-        // Event is triggered with: triggerEvent('onFinderIndexAfterIndex', [$item, $linkId])
-        $arguments = $event->getArguments();
-        $item      = $arguments[0] ?? null;
-        $linkId    = (int) ($arguments[1] ?? 0);
+        return parent::onBuildIndex();
+    }
 
-        if (!$item instanceof Result) {
-            return;
-        }
+    /**
+     * Remove all com_content article entries from the finder index
+     * when they have an associated enabled J2Commerce product.
+     *
+     * Uses a direct DELETE rather than Indexer::remove() to avoid
+     * Taxonomy::removeOrphanNodes() which rebuilds the nested set
+     * and breaks other plugins still indexing in the same batch.
+     * Orphaned terms and taxonomy maps are cleaned up by the
+     * Indexer::optimize() step that runs after all batches complete.
+     *
+     * @return  void
+     *
+     * @since   6.1.8
+     */
+    protected function purgeLinkedArticlesFromIndex(): void
+    {
+        try {
+            $db = $this->getDatabase();
 
-        // Check if this is a com_content article (indexed by plg_finder_content)
-        // The context is set by plg_finder_content when indexing articles
-        if (!isset($item->context) || $item->context !== 'com_content.article') {
-            return;
-        }
+            // Get all article IDs linked to enabled J2Commerce products
+            $subQuery = $db->getQuery(true)
+                ->select($db->quoteName('product_source_id'))
+                ->from($db->quoteName('#__j2commerce_products'))
+                ->where($db->quoteName('product_source') . ' = ' . $db->quote('com_content'))
+                ->where($db->quoteName('enabled') . ' = 1');
 
-        // Get the article ID from the item
-        $articleId = (int) ($item->id ?? 0);
+            $db->setQuery($subQuery);
+            $articleIds = $db->loadColumn();
 
-        if ($articleId <= 0) {
-            return;
-        }
+            if (empty($articleIds)) {
+                return;
+            }
 
-        // Check if this article has an associated J2Commerce product
-        if ($this->hasJ2CommerceProduct($articleId) && $this->indexer !== null) {
-            // Remove this article link from the index - it was just indexed by plg_finder_content
-            // but we want only the J2Commerce product to appear in search results
-            $this->indexer->remove($linkId);
+            // Build the content URLs that plg_finder_content would use
+            $urls = [];
+
+            foreach ($articleIds as $id) {
+                $urls[] = 'index.php?option=com_content&view=article&id=' . (int) $id;
+            }
+
+            // Delete these links from the finder index
+            $query = $db->getQuery(true)
+                ->delete($db->quoteName('#__finder_links'))
+                ->whereIn($db->quoteName('url'), $urls, ParameterType::STRING);
+
+            $db->setQuery($query);
+            $db->execute();
+        } catch (\Throwable $e) {
+            // Silently ignore — don't break the indexing process
         }
     }
 
@@ -890,21 +912,14 @@ final class J2commerce extends Adapter implements SubscriberInterface
         // Build the URL that plg_finder_content would use for this article
         $articleUrl = 'index.php?option=com_content&view=article&id=' . $articleId;
 
-        // Find and remove the article from the finder links table
+        // Delete directly — orphaned terms/maps are cleaned up by optimize()
         $query = $db->getQuery(true)
-            ->select($db->quoteName('link_id'))
-            ->from($db->quoteName('#__finder_links'))
+            ->delete($db->quoteName('#__finder_links'))
             ->where($db->quoteName('url') . ' = :url')
             ->bind(':url', $articleUrl);
 
         $db->setQuery($query);
-        $linkIds = $db->loadColumn();
-
-        if (!empty($linkIds)) {
-            foreach ($linkIds as $linkId) {
-                $this->indexer->remove((int) $linkId);
-            }
-        }
+        $db->execute();
     }
 
     /**


### PR DESCRIPTION
## Summary
Fixes #593 — Supersedes #595

Smart Search indexing caused `MapTable::_getNode()` errors because removing duplicate article entries triggered `Taxonomy::removeOrphanNodes()` mid-batch, corrupting the nested set tree for other plugins still indexing.

## Changes
- **Replace per-item removal with batch-level purge** — `onBuildIndex()` override calls `purgeLinkedArticlesFromIndex()` before parent processing on every batch request, catching articles indexed by plg_finder_content in any prior batch
- **Direct DELETE from `#__finder_links`** — avoids `Indexer::remove()` and its taxonomy rebuild entirely; orphaned data cleaned up by `Indexer::optimize()` after all batches
- **Plugin ordering set to 99** — `script.j2commerce.php` postflight ensures plg_finder_j2commerce runs after all other finder plugins, so the purge always catches articles from the same batch
- **Simplified `removeArticleFromIndex()`** — single DELETE query for article saves (used by `onFinderAfterSave`)
- **Removed `onFinderIndexAfterIndex`** — unreliable event dispatching replaced by the batch-level approach
- **Bumped manifest version** to 6.2.0 to match SQL update files

## Files Modified
| Type | Count |
|------|-------|
| PHP files | 2 |
| XML/Config | 1 |

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only

## Testing
1. Components > Smart Search > Index → click "Index"
2. Verify: completes without errors
3. Verify: J2Commerce products appear in search results
4. Verify: articles linked to J2Commerce products do NOT appear
5. Clear index, rebuild — same results