### PR TITLE
Remove description attribute from enabled list field in filter form

### DIFF
--- a/administrator/components/com_j2commerce/forms/filter_invoicetemplates.xml
+++ b/administrator/components/com_j2commerce/forms/filter_invoicetemplates.xml
@@ -14,7 +14,6 @@
             name="enabled"
             type="list"
             label="JOPTION_SELECT_PUBLISHED"
-            description="JOPTION_SELECT_PUBLISHED_DESC"
             onchange="this.form.submit();"
             class="form-select"
         >


### PR DESCRIPTION
The desc string doesnt exist so it creates invalid markup