### PR TITLE
fix(ui): remove redundant Available Shortcodes toolbar button and offcanvas

### DIFF
--- a/administrator/components/com_j2commerce/src/View/Emailtemplate/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Emailtemplate/HtmlView.php
@@ -144,7 +144,6 @@ class HtmlView extends BaseHtmlView
 
         HTMLHelper::_('bootstrap.modal', '#sendTestModal');
         HTMLHelper::_('bootstrap.modal', '#loadTemplateModal');
-        HTMLHelper::_('bootstrap.offcanvas', '#shortcodesOffcanvas');
 
         $bodySource = $this->item->body_source ?? 'visual';
 
@@ -245,12 +244,6 @@ class HtmlView extends BaseHtmlView
                 . Text::_('COM_J2COMMERCE_EMAILTEMPLATE_LOAD_TEMPLATE')
                 . '</button>');
 
-        // View Shortcodes button (opens offcanvas)
-        $toolbar->customButton('viewShortcodes')
-            ->html('<button type="button" class="btn btn-outline-info" data-bs-toggle="offcanvas" data-bs-target="#shortcodesOffcanvas">'
-                . '<span class="icon-tags me-1" aria-hidden="true"></span>'
-                . Text::_('COM_J2COMMERCE_EMAILTEMPLATE_SHORTCODES')
-                . '</button>');
 
         $toolbar->divider();
         $toolbar->help('J2Commerce_Email_Template', false, 'https://docs.j2commerce.com/design/email-templates');

--- a/administrator/components/com_j2commerce/src/View/Invoicetemplate/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Invoicetemplate/HtmlView.php
@@ -61,7 +61,6 @@ class HtmlView extends BaseHtmlView
         $this->addToolbar();
 
         HTMLHelper::_('bootstrap.modal', '#loadTemplateModal');
-        HTMLHelper::_('bootstrap.offcanvas', '#shortcodesOffcanvas');
 
         $bodySource = $this->item->body_source ?? 'editor';
 
@@ -163,11 +162,6 @@ class HtmlView extends BaseHtmlView
                 . Text::_('COM_J2COMMERCE_INVOICETEMPLATE_LOAD_TEMPLATE')
                 . '</button>');
 
-        $toolbar->customButton('viewShortcodes')
-            ->html('<button type="button" class="btn btn-outline-info me-1" data-bs-toggle="offcanvas" data-bs-target="#shortcodesOffcanvas">'
-                . '<span class="icon-tags me-2" aria-hidden="true"></span>'
-                . Text::_('COM_J2COMMERCE_INVOICETEMPLATE_SHORTCODES')
-                . '</button>');
 
         $toolbar->customButton('printTest')
             ->html('<button type="button" class="btn btn-success" id="btn-print-test">'

--- a/administrator/components/com_j2commerce/tmpl/emailtemplate/edit.php
+++ b/administrator/components/com_j2commerce/tmpl/emailtemplate/edit.php
@@ -210,7 +210,7 @@ document.addEventListener("DOMContentLoaded", function() {
         });
     }
 
-    // Shortcode search filter (offcanvas + sidebar)
+    // Shortcode search filter (sidebar)
     function applyShortcodeSearch(container, term) {
         container.querySelectorAll(".shortcode-group").forEach(function(group) {
             const btns = group.querySelectorAll(".shortcode-btn");
@@ -222,13 +222,6 @@ document.addEventListener("DOMContentLoaded", function() {
                 if (visible) hasVisible = true;
             });
             group.style.display = hasVisible ? "" : "none";
-        });
-    }
-
-    const searchInput = document.getElementById("shortcode-search");
-    if (searchInput) {
-        searchInput.addEventListener("input", function() {
-            applyShortcodeSearch(document.getElementById("shortcodesOffcanvas"), this.value.toLowerCase());
         });
     }
 
