### PR TITLE
fix(checkout): prevent duplicate order emails on AJAX payment

### DIFF
--- a/components/com_j2commerce/src/Controller/CheckoutController.php
+++ b/components/com_j2commerce/src/Controller/CheckoutController.php
@@ -1397,7 +1397,12 @@ class CheckoutController extends BaseController
             $orderTable->load(['order_id' => $orderId]);
         }
 
-        if (isset($orderTable->order_id) && !empty($orderTable->order_id)) {
+        // The paction=display call is the confirmation page after an AJAX
+        // payment (paction=process) already sent emails and dispatched
+        // AfterPayment.  Only fire these for the initial payment path.
+        $paction = $this->input->getString('paction', '');
+
+        if (isset($orderTable->order_id) && !empty($orderTable->order_id) && $paction !== 'display') {
             $results = J2CommerceHelper::plugin()->eventWithArray('AfterPayment', [$orderTable]);
 
             foreach ($results as $result) {
@@ -1411,8 +1416,6 @@ class CheckoutController extends BaseController
         // Clear cart only after confirmed success. When paction=process and
         // the plugin did NOT redirect, payment likely failed — preserve cart.
         // Cart is cleared on the subsequent paction=display call instead.
-        $paction = $this->input->getString('paction', '');
-
         if ($paction !== 'process') {
             $this->clearCartAndSession($orderId, $session);
         }


### PR DESCRIPTION
## Core Update

### Changes
Fixes a bug where AJAX payment plugins (PayTrace, Stripe, etc.) triggered **duplicate customer and admin order confirmation emails**.

**Root cause:** For AJAX payment flows, `confirmPayment()` runs twice:
1. `paction=process` — processes the payment, dispatches `AfterPayment`, sends emails
2. `paction=display` — confirmation page redirect — was **re-dispatching** `AfterPayment` and calling `sendOrderEmails()` again

**Fix:** Added a `$paction !== 'display'` guard so `AfterPayment` and `sendOrderEmails()` only fire on the initial payment path. Traditional non-AJAX redirect payments are unaffected.

### Files Modified
| Type | Count |
|------|-------|
| PHP files | 1 |

- `components/com_j2commerce/src/Controller/CheckoutController.php`

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Code style (php-cs-fixer) passed
- [x] Core files only (non-core excluded)