### PR TITLE
feat(core): add RegisterLayoutPaths plugin event for product layouts

### DIFF
--- a/components/com_j2commerce/src/Service/ProductLayoutService.php
+++ b/components/com_j2commerce/src/Service/ProductLayoutService.php
@@ -163,6 +163,17 @@ final class ProductLayoutService
             }
         }
 
+        // Allow third-party product-type plugins to register additional layout search paths.
+        // Subscribers receive &$paths by reference plus the active $pluginElement and $layoutId,
+        // and should append any plugin-owned directories to $paths. Appended paths have the
+        // lowest search priority (can be overridden by template overrides, component layouts,
+        // and the active core subtemplate plugin's own layouts).
+        J2CommerceHelper::plugin()->event('RegisterLayoutPaths', [
+            &$paths,
+            $pluginElement,
+            $layoutId,
+        ]);
+
         if (!empty($paths)) {
             $layout->setIncludePaths($paths);
         }


### PR DESCRIPTION
## Core Update

Adds a `RegisterLayoutPaths` plugin event in `ProductLayoutService::resolveLayout()` so third-party product-type plugins (e.g. subscription products, custom variant types) can append their own layout search directories without editing core.

### Changes
- New event dispatch via `J2CommerceHelper::plugin()->event('RegisterLayoutPaths', [&$paths, $pluginElement, $layoutId])`
- Subscribers receive `$paths` by reference plus the active `$pluginElement` and `$layoutId`
- Appended paths have the **lowest** search priority — template overrides, component layouts, and the active core subtemplate plugin's own layouts still win

### Why
3rd-party product types must register layout paths via plugin events rather than hardcoding into the core dispatcher. This is the registration hook that makes that contract work.

### Files Modified
| Type | Count |
|------|-------|
| PHP files | 1 |

`components/com_j2commerce/src/Service/ProductLayoutService.php` (+11 lines, additive only)

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Code style (php-cs-fixer) passed
- [x] Core files only (non-core excluded)