### PR TITLE
fix(myprofile): make Print button work on single-order view

### DIFF
--- a/components/com_j2commerce/tmpl/myprofile/order.php
+++ b/components/com_j2commerce/tmpl/myprofile/order.php
@@ -283,6 +283,33 @@ $statusName = !empty($order->orderstatus_name) ? Text::_($order->orderstatus_nam
     <?php endif; ?>
 </div>
 
+<?php if (!$isPrint): ?>
+<!-- Order Print Modal (shared with myprofile dashboard) -->
+<div class="modal fade" id="j2commerceOrderModal" tabindex="-1" aria-labelledby="j2commerceOrderModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-xl modal-dialog-scrollable">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="j2commerceOrderModalLabel"><?php echo Text::_('COM_J2COMMERCE_ORDER_PRINT'); ?></h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="<?php echo Text::_('JCLOSE'); ?>"></button>
+            </div>
+            <div class="modal-body" id="j2commerceOrderModalBody">
+                <div class="text-center py-5">
+                    <div class="spinner-border" role="status">
+                        <span class="visually-hidden"><?php echo Text::_('COM_J2COMMERCE_LOADING'); ?></span>
+                    </div>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal"><?php echo Text::_('JCLOSE'); ?></button>
+                <button type="button" class="btn btn-primary" id="j2commerceOrderPrintBtn">
+                    <span class="icon-print" aria-hidden="true"></span> <?php echo Text::_('COM_J2COMMERCE_ORDER_PRINT'); ?>
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+<?php endif; ?>
+
 <?php if ($isPrint): ?>
 <script>window.print();</script>
 <?php endif; ?>


### PR DESCRIPTION
## Summary

Fixes #637

The **Print** button on the single-order view in *My Profile → View order* did nothing. The `.j2commerce-order-print` click handler in `myprofile.js` assumes the `#j2commerceOrderModal` Bootstrap modal is present on the page — true on the myprofile dashboard (`default.php`), but the modal markup was not in the single-order view (`order.php`). The handler called `preventDefault()` and then bailed silently when the modal lookup failed.

## Changes

- Added the `#j2commerceOrderModal` Bootstrap modal markup to `components/com_j2commerce/tmpl/myprofile/order.php`, wrapped in `!$isPrint` so it doesn't appear inside the print popup itself.
- Markup is identical to the modal already defined in `default.php` (same IDs, same language keys, same classes), so the Print button now behaves **exactly** like the one in the orders list on the myprofile dashboard.
- No JS changes — `HtmlView::display()` already registers `myprofile.js` and calls `HTMLHelper::_('bootstrap.modal', 'j2commerceOrderModal')` on every layout, so the modal infrastructure was already in place.

## Testing

1. Log in to the frontend, navigate to **My Profile**
2. Orders tab → click the print icon (`.icon-print`) next to an order → modal opens with order content (regression check; unchanged behaviour)
3. Click **View** on any order to load the single-order view (`layout=order`)
4. Click the **Print** button at the top right
5. Verify the same modal opens, the spinner shows, then the order content loads
6. Click the modal's **Print** button → verify the print popup opens and auto-prints

## Files Changed

- `components/com_j2commerce/tmpl/myprofile/order.php` — added the Order Print Modal markup (27 lines, wrapped in `!$isPrint`)