### PR TITLE
fix(a11y): add aria-labels to quantity and price-range inputs

### DIFF
--- a/administrator/components/com_j2commerce/src/Helper/ProductHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/ProductHelper.php
@@ -3711,6 +3711,7 @@ class ProductHelper
             $input .= ' readonly';
         }
         $input .= ' class="' . htmlspecialchars($inputClass, ENT_QUOTES, 'UTF-8') . '"';
+        $input .= ' aria-label="' . htmlspecialchars(Text::_('COM_J2COMMERCE_QUANTITY'), ENT_QUOTES, 'UTF-8') . '"';
         $input .= ' />';
 
         if ($isCart || !$showButtons) {

--- a/components/com_j2commerce/language/en-GB/com_j2commerce.ini
+++ b/components/com_j2commerce/language/en-GB/com_j2commerce.ini
@@ -138,6 +138,7 @@ COM_J2COMMERCE_NOT_ENOUGH_STOCK="Sorry, only %d items available in stock."
 ; Basket Quantity Controls (Accessibility)
 COM_J2COMMERCE_DECREASE_QUANTITY="Decrease quantity"
 COM_J2COMMERCE_INCREASE_QUANTITY="Increase quantity"
+COM_J2COMMERCE_QUANTITY="Quantity"
 
 ; Coupon
 COM_J2COMMERCE_COUPON_CODE="Coupon Code"

--- a/components/com_j2commerce/language/en-US/com_j2commerce.ini
+++ b/components/com_j2commerce/language/en-US/com_j2commerce.ini
@@ -138,6 +138,7 @@ COM_J2COMMERCE_NOT_ENOUGH_STOCK="Sorry, only %d items available in stock."
 ; Cart Quantity Controls (Accessibility)
 COM_J2COMMERCE_DECREASE_QUANTITY="Decrease quantity"
 COM_J2COMMERCE_INCREASE_QUANTITY="Increase quantity"
+COM_J2COMMERCE_QUANTITY="Quantity"
 
 ; Coupon
 COM_J2COMMERCE_COUPON_CODE="Coupon Code"

--- a/components/com_j2commerce/tmpl/products/default_filters.php
+++ b/components/com_j2commerce/tmpl/products/default_filters.php
@@ -474,8 +474,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
     sliderContainer.innerHTML = `
         <div class="j2commerce-dual-range">
-            <input type="range" id="j2commerce-range-min" min="${sliderMin}" max="${sliderMax}" value="${sliderCurrentMin}" step="1">
-            <input type="range" id="j2commerce-range-max" min="${sliderMin}" max="${sliderMax}" value="${sliderCurrentMax}" step="1">
+            <input type="range" id="j2commerce-range-min" min="${sliderMin}" max="${sliderMax}" value="${sliderCurrentMin}" step="1" aria-label="<?php echo $this->escape(Text::_('COM_J2COMMERCE_FILTER_PRICE_MIN')); ?>">
+            <input type="range" id="j2commerce-range-max" min="${sliderMin}" max="${sliderMax}" value="${sliderCurrentMax}" step="1" aria-label="<?php echo $this->escape(Text::_('COM_J2COMMERCE_FILTER_PRICE_MAX')); ?>">
         </div>
     `;
 

--- a/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/default_filters.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/default_filters.php
@@ -474,8 +474,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
     sliderContainer.innerHTML = `
         <div class="j2commerce-dual-range">
-            <input type="range" id="j2commerce-range-min" min="${sliderMin}" max="${sliderMax}" value="${sliderCurrentMin}" step="1">
-            <input type="range" id="j2commerce-range-max" min="${sliderMin}" max="${sliderMax}" value="${sliderCurrentMax}" step="1">
+            <input type="range" id="j2commerce-range-min" min="${sliderMin}" max="${sliderMax}" value="${sliderCurrentMin}" step="1" aria-label="<?php echo $this->escape(Text::_('COM_J2COMMERCE_FILTER_PRICE_MIN')); ?>">
+            <input type="range" id="j2commerce-range-max" min="${sliderMin}" max="${sliderMax}" value="${sliderCurrentMax}" step="1" aria-label="<?php echo $this->escape(Text::_('COM_J2COMMERCE_FILTER_PRICE_MAX')); ?>">
         </div>
     `;
 

--- a/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/default_filters.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/default_filters.php
@@ -472,8 +472,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
     sliderContainer.innerHTML = `
         <div class="j2commerce-dual-range">
-            <input type="range" id="j2commerce-range-min" min="${sliderMin}" max="${sliderMax}" value="${sliderCurrentMin}" step="1">
-            <input type="range" id="j2commerce-range-max" min="${sliderMin}" max="${sliderMax}" value="${sliderCurrentMax}" step="1">
+            <input type="range" id="j2commerce-range-min" min="${sliderMin}" max="${sliderMax}" value="${sliderCurrentMin}" step="1" aria-label="<?php echo $this->escape(Text::_('COM_J2COMMERCE_FILTER_PRICE_MIN')); ?>">
+            <input type="range" id="j2commerce-range-max" min="${sliderMin}" max="${sliderMax}" value="${sliderCurrentMax}" step="1" aria-label="<?php echo $this->escape(Text::_('COM_J2COMMERCE_FILTER_PRICE_MAX')); ?>">
         </div>
     `;
 

--- a/plugins/j2commerce/app_uikit/tmpl/tag_uikit/default_filters.php
+++ b/plugins/j2commerce/app_uikit/tmpl/tag_uikit/default_filters.php
@@ -564,8 +564,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
     sliderContainer.innerHTML = `
         <div class="j2commerce-dual-range">
-            <input type="range" id="j2commerce-range-min" min="${sliderMin}" max="${sliderMax}" value="${sliderCurrentMin}" step="1">
-            <input type="range" id="j2commerce-range-max" min="${sliderMin}" max="${sliderMax}" value="${sliderCurrentMax}" step="1">
+            <input type="range" id="j2commerce-range-min" min="${sliderMin}" max="${sliderMax}" value="${sliderCurrentMin}" step="1" aria-label="<?php echo $this->escape(Text::_('COM_J2COMMERCE_FILTER_PRICE_MIN')); ?>">
+            <input type="range" id="j2commerce-range-max" min="${sliderMin}" max="${sliderMax}" value="${sliderCurrentMax}" step="1" aria-label="<?php echo $this->escape(Text::_('COM_J2COMMERCE_FILTER_PRICE_MAX')); ?>">
         </div>
     `;
 

--- a/plugins/j2commerce/app_uikit/tmpl/uikit/default_filters.php
+++ b/plugins/j2commerce/app_uikit/tmpl/uikit/default_filters.php
@@ -574,8 +574,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
     sliderContainer.innerHTML = `
         <div class="j2commerce-dual-range">
-            <input type="range" id="j2commerce-range-min" min="${sliderMin}" max="${sliderMax}" value="${sliderCurrentMin}" step="1">
-            <input type="range" id="j2commerce-range-max" min="${sliderMin}" max="${sliderMax}" value="${sliderCurrentMax}" step="1">
+            <input type="range" id="j2commerce-range-min" min="${sliderMin}" max="${sliderMax}" value="${sliderCurrentMin}" step="1" aria-label="<?php echo $this->escape(Text::_('COM_J2COMMERCE_FILTER_PRICE_MIN')); ?>">
+            <input type="range" id="j2commerce-range-max" min="${sliderMin}" max="${sliderMax}" value="${sliderCurrentMax}" step="1" aria-label="<?php echo $this->escape(Text::_('COM_J2COMMERCE_FILTER_PRICE_MAX')); ?>">
         </div>
     `;
 


### PR DESCRIPTION
## Summary
Fixes #648

Adds `aria-label` attributes to form controls that previously had no accessible name, so screen readers and accessibility tooling (axe, WAVE, Lighthouse) can announce them correctly.

## Changes
- `ProductHelper::displayQuantity()` — sets `aria-label="Quantity"` on the built `<input type="number">`. One change covers both product-list (`product_qty`) and cart line-item (`qty[...]`) contexts.
- Price filter dual-range sliders — `aria-label="Min"` / `"Max"` added to both `<input type="range">` elements (the ones injected via `innerHTML`) across 5 filter templates:
  - `components/com_j2commerce/tmpl/products/default_filters.php`
  - `plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/default_filters.php`
  - `plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/default_filters.php`
  - `plugins/j2commerce/app_uikit/tmpl/uikit/default_filters.php`
  - `plugins/j2commerce/app_uikit/tmpl/tag_uikit/default_filters.php`
- New language key `COM_J2COMMERCE_QUANTITY="Quantity"` added to both en-US and en-GB. Existing `COM_J2COMMERCE_FILTER_PRICE_MIN` / `_MAX` keys reused for the slider handles.

Purely additive — no layout, JS behavior, or input name/value changes.

## Testing
1. Open a category page on the frontend → inspect the "Add to Basket" row: `<input name="product_qty">` has `aria-label="Quantity"`.
2. Expand the **Price** filter → inspect slider handles: both `<input type="range">` have `aria-label="Min"` / `"Max"`.
3. Add a product to cart → inspect line-item qty inputs: each `<input name="qty[...]">` has `aria-label="Quantity"`.
4. Run axe DevTools on the category and cart pages → zero "Form elements must have labels" violations on these controls.

## Files Changed
- `administrator/components/com_j2commerce/src/Helper/ProductHelper.php` — quantity input aria-label
- `components/com_j2commerce/language/en-GB/com_j2commerce.ini` — new QUANTITY key
- `components/com_j2commerce/language/en-US/com_j2commerce.ini` — new QUANTITY key
- `components/com_j2commerce/tmpl/products/default_filters.php` — slider aria-labels
- `plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/default_filters.php` — slider aria-labels
- `plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/default_filters.php` — slider aria-labels
- `plugins/j2commerce/app_uikit/tmpl/uikit/default_filters.php` — slider aria-labels
- `plugins/j2commerce/app_uikit/tmpl/tag_uikit/default_filters.php` — slider aria-labels