### PR TITLE
fix(a11y): add proper label for product filter input

### DIFF
--- a/administrator/components/com_j2commerce/tmpl/product/form_ajax_avfilter.php
+++ b/administrator/components/com_j2commerce/tmpl/product/form_ajax_avfilter.php
@@ -72,7 +72,7 @@ $productFilters = (new ProductfiltersModel)->getFiltersByProduct($item->j2commer
         <?php endif;?>
         <tr class="j2commerce_a_filter">
             <td colspan="2">
-                <small><strong><?php echo Text::_('COM_J2COMMERCE_SEARCH_AND_PRODUCT_FILTERS');?></strong></small>
+                <label for="J2CommerceproductFilter" class="form-label fw-semibold small"><?php echo Text::_('COM_J2COMMERCE_SEARCH_AND_PRODUCT_FILTERS');?></label>
                 <?php echo LayoutHelper::render('joomla.form.field.text', ['name'  => 'productfilter','id'    => 'J2CommerceproductFilter','value' => '','class' => 'form-control ms-2',] + $textFieldDefaults);?>
             </td>
         </tr>


### PR DESCRIPTION
## Summary
Fixes #612

## Changes
- Replaced `<small><strong>` wrapper with a proper `<label for="J2CommerceproductFilter">` element
- Visual styling preserved via Bootstrap classes (`form-label fw-semibold small`)

## Testing
1. Navigate to J2Commerce > Products > Edit any product
2. Open the "Filters" tab
3. Click the "Search and add product filters" label text
4. Verify the input field receives focus
5. Inspect with DevTools — confirm `<label for="J2CommerceproductFilter">`

## Files Changed
- `administrator/components/com_j2commerce/tmpl/product/form_ajax_avfilter.php` — replaced inline markup with accessible label

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] Core files only