### PR TITLE
Update default value for display name in bank transfer config

### DIFF
--- a/plugins/j2commerce/payment_banktransfer/payment_banktransfer.xml
+++ b/plugins/j2commerce/payment_banktransfer/payment_banktransfer.xml
@@ -77,7 +77,7 @@
                     type="text"
                     label="COM_J2COMMERCE_PLUGIN_DISPLAY_NAME"
                     description="COM_J2COMMERCE_PLUGIN_DISPLAY_NAME_DESC"
-                    default="PLG_J2COMMERCE_PAYMENT_BANKTRANSFER"
+                    default="PLG_J2COMMERCE_PAYMENT_BANKTRANSFER_DEFAULT"
                 />
 
                 <field

--- a/plugins/j2commerce/payment_cash/payment_cash.xml
+++ b/plugins/j2commerce/payment_cash/payment_cash.xml
@@ -77,7 +77,7 @@
                     type="text"
                     label="COM_J2COMMERCE_PLUGIN_DISPLAY_NAME"
                     description="COM_J2COMMERCE_PLUGIN_DISPLAY_NAME_DESC"
-                    default="PLG_J2COMMERCE_PAYMENT_CASH"
+                    default="PLG_J2COMMERCE_PAYMENT_CASH_DEFAULT"
                 />
 
                 <field

--- a/plugins/j2commerce/payment_moneyorder/payment_moneyorder.xml
+++ b/plugins/j2commerce/payment_moneyorder/payment_moneyorder.xml
@@ -77,7 +77,7 @@
                     type="text"
                     label="COM_J2COMMERCE_PLUGIN_DISPLAY_NAME"
                     description="COM_J2COMMERCE_PLUGIN_DISPLAY_NAME_DESC"
-                    default="PLG_J2COMMERCE_PAYMENT_MONEYORDER"
+                    default="PLG_J2COMMERCE_PAYMENT_MONEYORDER_DEFAULT"
                 />
 
                 <field

--- a/plugins/j2commerce/payment_paypal/payment_paypal.xml
+++ b/plugins/j2commerce/payment_paypal/payment_paypal.xml
@@ -78,7 +78,7 @@
                     type="text"
                     label="COM_J2COMMERCE_PLUGIN_DISPLAY_NAME"
                     description="COM_J2COMMERCE_PLUGIN_DISPLAY_NAME_DESC"
-                    default="PLG_J2COMMERCE_PAYMENT_PAYPAL"
+                    default="PLG_J2COMMERCE_PAYMENT_PAYPAL_DEFAULT"
                 />
                 <field
                     name="display_image"

--- a/plugins/j2commerce/shipping_free/shipping_free.xml
+++ b/plugins/j2commerce/shipping_free/shipping_free.xml
@@ -60,7 +60,7 @@
                     type="text"
                     label="PLG_J2COMMERCE_SHIPPING_FREE_DISPLAY_NAME"
                     description="PLG_J2COMMERCE_SHIPPING_FREE_DISPLAY_NAME_DESC"
-                    default="PLG_J2COMMERCE_SHIPPING_FREE"
+                    default="PLG_J2COMMERCE_SHIPPING_FREE_DEFAULT"
                 />
 
                 <field


### PR DESCRIPTION
this string was previously reported as unused. it was unused but as you can see it should have been otherwise if you created an override of the current string you would change the name of the plugin


<img width="922" height="325" alt="image" src="https://github.com/user-attachments/assets/0897a15e-3690-4a56-90be-1d3aac064d19" />

<img width="1298" height="169" alt="image" src="https://github.com/user-attachments/assets/f0f76584-8012-4ad8-9e15-642d9ccba687" />


## IMPORTANT UPDATE
While checking the other _DEFAULT strings I saw this commit #362 
i think that PR was wrong and is causing this problem. Basically you cant use the same string for the plugin name and the plugin default value

I have stopped checking the other plugins for this as #362 was a bigger change