### PR TITLE
fix(a11y): replace invalid h5 heading with div in order history timeline

### DIFF
--- a/administrator/components/com_j2commerce/tmpl/order/view_history.php
+++ b/administrator/components/com_j2commerce/tmpl/order/view_history.php
@@ -103,9 +103,9 @@ $currentUserId = (int) (Factory::getApplication()->getIdentity()?->id ?? 0);
                             <div class="col<?php echo $col1; ?>"></div>
                             <div class="col"></div>
                         </div>
-                        <h5 class="m-2">
+                        <div class="m-2 fs-5 j2c-history-indicator">
                             <span class="<?php echo $this->escape($icon); ?>" aria-hidden="true"></span>
-                        </h5>
+                        </div>
                         <div class="row h-50">
                             <div class="col<?php echo $col2; ?>"></div>
                             <div class="col"></div>


### PR DESCRIPTION
## Summary
Fixes #614

## Changes
- Replaced semantically invalid `<h5>` element with `<div>` in the order history timeline
- Added `fs-5` class to preserve Bootstrap h5 font-size (1.25rem)
- Added `j2c-history-indicator` class as a styling hook for future customization

## Files Modified
| Type | Count |
|------|-------|
| PHP template | 1 |

## Testing
1. Navigate to J2Commerce > Orders
2. Click any order to view it
3. Check the History timeline — icons should display identically with proper spacing
4. Inspect elements to confirm `<div class="m-2 fs-5 j2c-history-indicator">` instead of `<h5>`

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only (non-core excluded)