### PR TITLE
Add leading backslashes to function calls for PHP global scope

### DIFF
--- a/administrator/components/com_j2commerce/version.php
+++ b/administrator/components/com_j2commerce/version.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @package     J2Commerce
  * @subpackage  com_j2commerce
@@ -8,10 +9,10 @@
  */
 
 // No direct access
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 // Version constants for J2Commerce
-define('J2COMMERCE_PRO', true);
-define('J2COMMERCE_VERSION', '6.2.0');
-define('J2COMMERCE_EXTRA_VERSION', '');
-define('J2COMMERCE_DATE', '2026-04-09');
+\define('J2COMMERCE_PRO', true);
+\define('J2COMMERCE_VERSION', '6.2.0');
+\define('J2COMMERCE_EXTRA_VERSION', '');
+\define('J2COMMERCE_DATE', '2026-04-09');


### PR DESCRIPTION
this was missed by me in the original code style fix pr