### PR TITLE
fix(emailtemplate): guard null element for non-super-admin ACL

### DIFF
--- a/administrator/components/com_j2commerce/src/View/Emailtemplate/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Emailtemplate/HtmlView.php
@@ -63,7 +63,7 @@ class HtmlView extends BaseHtmlView
             $bodySourceField = $this->form->getField('body_source');
             if ($bodySourceField) {
                 $element = $bodySourceField->__get('element');
-                foreach ($element->children() as $option) {
+                foreach ($element ? $element->children() : [] as $option) {
                     if ((string) $option['value'] === 'file') {
                         $dom = dom_import_simplexml($option);
                         $dom->parentNode->removeChild($dom);


### PR DESCRIPTION
## Summary
Fixes #615

## Changes
- Added null guard on `$element` before calling `->children()` in the email template HtmlView
- When `$bodySourceField->__get('element')` returns null for non-super-admin users, the foreach now safely iterates over an empty array instead of throwing a fatal error

## Testing
1. Log in as an administrator (not super admin)
2. Navigate to J2Commerce > Email Templates
3. Edit an existing template or create a new one
4. Verify: no error, page loads correctly

## Files Changed
- `administrator/components/com_j2commerce/src/View/Emailtemplate/HtmlView.php` — null guard on element children loop

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] Core files only