### PR TITLE
fix(headers): replace obsolete cache-control directives with modern standards

### DIFF
--- a/administrator/components/com_j2commerce/src/Controller/ReportpluginController.php
+++ b/administrator/components/com_j2commerce/src/Controller/ReportpluginController.php
@@ -153,9 +153,9 @@ class ReportpluginController extends BaseController
         // Set headers for CSV download
         $app->setHeader('Content-Type', 'text/csv; charset=utf-8');
         $app->setHeader('Content-Disposition', 'attachment; filename="' . $csvFilename . '"');
-        $app->setHeader('Pragma', 'public');
+        $app->setHeader('Cache-Control', 'no-store, no-cache, must-revalidate');
+        $app->setHeader('Pragma', 'no-cache');
         $app->setHeader('Expires', '0');
-        $app->setHeader('Cache-Control', 'must-revalidate, post-check=0, pre-check=0');
         $app->sendHeaders();
 
         // Output CSV

--- a/administrator/components/com_j2commerce/src/Controller/ReportsController.php
+++ b/administrator/components/com_j2commerce/src/Controller/ReportsController.php
@@ -138,9 +138,9 @@ class ReportsController extends AdminController
         // Set headers for CSV download
         $app->setHeader('Content-Type', 'text/csv; charset=utf-8');
         $app->setHeader('Content-Disposition', 'attachment; filename="' . $csvFilename . '"');
-        $app->setHeader('Pragma', 'public');
+        $app->setHeader('Cache-Control', 'no-store, no-cache, must-revalidate');
+        $app->setHeader('Pragma', 'no-cache');
         $app->setHeader('Expires', '0');
-        $app->setHeader('Cache-Control', 'must-revalidate, post-check=0, pre-check=0');
         $app->sendHeaders();
 
         // Output CSV

--- a/administrator/components/com_j2commerce/src/Helper/UtilitiesHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/UtilitiesHelper.php
@@ -129,9 +129,8 @@ class UtilitiesHelper
         }
 
         header('Cache-Control: no-store, no-cache, must-revalidate');
-        header('Cache-Control: post-check=0, pre-check=0', false);
         header('Pragma: no-cache');
-        header('Expires: Wed, 17 Sep 1975 21:32:10 GMT');
+        header('Expires: 0');
 
         return true;
     }


### PR DESCRIPTION
## Summary
Fixes #608

Removes IE8-era `post-check=0, pre-check=0` directives and standardizes all cache-control headers to the modern pattern recommended in the issue.

## Changes
- **UtilitiesHelper.php** — Removed obsolete `post-check=0, pre-check=0` second header line and replaced quirky 1975 Expires date with `0`
- **ReportsController.php** — Replaced `Pragma: public` + obsolete directives with `no-store, no-cache, must-revalidate` + `Pragma: no-cache`
- **ReportpluginController.php** — Same fix as ReportsController

All three now use the consistent modern pattern:
```
Cache-Control: no-store, no-cache, must-revalidate
Pragma: no-cache
Expires: 0
```

## Files Changed
| Type | Count |
|------|-------|
| PHP files | 3 |

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only (non-core excluded)