### PR TITLE
feat(admin): add Badge Style config (Atum vs J2Commerce) (fixes #627)

### DIFF
--- a/administrator/components/com_j2commerce/config.xml
+++ b/administrator/components/com_j2commerce/config.xml
@@ -84,6 +84,17 @@
         />
 
         <field
+            name="badge_style"
+            type="list"
+            label="COM_J2COMMERCE_CONFIG_BADGE_STYLE"
+            description="COM_J2COMMERCE_CONFIG_BADGE_STYLE_DESC"
+            default="atum"
+        >
+            <option value="atum">COM_J2COMMERCE_CONFIG_BADGE_STYLE_ATUM</option>
+            <option value="j2commerce">COM_J2COMMERCE_CONFIG_BADGE_STYLE_J2COMMERCE</option>
+        </field>
+
+        <field
             name="spacer_store_1"
             type="spacer"
             hr="true"

--- a/administrator/components/com_j2commerce/language/en-GB/com_j2commerce.ini
+++ b/administrator/components/com_j2commerce/language/en-GB/com_j2commerce.ini
@@ -1173,6 +1173,10 @@ COM_J2COMMERCE_CRON_LAST_TRIGGER_NOT_FOUND="Cron has not been triggered yet."
 COM_J2COMMERCE_CRON_LAST_TRIGGER_DETAILS="Last triggered: %s from URL: %s (IP: %s)"
 COM_J2COMMERCE_CONFIG_QUEUE_REPEAT_COUNT="Maximum Queue Repeat"
 COM_J2COMMERCE_CONFIG_QUEUE_REPEAT_COUNT_DESC="Set maximum queue repeat for Queue system."
+COM_J2COMMERCE_CONFIG_BADGE_STYLE="Badge Style"
+COM_J2COMMERCE_CONFIG_BADGE_STYLE_DESC="Choose how status badges are rendered in the administrator. Atum Style uses the classic Joomla core look (bg-*). J2Commerce Style uses the Bootstrap 5.2 combined class (text-bg-*) which automatically pairs background and text colours for contrast."
+COM_J2COMMERCE_CONFIG_BADGE_STYLE_ATUM="Atum Style"
+COM_J2COMMERCE_CONFIG_BADGE_STYLE_J2COMMERCE="J2Commerce Style"
 
 ; ===========================================
 ; Configuration - Updates

--- a/administrator/components/com_j2commerce/language/en-US/com_j2commerce.ini
+++ b/administrator/components/com_j2commerce/language/en-US/com_j2commerce.ini
@@ -1173,6 +1173,10 @@ COM_J2COMMERCE_CRON_LAST_TRIGGER_NOT_FOUND="Cron has not been triggered yet."
 COM_J2COMMERCE_CRON_LAST_TRIGGER_DETAILS="Last triggered: %s from URL: %s (IP: %s)"
 COM_J2COMMERCE_CONFIG_QUEUE_REPEAT_COUNT="Maximum Queue Repeat"
 COM_J2COMMERCE_CONFIG_QUEUE_REPEAT_COUNT_DESC="Set maximum queue repeat for Queue system."
+COM_J2COMMERCE_CONFIG_BADGE_STYLE="Badge Style"
+COM_J2COMMERCE_CONFIG_BADGE_STYLE_DESC="Choose how status badges are rendered in the administrator. Atum Style uses the classic Joomla core look (bg-*). J2Commerce Style uses the Bootstrap 5.2 combined class (text-bg-*) which automatically pairs background and text colors for contrast."
+COM_J2COMMERCE_CONFIG_BADGE_STYLE_ATUM="Atum Style"
+COM_J2COMMERCE_CONFIG_BADGE_STYLE_J2COMMERCE="J2Commerce Style"
 
 ; ===========================================
 ; Configuration - Updates

--- a/administrator/components/com_j2commerce/layouts/dashboard/quickicon.php
+++ b/administrator/components/com_j2commerce/layouts/dashboard/quickicon.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 defined('_JEXEC') or die;
 
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2htmlHelper;
 use Joomla\CMS\Language\Text;
 
 $id      = empty($displayData['id']) ? '' : (' id="' . $displayData['id'] . '"');
@@ -62,7 +63,7 @@ if (isset($displayData['linkadd'])) : ?>
                     <div class="quickicon-name d-flex align-items-end" <?php echo isset($displayData['ajaxurl']) ? ' aria-hidden="true"' : ''; ?>>
                         <?php echo Text::_($displayData['name']); ?>
                         <?php if (!empty($displayData['badge'])) : ?>
-                            <span class="badge text-bg-<?php echo $this->escape($displayData['class'] ?? 'secondary'); ?> ms-2"><?php echo $this->escape($displayData['badge']); ?></span>
+                            <span class="<?php echo J2htmlHelper::badgeClass('badge text-bg-' . $this->escape($displayData['class'] ?? 'secondary')); ?> ms-2"><?php echo $this->escape($displayData['badge']); ?></span>
                         <?php endif; ?>
                     </div>
                 <?php endif; ?>
@@ -71,7 +72,7 @@ if (isset($displayData['linkadd'])) : ?>
                     <div class="quickicon-name d-flex align-items-center">
                         <?php echo $text; ?>
                         <?php if (!empty($displayData['badge'])) : ?>
-                            <span class="badge text-bg-<?php echo $this->escape($displayData['class'] ?? 'secondary'); ?> ms-2"><?php echo $this->escape($displayData['badge']); ?></span>
+                            <span class="<?php echo J2htmlHelper::badgeClass('badge text-bg-' . $this->escape($displayData['class'] ?? 'secondary')); ?> ms-2"><?php echo $this->escape($displayData['badge']); ?></span>
                         <?php endif; ?>
                     </div>
                 <?php endif; ?>

--- a/administrator/components/com_j2commerce/layouts/widget/liveusers.php
+++ b/administrator/components/com_j2commerce/layouts/widget/liveusers.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 defined('_JEXEC') or die;
 
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2htmlHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\User\UserFactoryInterface;
@@ -30,21 +31,21 @@ $userFactory = Factory::getContainer()->get(UserFactoryInterface::class);
 <div class="card j2commerce-liveusers-widget" id="j2commerce-liveusers">
     <div class="card-header d-flex justify-content-between align-items-center">
         <h2 class="mb-0 fs-4"><span class="fa-solid fa-users me-2 text-info" aria-hidden="true"></span><?php echo Text::_('COM_J2COMMERCE_LIVE_USERS'); ?></h2>
-        <span class="badge text-bg-success"><?php echo $total; ?></span>
+        <span class="<?php echo J2htmlHelper::badgeClass('badge text-bg-success'); ?>"><?php echo $total; ?></span>
     </div>
     <div class="card-body">
         <?php if ($total > 0) : ?>
         <div class="row">
             <div class="col-2 stats-sidebar">
-                <div class="report-stat-box p-2 text-bg-success mb-2 text-center">
+                <div class="report-stat-box p-2 <?php echo J2htmlHelper::badgeClass('text-bg-success'); ?> mb-2 text-center">
                     <div class="fs-2 fw-bold j2commerce-liveusers-total"><?php echo $total; ?></div>
                     <div class="report-stat-title small"><?php echo Text::_('COM_J2COMMERCE_LIVE_USERS_TOTAL'); ?></div>
                 </div>
-                <div class="report-stat-box p-2 text-bg-info mb-2 text-center">
+                <div class="report-stat-box p-2 <?php echo J2htmlHelper::badgeClass('text-bg-info'); ?> mb-2 text-center">
                     <div class="fs-2 fw-bold j2commerce-liveusers-registered"><?php echo $registered; ?></div>
                     <div class="report-stat-title small"><?php echo Text::_('COM_J2COMMERCE_LIVE_USERS_REGISTERED'); ?></div>
                 </div>
-                <div class="report-stat-box p-2 text-bg-warning text-center">
+                <div class="report-stat-box p-2 <?php echo J2htmlHelper::badgeClass('text-bg-warning'); ?> text-center">
                     <div class="fs-2 fw-bold j2commerce-liveusers-guests"><?php echo $guests; ?></div>
                     <div class="report-stat-title small"><?php echo Text::_('COM_J2COMMERCE_LIVE_USERS_GUESTS'); ?></div>
                 </div>

--- a/administrator/components/com_j2commerce/src/Builder/sublayouts/item-images/view-edit.php
+++ b/administrator/components/com_j2commerce/src/Builder/sublayouts/item-images/view-edit.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 
 defined('_JEXEC') or die;
 
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2htmlHelper;
+
 extract($displayData);
 
 $productName = htmlspecialchars($product->product_name ?? 'Product', ENT_QUOTES, 'UTF-8');
@@ -24,7 +26,7 @@ $showDiscountPercentage = true;
 <j2c-conditional data-condition="$showImage">
     <div class="j2commerce-product-image position-relative border mb-3">
         <j2c-conditional data-condition="$showDiscountPercentage && $basePrice > 0">
-            <span class="discount-percentage badge text-bg-info position-absolute top-0 start-0 mt-2 ms-2 mt-lg-3 ms-lg-3">
+            <span class="discount-percentage <?php echo J2htmlHelper::badgeClass('badge text-bg-info'); ?> position-absolute top-0 start-0 mt-2 ms-2 mt-lg-3 ms-lg-3">
                 <?php
                 $discount = ($basePrice > 0) ? (1 - ($salePrice / $basePrice)) * 100 : 0;
                 echo ($discount > 0) ? round($discount) . '% Off' : '';

--- a/administrator/components/com_j2commerce/src/Controller/OrdersController.php
+++ b/administrator/components/com_j2commerce/src/Controller/OrdersController.php
@@ -15,6 +15,7 @@ namespace J2Commerce\Component\J2commerce\Administrator\Controller;
 \defined('_JEXEC') or die;
 
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2htmlHelper;
 use Joomla\CMS\Application\CMSApplication;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
@@ -184,7 +185,7 @@ class OrdersController extends AdminController
                 'message' => Text::sprintf('COM_J2COMMERCE_ORDER_STATUS_UPDATED_TO', Text::_($statusInfo->orderstatus_name ?? '')),
                 'data'    => [
                     'statusName' => Text::_($statusInfo->orderstatus_name ?? ''),
-                    'cssclass'   => $statusInfo->orderstatus_cssclass ?? 'badge text-bg-secondary',
+                    'cssclass'   => J2htmlHelper::badgeClass($statusInfo->orderstatus_cssclass ?? 'badge text-bg-secondary'),
                 ],
             ];
         } catch (\Exception $e) {

--- a/administrator/components/com_j2commerce/src/Helper/J2htmlHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/J2htmlHelper.php
@@ -14,12 +14,38 @@ namespace J2Commerce\Component\J2commerce\Administrator\Helper;
 
 \defined('_JEXEC') or die;
 
+use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\Database\ParameterType;
 
 class J2htmlHelper
 {
+    /**
+     * Cached badge style preference ('atum' or 'j2commerce').
+     */
+    private static ?string $badgeStyle = null;
+
+    /**
+     * Transforms a badge CSS class string to match the configured
+     * badge style. When set to "atum" the helper strips the `text-`
+     * prefix from `text-bg-*` classes, leaving plain `bg-*`. When set
+     * to "j2commerce" the classes are returned unchanged.
+     */
+    public static function badgeClass(string $classes): string
+    {
+        if (self::$badgeStyle === null) {
+            $params           = ComponentHelper::getParams('com_j2commerce');
+            self::$badgeStyle = (string) $params->get('badge_style', 'atum');
+        }
+
+        if (self::$badgeStyle === 'atum') {
+            return preg_replace('/\btext-bg-/', 'bg-', $classes);
+        }
+
+        return $classes;
+    }
+
     public static function getOrderStatusHtml(int $id): string
     {
         if ($id <= 0) {
@@ -45,6 +71,8 @@ class J2htmlHelper
         if ($cssClass === 'badge-important') {
             $cssClass = 'badge text-bg-dark';
         }
+
+        $cssClass = self::badgeClass($cssClass);
 
         return '<span class="' . htmlspecialchars($cssClass, ENT_QUOTES, 'UTF-8') . '">'
             . Text::_($item->orderstatus_name) . '</span>';

--- a/administrator/components/com_j2commerce/tmpl/analytics/default.php
+++ b/administrator/components/com_j2commerce/tmpl/analytics/default.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 defined('_JEXEC') or die;
 
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2htmlHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\ModuleHelper;
 use Joomla\CMS\HTML\HTMLHelper;
@@ -231,7 +232,7 @@ $changeHtml = function (array $change): string {
                                         <div class="progress-bar" role="progressbar" style="width:<?php echo $stage['rate']; ?>%;background-color:rgba(54,162,235,<?php echo $stage['opacity']; ?>)" aria-valuenow="<?php echo $stage['rate']; ?>" aria-valuemin="0" aria-valuemax="100"><?php echo $stage['rate']; ?>%</div>
                                     </div>
                                 </div>
-                                <span class="badge text-bg-info"><?php echo (int) $stage['count']; ?></span>
+                                <span class="<?php echo J2htmlHelper::badgeClass('badge text-bg-info'); ?>"><?php echo (int) $stage['count']; ?></span>
                             </div>
                         <?php endforeach; ?>
                     </div>
@@ -254,7 +255,7 @@ $changeHtml = function (array $change): string {
             <div class="card h-100" id="j2commerce-sessions-widget">
                 <div class="card-header d-flex justify-content-between align-items-center">
                     <h2 class="mb-0 fs-4"><span class="fa-solid fa-chart-line me-2 text-info" aria-hidden="true"></span><?php echo Text::_('COM_J2COMMERCE_ANALYTICS_SESSIONS_BY_TIME'); ?></h2>
-                    <span class="badge text-bg-<?php echo $this->sessionsTotal > 0 ? 'success' : 'warning'; ?>" id="badge-sessions-total"><?php echo $this->sessionsTotal; ?></span>
+                    <span class="<?php echo J2htmlHelper::badgeClass('badge text-bg-' . ($this->sessionsTotal > 0 ? 'success' : 'warning')); ?>" id="badge-sessions-total"><?php echo $this->sessionsTotal; ?></span>
                 </div>
                 <div class="card-body">
                     <div style="height:200px"><canvas id="chart-sessions"></canvas></div>
@@ -265,7 +266,7 @@ $changeHtml = function (array $change): string {
             <div class="card h-100" id="j2commerce-conversions-widget">
                 <div class="card-header d-flex justify-content-between align-items-center">
                     <h2 class="mb-0 fs-4"><span class="fa-solid fa-chart-area me-2 text-info" aria-hidden="true"></span><?php echo Text::_('COM_J2COMMERCE_ANALYTICS_CONVERSIONS_BY_TIME'); ?></h2>
-                    <span class="badge text-bg-<?php echo $this->conversionsTotal > 0 ? 'success' : 'warning'; ?>" id="badge-conversions-total"><?php echo $this->conversionsTotal; ?></span>
+                    <span class="<?php echo J2htmlHelper::badgeClass('badge text-bg-' . ($this->conversionsTotal > 0 ? 'success' : 'warning')); ?>" id="badge-conversions-total"><?php echo $this->conversionsTotal; ?></span>
                 </div>
                 <div class="card-body">
                     <div style="height:200px"><canvas id="chart-conversions"></canvas></div>

--- a/administrator/components/com_j2commerce/tmpl/apps/default.php
+++ b/administrator/components/com_j2commerce/tmpl/apps/default.php
@@ -9,6 +9,7 @@
 
 defined('_JEXEC') or die;
 
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2htmlHelper;
 use Joomla\CMS\Button\PublishedButton;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
@@ -171,7 +172,7 @@ $return = rawurlencode($encodedReturn);
                                                     <span class="text-dark"><?php echo $item->display_name; ?></span>
                                                 <?php endif; ?>
                                                 <?php if ($item->folder !== 'j2commerce'): ?>
-                                                    <span class="badge text-bg-info ms-1"><?php echo $this->escape($item->folder); ?></span>
+                                                    <span class="<?php echo J2htmlHelper::badgeClass('badge text-bg-info'); ?> ms-1"><?php echo $this->escape($item->folder); ?></span>
                                                 <?php endif; ?>
                                             </div>
                                             <div class="small d-none d-md-block"><?php echo $desc; ?></div>

--- a/administrator/components/com_j2commerce/tmpl/coupons/default.php
+++ b/administrator/components/com_j2commerce/tmpl/coupons/default.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 defined('_JEXEC') or die;
 
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2htmlHelper;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
@@ -147,9 +148,9 @@ if ($saveOrder && !empty($this->items)) {
                                 </td>
                                 <td class="d-none d-md-table-cell text-center">
                                     <?php if ($item->is_expired) : ?>
-                                        <span class="badge text-bg-danger"><?php echo Text::_('COM_J2COMMERCE_COUPON_EXPIRED'); ?></span>
+                                        <span class="<?php echo J2htmlHelper::badgeClass('badge text-bg-danger'); ?>"><?php echo Text::_('COM_J2COMMERCE_COUPON_EXPIRED'); ?></span>
                                     <?php else : ?>
-                                        <span class="badge text-bg-success"><?php echo Text::_('COM_J2COMMERCE_COUPON_ACTIVE'); ?></span>
+                                        <span class="<?php echo J2htmlHelper::badgeClass('badge text-bg-success'); ?>"><?php echo Text::_('COM_J2COMMERCE_COUPON_ACTIVE'); ?></span>
                                     <?php endif; ?>
                                 </td>
                                 <td class="d-none d-lg-table-cell">

--- a/administrator/components/com_j2commerce/tmpl/customfield/edit.php
+++ b/administrator/components/com_j2commerce/tmpl/customfield/edit.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 defined('_JEXEC') or die;
 
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2htmlHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
@@ -344,7 +345,7 @@ document.addEventListener('DOMContentLoaded', function() {
         }
 
         if (fieldWidth) {
-            html += '<div class="mt-2"><span class="badge text-bg-secondary">' + esc(fieldWidth) + '</span></div>';
+            html += '<div class="mt-2"><span class="<?php echo J2htmlHelper::badgeClass('badge text-bg-secondary'); ?>">' + esc(fieldWidth) + '</span></div>';
         }
         preview.innerHTML = html;
     }

--- a/administrator/components/com_j2commerce/tmpl/customfields/default.php
+++ b/administrator/components/com_j2commerce/tmpl/customfields/default.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 defined('_JEXEC') or die;
 
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2htmlHelper;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
@@ -118,9 +119,9 @@ if ($saveOrder && !empty($this->items)) {
                                 </td>
                                 <td class="text-center d-none d-md-table-cell">
                                     <?php if ($item->field_required == 1) : ?>
-                                        <span class="badge text-bg-success"><?php echo Text::_('COM_J2COMMERCE_REQUIRED'); ?></span>
+                                        <span class="<?php echo J2htmlHelper::badgeClass('badge text-bg-success'); ?>"><?php echo Text::_('COM_J2COMMERCE_REQUIRED'); ?></span>
                                     <?php else : ?>
-                                        <span class="badge text-bg-danger"><?php echo Text::_('COM_J2COMMERCE_NOT_REQUIRED'); ?></span>
+                                        <span class="<?php echo J2htmlHelper::badgeClass('badge text-bg-danger'); ?>"><?php echo Text::_('COM_J2COMMERCE_NOT_REQUIRED'); ?></span>
                                     <?php endif; ?>
                                 </td>
                                 <td>
@@ -128,11 +129,11 @@ if ($saveOrder && !empty($this->items)) {
                                 </td>
                                 <td class="text-center d-none d-md-table-cell">
                                     <?php if ($item->field_core == 1) : ?>
-                                        <span class="badge text-bg-success">
+                                        <span class="<?php echo J2htmlHelper::badgeClass('badge text-bg-success'); ?>">
                                             <?php echo Text::_('COM_J2COMMERCE_CORE_FIELD_YES'); ?>
                                         </span>
                                     <?php else : ?>
-                                        <span class="badge text-bg-secondary">
+                                        <span class="<?php echo J2htmlHelper::badgeClass('badge text-bg-secondary'); ?>">
                                             <?php echo Text::_('COM_J2COMMERCE_CORE_FIELD_NO'); ?>
                                         </span>
                                     <?php endif; ?>

--- a/administrator/components/com_j2commerce/tmpl/inventory/default.php
+++ b/administrator/components/com_j2commerce/tmpl/inventory/default.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2htmlHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
@@ -412,7 +413,7 @@ document.addEventListener("DOMContentLoaded", function() {
                                                     <div class="col-md-3">
                                                         <strong>
                                                             <?php if ($variant->is_master) : ?>
-                                                                <span class="badge text-bg-success me-1"><?php echo Text::_('COM_J2COMMERCE_MASTER'); ?></span>
+                                                                <span class="<?php echo J2htmlHelper::badgeClass('badge text-bg-success'); ?> me-1"><?php echo Text::_('COM_J2COMMERCE_MASTER'); ?></span>
                                                             <?php endif; ?>
                                                             <?php echo Text::_('COM_J2COMMERCE_VARIANT'); ?> #<?php echo $variant->j2commerce_variant_id; ?>
                                                         </strong>

--- a/administrator/components/com_j2commerce/tmpl/order/edit_basic.php
+++ b/administrator/components/com_j2commerce/tmpl/order/edit_basic.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 defined('_JEXEC') or die;
 
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2htmlHelper;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
@@ -53,7 +54,7 @@ $item = $this->item;
         <div class="mb-3">
             <label class="form-label"><?php echo Text::_('COM_J2COMMERCE_FIELD_ORDER_STATUS'); ?></label>
             <div>
-                <span class="<?php echo $this->escape($item->orderstatus_cssclass ?? 'badge text-bg-secondary'); ?>">
+                <span class="<?php echo $this->escape(J2htmlHelper::badgeClass($item->orderstatus_cssclass ?? 'badge text-bg-secondary')); ?>">
                     <?php echo Text::_($item->orderstatus_name ?? 'Unknown'); ?>
                 </span>
             </div>

--- a/administrator/components/com_j2commerce/tmpl/order/view.php
+++ b/administrator/components/com_j2commerce/tmpl/order/view.php
@@ -13,6 +13,7 @@ defined('_JEXEC') or die;
 
 use J2Commerce\Component\J2commerce\Administrator\Helper\ImageHelper;
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2htmlHelper;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
@@ -49,7 +50,7 @@ if (empty($customerName)) {
                     <div class="j2-title-top d-flex align-items-center mb-1">
                         <h2 class="h3 mb-0 order-id">#<?php echo $this->escape($item->invoice); ?></h2>
                         <div class="ms-2 fw-normal fs-5">(<b><?php echo $this->escape($item->order_id); ?></b>)</div>
-                        <div class="<?php echo $this->escape($item->orderstatus_cssclass ?? 'badge text-bg-secondary'); ?> ms-2" id="orderStatusBadge">
+                        <div class="<?php echo $this->escape(J2htmlHelper::badgeClass($item->orderstatus_cssclass ?? 'badge text-bg-secondary')); ?> ms-2" id="orderStatusBadge">
                             <?php echo Text::_($item->orderstatus_name ?? 'Unknown'); ?>
                         </div>
                     </div>

--- a/administrator/components/com_j2commerce/tmpl/order/view_details.php
+++ b/administrator/components/com_j2commerce/tmpl/order/view_details.php
@@ -13,6 +13,7 @@ defined('_JEXEC') or die;
 
 use J2Commerce\Component\J2commerce\Administrator\Helper\ImageHelper;
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2htmlHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\Registry\Registry;
@@ -133,7 +134,7 @@ if ($hasDetails) {
                                                 default                            => 'text-bg-dark',
                                             };
                                             ?>
-                                            <span class="d-inline-block badge <?php echo $statusClass; ?>"><?php echo $this->escape($item->transaction_status); ?></span>
+                                            <span class="d-inline-block <?php echo J2htmlHelper::badgeClass('badge ' . $statusClass); ?>"><?php echo $this->escape($item->transaction_status); ?></span>
                                         </div>
                                     <?php endif; ?>
                                 </div>

--- a/administrator/components/com_j2commerce/tmpl/order/view_history.php
+++ b/administrator/components/com_j2commerce/tmpl/order/view_history.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 defined('_JEXEC') or die;
 
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2htmlHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
@@ -32,7 +33,7 @@ $currentUserId = (int) (Factory::getApplication()->getIdentity()?->id ?? 0);
     <div class="card-header d-flex justify-content-between align-items-center px-0">
         <h4 class="card-title mb-0"><?php echo Text::_('COM_J2COMMERCE_ORDER_HISTORY'); ?></h4>
         <?php if ($totalItems > 0) : ?>
-            <span class="badge text-bg-secondary"><?php echo $totalItems; ?></span>
+            <span class="<?php echo J2htmlHelper::badgeClass('badge text-bg-secondary'); ?>"><?php echo $totalItems; ?></span>
         <?php endif; ?>
     </div>
 
@@ -126,7 +127,7 @@ $currentUserId = (int) (Factory::getApplication()->getIdentity()?->id ?? 0);
                                 </div>
                                 <?php if (!empty($history->order_state_id)) : ?>
                                     <h4 class="card-title small mb-1">
-                                        <span class="badge rounded-2 px-2 text-bg-<?php echo $this->escape($foundColor); ?>">
+                                        <span class="<?php echo J2htmlHelper::badgeClass('badge rounded-2 px-2 text-bg-' . $this->escape($foundColor)); ?>">
                                             <?php echo $this->escape(Text::_($history->orderstatus_name ?? 'Unknown')); ?>
                                         </span>
                                     </h4>

--- a/administrator/components/com_j2commerce/tmpl/order/view_sidebar.php
+++ b/administrator/components/com_j2commerce/tmpl/order/view_sidebar.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 defined('_JEXEC') or die;
 
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2htmlHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
@@ -88,13 +89,13 @@ if ($orderInfo) {
                 </div>
                 <div class="col-3 stats-sidebar">
                     <?php if ($this->customerDays > 0) : ?>
-                        <div class="report-stat-box p-2 text-bg-success mb-2 text-center">
+                        <div class="report-stat-box p-2 <?php echo J2htmlHelper::badgeClass('text-bg-success'); ?> mb-2 text-center">
                             <div class="fs-2 fw-bold j2commerce-customer-age"><?php echo $this->customerDays;?></div>
                             <div class="report-stat-title small"><?php echo Text::_('COM_J2COMMERCE_CUSTOMER_AGE');?></div>
                         </div>
                     <?php endif; ?>
                     <?php if ($this->totalSales > 0) : ?>
-                        <div class="report-stat-box p-2 text-bg-info mb-2 text-center">
+                        <div class="report-stat-box p-2 <?php echo J2htmlHelper::badgeClass('text-bg-info'); ?> mb-2 text-center">
                             <div class="fs-2 fw-bold j2commerce-customer-orders"><?php echo $this->totalSales;?></div>
                             <div class="report-stat-title small"><?php echo Text::_('COM_J2COMMERCE_CUSTOMER_ORDERS');?></div>
                         </div>

--- a/administrator/components/com_j2commerce/tmpl/orders/default.php
+++ b/administrator/components/com_j2commerce/tmpl/orders/default.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 defined('_JEXEC') or die;
 
 use J2Commerce\Component\J2commerce\Administrator\Helper\CurrencyHelper;
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2htmlHelper;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
@@ -133,7 +134,7 @@ $dateFormat = ComponentHelper::getParams('com_j2commerce')->get('date_format', '
                                     <small><?php echo $this->escape(strip_tags($paymentDisplay)); ?></small>
                                 </td>
                                 <td class="text-center">
-                                    <span class="order-status-badge <?php echo $this->escape($item->orderstatus_cssclass ?? 'badge text-bg-secondary'); ?>">
+                                    <span class="order-status-badge <?php echo $this->escape(J2htmlHelper::badgeClass($item->orderstatus_cssclass ?? 'badge text-bg-secondary')); ?>">
                                         <?php echo Text::_($item->orderstatus_name ?? 'COM_J2COMMERCE_UNKNOWN'); ?>
                                     </span>
                                 </td>

--- a/administrator/components/com_j2commerce/tmpl/overrides/default_overrides.php
+++ b/administrator/components/com_j2commerce/tmpl/overrides/default_overrides.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2htmlHelper;
 use J2Commerce\Component\J2commerce\Administrator\Service\OverrideRegistry;
 
 /** @var \J2Commerce\Component\J2commerce\Administrator\View\Overrides\HtmlView $this */
@@ -82,7 +83,7 @@ $wa->addInlineStyle($style);
                                 <div class="flex-grow-1">
                                     <div class="d-flex align-items-center gap-2 mb-2">
                                         <span class="fw-semibold"><?php echo Text::_($subtemplate['name']); ?></span>
-                                        <span class="badge text-bg-secondary">
+                                        <span class="<?php echo J2htmlHelper::badgeClass('badge text-bg-secondary'); ?>">
                                             <?php echo Text::plural('COM_J2COMMERCE_OVERRIDE_FILES_COUNT', $layoutCount); ?>
                                         </span>
                                     </div>
@@ -92,7 +93,7 @@ $wa->addInlineStyle($style);
                                 </div>
                                 <div class="d-flex align-items-center gap-2 me-3">
                                     <?php if ($activeCount > 0) : ?>
-                                        <span class="badge text-bg-success">
+                                        <span class="<?php echo J2htmlHelper::badgeClass('badge text-bg-success'); ?>">
                                             <span class="icon-check me-1" aria-hidden="true"></span>
                                             <?php echo Text::plural('COM_J2COMMERCE_OVERRIDE_N_ACTIVE', $activeCount); ?>
                                         </span>
@@ -125,11 +126,11 @@ $wa->addInlineStyle($style);
                                                                 <h5 class="card-title mb-0">
                                                                     <?php echo $this->escape($file['displayName'] ?? $file['filename']); ?>
                                                                     <?php if (($file['context'] ?? '') === 'tag') : ?>
-                                                                        <span class="ms-1 badge text-bg-purple">Tag</span>
+                                                                        <span class="ms-1 <?php echo J2htmlHelper::badgeClass('badge text-bg-purple'); ?>">Tag</span>
                                                                     <?php endif; ?>
                                                                 </h5>
                                                                 <?php if ($file['hasOverride'] ?? false) : ?>
-                                                                    <span class="badge text-bg-success ms-2 flex-shrink-0">
+                                                                    <span class="<?php echo J2htmlHelper::badgeClass('badge text-bg-success'); ?> ms-2 flex-shrink-0">
                                                                         <span class="icon-check" aria-hidden="true"></span>
                                                                         <?php echo Text::_('COM_J2COMMERCE_OVERRIDE_ACTIVE'); ?>
                                                                     </span>

--- a/administrator/components/com_j2commerce/tmpl/product/form.php
+++ b/administrator/components/com_j2commerce/tmpl/product/form.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 
 use J2Commerce\Component\J2commerce\Administrator\Helper\ImageHelper;
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2htmlHelper;
 use J2Commerce\Component\J2commerce\Administrator\Field\ProductTypeField;
 use J2Commerce\Component\J2commerce\Administrator\View\Product\HtmlView;
 use Joomla\CMS\Factory;
@@ -204,9 +205,9 @@ $wa->addInlineScript($submitButtonJs);
                                     <span class="data-key"><?php echo Text::_('COM_J2COMMERCE_MANAGE_INVENTORY'); ?></span>
                                     <span class="data-val">
                                         <?php if($variantStats['manage_inventory_yes'] > 0){
-                                            echo '<span class="badge text-bg-success">'.Text::_('JYES').'</span>';
+                                            echo '<span class="'.J2htmlHelper::badgeClass('badge text-bg-success').'">'.Text::_('JYES').'</span>';
                                         } else {
-                                            echo '<span class="badge text-bg-danger">'.Text::_('JNO').'</span>';
+                                            echo '<span class="'.J2htmlHelper::badgeClass('badge text-bg-danger').'">'.Text::_('JNO').'</span>';
                                         }
                                         ?>
                                     </span>
@@ -219,9 +220,9 @@ $wa->addInlineScript($submitButtonJs);
                                     <span class="data-key"><?php echo Text::_('COM_J2COMMERCE_SHIPPING'); ?></span>
                                     <span class="data-val">
                                         <?php if($variantStats['shipping_enabled'] > 0){
-                                            echo '<span class="badge text-bg-success">'.Text::_('JYES').'</span>';
+                                            echo '<span class="'.J2htmlHelper::badgeClass('badge text-bg-success').'">'.Text::_('JYES').'</span>';
                                         } else {
-                                            echo '<span class="badge text-bg-danger">'.Text::_('JNO').'</span>';
+                                            echo '<span class="'.J2htmlHelper::badgeClass('badge text-bg-danger').'">'.Text::_('JNO').'</span>';
                                         }
                                         ?>
                                     </span>
@@ -234,9 +235,9 @@ $wa->addInlineScript($submitButtonJs);
                                     <span class="data-key"><?php echo Text::_('COM_J2COMMERCE_RELATIONS'); ?></span>
                                     <span class="data-val">
                                         <?php if($hasRelations){
-                                            echo '<span class="badge text-bg-success">'.Text::_('JYES').'</span>';
+                                            echo '<span class="'.J2htmlHelper::badgeClass('badge text-bg-success').'">'.Text::_('JYES').'</span>';
                                         } else {
-                                            echo '<span class="badge text-bg-danger">'.Text::_('JNO').'</span>';
+                                            echo '<span class="'.J2htmlHelper::badgeClass('badge text-bg-danger').'">'.Text::_('JNO').'</span>';
                                         }
                                         ?>
                                     </span>

--- a/administrator/components/com_j2commerce/tmpl/products/default.php
+++ b/administrator/components/com_j2commerce/tmpl/products/default.php
@@ -13,6 +13,7 @@ defined('_JEXEC') or die;
 
 use J2Commerce\Component\J2commerce\Administrator\Field\ProductTypeField;
 use J2Commerce\Component\J2commerce\Administrator\Helper\CurrencyHelper;
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2htmlHelper;
 use Joomla\CMS\Button\PublishedButton;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
@@ -176,16 +177,16 @@ $canChangeState = $user->authorise('core.edit.state', 'com_content');
                                 </td>
                                 <td class="text-center d-none d-lg-table-cell">
                                     <?php if ($item->shipping) : ?>
-                                        <span class="badge text-bg-success"><?php echo Text::_('COM_J2COMMERCE_ENABLED'); ?></span>
+                                        <span class="<?php echo J2htmlHelper::badgeClass('badge text-bg-success'); ?>"><?php echo Text::_('COM_J2COMMERCE_ENABLED'); ?></span>
                                     <?php else : ?>
-                                        <span class="badge text-bg-danger"><?php echo Text::_('COM_J2COMMERCE_DISABLED'); ?></span>
+                                        <span class="<?php echo J2htmlHelper::badgeClass('badge text-bg-danger'); ?>"><?php echo Text::_('COM_J2COMMERCE_DISABLED'); ?></span>
                                     <?php endif; ?>
                                 </td>
                                 <td class="text-center d-none d-lg-table-cell">
                                     <?php if ($item->visibility) : ?>
-                                        <span class="badge text-bg-success"><?php echo Text::_('JYES'); ?></span>
+                                        <span class="<?php echo J2htmlHelper::badgeClass('badge text-bg-success'); ?>"><?php echo Text::_('JYES'); ?></span>
                                     <?php else : ?>
-                                        <span class="badge text-bg-danger"><?php echo Text::_('JNO'); ?></span>
+                                        <span class="<?php echo J2htmlHelper::badgeClass('badge text-bg-danger'); ?>"><?php echo Text::_('JNO'); ?></span>
                                     <?php endif; ?>
                                 </td>
                                 <td class="text-center d-none d-md-table-cell">

--- a/administrator/components/com_j2commerce/tmpl/products/modal_multiselect.php
+++ b/administrator/components/com_j2commerce/tmpl/products/modal_multiselect.php
@@ -12,6 +12,7 @@ defined('_JEXEC') or die;
 use J2Commerce\Component\J2commerce\Administrator\Field\ProductTypeField;
 use J2Commerce\Component\J2commerce\Administrator\Helper\CurrencyHelper;
 use J2Commerce\Component\J2commerce\Administrator\Helper\ImageHelper;
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2htmlHelper;
 use Joomla\CMS\Button\PublishedButton;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
@@ -244,9 +245,9 @@ $canChangeState = $user->authorise('core.edit.state', 'com_content');
                         </td>
                         <td class="text-center d-none d-md-table-cell">
                             <?php if ($item->shipping) : ?>
-                                <span class="badge text-bg-success"><?php echo Text::_('COM_J2COMMERCE_ENABLED'); ?></span>
+                                <span class="<?php echo J2htmlHelper::badgeClass('badge text-bg-success'); ?>"><?php echo Text::_('COM_J2COMMERCE_ENABLED'); ?></span>
                             <?php else : ?>
-                                <span class="badge text-bg-danger"><?php echo Text::_('COM_J2COMMERCE_DISABLED'); ?></span>
+                                <span class="<?php echo J2htmlHelper::badgeClass('badge text-bg-danger'); ?>"><?php echo Text::_('COM_J2COMMERCE_DISABLED'); ?></span>
                             <?php endif; ?>
                         </td>
                         <td class="text-center d-none d-md-table-cell">

--- a/administrator/components/com_j2commerce/tmpl/queuelogs/default.php
+++ b/administrator/components/com_j2commerce/tmpl/queuelogs/default.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 defined('_JEXEC') or die;
 
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2htmlHelper;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
@@ -90,7 +91,7 @@ $statusBadges = [
                         <tbody>
                         <?php foreach ($this->items as $i => $item) : ?>
                             <?php
-                            $badgeClass = $statusBadges[$item->status] ?? 'bg-secondary';
+                            $badgeClass = J2htmlHelper::badgeClass($statusBadges[$item->status] ?? 'bg-secondary');
                             $durationMs = (int) $item->duration_ms;
                             $duration   = $durationMs >= 1000
                                 ? number_format($durationMs / 1000, 1) . 's'
@@ -121,38 +122,38 @@ $statusBadges = [
                                 </td>
                                 <td class="d-none d-md-table-cell">
                                     <?php if ($successCount > 0) : ?>
-                                        <a href="#" class="badge text-bg-success text-decoration-none js-queuelog-details"
+                                        <a href="#" class="<?php echo J2htmlHelper::badgeClass('badge text-bg-success'); ?> text-decoration-none js-queuelog-details"
                                            data-details="<?php echo $this->escape($detailsJson); ?>"
                                            data-filter="completed"
                                            data-title="<?php echo $this->escape(Text::sprintf('COM_J2COMMERCE_QUEUE_LOG_SUCCESSFUL_ITEMS', $successCount)); ?>">
                                             <?php echo $successCount; ?>
                                         </a>
                                     <?php else : ?>
-                                        <span class="badge text-bg-light">0</span>
+                                        <span class="<?php echo J2htmlHelper::badgeClass('badge text-bg-light'); ?>">0</span>
                                     <?php endif; ?>
                                 </td>
                                 <td class="d-none d-md-table-cell">
                                     <?php if ($failedCount > 0) : ?>
-                                        <a href="#" class="badge text-bg-danger text-decoration-none js-queuelog-details"
+                                        <a href="#" class="<?php echo J2htmlHelper::badgeClass('badge text-bg-danger'); ?> text-decoration-none js-queuelog-details"
                                            data-details="<?php echo $this->escape($detailsJson); ?>"
                                            data-filter="failed"
                                            data-title="<?php echo $this->escape(Text::sprintf('COM_J2COMMERCE_QUEUE_LOG_FAILED_ITEMS', $failedCount)); ?>">
                                             <?php echo $failedCount; ?>
                                         </a>
                                     <?php else : ?>
-                                        <span class="badge text-bg-light">0</span>
+                                        <span class="<?php echo J2htmlHelper::badgeClass('badge text-bg-light'); ?>">0</span>
                                     <?php endif; ?>
                                 </td>
                                 <td class="d-none d-lg-table-cell">
                                     <?php if ($skippedCount > 0) : ?>
-                                        <a href="#" class="badge text-bg-warning text-decoration-none js-queuelog-details"
+                                        <a href="#" class="<?php echo J2htmlHelper::badgeClass('badge text-bg-warning'); ?> text-decoration-none js-queuelog-details"
                                            data-details="<?php echo $this->escape($detailsJson); ?>"
                                            data-filter="skipped"
                                            data-title="<?php echo $this->escape(Text::sprintf('COM_J2COMMERCE_QUEUE_LOG_SKIPPED_ITEMS', $skippedCount)); ?>">
                                             <?php echo $skippedCount; ?>
                                         </a>
                                     <?php else : ?>
-                                        <span class="badge text-bg-light">0</span>
+                                        <span class="<?php echo J2htmlHelper::badgeClass('badge text-bg-light'); ?>">0</span>
                                     <?php endif; ?>
                                 </td>
                                 <td class="d-none d-md-table-cell">
@@ -249,7 +250,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 html += '<td>' + esc(item.id) + '</td>';
                 html += '<td>' + esc(item.item_type) + '</td>';
                 html += '<td>' + esc(item.relation_id) + '</td>';
-                html += '<td><span class="badge ' + (item.status === 'completed' ? 'text-bg-success' : item.status === 'failed' ? 'text-bg-danger' : 'text-bg-warning') + '">' + esc(statusMap[item.status] || item.status) + '</span></td>';
+                html += '<td><span class="badge ' + (item.status === 'completed' ? '<?php echo J2htmlHelper::badgeClass('text-bg-success'); ?>' : item.status === 'failed' ? '<?php echo J2htmlHelper::badgeClass('text-bg-danger'); ?>' : '<?php echo J2htmlHelper::badgeClass('text-bg-warning'); ?>') + '">' + esc(statusMap[item.status] || item.status) + '</span></td>';
                 if (showError) {
                     html += '<td><small class="text-danger">' + esc(item.error || '&mdash;') + '</small></td>';
                 }

--- a/administrator/components/com_j2commerce/tmpl/queues/default.php
+++ b/administrator/components/com_j2commerce/tmpl/queues/default.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 defined('_JEXEC') or die;
 
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2htmlHelper;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
@@ -92,7 +93,7 @@ $statusBadges = [
                         </thead>
                         <tbody>
                         <?php foreach ($this->items as $i => $item) : ?>
-                            <?php $badgeClass = $statusBadges[$item->status] ?? 'bg-secondary'; ?>
+                            <?php $badgeClass = J2htmlHelper::badgeClass($statusBadges[$item->status] ?? 'bg-secondary'); ?>
                             <tr class="row<?php echo $i % 2; ?>">
                                 <td class="text-center">
                                     <?php echo HTMLHelper::_('grid.id', $i, $item->j2commerce_queue_id, false, 'cid', 'cb', $item->relation_id); ?>

--- a/administrator/components/com_j2commerce/tmpl/shippingtroubles/default_shipping.php
+++ b/administrator/components/com_j2commerce/tmpl/shippingtroubles/default_shipping.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2htmlHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
@@ -48,7 +49,7 @@ function getStatusBadge($status, $message = '') {
             $icon = 'fa-question-circle';
     }
 
-    return '<span class="badge ' . $badgeClass . '"><span class="fa-solid ' . $icon . ' me-1" aria-hidden="true"></span>' . Text::_($message) . '</span>';
+    return '<span class="' . J2htmlHelper::badgeClass('badge ' . $badgeClass) . '"><span class="fa-solid ' . $icon . ' me-1" aria-hidden="true"></span>' . Text::_($message) . '</span>';
 }
 
 

--- a/administrator/components/com_j2commerce/tmpl/shippingtroubles/default_shipping_product.php
+++ b/administrator/components/com_j2commerce/tmpl/shippingtroubles/default_shipping_product.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2htmlHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
@@ -61,7 +62,7 @@ function getProductStatusBadge($status) {
             $text = 'COM_J2COMMERCE_SHIPPING_TROUBLESHOOTER_STATUS_UNKNOWN';
     }
 
-    return '<span class="badge ' . $badgeClass . '"><span class="fa-solid ' . $icon . ' me-1" aria-hidden="true"></span>' . Text::_($text) . '</span>';
+    return '<span class="' . J2htmlHelper::badgeClass('badge ' . $badgeClass) . '"><span class="fa-solid ' . $icon . ' me-1" aria-hidden="true"></span>' . Text::_($text) . '</span>';
 }
 ?>
 <?php echo $this->navbar;?>
@@ -248,9 +249,9 @@ function getProductStatusBadge($status) {
                                     </td>
                                     <td class="text-center d-none d-lg-table-cell">
                                         <?php if (!empty($product->weight) && $product->weight > 0): ?>
-                                            <span class="badge text-bg-success"><?php echo number_format($product->weight, 2); ?></span>
+                                            <span class="<?php echo J2htmlHelper::badgeClass('badge text-bg-success'); ?>"><?php echo number_format($product->weight, 2); ?></span>
                                         <?php else: ?>
-                                            <span class="badge text-bg-purple">N/A</span>
+                                            <span class="<?php echo J2htmlHelper::badgeClass('badge text-bg-purple'); ?>">N/A</span>
                                         <?php endif; ?>
                                     </td>
                                     <td class="text-center d-none d-lg-table-cell">
@@ -258,11 +259,11 @@ function getProductStatusBadge($status) {
                                         $hasDimensions = !empty($product->length) && !empty($product->width) && !empty($product->height);
                                         ?>
                                         <?php if ($hasDimensions): ?>
-                                            <span class="badge text-bg-success">
+                                            <span class="<?php echo J2htmlHelper::badgeClass('badge text-bg-success'); ?>">
                                                 <?php echo $product->length . '×' . $product->width . '×' . $product->height; ?>
                                             </span>
                                         <?php else: ?>
-                                            <span class="badge text-bg-purple">N/A</span>
+                                            <span class="<?php echo J2htmlHelper::badgeClass('badge text-bg-purple'); ?>">N/A</span>
                                         <?php endif; ?>
                                     </td>
                                     <td class="text-center">


### PR DESCRIPTION
## Summary

Fixes #627

Adds a new **Badge Style** select field under **Components → J2Commerce → Options → Store** that lets store owners choose how status badges are rendered across the J2Commerce administrator:

- **Atum Style** (default) — classic Joomla core look using plain `bg-success`, `bg-info`, `bg-warning`, etc.
- **J2Commerce Style** — current Bootstrap 5.2 combined classes `text-bg-success`, `text-bg-info`, etc.

## How it works

A new helper `J2htmlHelper::badgeClass(string $classes): string` reads the `com_j2commerce` params once (cached in a static), and when the style is set to `atum` runs `preg_replace('/\btext-bg-/', 'bg-', $classes)` on the supplied class string. When set to `j2commerce` it returns the string unchanged.

Every hard-coded `text-bg-*` class string in the admin templates, dashboard layouts, the visual builder sub-layout, and the JSON status response in `OrdersController::ajaxUpdateStatus` is now wrapped through this helper at the render site. Dynamic classes coming from the `#__j2commerce_orderstatuses.orderstatus_cssclass` column also get transformed at display time, so user-defined order statuses honour the setting without touching seed data.

`getOrderStatusHtml()` was wired to the helper too.

## Files Modified

| Type | Count |
|------|-------|
| PHP templates / layouts | 23 |
| PHP src (Helper / Controller / Builder sublayout) | 3 |
| XML config | 1 |
| Language INI (en-US + en-GB) | 2 |
| **Total** | **28 + 1** |

Intentionally left unchanged:
- `sql/install.mysql.utf8.sql` seed orderstatus rows — transformed at render via the helper
- `forms/orderstatus.xml` `hint="badge text-bg-success"` — only a placeholder hint
- `OrderController::getHistory()` local `$cssClass` variable — only used by `str_contains` to extract a color keyword for icons, never sent to HTML

## Pre-Flight

- [x] PHP syntax (`php -l`) passed on all 25 modified PHP files
- [x] No secrets / API keys in diff
- [x] No FOF remnants (`F0FModel`, `JFactory::`, etc.)
- [x] `php-cs-fixer` clean on changed src/ PHP files
- [x] Language sync checker — 0 new key discrepancies introduced
- [x] Core files only

## Test plan

- [ ] Open Components → J2Commerce → Options → Store. The new **Badge Style** field appears right after **Store Logo**, defaulting to **Atum Style**. Save.
- [ ] Visit Dashboard, Orders list, Order view (header + sidebar + history + transaction details), Products list, Coupons, Inventory, Analytics, Queues, Queue Logs, Apps, Custom Fields, Overrides, Shipping Troubleshooter — view-source confirms badges render with plain `bg-*` classes.
- [ ] Change Badge Style to **J2Commerce Style**, save, reload — badges now render with `text-bg-*` (current behavior).
- [ ] Open an order with a custom `orderstatus_cssclass` set in the database — both styles render correctly without DB changes.
- [ ] AJAX status change in the orders list returns the correctly transformed CSS class.