### PR TITLE
fix(customer): always render card view for guest customers

### DIFF
--- a/administrator/components/com_j2commerce/src/Model/AddressesModel.php
+++ b/administrator/components/com_j2commerce/src/Model/AddressesModel.php
@@ -77,6 +77,48 @@ class AddressesModel extends ListModel
         return $db->loadObjectList() ?: [];
     }
 
+    /**
+     * Get all addresses for a guest customer identified by email, with country and
+     * zone names. Used by the customer edit view so guest customers (user_id = 0)
+     * can still render the card grid the same way registered customers do.
+     */
+    public function getAddressesByEmail(string $email): array
+    {
+        $email = trim($email);
+
+        if ($email === '') {
+            return [];
+        }
+
+        $db    = $this->getDatabase();
+        $query = $db->getQuery(true);
+
+        $query->select($db->quoteName([
+            'a.j2commerce_address_id', 'a.user_id', 'a.first_name', 'a.last_name',
+            'a.email', 'a.address_1', 'a.address_2', 'a.city', 'a.zip',
+            'a.zone_id', 'a.country_id', 'a.phone_1', 'a.phone_2', 'a.fax',
+            'a.type', 'a.company', 'a.tax_number',
+        ]))
+            ->from($db->quoteName('#__j2commerce_addresses', 'a'))
+            ->leftJoin(
+                $db->quoteName('#__j2commerce_countries', 'c') .
+                ' ON ' . $db->quoteName('c.j2commerce_country_id') . ' = ' . $db->quoteName('a.country_id')
+            )
+            ->select($db->quoteName('c.country_name'))
+            ->leftJoin(
+                $db->quoteName('#__j2commerce_zones', 'z') .
+                ' ON ' . $db->quoteName('z.j2commerce_zone_id') . ' = ' . $db->quoteName('a.zone_id')
+            )
+            ->select($db->quoteName('z.zone_name'))
+            ->where($db->quoteName('a.email') . ' = :email')
+            ->bind(':email', $email, ParameterType::STRING)
+            ->order($db->quoteName('a.j2commerce_address_id') . ' ASC');
+
+        $db->setQuery($query);
+
+        return $db->loadObjectList() ?: [];
+    }
+
     protected function getListQuery(): QueryInterface
     {
         $db    = $this->getDatabase();

--- a/administrator/components/com_j2commerce/src/Model/CustomerModel.php
+++ b/administrator/components/com_j2commerce/src/Model/CustomerModel.php
@@ -277,6 +277,36 @@ class CustomerModel extends AdminModel
     }
 
     /**
+     * Get all addresses belonging to a guest customer identified by email
+     * (with country and zone names). Used when user_id = 0 so the edit view
+     * can still render the card grid consistently with registered customers.
+     *
+     * @param   string  $email  Customer email.
+     *
+     * @return  array  Array of address objects (empty if email is blank).
+     *
+     * @since   6.0.9
+     */
+    public function getAddressesByEmail(string $email): array
+    {
+        if (trim($email) === '') {
+            return [];
+        }
+
+        /** @var AddressesModel $addressesModel */
+        $addressesModel = Factory::getApplication()
+            ->bootComponent('com_j2commerce')
+            ->getMVCFactory()
+            ->createModel('Addresses', 'Administrator', ['ignore_request' => true]);
+
+        if (!$addressesModel) {
+            return [];
+        }
+
+        return $addressesModel->getAddressesByEmail($email);
+    }
+
+    /**
      * Get enabled custom fields for the address table.
      *
      * Mirrors ManufacturerModel::getAddressCustomFields() so the customer edit view can

--- a/administrator/components/com_j2commerce/src/View/Customer/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Customer/HtmlView.php
@@ -106,11 +106,20 @@ class HtmlView extends BaseHtmlView
         $this->state = $model->getState();
 
         // Decide whether to render the Bootstrap 5 card grid or the inline form.
+        // Registered customers resolve their address book by user_id; guest customers
+        // (user_id = 0) fall back to lookup by email so they render the card grid the
+        // same way — matching how CustomersModel groups the customer list by email.
         $userId    = (int) ($this->item->user_id ?? 0);
         $addressId = (int) ($this->item->j2commerce_address_id ?? 0);
+        $email     = (string) ($this->item->email ?? '');
 
-        if ($userId > 0 && $addressId > 0) {
-            $this->addresses   = $model->getAddressesByUser($userId);
+        if ($addressId > 0) {
+            if ($userId > 0) {
+                $this->addresses = $model->getAddressesByUser($userId);
+            } elseif ($email !== '') {
+                $this->addresses = $model->getAddressesByEmail($email);
+            }
+
             $this->useCardMode = !empty($this->addresses);
         }
 


### PR DESCRIPTION
## Summary
Fixes #663

The admin customer edit view only activated the Bootstrap 5 card grid when the address had a linked Joomla user (`user_id > 0`). Guest customers fell through to the legacy tabbed inline form, so shops with a mix of registered and guest customers saw inconsistent layouts — cards for some customers, tabs for others.

This resolves the address book by `email` when `user_id = 0` so guest customers render the same card grid as registered customers. Matches how `CustomersModel` already groups the customer list by email.

## Changes
- **`administrator/components/com_j2commerce/src/Model/AddressesModel.php`** — new `getAddressesByEmail(string $email): array` method (mirrors `getAddressesByUser` but filters on `a.email`, bound as `ParameterType::STRING`)
- **`administrator/components/com_j2commerce/src/Model/CustomerModel.php`** — new `getAddressesByEmail()` wrapper that boots `AddressesModel` via the MVC factory
- **`administrator/components/com_j2commerce/src/View/Customer/HtmlView.php`** — when editing an existing address, resolve the address book by `user_id` if linked, otherwise fall back to `email`. `useCardMode` now activates for any customer with ≥1 address, registered or guest

## Root Cause
`HtmlView::display()` had a guard clause `if ($userId > 0 && $addressId > 0)` and no fallback path for guest customers. Combined with `AddressesModel::getAddressesByUser()` short-circuiting on `$userId <= 0`, there was literally no branch that could populate `$this->addresses` for a guest, so `useCardMode` stayed `false` and the template rendered the tabbed inline form.

## Testing
1. Open **Components → J2Commerce → Customers**
2. **Guest customer, 1 address** (`user_id = 0`): click to edit — expect Bootstrap 5 card grid (not tabs). Toolbar shows **Add New Address** only.
3. **Guest customer, 2+ addresses**: card grid, multiple cards.
4. **Registered customer, 1 address** (`user_id > 0`): card grid, user dropdown populated in sidebar.
5. **Registered customer, 2+ addresses**: unchanged — card grid.
6. Click **Add New Address** → modal loads the form fragment via AJAX, save round-trips.
7. Click edit/delete on an existing card → modal + AJAX flow still works.
8. Check `administrator/logs/` for PHP notices — none expected.

## Files Changed
| Type | Count |
|------|-------|
| PHP files | 3 |
| JS/CSS assets | 0 |
| Language files | 0 |
| XML/Config | 0 |

## Pre-Flight
- [x] PHP syntax check passed (`php -l` on all 3 files)
- [x] No secrets detected
- [x] No FOF remnants
- [x] Code style (php-cs-fixer) passed — 0 of 3 files needed fixes
- [x] Core files only
- [x] Based on latest `upstream/main`