### PR TITLE
fix(cart): cart module only updates on page load (fixes #640)

### DIFF
--- a/components/com_j2commerce/src/Controller/CartsController.php
+++ b/components/com_j2commerce/src/Controller/CartsController.php
@@ -273,7 +273,7 @@ class CartsController extends BaseController
 
             if ($ajax) {
                 if (isset($json['success'])) {
-                    if ($config->get('addtocart_action', 3) == 3) {
+                    if ($config->get('addtocart_action', 1) == 3) {
                         $json['redirect'] = $cartUrl;
                     }
                 }


### PR DESCRIPTION
## Summary
Fixes #640

The J2Commerce Basket module only updated on full page reload after adding an item to the cart. Root cause was a PHP fallback default mismatch in `CartsController::addItem()`:

- `config.xml` declares `addtocart_action` default = `1` (inline)
- `CartsController.php:276` used PHP fallback = `3` (redirect)

On fresh installs where the param wasn't explicitly saved, the controller emitted `$json['redirect']`, causing `j2commerce.js` to fire `window.location.href = json.redirect` **immediately after** dispatching the `cart:updated` event. The browser aborted the in-flight `ajaxmini` fetch before it could update the DOM, and the basket module appeared to only refresh on page load — because the page was literally reloading.

## Changes
- `components/com_j2commerce/src/Controller/CartsController.php`: change PHP fallback for `addtocart_action` from `3` → `1` to match the declared `config.xml` default

## Testing
1. Ensure `addtocart_action` is unset or set to `1` (Inline) in J2Commerce config
2. Add the J2Commerce Basket module to a sidebar position on a category product list page
3. Click "Add to Basket" on a product
4. Verify:
   - Page does NOT reload
   - Basket module item count, line items, subtotal, tax, and total all refresh in place via AJAX
5. Regression check: set `addtocart_action=3` (Redirect) and confirm the redirect-to-cart behavior still works for users who explicitly opt in

## Files Changed
- `components/com_j2commerce/src/Controller/CartsController.php` — PHP fallback for `addtocart_action` changed from `3` to `1` (line 276)

## Notes
All 6 cart module tmpl files (`default.php`, `default_uikit.php`, `minicart.php`, `minicart_uikit.php`, `detailcartonhover.php`, `detailcartonhover_uikit.php`) already had the `j2commerce:cart:updated` listener wired up correctly via the fix for #552. The listener itself was fine — the redirect was interrupting the AJAX refresh before it could run.