### PR TITLE
fix(currency): preserve user-selected currency across reloads

### DIFF
--- a/administrator/components/com_j2commerce/src/Helper/CurrencyHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/CurrencyHelper.php
@@ -153,9 +153,11 @@ class CurrencyHelper
             self::setCurrencyInternal($requestedCurrency);
         } elseif ($session->has('j2commerce_currency') && self::has($session->get('j2commerce_currency', ''))) {
             $sessionCurrency = $session->get('j2commerce_currency', '');
+            $userSet         = (bool) $session->get('j2commerce_currency_user_set', false);
 
-            // If the config default changed, update session to match
-            if ($sessionCurrency !== $defaultCurrency && self::has($defaultCurrency)) {
+            if ($userSet) {
+                self::$currentCode = $sessionCurrency;
+            } elseif ($sessionCurrency !== $defaultCurrency && self::has($defaultCurrency)) {
                 self::setCurrencyInternal($defaultCurrency);
             } else {
                 self::$currentCode = $sessionCurrency;
@@ -244,6 +246,8 @@ class CurrencyHelper
         if ($session->get('j2commerce_currency', '') !== $currencyCode) {
             $session->set('j2commerce_currency', $currencyCode);
         }
+
+        $session->set('j2commerce_currency_user_set', true);
     }
 
     /**


### PR DESCRIPTION
## Summary

Fixes #635

PR #181 (issue #173) added logic in `CurrencyHelper::initialize()` that unconditionally reset the session currency back to the configured default whenever they differed. That broke the frontend currency switcher: when a visitor picked a non-default currency, `CartsController::setcurrency` would store the choice in the session and redirect, then on the very next request `initialize()` would force the session right back to the default — so the page reloaded but the displayed prices never changed.

## Fix

Track whether the session currency was explicitly user-initiated:

- `setCurrency()` (the public path called by `CartsController::setcurrency` when the visitor picks from the dropdown) now also writes `j2commerce_currency_user_set = true` to the session
- `initialize()` reads that flag — when `true`, the session currency is preserved unconditionally; when not set, the existing PR #181 fallback (auto-pick up admin config-default changes for visitors who never manually picked) still runs

The internal `setCurrencyInternal()` path used by `initialize()` itself does NOT set the flag, so first-visit system-set sessions remain candidates for the issue #173 auto-update behaviour.

## Test plan

- [x] Open the storefront, currency switcher pick a different currency (e.g. USD → EUR), confirm the page reloads **and** prices are now in EUR
- [x] Navigate to other product pages — currency stays EUR across the session
- [x] Open a private window — fresh session uses the configured default currency
- [x] **Regression check (issue #173)**: in a fresh session that has never picked a currency, change the configured default in admin → reload front-end → session auto-updates to the new default

## Files Changed

- `administrator/components/com_j2commerce/src/Helper/CurrencyHelper.php` — `setCurrency()` writes the new `j2commerce_currency_user_set` session flag; `initialize()` honours the flag

## Pre-Flight

- [x] PHP syntax check passed
- [x] No language strings touched
- [x] No schema changes
- [x] Backward compatible (sessions without the new key fall through to existing logic)
- [x] Core file only