@@ -275,21 +268,6 @@ document.addEventListener("DOMContentLoaded", function() {
                 const json = await response.json();
 
                 if (json.success) {
-                    // Update offcanvas sidebar
-                    const offcanvasBody = document.querySelector("#shortcodesOffcanvas .offcanvas-body");
-                    if (offcanvasBody) {
-                        const searchEl = offcanvasBody.querySelector("#shortcode-search");
-                        const searchHtml = searchEl ? searchEl.outerHTML : "";
-                        offcanvasBody.innerHTML = (searchHtml ? "<div class=\"mb-3\">" + searchHtml + "</div>" : "") + json.html;
-                        bindShortcodeButtons(offcanvasBody);
-                        const newSearch = offcanvasBody.querySelector("#shortcode-search");
-                        if (newSearch) {
-                            newSearch.addEventListener("input", function() {
-                                applyShortcodeSearch(offcanvasBody, this.value.toLowerCase());
-                            });
-                        }
-                    }
-
                     // Update inline sidebar
                     const sidebarContent = document.querySelector("#shortcodes-sidebar-col .options-form > div[style]");
                     if (sidebarContent) {
@@ -608,22 +586,6 @@ $tmpl = $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=component' : '';
         </div>
     </div>
 
-    <!-- Shortcodes Offcanvas Sidebar (opened from toolbar) -->
-    <div class="offcanvas offcanvas-end" tabindex="-1" id="shortcodesOffcanvas" aria-labelledby="shortcodesOffcanvasLabel" style="width: 380px;">
-        <div class="offcanvas-header">
-            <h5 class="offcanvas-title" id="shortcodesOffcanvasLabel">
-                <span class="icon-tags me-1" aria-hidden="true"></span>
-                <?php echo Text::_('COM_J2COMMERCE_EMAILTEMPLATE_SHORTCODES'); ?>
-            </h5>
-            <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="<?php echo Text::_('JCLOSE'); ?>"></button>
-        </div>
-        <div class="offcanvas-body">
-            <div class="mb-3">
-                <input type="text" class="form-control form-control-sm" id="shortcode-search" placeholder="<?php echo Text::_('COM_J2COMMERCE_EMAILTEMPLATE_SEARCH_SHORTCODES'); ?>">
-            </div>
-            <?php echo $this->loadTemplate('shortcodes_list'); ?>
-        </div>
-    </div>
 
     <input type="hidden" name="task" value="">
     <?php echo HTMLHelper::_('form.token'); ?>

--- a/administrator/components/com_j2commerce/tmpl/invoicetemplate/edit.php
+++ b/administrator/components/com_j2commerce/tmpl/invoicetemplate/edit.php
@@ -168,12 +168,12 @@ document.addEventListener("DOMContentLoaded", function() {
         });
     }
 
-    // Shortcode search filter (offcanvas)
-    const searchInput = document.getElementById("shortcode-search");
-    if (searchInput) {
-        searchInput.addEventListener("input", function() {
+    // Shortcode search filter (sidebar)
+    const sidebarSearch = document.getElementById("shortcode-search-sidebar");
+    if (sidebarSearch) {
+        sidebarSearch.addEventListener("input", function() {
             const term = this.value.toLowerCase();
-            document.querySelectorAll(".shortcode-group").forEach(function(group) {
+            document.querySelectorAll("#shortcodes-sidebar-col .shortcode-group").forEach(function(group) {
                 const btns = group.querySelectorAll(".shortcode-btn");
                 let hasVisible = false;
                 btns.forEach(function(btn) {
@@ -416,22 +416,6 @@ $tmpl   = $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=component' : '
         </div>
     </div>
 
-    <!-- Shortcodes Offcanvas Sidebar (opened from toolbar) -->
-    <div class="offcanvas offcanvas-end" tabindex="-1" id="shortcodesOffcanvas" aria-labelledby="shortcodesOffcanvasLabel" style="width: 380px;">
-        <div class="offcanvas-header">
-            <h5 class="offcanvas-title" id="shortcodesOffcanvasLabel">
-                <span class="icon-tags me-1" aria-hidden="true"></span>
-                <?php echo Text::_('COM_J2COMMERCE_INVOICETEMPLATE_SHORTCODES'); ?>
-            </h5>
-            <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="<?php echo Text::_('JCLOSE'); ?>"></button>
-        </div>
-        <div class="offcanvas-body">
-            <div class="mb-3">
-                <input type="text" class="form-control form-control-sm" id="shortcode-search" placeholder="<?php echo Text::_('COM_J2COMMERCE_INVOICETEMPLATE_SEARCH_SHORTCODES'); ?>">
-            </div>
-            <?php echo $this->loadTemplate('shortcodes_list'); ?>
-        </div>
-    </div>
 
     <input type="hidden" name="task" value="">
     <input type="hidden" name="j2commerce_invoicetemplate_id" value="<?php echo (int) $this->item->j2commerce_invoicetemplate_id; ?>">


### PR DESCRIPTION
## Summary
Fixes #617

## Changes
- Removed "Available Shortcodes" toolbar button from email and invoice template editors
- Removed offcanvas HTML panel from both template editors
- Removed Bootstrap offcanvas initialization from both HtmlView files
- Removed offcanvas-specific JavaScript (search handler, AJAX update)
- Wired invoice template sidebar search input to correct `#shortcode-search-sidebar` element

## Files Modified
| Type | Count |
|------|-------|
| PHP Views | 2 |
| PHP Templates | 2 |

## Testing
1. Navigate to J2Commerce > Design > Email Templates, edit any template
2. Verify no "Available Shortcodes" button in toolbar, sidebar shortcodes still visible
3. Change email type — verify sidebar shortcodes update via AJAX
4. Navigate to J2Commerce > Design > Invoice Templates, edit any template
5. Verify same — no toolbar button, sidebar works, sidebar search filters correctly

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only (non-core excluded)
- [x] No language file changes needed (keys still used by sidebar legend)