### PR TITLE
fix(a11y): correct admin heading hierarchy skips (part of #649)

### DIFF
--- a/administrator/components/com_j2commerce/tmpl/advancedpricing/default_batch.php
+++ b/administrator/components/com_j2commerce/tmpl/advancedpricing/default_batch.php
@@ -26,7 +26,7 @@ $userGroups = $db->loadObjectList();
     <div class="modal-dialog modal-lg">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title" id="collapseModalLabel"><?php echo Text::_('COM_J2COMMERCE_BATCH_TITLE'); ?></h5>
+                <h2 class="modal-title fs-5" id="collapseModalLabel"><?php echo Text::_('COM_J2COMMERCE_BATCH_TITLE'); ?></h2>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="<?php echo Text::_('JCLOSE'); ?>"></button>
             </div>
             <div class="modal-body px-4 pt-4 pb-2">

--- a/administrator/components/com_j2commerce/tmpl/coupon/history.php
+++ b/administrator/components/com_j2commerce/tmpl/coupon/history.php
@@ -24,10 +24,10 @@ J2CommerceHelper::strapper()->addCSS();
     <div class="col-md-12">
         <div class="card">
             <div class="card-header">
-                <h3 class="card-title">
+                <h2 class="card-title fs-3">
                     <?php echo Text::_('COM_J2COMMERCE_COUPON_HISTORY'); ?>:
                     <span class="badge bg-primary"><?php echo htmlspecialchars($this->item->coupon_code, ENT_QUOTES, 'UTF-8'); ?></span>
-                </h3>
+                </h2>
             </div>
             <div class="card-body">
                 <?php if (!empty($this->orders) && count($this->orders) > 0) : ?>

--- a/administrator/components/com_j2commerce/tmpl/customfields/default_batch.php
+++ b/administrator/components/com_j2commerce/tmpl/customfields/default_batch.php
@@ -38,13 +38,13 @@ $noChange = Text::_('COM_J2COMMERCE_BATCH_NOCHANGE');
     <div class="modal-dialog modal-lg">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title" id="collapseModalLabel"><?php echo Text::_('COM_J2COMMERCE_BATCH_DISPLAY_TITLE'); ?></h5>
+                <h2 class="modal-title fs-5" id="collapseModalLabel"><?php echo Text::_('COM_J2COMMERCE_BATCH_DISPLAY_TITLE'); ?></h2>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="<?php echo Text::_('JCLOSE'); ?>"></button>
             </div>
             <div class="modal-body px-4 pt-4 pb-2">
                 <p class="text-muted small mb-3"><?php echo Text::_('COM_J2COMMERCE_BATCH_DISPLAY_DESC'); ?></p>
 
-                <h6 class="fw-bold mb-2"><?php echo Text::_('COM_J2COMMERCE_BATCH_DISPLAY_CORE_HEADING'); ?></h6>
+                <h3 class="fw-bold mb-2 fs-6"><?php echo Text::_('COM_J2COMMERCE_BATCH_DISPLAY_CORE_HEADING'); ?></h3>
                 <div class="row">
                     <?php foreach ($coreAreas as $areaKey => $labelKey) : ?>
                         <?php $safeKey = htmlspecialchars($areaKey, ENT_QUOTES, 'UTF-8'); ?>
@@ -65,7 +65,7 @@ $noChange = Text::_('COM_J2COMMERCE_BATCH_NOCHANGE');
 
                 <?php if (!empty($pluginAreas)) : ?>
                     <hr class="my-3">
-                    <h6 class="fw-bold mb-2"><?php echo Text::_('COM_J2COMMERCE_BATCH_DISPLAY_PLUGIN_HEADING'); ?></h6>
+                    <h3 class="fw-bold mb-2 fs-6"><?php echo Text::_('COM_J2COMMERCE_BATCH_DISPLAY_PLUGIN_HEADING'); ?></h3>
                     <div class="row">
                         <?php foreach ($pluginAreas as $area) : ?>
                             <?php

--- a/administrator/components/com_j2commerce/tmpl/dashboard/default.php
+++ b/administrator/components/com_j2commerce/tmpl/dashboard/default.php
@@ -79,7 +79,7 @@ $doc->getWebAssetManager()->registerAndUseScript(
     <div class="card mb-4">
         <div class="card-body text-center py-5">
             <span class="fa-solid fa-box-open fa-3x text-muted d-block mb-3" aria-hidden="true"></span>
-            <h5><?php echo Text::_('COM_J2COMMERCE_DASHBOARD_EMPTY_STORE_TITLE'); ?></h5>
+            <h2 class="fs-5"><?php echo Text::_('COM_J2COMMERCE_DASHBOARD_EMPTY_STORE_TITLE'); ?></h2>
             <p class="text-muted"><?php echo Text::_('COM_J2COMMERCE_DASHBOARD_EMPTY_STORE_DESC'); ?></p>
             <button type="button" class="btn btn-primary" id="j2c-load-sampledata">
                 <span class="fa-solid fa-database me-1" aria-hidden="true"></span>

--- a/administrator/components/com_j2commerce/tmpl/dashboard/default_categorywizard.php
+++ b/administrator/components/com_j2commerce/tmpl/dashboard/default_categorywizard.php
@@ -32,10 +32,10 @@ $sefRewrite = (bool) $app->get('sef_rewrite', false);
 
             <!-- Header -->
             <div class="modal-header border-0 p-3">
-                <h5 class="modal-title" id="categoryWizardModalLabel">
+                <h2 class="modal-title fs-5" id="categoryWizardModalLabel">
                     <span class="fa-solid fa-wand-magic-sparkles me-2" aria-hidden="true"></span>
                     <?php echo Text::_('COM_J2COMMERCE_WIZARD_TITLE'); ?>
-                </h5>
+                </h2>
                 <button type="button" class="btn-close" data-bs-dismiss="modal"
                         aria-label="<?php echo Text::_('JCLOSE'); ?>"></button>
             </div>
@@ -48,7 +48,7 @@ $sefRewrite = (bool) $app->get('sef_rewrite', false);
 
                 <!-- Step 1: Product count -->
                 <div class="j2c-wizard-step" data-step="step1">
-                    <h5 class="mb-4"><?php echo Text::_('COM_J2COMMERCE_WIZARD_STEP1_TITLE'); ?></h5>
+                    <h3 class="mb-4 fs-5"><?php echo Text::_('COM_J2COMMERCE_WIZARD_STEP1_TITLE'); ?></h3>
                     <div class="row g-3">
                         <div class="col-12 col-md-6">
                             <label class="j2c-wizard-card">
@@ -91,7 +91,7 @@ $sefRewrite = (bool) $app->get('sef_rewrite', false);
 
                 <!-- Step 2a: Single product name -->
                 <div class="j2c-wizard-step d-none" inert data-step="2a">
-                    <h5 class="mb-4"><?php echo Text::_('COM_J2COMMERCE_WIZARD_PRODUCT_NAME'); ?></h5>
+                    <h3 class="mb-4 fs-5"><?php echo Text::_('COM_J2COMMERCE_WIZARD_PRODUCT_NAME'); ?></h3>
                     <div class="mb-3">
                         <input type="text" class="form-control form-control-lg" id="j2c-product-name"
                                name="product_name"
@@ -102,7 +102,7 @@ $sefRewrite = (bool) $app->get('sef_rewrite', false);
 
                 <!-- Step 3a: Product type -->
                 <div class="j2c-wizard-step d-none" inert data-step="3a">
-                    <h5 class="mb-4"><?php echo Text::_('COM_J2COMMERCE_WIZARD_PRODUCT_TYPE'); ?></h5>
+                    <h3 class="mb-4 fs-5"><?php echo Text::_('COM_J2COMMERCE_WIZARD_PRODUCT_TYPE'); ?></h3>
                     <div class="row g-3">
                         <div class="col-12">
                             <label class="j2c-wizard-card">
@@ -151,7 +151,7 @@ $sefRewrite = (bool) $app->get('sef_rewrite', false);
 
                 <!-- Step 3b: Define option titles -->
                 <div class="j2c-wizard-step d-none" inert data-step="3b">
-                    <h5 class="mb-4"><?php echo Text::_('COM_J2COMMERCE_WIZARD_OPTIONS_TITLE'); ?></h5>
+                    <h3 class="mb-4 fs-5"><?php echo Text::_('COM_J2COMMERCE_WIZARD_OPTIONS_TITLE'); ?></h3>
                     <div id="j2c-option-titles-list">
                         <div class="j2c-option-title-row mb-3 d-flex gap-2 align-items-center">
                             <input type="text" class="form-control j2c-option-title-input"
@@ -167,7 +167,7 @@ $sefRewrite = (bool) $app->get('sef_rewrite', false);
 
                 <!-- Step 3c: Add option values -->
                 <div class="j2c-wizard-step d-none" inert data-step="3c">
-                    <h5 class="mb-4"><?php echo Text::_('COM_J2COMMERCE_WIZARD_OPTION_VALUES_TITLE'); ?></h5>
+                    <h3 class="mb-4 fs-5"><?php echo Text::_('COM_J2COMMERCE_WIZARD_OPTION_VALUES_TITLE'); ?></h3>
                     <div id="j2c-option-values-container">
                         <!-- Populated dynamically by JS based on option titles -->
                     </div>
@@ -175,7 +175,7 @@ $sefRewrite = (bool) $app->get('sef_rewrite', false);
 
                 <!-- Step 2b: Category count (multi) -->
                 <div class="j2c-wizard-step d-none" inert data-step="2b">
-                    <h5 class="mb-4"><?php echo Text::_('COM_J2COMMERCE_WIZARD_CATEGORY_COUNT'); ?></h5>
+                    <h3 class="mb-4 fs-5"><?php echo Text::_('COM_J2COMMERCE_WIZARD_CATEGORY_COUNT'); ?></h3>
                     <div class="row g-3">
                         <div class="col-12 col-md-6">
                             <label class="j2c-wizard-card">
@@ -215,7 +215,7 @@ $sefRewrite = (bool) $app->get('sef_rewrite', false);
 
                 <!-- Step: Category source (existing vs new) -->
                 <div class="j2c-wizard-step d-none" inert data-step="category-source">
-                    <h5 class="mb-4"><?php echo Text::_('COM_J2COMMERCE_WIZARD_CATEGORY_SOURCE_TITLE'); ?></h5>
+                    <h3 class="mb-4 fs-5"><?php echo Text::_('COM_J2COMMERCE_WIZARD_CATEGORY_SOURCE_TITLE'); ?></h3>
                     <div class="row g-3">
                         <div class="col-12">
                             <label class="j2c-wizard-card">
@@ -250,7 +250,7 @@ $sefRewrite = (bool) $app->get('sef_rewrite', false);
 
                 <!-- Step: Select existing categories (fancy-select) -->
                 <div class="j2c-wizard-step d-none" inert data-step="category-select">
-                    <h5 class="mb-4"><?php echo Text::_('COM_J2COMMERCE_WIZARD_CATEGORY_SELECT_TITLE'); ?></h5>
+                    <h3 class="mb-4 fs-5"><?php echo Text::_('COM_J2COMMERCE_WIZARD_CATEGORY_SELECT_TITLE'); ?></h3>
                     <p class="text-muted"><?php echo Text::_('COM_J2COMMERCE_WIZARD_CATEGORY_SELECT_DESC'); ?></p>
                     <div id="j2c-category-select-container">
                         <!-- Populated by JS with a fancy-select multi-select -->
@@ -259,7 +259,7 @@ $sefRewrite = (bool) $app->get('sef_rewrite', false);
 
                 <!-- Step 3b-multi: Display settings (>1 category) -->
                 <div class="j2c-wizard-step d-none" inert data-step="3b-multi">
-                    <h5 class="mb-4"><?php echo Text::_('COM_J2COMMERCE_WIZARD_DISPLAY_SETTINGS'); ?></h5>
+                    <h3 class="mb-4 fs-5"><?php echo Text::_('COM_J2COMMERCE_WIZARD_DISPLAY_SETTINGS'); ?></h3>
                     <div class="row g-3">
                         <div class="col-12">
                             <label class="j2c-wizard-card">
@@ -284,7 +284,7 @@ $sefRewrite = (bool) $app->get('sef_rewrite', false);
 
                 <!-- Step: Category naming -->
                 <div class="j2c-wizard-step d-none" inert data-step="category-naming">
-                    <h5 class="mb-4 j2c-cat-naming-title"><?php echo Text::_('COM_J2COMMERCE_WIZARD_CATEGORY_NAME'); ?></h5>
+                    <h3 class="mb-4 fs-5 j2c-cat-naming-title"><?php echo Text::_('COM_J2COMMERCE_WIZARD_CATEGORY_NAME'); ?></h3>
                     <div id="j2c-category-names-container">
                         <!-- Populated by JS based on category count selection -->
                     </div>
@@ -323,7 +323,7 @@ $sefRewrite = (bool) $app->get('sef_rewrite', false);
 
                 <!-- Step: Confirmation -->
                 <div class="j2c-wizard-step d-none" inert data-step="confirm">
-                    <h6 class="mb-3"><?php echo Text::_('COM_J2COMMERCE_WIZARD_CONFIRM_TITLE'); ?></h6>
+                    <h4 class="mb-3 fs-6"><?php echo Text::_('COM_J2COMMERCE_WIZARD_CONFIRM_TITLE'); ?></h4>
                     <ul class="list-unstyled" id="j2c-wizard-summary">
                         <!-- Populated by JS -->
                     </ul>
@@ -333,13 +333,13 @@ $sefRewrite = (bool) $app->get('sef_rewrite', false);
                 <div class="j2c-wizard-step d-none" inert data-step="success">
                     <div class="text-center py-3">
                         <span class="fa-solid fa-circle-check fa-4x text-success mb-3 d-block" aria-hidden="true"></span>
-                        <h4><?php echo Text::_('COM_J2COMMERCE_WIZARD_SUCCESS_TITLE'); ?></h4>
+                        <h3 class="fs-4"><?php echo Text::_('COM_J2COMMERCE_WIZARD_SUCCESS_TITLE'); ?></h3>
                     </div>
                     <div class="alert alert-info mb-3">
-                        <h6 class="alert-heading">
+                        <h4 class="alert-heading fs-6">
                             <span class="fa-solid fa-circle-info me-2" aria-hidden="true"></span>
                             <?php echo Text::_('COM_J2COMMERCE_WIZARD_URL_TITLE'); ?>
-                        </h6>
+                        </h4>
                         <p class="mb-1"><?php echo Text::_('COM_J2COMMERCE_WIZARD_URL_DESC'); ?></p>
                         <a href="#" id="j2c-wizard-url-example" target="_blank" class="d-block"><code id="j2c-wizard-url-code"></code></a>
                     </div>

--- a/administrator/components/com_j2commerce/tmpl/dashboard/default_onboarding.php
+++ b/administrator/components/com_j2commerce/tmpl/dashboard/default_onboarding.php
@@ -136,7 +136,7 @@ $e = fn(string $s): string => htmlspecialchars($s, ENT_QUOTES, 'UTF-8');
 
       <!-- Header -->
       <div class="modal-header border-0 p-3">
-        <h5 class="modal-title" id="j2commerceOnboardingLabel"><?php echo Text::_('COM_J2COMMERCE_ONBOARDING_WIZARD_TITLE'); ?></h5>
+        <h2 class="modal-title fs-5" id="j2commerceOnboardingLabel"><?php echo Text::_('COM_J2COMMERCE_ONBOARDING_WIZARD_TITLE'); ?></h2>
         <button type="button" class="btn-close" data-action="dismiss-onboarding"
                 aria-label="<?php echo Text::_('JCLOSE'); ?>"></button>
       </div>
@@ -185,7 +185,7 @@ $e = fn(string $s): string => htmlspecialchars($s, ENT_QUOTES, 'UTF-8');
         <!-- ============ STEP 1: Store Info ============ -->
         <div class="j2c-step" data-step="1" <?php echo $resumeStep !== 1 ? 'hidden' : ''; ?>>
           <div class="j2c-step-icon"><span class="fa-solid fa-location-dot" aria-hidden="true"></span></div>
-          <h4 class="j2c-step-title"><?php echo Text::_('COM_J2COMMERCE_ONBOARDING_STEP1_TITLE'); ?></h4>
+          <h3 class="j2c-step-title fs-4"><?php echo Text::_('COM_J2COMMERCE_ONBOARDING_STEP1_TITLE'); ?></h3>
           <p class="j2c-step-desc"><?php echo Text::_('COM_J2COMMERCE_ONBOARDING_STEP1_DESC'); ?></p>
           <hr>
           <div class="row g-3">
@@ -299,7 +299,7 @@ $e = fn(string $s): string => htmlspecialchars($s, ENT_QUOTES, 'UTF-8');
         <!-- ============ STEP 2: Currency & Measurements ============ -->
         <div class="j2c-step" data-step="2" <?php echo $resumeStep !== 2 ? 'hidden' : ''; ?>>
           <div class="j2c-step-icon"><span class="fa-solid fa-coins" aria-hidden="true"></span></div>
-          <h4 class="j2c-step-title"><?php echo Text::_('COM_J2COMMERCE_ONBOARDING_STEP2_TITLE'); ?></h4>
+          <h3 class="j2c-step-title fs-4"><?php echo Text::_('COM_J2COMMERCE_ONBOARDING_STEP2_TITLE'); ?></h3>
           <p class="j2c-step-desc"><?php echo Text::_('COM_J2COMMERCE_ONBOARDING_STEP2_DESC'); ?></p>
           <div class="alert alert-info small d-none" id="ob-currency-defaults-preview"></div>
           <hr>
@@ -350,7 +350,7 @@ $e = fn(string $s): string => htmlspecialchars($s, ENT_QUOTES, 'UTF-8');
         <!-- ============ STEP 3: Tax ============ -->
         <div class="j2c-step" data-step="3" <?php echo $resumeStep !== 3 ? 'hidden' : ''; ?>>
           <div class="j2c-step-icon"><span class="fa-solid fa-receipt" aria-hidden="true"></span></div>
-          <h4 class="j2c-step-title"><?php echo Text::_('COM_J2COMMERCE_ONBOARDING_STEP3_TITLE'); ?></h4>
+          <h3 class="j2c-step-title fs-4"><?php echo Text::_('COM_J2COMMERCE_ONBOARDING_STEP3_TITLE'); ?></h3>
           <p class="j2c-step-desc"><?php echo Text::_('COM_J2COMMERCE_ONBOARDING_STEP3_DESC'); ?></p>
           <hr>
           <div class="row g-3">
@@ -383,7 +383,7 @@ $e = fn(string $s): string => htmlspecialchars($s, ENT_QUOTES, 'UTF-8');
         <!-- ============ STEP 4: Product Type ============ -->
         <div class="j2c-step" data-step="4" <?php echo $resumeStep !== 4 ? 'hidden' : ''; ?>>
           <div class="j2c-step-icon"><span class="fa-solid fa-boxes-stacked" aria-hidden="true"></span></div>
-          <h4 class="j2c-step-title"><?php echo Text::_('COM_J2COMMERCE_ONBOARDING_STEP4_TITLE'); ?></h4>
+          <h3 class="j2c-step-title fs-4"><?php echo Text::_('COM_J2COMMERCE_ONBOARDING_STEP4_TITLE'); ?></h3>
           <p class="j2c-step-desc"><?php echo Text::_('COM_J2COMMERCE_ONBOARDING_STEP4_DESC'); ?></p>
           <hr>
           <div class="row g-3 mb-3">
@@ -576,7 +576,7 @@ $e = fn(string $s): string => htmlspecialchars($s, ENT_QUOTES, 'UTF-8');
         <!-- ============ STEP 5: Payment ============ -->
         <div class="j2c-step" data-step="5" <?php echo $resumeStep !== 5 ? 'hidden' : ''; ?>>
           <div class="j2c-step-icon"><span class="fa-solid fa-credit-card" aria-hidden="true"></span></div>
-          <h4 class="j2c-step-title"><?php echo Text::_('COM_J2COMMERCE_ONBOARDING_STEP5_TITLE'); ?></h4>
+          <h3 class="j2c-step-title fs-4"><?php echo Text::_('COM_J2COMMERCE_ONBOARDING_STEP5_TITLE'); ?></h3>
           <p class="j2c-step-desc"><?php echo Text::_('COM_J2COMMERCE_ONBOARDING_STEP5_DESC'); ?></p>
           <hr>
 
@@ -690,7 +690,7 @@ $e = fn(string $s): string => htmlspecialchars($s, ENT_QUOTES, 'UTF-8');
         <!-- ============ STEP 6: Ready! ============ -->
         <div class="j2c-step" data-step="6" <?php echo $resumeStep !== 6 ? 'hidden' : ''; ?>>
           <div class="j2c-step-icon j2c-celebration-icon"><span class="fa-solid fa-circle-check text-primary" aria-hidden="true"></span></div>
-          <h4 class="j2c-step-title"><?php echo Text::_('COM_J2COMMERCE_ONBOARDING_STEP6_TITLE'); ?></h4>
+          <h3 class="j2c-step-title fs-4"><?php echo Text::_('COM_J2COMMERCE_ONBOARDING_STEP6_TITLE'); ?></h3>
           <p class="j2c-step-desc"><?php echo Text::_('COM_J2COMMERCE_ONBOARDING_STEP6_DESC'); ?></p>
           <hr>
 

--- a/administrator/components/com_j2commerce/tmpl/dashboard/default_setup_guide.php
+++ b/administrator/components/com_j2commerce/tmpl/dashboard/default_setup_guide.php
@@ -20,10 +20,10 @@ use Joomla\CMS\Language\Text;
                 aria-label="<?php echo Text::_('COM_J2COMMERCE_SETUP_GUIDE_BACK'); ?>">
             <span class="icon-chevron-left" aria-hidden="true"></span>
         </button>
-        <h5 class="offcanvas-title d-flex align-items-center gap-2" id="j2commerce-setup-guide-label">
+        <h2 class="offcanvas-title d-flex align-items-center gap-2 fs-5" id="j2commerce-setup-guide-label">
             <span class="fa-solid fa-wand-magic-sparkles" aria-hidden="true"></span>
             <?php echo Text::_('COM_J2COMMERCE_SETUP_GUIDE'); ?>
-        </h5>
+        </h2>
         <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="<?php echo Text::_('JCLOSE'); ?>"></button>
     </div>
     <div class="offcanvas-body p-0">

--- a/administrator/components/com_j2commerce/tmpl/emailtemplate/edit.php
+++ b/administrator/components/com_j2commerce/tmpl/emailtemplate/edit.php
@@ -488,7 +488,7 @@ $tmpl = $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=component' : '';
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <h5 class="modal-title" id="sendTestModalLabel"><?php echo Text::_('COM_J2COMMERCE_EMAILTEMPLATE_SEND_TEST'); ?></h5>
+                        <h2 class="modal-title fs-5" id="sendTestModalLabel"><?php echo Text::_('COM_J2COMMERCE_EMAILTEMPLATE_SEND_TEST'); ?></h2>
                         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="<?php echo Text::_('JCLOSE'); ?>"></button>
                     </div>
                     <div class="modal-body p-3">
@@ -517,7 +517,7 @@ $tmpl = $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=component' : '';
         <div class="modal-dialog modal-lg">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="loadTemplateModalLabel"><?php echo Text::_('COM_J2COMMERCE_EMAILTEMPLATE_LOAD_TEMPLATE'); ?></h5>
+                    <h2 class="modal-title fs-5" id="loadTemplateModalLabel"><?php echo Text::_('COM_J2COMMERCE_EMAILTEMPLATE_LOAD_TEMPLATE'); ?></h2>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="<?php echo Text::_('JCLOSE'); ?>"></button>
                 </div>
                 <div class="modal-body p-3">
@@ -557,7 +557,7 @@ $tmpl = $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=component' : '';
                             <div class="card h-100 template-card" role="button" data-template-type="<?php echo $this->escape($dir); ?>" data-template-design="<?php echo $this->escape($design); ?>" data-email-type="<?php echo $this->escape($dirEmailType); ?>">
                                 <div class="card-body text-center p-3">
                                     <span class="icon-envelope d-block mb-2" style="font-size: 2rem; color: var(--gjs-text-muted, #6c757d);" aria-hidden="true"></span>
-                                    <h6 class="card-title mb-1"><?php echo $this->escape(ucfirst($design)); ?></h6>
+                                    <h3 class="card-title mb-1 fs-6"><?php echo $this->escape(ucfirst($design)); ?></h3>
                                     <small class="text-muted"><?php echo $this->escape(ucfirst($dir)); ?></small>
                                 </div>
                             </div>
@@ -571,7 +571,7 @@ $tmpl = $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=component' : '';
                                 data-email-type="<?php echo $this->escape($card['email_type'] ?? $card['type'] ?? ''); ?>">
                                 <div class="card-body text-center p-3">
                                     <span class="icon-envelope d-block mb-2" style="font-size: 2rem; color: var(--gjs-text-muted, #6c757d);" aria-hidden="true"></span>
-                                    <h6 class="card-title mb-1"><?php echo $this->escape($card['label'] ?? ''); ?></h6>
+                                    <h3 class="card-title mb-1 fs-6"><?php echo $this->escape($card['label'] ?? ''); ?></h3>
                                     <small class="text-muted"><?php echo $this->escape($card['category'] ?? ''); ?></small>
                                 </div>
                             </div>

--- a/administrator/components/com_j2commerce/tmpl/invoicetemplate/edit.php
+++ b/administrator/components/com_j2commerce/tmpl/invoicetemplate/edit.php
@@ -254,7 +254,7 @@ document.addEventListener("DOMContentLoaded", function() {
                             + \'<div class="card h-100 template-card" role="button" data-template-type="\' + preset.type + \'" data-template-design="\' + preset.design + \'">\'
                             + \'<div class="card-body text-center p-3">\'
                             + \'<span class="icon-print d-block mb-2" style="font-size:2rem;color:var(--gjs-text-muted,#6c757d);" aria-hidden="true"></span>\'
-                            + \'<h6 class="card-title mb-1">\' + preset.label + \'</h6>\'
+                            + \'<h3 class="card-title mb-1 fs-6">\' + preset.label + \'</h3>\'
                             + \'<small class="text-muted">\' + type.charAt(0).toUpperCase() + type.slice(1).replace("_", " ") + \'</small>\'
                             + \'</div></div></div>\';
                     });
@@ -396,7 +396,7 @@ $tmpl   = $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=component' : '
         <div class="modal-dialog modal-lg">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="loadTemplateModalLabel"><?php echo Text::_('COM_J2COMMERCE_INVOICETEMPLATE_LOAD_TEMPLATE'); ?></h5>
+                    <h2 class="modal-title fs-5" id="loadTemplateModalLabel"><?php echo Text::_('COM_J2COMMERCE_INVOICETEMPLATE_LOAD_TEMPLATE'); ?></h2>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="<?php echo Text::_('JCLOSE'); ?>"></button>
                 </div>
                 <div class="modal-body p-3">

--- a/administrator/components/com_j2commerce/tmpl/option/edit.php
+++ b/administrator/components/com_j2commerce/tmpl/option/edit.php
@@ -45,10 +45,10 @@ $tmpl    = Factory::getApplication()->input->get('tmpl', '', 'cmd') === 'compone
                     <?php echo $this->form->renderField('published'); ?>
 
                     <div class="alert alert-info">
-                        <h6><?php echo Text::_('COM_J2COMMERCE_OPTION_HELP_TITLE'); ?></h6>
+                        <h2 class="fs-6"><?php echo Text::_('COM_J2COMMERCE_OPTION_HELP_TITLE'); ?></h2>
                         <p class="small"><?php echo Text::_('COM_J2COMMERCE_OPTION_HELP_TEXT'); ?></p>
                         <hr>
-                        <h6><?php echo Text::_('COM_J2COMMERCE_OPTION_UNIQUE_NAME_HELP'); ?></h6>
+                        <h3 class="fs-6"><?php echo Text::_('COM_J2COMMERCE_OPTION_UNIQUE_NAME_HELP'); ?></h3>
                         <p class="small"><?php echo Text::_('COM_J2COMMERCE_OPTION_UNIQUE_NAME_HELP_TEXT'); ?></p>
                     </div>
                 </fieldset>
@@ -58,7 +58,7 @@ $tmpl    = Factory::getApplication()->input->get('tmpl', '', 'cmd') === 'compone
                         <legend><?php echo Text::_('COM_J2COMMERCE_OPTION_CONFIGURATION'); ?></legend>
                         <?php echo $this->form->renderField('option_params'); ?>
                         <div class="alert alert-info">
-                            <h5><?php echo Text::_('COM_J2COMMERCE_OPTION_PARAMS_EXAMPLES'); ?></h5>
+                            <h2 class="fs-5"><?php echo Text::_('COM_J2COMMERCE_OPTION_PARAMS_EXAMPLES'); ?></h2>
                             <code>{"placeholder": "Enter text here", "maxlength": 100, "required": true}</code>
                         </div>
                     </fieldset>

--- a/administrator/components/com_j2commerce/tmpl/order/edit_billing.php
+++ b/administrator/components/com_j2commerce/tmpl/order/edit_billing.php
@@ -19,7 +19,7 @@ $orderInfo = $item->orderinfo ?? null;
 ?>
 <div class="row">
     <div class="col-lg-8">
-        <h4><?php echo Text::_('COM_J2COMMERCE_TAB_BILLING_ADDRESS'); ?></h4>
+        <h2 class="fs-4"><?php echo Text::_('COM_J2COMMERCE_TAB_BILLING_ADDRESS'); ?></h2>
 
         <?php if ($orderInfo) : ?>
         <div class="card">

--- a/administrator/components/com_j2commerce/tmpl/order/edit_items.php
+++ b/administrator/components/com_j2commerce/tmpl/order/edit_items.php
@@ -94,7 +94,7 @@ $currency = $item->currency_code ?? 'USD';
 
         <hr>
 
-        <h5><?php echo Text::_('COM_J2COMMERCE_ADD_PRODUCTS'); ?></h5>
+        <h2 class="fs-5"><?php echo Text::_('COM_J2COMMERCE_ADD_PRODUCTS'); ?></h2>
         <div class="row">
             <div class="col-md-6">
                 <div class="input-group">

--- a/administrator/components/com_j2commerce/tmpl/order/edit_payment_shipping.php
+++ b/administrator/components/com_j2commerce/tmpl/order/edit_payment_shipping.php
@@ -19,7 +19,7 @@ $orderShipping = $item->ordershipping ?? null;
 ?>
 <div class="row">
     <div class="col-lg-6">
-        <h4><?php echo Text::_('COM_J2COMMERCE_ENTER_SHIPPING_DETAILS'); ?></h4>
+        <h2 class="fs-4"><?php echo Text::_('COM_J2COMMERCE_ENTER_SHIPPING_DETAILS'); ?></h2>
         <div class="mb-3">
             <label for="ordershipping_name" class="form-label"><?php echo Text::_('COM_J2COMMERCE_FIELD_SHIPPING_METHOD'); ?></label>
             <input type="text" class="form-control" name="jform[ordershipping_name]" id="ordershipping_name"
@@ -41,7 +41,7 @@ $orderShipping = $item->ordershipping ?? null;
         </div>
     </div>
     <div class="col-lg-6">
-        <h4><?php echo Text::_('COM_J2COMMERCE_SELECT_PAYMENT_METHOD'); ?></h4>
+        <h2 class="fs-4"><?php echo Text::_('COM_J2COMMERCE_SELECT_PAYMENT_METHOD'); ?></h2>
         <div class="mb-3">
             <div class="card">
                 <div class="card-body">

--- a/administrator/components/com_j2commerce/tmpl/order/edit_shipping.php
+++ b/administrator/components/com_j2commerce/tmpl/order/edit_shipping.php
@@ -19,7 +19,7 @@ $orderInfo = $item->orderinfo ?? null;
 ?>
 <div class="row">
     <div class="col-lg-8">
-        <h4><?php echo Text::_('COM_J2COMMERCE_TAB_SHIPPING_ADDRESS'); ?></h4>
+        <h2 class="fs-4"><?php echo Text::_('COM_J2COMMERCE_TAB_SHIPPING_ADDRESS'); ?></h2>
 
         <?php if ($orderInfo && $item->is_shippable) : ?>
         <div class="card">

--- a/administrator/components/com_j2commerce/tmpl/order/edit_summary.php
+++ b/administrator/components/com_j2commerce/tmpl/order/edit_summary.php
@@ -23,7 +23,7 @@ $currency = $item->currency_code ?? 'USD';
     <div class="col-lg-8">
         <?php // Item summary table (readonly) ?>
         <?php if (!empty($orderItems)) : ?>
-        <h5><?php echo Text::_('COM_J2COMMERCE_ORDER_ITEMS'); ?></h5>
+        <h2 class="fs-5"><?php echo Text::_('COM_J2COMMERCE_ORDER_ITEMS'); ?></h2>
         <table class="table table-sm table-striped mb-4">
             <thead>
                 <tr>
@@ -67,7 +67,7 @@ $currency = $item->currency_code ?? 'USD';
         </div>
 
         <?php // Cart Totals ?>
-        <h5><?php echo Text::_('COM_J2COMMERCE_CART_TOTALS'); ?></h5>
+        <h2 class="fs-5"><?php echo Text::_('COM_J2COMMERCE_CART_TOTALS'); ?></h2>
         <table class="table table-sm j2c-summary-table mb-4">
             <tbody>
                 <tr>
@@ -106,7 +106,7 @@ $currency = $item->currency_code ?? 'USD';
         </table>
 
         <?php // Add Fee section ?>
-        <h5><?php echo Text::_('COM_J2COMMERCE_ADD_FEE'); ?></h5>
+        <h2 class="fs-5"><?php echo Text::_('COM_J2COMMERCE_ADD_FEE'); ?></h2>
         <div class="row mb-3">
             <div class="col-md-4">
                 <input type="text" class="form-control" name="fee_name" id="feeName"

--- a/administrator/components/com_j2commerce/tmpl/order/view_details.php
+++ b/administrator/components/com_j2commerce/tmpl/order/view_details.php
@@ -69,7 +69,7 @@ if ($hasDetails) {
 ?>
 <div class="card mb-4">
     <div class="card-header">
-        <h5 class="card-title mb-0"><?php echo Text::_('COM_J2COMMERCE_ORDER_DETAILS'); ?></h5>
+        <h2 class="card-title mb-0 fs-5"><?php echo Text::_('COM_J2COMMERCE_ORDER_DETAILS'); ?></h2>
     </div>
     <div class="card-body">
         <div class="j2c-detail-card-payment j2c-detail-card d-flex justify-content-between align-items-center p-3 mb-3">
@@ -107,9 +107,9 @@ if ($hasDetails) {
                 <div class="modal-dialog modal-lg modal-dialog-scrollable">
                     <div class="modal-content">
                         <div class="modal-header">
-                            <h5 class="modal-title" id="transactionDetailsModalLabel">
+                            <h3 class="modal-title fs-5" id="transactionDetailsModalLabel">
                                 <?php echo Text::_('COM_J2COMMERCE_TRANSACTION_DETAILS'); ?>
-                            </h5>
+                            </h3>
                             <button type="button" class="btn-close" data-bs-dismiss="modal"
                                     aria-label="<?php echo Text::_('JCLOSE'); ?>"></button>
                         </div>

--- a/administrator/components/com_j2commerce/tmpl/order/view_history.php
+++ b/administrator/components/com_j2commerce/tmpl/order/view_history.php
@@ -31,7 +31,7 @@ $currentUserId = (int) (Factory::getApplication()->getIdentity()?->id ?? 0);
 ?>
 <div class="card order-history-card mb-4 border-0 shadow-none bg-transparent" id="j2c-order-history-card">
     <div class="card-header d-flex justify-content-between align-items-center px-0">
-        <h4 class="card-title mb-0"><?php echo Text::_('COM_J2COMMERCE_ORDER_HISTORY'); ?></h4>
+        <h2 class="card-title mb-0 fs-4"><?php echo Text::_('COM_J2COMMERCE_ORDER_HISTORY'); ?></h2>
         <?php if ($totalItems > 0) : ?>
             <span class="<?php echo J2htmlHelper::badgeClass('badge text-bg-secondary'); ?>"><?php echo $totalItems; ?></span>
         <?php endif; ?>
@@ -39,7 +39,7 @@ $currentUserId = (int) (Factory::getApplication()->getIdentity()?->id ?? 0);
 
     <div class="admin-note-card card mb-3 mx-0 mt-3">
         <div class="card-header d-flex justify-content-between align-items-center">
-            <h5 class="card-title mb-0"><?php echo Text::_('COM_J2COMMERCE_ORDER_NOTE'); ?></h5>
+            <h3 class="card-title mb-0 fs-5"><?php echo Text::_('COM_J2COMMERCE_ORDER_NOTE'); ?></h3>
             <button type="button" class="btn btn-sm btn-primary" id="addAdminNoteBtn">
                 <span class="icon-plus" aria-hidden="true"></span> <?php echo Text::_('COM_J2COMMERCE_ADD_NOTE'); ?>
             </button>
@@ -126,11 +126,11 @@ $currentUserId = (int) (Factory::getApplication()->getIdentity()?->id ?? 0);
                                     <?php endif; ?>
                                 </div>
                                 <?php if (!empty($history->order_state_id)) : ?>
-                                    <h4 class="card-title small mb-1">
+                                    <h3 class="card-title small mb-1 fs-4">
                                         <span class="<?php echo J2htmlHelper::badgeClass('badge rounded-2 px-2 text-bg-' . $this->escape($foundColor)); ?>">
                                             <?php echo $this->escape(Text::_($history->orderstatus_name ?? 'Unknown')); ?>
                                         </span>
-                                    </h4>
+                                    </h3>
                                 <?php endif; ?>
                                 <?php if (!empty($comment)) : ?>
                                     <p class="card-text text-body-secondary small mb-0"><?php echo $this->escape($comment); ?></p>

--- a/administrator/components/com_j2commerce/tmpl/order/view_items.php
+++ b/administrator/components/com_j2commerce/tmpl/order/view_items.php
@@ -25,7 +25,7 @@ $currencyCode = $item->currency_code ?? '';
 <?php echo J2CommerceHelper::plugin()->eventWithHtml('BeforeAdminOrderItems', array($item))->getArgument('html', ''); ?>
 <div class="order-items-card card mb-4">
     <div class="card-header d-flex justify-content-between align-items-center">
-        <h4 class="card-title mb-0"><?php echo Text::_('COM_J2COMMERCE_ORDER_ITEMS'); ?></h4>
+        <h2 class="card-title mb-0 fs-4"><?php echo Text::_('COM_J2COMMERCE_ORDER_ITEMS'); ?></h2>
     </div>
     <div class="card-body">
         <?php if (!empty($orderItems)) : ?>
@@ -49,7 +49,7 @@ $currencyCode = $item->currency_code ?? '';
                                                 </div>
                                             <?php endif; ?>
                                             <div class="cart-product-info">
-                                                <h5 class="cart-product-name mb-1"><?php echo $this->escape($orderItem->orderitem_name); ?></h5>
+                                                <h3 class="cart-product-name mb-1 fs-5"><?php echo $this->escape($orderItem->orderitem_name); ?></h3>
                                                 <?php echo J2CommerceHelper::plugin()->eventWithHtml('AfterDisplayLineItemTitle', array($orderItem, $item, $this->params))->getArgument('html', ''); ?>
                                                 <div class="small d-flex align-items-center">
                                                     <div class="item-option item-option-name"><?php echo Text::_('COM_J2COMMERCE_PRODUCT_SKU');?>:</div>

--- a/administrator/components/com_j2commerce/tmpl/order/view_sidebar.php
+++ b/administrator/components/com_j2commerce/tmpl/order/view_sidebar.php
@@ -48,7 +48,7 @@ if ($orderInfo) {
 <?php // === Customer Note === ?>
 <div class="customer-note-card card mb-3">
     <div class="card-header">
-        <h5 class="card-title mb-0"><?php echo Text::_('COM_J2COMMERCE_CUSTOMER_NOTE'); ?></h5>
+        <h2 class="card-title mb-0 fs-5"><?php echo Text::_('COM_J2COMMERCE_CUSTOMER_NOTE'); ?></h2>
     </div>
     <div class="card-body">
         <textarea class="form-control" id="customerNote" rows="2" readonly><?php echo $this->escape($item->customer_note ?? ''); ?></textarea>
@@ -60,7 +60,7 @@ if ($orderInfo) {
     <?php echo J2CommerceHelper::plugin()->eventWithHtml('BeforeAdminOrderCustomerInformation', array($item))->getArgument('html', ''); ?>
     <div class="customer-information-card card mb-3">
         <div class="card-header">
-            <h5 class="card-title mb-0"><?php echo Text::_('COM_J2COMMERCE_CUSTOMER_INFORMATION'); ?></h5>
+            <h2 class="card-title mb-0 fs-5"><?php echo Text::_('COM_J2COMMERCE_CUSTOMER_INFORMATION'); ?></h2>
         </div>
         <div class="card-body">
             <div class="row customer-information-row">

--- a/administrator/components/com_j2commerce/tmpl/order/view_summary.php
+++ b/administrator/components/com_j2commerce/tmpl/order/view_summary.php
@@ -33,7 +33,7 @@ $fees      = $item->orderfees ?? [];
 ?>
 <div class="card mb-4 order-card order-summary-card">
     <div class="card-header">
-        <h4 class="card-title mb-0"><?php echo Text::_('COM_J2COMMERCE_ORDER_SUMMARY'); ?></h4>
+        <h2 class="card-title mb-0 fs-4"><?php echo Text::_('COM_J2COMMERCE_ORDER_SUMMARY'); ?></h2>
     </div>
     <div class="card-body">
         <?php echo J2CommerceHelper::plugin()->eventWithHtml('BeforeAdminOrderSummery', array(&$order,&$items))->getArgument('html', ''); ?>

--- a/administrator/components/com_j2commerce/tmpl/orders/default_batch_body.php
+++ b/administrator/components/com_j2commerce/tmpl/orders/default_batch_body.php
@@ -19,7 +19,7 @@ use Joomla\CMS\Language\Text;
 <div class="p-3">
     <!-- Change Status Section -->
     <div class="mb-4">
-        <h5 class="fw-bold"><?php echo Text::_('COM_J2COMMERCE_CHANGE_ORDER_STATUS'); ?></h5>
+        <h2 class="fw-bold fs-5"><?php echo Text::_('COM_J2COMMERCE_CHANGE_ORDER_STATUS'); ?></h2>
         <div class="mb-2">
             <select name="order_state_id" id="batch_order_state_id" class="form-select">
                 <option value=""><?php echo Text::_('COM_J2COMMERCE_SELECT_ORDER_STATUS'); ?></option>
@@ -49,7 +49,7 @@ use Joomla\CMS\Language\Text;
     <?php if ($this->hasPackingSlipTemplate) : ?>
     <!-- Print Packing Slips Section -->
     <div class="mb-4">
-        <h5 class="fw-bold"><?php echo Text::_('COM_J2COMMERCE_PRINT_PACKING_SLIPS'); ?></h5>
+        <h2 class="fw-bold fs-5"><?php echo Text::_('COM_J2COMMERCE_PRINT_PACKING_SLIPS'); ?></h2>
         <button type="button" class="btn btn-outline-secondary btn-sm" onclick="window.j2cPrintPackingSlips();">
             <span class="icon-print" aria-hidden="true"></span>
             <?php echo Text::_('COM_J2COMMERCE_PRINT_PACKING_SLIPS'); ?>
@@ -60,7 +60,7 @@ use Joomla\CMS\Language\Text;
     <?php if ($this->canDelete) : ?>
     <!-- Delete Section -->
     <div class="mb-2">
-        <h5 class="fw-bold text-danger"><?php echo Text::_('COM_J2COMMERCE_DELETE_SELECTED_ORDERS'); ?></h5>
+        <h2 class="fw-bold text-danger fs-5"><?php echo Text::_('COM_J2COMMERCE_DELETE_SELECTED_ORDERS'); ?></h2>
         <p class="text-muted small"><?php echo Text::_('COM_J2COMMERCE_DELETE_ORDERS_WARNING'); ?></p>
         <joomla-toolbar-button task="orders.delete">
             <button type="button" class="btn btn-danger btn-sm"

--- a/administrator/components/com_j2commerce/tmpl/overrides/default_builder.php
+++ b/administrator/components/com_j2commerce/tmpl/overrides/default_builder.php
@@ -124,7 +124,7 @@ $token = Session::getFormToken();
                         <div class="d-flex align-items-center justify-content-center h-100 align-self-stretch" id="builder-placeholder">
                             <div class="text-center builder-placeholder-content">
                                 <span class="fa-solid fa-wand-magic-sparkles text-warning fa-3x mb-3" aria-hidden="true"></span>
-                                <h4 class="mt-3"><?php echo Text::_('COM_J2COMMERCE_BUILDER_PLACEHOLDER_TITLE'); ?></h4>
+                                <h2 class="mt-3 fs-4"><?php echo Text::_('COM_J2COMMERCE_BUILDER_PLACEHOLDER_TITLE'); ?></h2>
                                 <p class="text-muted"><?php echo Text::_('COM_J2COMMERCE_BUILDER_PLACEHOLDER_TEXT'); ?></p>
                             </div>
                         </div>
@@ -140,9 +140,9 @@ $token = Session::getFormToken();
     <div class="modal-dialog modal-lg">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title" id="builderTemplatesModalLabel">
+                <h2 class="modal-title fs-5" id="builderTemplatesModalLabel">
                     <span class="fa-solid fa-layer-group me-2 text-warning" aria-hidden="true"></span><?php echo Text::_('COM_J2COMMERCE_BUILDER_TEMPLATES_TITLE'); ?>
-                </h5>
+                </h2>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body">

--- a/administrator/components/com_j2commerce/tmpl/overrides/default_overrides.php
+++ b/administrator/components/com_j2commerce/tmpl/overrides/default_overrides.php
@@ -123,12 +123,12 @@ $wa->addInlineStyle($style);
                                                     <div class="card layout-card rounded-1 h-100 border-2 <?php echo ($file['hasOverride'] ?? false) ? 'border-success' : ''; ?>">
                                                         <div class="card-body d-flex flex-column">
                                                             <div class="d-flex align-items-start justify-content-between mb-2">
-                                                                <h5 class="card-title mb-0">
+                                                                <h3 class="card-title mb-0 fs-5">
                                                                     <?php echo $this->escape($file['displayName'] ?? $file['filename']); ?>
                                                                     <?php if (($file['context'] ?? '') === 'tag') : ?>
                                                                         <span class="ms-1 <?php echo J2htmlHelper::badgeClass('badge text-bg-purple'); ?>">Tag</span>
                                                                     <?php endif; ?>
-                                                                </h5>
+                                                                </h3>
                                                                 <?php if ($file['hasOverride'] ?? false) : ?>
                                                                     <span class="<?php echo J2htmlHelper::badgeClass('badge text-bg-success'); ?> ms-2 flex-shrink-0">
                                                                         <span class="icon-check" aria-hidden="true"></span>

--- a/administrator/components/com_j2commerce/tmpl/product/form.php
+++ b/administrator/components/com_j2commerce/tmpl/product/form.php
@@ -246,7 +246,7 @@ $wa->addInlineScript($submitButtonJs);
                         </div>
                         <div class="description-area">
                             <div class="d-flex align-items-center justify-content-between">
-                                <h6><?php echo Text::_('COM_J2COMMERCE_PLUGIN_SHORTCODE');?></h6>
+                                <h2 class="fs-6"><?php echo Text::_('COM_J2COMMERCE_PLUGIN_SHORTCODE');?></h2>
                                 <button type="button" class="btn btn-sm btn-soft-dark fw-medium" id="j2commerceToggleShortcodes" data-bs-toggle="collapse" data-bs-target="#collapseShortcodes" aria-expanded="false" aria-controls="collapseShortcodes">
                                     <?php echo Text::_('COM_J2COMMERCE_VIEW_ADDITIONAL_SHORTCODES'); ?>
                                 </button>
@@ -370,7 +370,7 @@ $wa->addInlineScript($submitButtonJs);
             <div class="modal-dialog modal-dialog-centered modal-lg">
                 <div class="modal-content">
                     <div class="modal-header border-0">
-                        <h5 class="modal-title fs-3 fw-bold" id="changeProductTypeModalLabel"><?php echo Text::_('COM_J2COMMERCE_CHANGE_PRODUCT_TYPE'); ?></h5>
+                        <h3 class="modal-title fs-3 fw-bold" id="changeProductTypeModalLabel"><?php echo Text::_('COM_J2COMMERCE_CHANGE_PRODUCT_TYPE'); ?></h3>
                         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="<?php echo Text::_('JCLOSE'); ?>"></button>
                     </div>
                     <div class="modal-body">

--- a/administrator/components/com_j2commerce/tmpl/product/form_ajax_avfilter.php
+++ b/administrator/components/com_j2commerce/tmpl/product/form_ajax_avfilter.php
@@ -52,7 +52,7 @@ $productFilters = (new ProductfiltersModel)->getFiltersByProduct($item->j2commer
         <?php if(isset($productFilters) && count($productFilters)): ?>
             <?php foreach($productFilters as $group_id=>$filters):?>
                 <tr>
-                    <td colspan="2"><h4 class="mb-0"><?php echo Text::_($this->escape($filters['group_name'])); ?></h4></td>
+                    <td colspan="2"><h2 class="mb-0 fs-4"><?php echo Text::_($this->escape($filters['group_name'])); ?></h2></td>
                 </tr>
                 <?php foreach($filters['filters'] as $filter):
                     ?>

--- a/administrator/components/com_j2commerce/tmpl/product/form_ajax_optionvalues.php
+++ b/administrator/components/com_j2commerce/tmpl/product/form_ajax_optionvalues.php
@@ -55,7 +55,7 @@ $wa->addInlineStyle($style, [], []);
     <!-- Add New Option Value Section -->
     <div class="card box-shadow-none mb-3">
         <div class="card-header">
-            <h6 class="mb-0"><?php echo Text::_('COM_J2COMMERCE_PAO_ADD_NEW_OPTION'); ?></h6>
+            <h3 class="mb-0 fs-6"><?php echo Text::_('COM_J2COMMERCE_PAO_ADD_NEW_OPTION'); ?></h3>
         </div>
         <div class="card-body">
             <div class="table-responsive">
@@ -157,7 +157,7 @@ $wa->addInlineStyle($style, [], []);
     <!-- Current Option Values Section -->
     <div class="card box-shadow-none">
         <div class="card-header d-flex justify-content-between align-items-center">
-            <h6 class="mb-0"><?php echo Text::_('COM_J2COMMERCE_PAO_CURRENT_OPTIONS'); ?></h6>
+            <h3 class="mb-0 fs-6"><?php echo Text::_('COM_J2COMMERCE_PAO_CURRENT_OPTIONS'); ?></h3>
             <button class="btn btn-success btn-sm" type="button" id="j2commerce-save-optionvalues-btn">
                 <?php echo Text::_('COM_J2COMMERCE_SAVE_CHANGES'); ?>
             </button>

--- a/administrator/components/com_j2commerce/tmpl/product/form_configoptions.php
+++ b/administrator/components/com_j2commerce/tmpl/product/form_configoptions.php
@@ -149,7 +149,7 @@ $csrfToken = \Joomla\CMS\Session\Session::getFormToken();
     <div class="modal-dialog modal-xl">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title" id="configOptionValuesModalLabel"><?php echo Text::_('COM_J2COMMERCE_OPTION_SET_VALUES'); ?></h5>
+                <h2 class="modal-title fs-5" id="configOptionValuesModalLabel"><?php echo Text::_('COM_J2COMMERCE_OPTION_SET_VALUES'); ?></h2>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="<?php echo Text::_('JCLOSE'); ?>"></button>
             </div>
             <div class="modal-body" id="j2commerceConfigOptionValuesModalBody" style="max-height: 70vh; overflow-y: auto;">

--- a/administrator/components/com_j2commerce/tmpl/product/form_downloadablefiles.php
+++ b/administrator/components/com_j2commerce/tmpl/product/form_downloadablefiles.php
@@ -150,7 +150,7 @@ $layoutPath = JPATH_ADMINISTRATOR . '/components/com_j2commerce/layouts';
     </fieldset>
 
     <div class="alert alert-info mt-3">
-        <h4 class="alert-heading"><?php echo Text::_('COM_J2COMMERCE_QUICK_HELP'); ?></h4>
+        <h2 class="alert-heading fs-4"><?php echo Text::_('COM_J2COMMERCE_QUICK_HELP'); ?></h2>
         <p class="mb-1"><?php echo Text::_('COM_J2COMMERCE_PRODUCT_FILES_HELP_TEXT'); ?></p>
         <ul class="mb-0">
             <li><?php echo Text::_('COM_J2COMMERCE_PRODUCT_FILES_HELP_DOWNLOAD_LIMIT'); ?></li>

--- a/administrator/components/com_j2commerce/tmpl/product/form_images.php
+++ b/administrator/components/com_j2commerce/tmpl/product/form_images.php
@@ -206,7 +206,7 @@ $base_path = JPATH_ADMINISTRATOR . '/components/com_j2commerce/tmpl/product';
     <?php echo J2CommerceHelper::plugin()->eventWithHtml('AfterProductImagesForm', array($this, $item, $formPrefix))->getArgument('html', ''); ?>
 
     <div class="alert alert-info mt-3">
-        <h4 class="alert-heading"><?php echo Text::_('COM_J2COMMERCE_QUICK_HELP'); ?></h4>
+        <h2 class="alert-heading fs-4"><?php echo Text::_('COM_J2COMMERCE_QUICK_HELP'); ?></h2>
         <p class="mb-1"><?php echo Text::_('COM_J2COMMERCE_FEATURE_AVAILABLE_IN_PRODUCT_LAYOUTS_AND_ARTICLES'); ?></p>
         <?php
         $db = Factory::getContainer()->get('DatabaseDriver');

--- a/administrator/components/com_j2commerce/tmpl/product/form_options.php
+++ b/administrator/components/com_j2commerce/tmpl/product/form_options.php
@@ -134,7 +134,7 @@ $csrfToken = \Joomla\CMS\Session\Session::getFormToken();
     <div class="modal-dialog modal-xl">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title" id="optionValuesModalLabel"><?php echo Text::_('COM_J2COMMERCE_OPTION_SET_VALUES'); ?></h5>
+                <h2 class="modal-title fs-5" id="optionValuesModalLabel"><?php echo Text::_('COM_J2COMMERCE_OPTION_SET_VALUES'); ?></h2>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="<?php echo Text::_('JCLOSE'); ?>"></button>
             </div>
             <div class="modal-body" id="j2commerceOptionValuesModalBody" style="max-height: 70vh; overflow-y: auto;">

--- a/administrator/components/com_j2commerce/tmpl/product/form_pricing.php
+++ b/administrator/components/com_j2commerce/tmpl/product/form_pricing.php
@@ -109,7 +109,7 @@ $link = $base_path . '/index.php?option=com_j2commerce&view=productprice&layout=
 
 
     <div class="alert alert-info">
-        <h4><?php echo Text::_('COM_J2COMMERCE_QUICK_HELP'); ?></h4>
+        <h2 class="fs-4"><?php echo Text::_('COM_J2COMMERCE_QUICK_HELP'); ?></h2>
         <?php echo Text::_('COM_J2COMMERCE_PRODUCT_PRICE_HELP_TEXT'); ?>
     </div>
 

--- a/administrator/components/com_j2commerce/tmpl/product/form_variable_options.php
+++ b/administrator/components/com_j2commerce/tmpl/product/form_variable_options.php
@@ -136,7 +136,7 @@ $csrfToken  = Session::getFormToken();
     <div class="modal-dialog modal-xl">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title" id="variableOptionValuesModalLabel"><?php echo Text::_('COM_J2COMMERCE_OPTION_SET_VALUES'); ?></h5>
+                <h2 class="modal-title fs-5" id="variableOptionValuesModalLabel"><?php echo Text::_('COM_J2COMMERCE_OPTION_SET_VALUES'); ?></h2>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="<?php echo Text::_('JCLOSE'); ?>"></button>
             </div>
             <div class="modal-body" id="j2commerceVariableOptionValuesModalBody" style="max-height: 70vh; overflow-y: auto;">

--- a/administrator/components/com_j2commerce/tmpl/queuelogs/default.php
+++ b/administrator/components/com_j2commerce/tmpl/queuelogs/default.php
@@ -179,7 +179,7 @@ $statusBadges = [
     <div class="modal-dialog modal-lg">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title" id="queuelogDetailsModalLabel"></h5>
+                <h2 class="modal-title fs-5" id="queuelogDetailsModalLabel"></h2>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="<?php echo Text::_('JCLOSE'); ?>"></button>
             </div>
             <div class="modal-body p-4" id="queuelogDetailsModalBody"></div>

--- a/administrator/components/com_j2commerce/tmpl/shippingtroubles/default_shipping.php
+++ b/administrator/components/com_j2commerce/tmpl/shippingtroubles/default_shipping.php
@@ -204,7 +204,7 @@ function getStatusBadge($status, $message = '') {
 
                 <?php if ($hasErrors): ?>
                     <div class="alert alert-danger" role="alert">
-                        <h5 class="text-danger"><span class="fa-solid fa-exclamation-triangle me-2" aria-hidden="true"></span><?php echo Text::_('COM_J2COMMERCE_SHIPPING_TROUBLESHOOTER_CRITICAL_ISSUES'); ?></h5>
+                        <h3 class="text-danger fs-5"><span class="fa-solid fa-exclamation-triangle me-2" aria-hidden="true"></span><?php echo Text::_('COM_J2COMMERCE_SHIPPING_TROUBLESHOOTER_CRITICAL_ISSUES'); ?></h3>
                         <ul class="mb-0">
                             <?php if ($diagnostics['shipping_methods']['status'] === 'error'): ?>
                                 <li><?php echo Text::_('COM_J2COMMERCE_SHIPPING_TROUBLESHOOTER_RECOMMENDATION_ADD_METHODS'); ?></li>
@@ -216,7 +216,7 @@ function getStatusBadge($status, $message = '') {
                     </div>
                 <?php elseif ($hasWarnings): ?>
                     <div class="alert alert-warning" role="alert">
-                        <h5 class="text-warning"><span class="fa-solid fa-info-circle me-2" aria-hidden="true"></span><?php echo Text::_('COM_J2COMMERCE_SHIPPING_TROUBLESHOOTER_IMPROVEMENTS'); ?></h5>
+                        <h3 class="text-warning fs-5"><span class="fa-solid fa-info-circle me-2" aria-hidden="true"></span><?php echo Text::_('COM_J2COMMERCE_SHIPPING_TROUBLESHOOTER_IMPROVEMENTS'); ?></h3>
                         <ul class="mb-0">
                             <?php if ($diagnostics['geozones']['status'] === 'warning'): ?>
                                 <li><?php echo Text::_('COM_J2COMMERCE_SHIPPING_TROUBLESHOOTER_RECOMMENDATION_ADD_GEOZONES'); ?></li>
@@ -225,7 +225,7 @@ function getStatusBadge($status, $message = '') {
                     </div>
                 <?php else: ?>
                     <div class="alert alert-success" role="alert">
-                        <h5 class="text-success"><span class="fa-solid fa-check-circle me-2" aria-hidden="true"></span><?php echo Text::_('COM_J2COMMERCE_SHIPPING_TROUBLESHOOTER_ALL_GOOD'); ?></h5>
+                        <h3 class="text-success fs-5"><span class="fa-solid fa-check-circle me-2" aria-hidden="true"></span><?php echo Text::_('COM_J2COMMERCE_SHIPPING_TROUBLESHOOTER_ALL_GOOD'); ?></h3>
                         <p class="mb-0"><?php echo Text::_('COM_J2COMMERCE_SHIPPING_TROUBLESHOOTER_ALL_GOOD_DESCRIPTION'); ?></p>
                     </div>
                 <?php endif; ?>

--- a/administrator/components/com_j2commerce/tmpl/voucher/history.php
+++ b/administrator/components/com_j2commerce/tmpl/voucher/history.php
@@ -24,10 +24,10 @@ J2CommerceHelper::strapper()->addCSS();
     <div class="col-md-12">
         <div class="card">
             <div class="card-header">
-                <h3 class="card-title">
+                <h2 class="card-title fs-3">
                     <?php echo Text::_('COM_J2COMMERCE_VOUCHER_HISTORY'); ?>:
                     <span class="badge bg-primary"><?php echo htmlspecialchars($this->item->voucher_code, ENT_QUOTES, 'UTF-8'); ?></span>
-                </h3>
+                </h2>
             </div>
             <div class="card-body">
                 <?php if (!empty($this->orders) && count($this->orders) > 0) : ?>


### PR DESCRIPTION
## Summary

Part of #649 — fixes WCAG 2.4.10 heading hierarchy violations across the J2Commerce administrator. This PR covers the **admin (backend) only**; site/frontend fixes are tracked separately and will follow in subsequent PRs.

## Problem

`ToolbarHelper::title()` renders the admin page `<h1>`, but most admin view templates jumped directly to `<h3>`, `<h4>`, `<h5>`, or `<h6>`, skipping levels and breaking screen-reader navigation. The Bootstrap convention of `<h5 class="card-title">` and `<h5 class="modal-title">` was used widely for visual sizing regardless of semantic depth.

## Fix Pattern (single rule)

**Change semantic level, preserve visual size with a Bootstrap `fs-*` utility class.**

```html
<!-- BEFORE -->
<h5 class="card-title">Section Title</h5>

<!-- AFTER (visually identical) -->
<h2 class="card-title fs-5">Section Title</h2>
```

Modal dialog titles set to `<h2>` (independent `role="dialog"` ARIA landmark, matching Bootstrap 5.3's `<h1 class="modal-title fs-5">` pattern at one level deeper). Composed views (`product/form.php`, `order/edit.php`, `order/view.php`) and their sub-templates aligned so child sub-templates use `h3` inside parent `h2` sections.

## Changes (35 files, 86 / 86 lines)

| Group | Files |
|---|---|
| Confirmed in-file skips | `overrides/default_overrides.php`, `shippingtroubles/default_shipping.php`, `dashboard/default_categorywizard.php` |
| Product form composition | `product/form.php` + 8 `form_*.php` sub-templates |
| Order edit/view composition | 10 files in `order/` |
| Dashboard | `dashboard/default.php`, `default_onboarding.php`, `default_setup_guide.php`, `default_categorywizard.php` |
| Standalone admin views | `advancedpricing/default_batch.php`, `coupon/history.php`, `customfields/default_batch.php`, `emailtemplate/edit.php`, `invoicetemplate/edit.php`, `option/edit.php`, `orders/default_batch_body.php`, `overrides/default_builder.php`, `queuelogs/default.php`, `voucher/history.php` |

## Notable Decisions

- **Modal titles → `h2`** — Bootstrap modals are `role="dialog"` independent landmarks; per Bootstrap 5.3 docs the modal title is the top of the dialog's heading tree.
- **AJAX-loaded sub-content** (`form_ajax_optionvalues.php`) — kept at `h3` because it injects into a modal body whose parent has `h2.modal-title` above.
- **JS-string heading** in `invoicetemplate/edit.php:257` — fixed `<h6>` → `<h3 class="card-title fs-6">` because the JS injects preset cards into a modal body below an `h2.modal-title`.

## Test Plan

- [ ] Open `/administrator/?option=com_j2commerce` — devtools accessibility tree shows `h1` (toolbar) → `h2` sections → `h3` sub-cards. No skips.
- [ ] **Products → Add New Product** — click each tab (Details, Images, Pricing, Options, Downloadable Files, Variable Options). Each tab panel starts at `h2`. Open the "Set Values" modal from Options tab → modal title is `h2`.
- [ ] **Orders → open any order** in View and Edit modes — heading outline correct.
- [ ] **Orders → batch update** — modal title is `h2`.
- [ ] **Email Templates → Edit → Load Template** modal — modal title is `h2`; preset cards (loaded via JS) are `h3`.
- [ ] **Vouchers → click any voucher → History** — page heading is `h2`.
- [ ] **Custom Fields → batch update** — modal heading is `h2`.
- [ ] Run Lighthouse Accessibility audit on dashboard + product edit + order edit. "Heading elements appear in a sequentially-descending order" passes.
- [ ] Visual regression: dashboard and product edit pages render identically to before (`fs-*` classes preserve appearance).

## Pre-Flight

- [x] PHP syntax check passed (`php -l` on all 35 files)
- [x] No secrets detected in diff
- [x] No FOF remnants (only `<h*>` tag changes)
- [x] No language string changes
- [x] Core files only (all under `administrator/components/com_j2commerce/tmpl/`)
- [x] `php-cs-fixer` N/A (all changed files are under `/tmpl/`, excluded by config)

## Scope

This is **part of #649**. The site (frontend) fixes are split into separate PRs:
- PR for plugin/app templates (~21 files)
- PR for site layout fragments (~53 files)
- PR for contributing guideline

#649 will be closed by the final site PR.