### PR TITLE
fix(checkout): remove duplicate checkout-sidecart-content ID (fixes #647)

### DIFF
--- a/components/com_j2commerce/tmpl/checkout/default.php
+++ b/components/com_j2commerce/tmpl/checkout/default.php
@@ -167,8 +167,12 @@ $selectZoneJs = htmlspecialchars(Text::sprintf('COM_J2COMMERCE_SELECT_PLACEHOLDE
                         <span class="fw-bold fs-5 j2commerce-sidecart-toggle-total"><?php echo $grandTotal; ?></span>
                     </button>
 
-                    <div class="bg-light rounded p-3 p-lg-4">
-                        <?php echo $this->loadTemplate('sidecart'); ?>
+                    <div class="j2commerce-checkout-sidecart">
+                        <div class="collapse d-lg-block" id="checkoutSidecartCollapse">
+                            <div class="sticky-lg-top" style="top: 1rem;" id="checkout-sidecart-content">
+                                <?php echo $this->loadTemplate('sidecart'); ?>
+                            </div>
+                        </div>
                     </div>
 
                     <?php echo J2CommerceHelper::modules()->loadposition('j2commerce-checkout-sidecart-bottom'); ?>
@@ -1271,7 +1275,10 @@ document.addEventListener('DOMContentLoaded', function() {
             .then(function(data) {
                 if (data.success && data.html) {
                     var container = document.getElementById('checkout-sidecart-content');
-                    if (container) container.innerHTML = data.html;
+                    if (container) {
+                        var parsed = new DOMParser().parseFromString(data.html, 'text/html');
+                        container.replaceChildren.apply(container, Array.from(parsed.body.childNodes));
+                    }
                     updateMobileTotal();
                 }
             })

--- a/components/com_j2commerce/tmpl/checkout/default_sidecart.php
+++ b/components/com_j2commerce/tmpl/checkout/default_sidecart.php
@@ -55,10 +55,7 @@ $totals = ($this->order && method_exists($this->order, 'get_formatted_order_tota
 $grandTotalValue = $totals['grandtotal']['value'] ?? '';
 
 ?>
-<div class="j2commerce-checkout-sidecart">
-
-    <div class="collapse d-lg-block" id="checkoutSidecartCollapse">
-        <div class="sticky-lg-top" style="top: 1rem;" id="checkout-sidecart-content">
+<div class="bg-light rounded p-3 p-lg-4">
 
             <?php if (!empty($this->items)): ?>
             <div class="checkout-sidebar-items list-group list-group-flush mb-3">
@@ -161,6 +158,4 @@ $grandTotalValue = $totals['grandtotal']['value'] ?? '';
             </div>
             <?php endif; ?>
 
-        </div>
-    </div>
 </div>


### PR DESCRIPTION
## Summary
Fixes #647

The checkout sidecart sub-template owned the `.j2commerce-checkout-sidecart` / `#checkoutSidecartCollapse` / `#checkout-sidecart-content` wrappers, and `CheckoutController::refreshSidecart()` returned the full template output via `$view->loadTemplate('sidecart')`. The JS then assigned that HTML to `#checkout-sidecart-content.innerHTML`, injecting a second copy of the wrapper chain (with duplicate IDs) inside the existing one after the first refresh.

## Changes
- Moved the three outer wrapper divs (`.j2commerce-checkout-sidecart` > `#checkoutSidecartCollapse` > `#checkout-sidecart-content`) out of `default_sidecart.php` and into `default.php`, so they render exactly once.
- The sub-template now emits only its inner `.bg-light rounded p-3 p-lg-4` content, which slots cleanly into `#checkout-sidecart-content` on refresh.
- Replaced `container.innerHTML = data.html` with `DOMParser` + `replaceChildren(...)` in the sidecart refresh handler. Per project policy, new code avoids `innerHTML` (XSS vector, doesn't execute injected scripts). `DOMParser` parses the markup in a disconnected document where inline event handlers don't fire.

## Testing
1. Add products to cart, navigate to checkout.
2. DevTools → Elements: search for `checkout-sidecart-content` — expect exactly **one** match.
3. Search for `checkoutSidecartCollapse` — expect exactly **one** match.
4. Trigger a sidecart refresh (change quantity, apply coupon, advance step).
5. Re-search both IDs — still exactly one each, no nested `.j2commerce-checkout-sidecart` inside itself.
6. Mobile viewport: the "Show order summary" collapse toggle still expands/collapses cleanly; the grand total in the toggle button updates after refresh.
7. Console is clean — no Bootstrap collapse warnings about duplicate targets.

## Files Changed
- `components/com_j2commerce/tmpl/checkout/default.php` — wrapper move into parent template; `innerHTML` replaced with `DOMParser` + `replaceChildren`.
- `components/com_j2commerce/tmpl/checkout/default_sidecart.php` — removed three outer wrapper divs; now emits only the `.bg-light` content block.