### PR TITLE
fix(onboarding): close modal on Explore Dashboard click (fixes #596)

### DIFF
--- a/administrator/components/com_j2commerce/tmpl/dashboard/default_onboarding.php
+++ b/administrator/components/com_j2commerce/tmpl/dashboard/default_onboarding.php
@@ -727,10 +727,10 @@ $e = fn(string $s): string => htmlspecialchars($s, ENT_QUOTES, 'UTF-8');
               </a>
             </div>
             <div class="col-md-3">
-              <a href="index.php?option=com_j2commerce&view=dashboard" class="btn btn-outline-primary w-100 shadow-none" data-action="close-onboarding">
+              <button type="button" class="btn btn-outline-primary w-100 shadow-none" data-action="close-onboarding">
                 <span class="fa-solid fa-gauge-high me-1" aria-hidden="true"></span>
                 <?php echo Text::_('COM_J2COMMERCE_ONBOARDING_READY_DASHBOARD'); ?>
-              </a>
+              </button>
             </div>
             <div class="col-md-3">
               <a href="index.php?option=com_config&view=component&component=com_j2commerce" class="btn btn-outline-secondary w-100 shadow-none">

--- a/media/com_j2commerce/js/administrator/onboarding.js
+++ b/media/com_j2commerce/js/administrator/onboarding.js
@@ -559,6 +559,11 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
                 break;
             }
+            case 'close-onboarding': {
+                e.preventDefault();
+                modalInstance.hide();
+                break;
+            }
             case 'dismiss-onboarding': {
                 const confirmed = window.confirm(Joomla.Text._('COM_J2COMMERCE_ONBOARDING_DISMISS_CONFIRM'));
                 if (!confirmed) return;


### PR DESCRIPTION
## Summary
Fixes #596

The "Explore Dashboard" button on the final onboarding step was an `<a>` link that navigated back to the dashboard URL. Since the user is already on the dashboard, this caused the page to reload and potentially re-show the onboarding wizard for skipped steps.

## Changes
- Changed the "Explore Dashboard" `<a>` tag to a `<button>` to prevent navigation
- Added `close-onboarding` handler in `onboarding.js` that closes the modal via `modalInstance.hide()`

## Files Modified
| Type | Count |
|------|-------|
| PHP (template) | 1 |
| JS assets | 1 |

## Test Plan
- [ ] Open admin dashboard, rerun onboarding (`&rerun_onboarding=1`)
- [ ] Skip steps 2-4, complete step 5 to reach step 6
- [ ] Click "Explore Dashboard"
- [ ] Verify: modal closes, dashboard visible, wizard does NOT reappear

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only