### PR TITLE
fix(a11y): correct frontend heading hierarchy skips (part of #649)

### DIFF
--- a/components/com_j2commerce/tmpl/dashboard/default.php
+++ b/components/com_j2commerce/tmpl/dashboard/default.php
@@ -26,7 +26,7 @@ use Joomla\CMS\Router\Route;
         <div class="col-md-4">
             <div class="card text-center">
                 <div class="card-body">
-                    <h5 class="card-title"><?php echo Text::_('COM_J2COMMERCE_DASHBOARD_PRODUCTS'); ?></h5>
+                    <h2 class="card-title fs-5"><?php echo Text::_('COM_J2COMMERCE_DASHBOARD_PRODUCTS'); ?></h2>
                     <p class="card-text">
                         <span class="badge bg-primary fs-3"><?php echo (int) $this->productsCount; ?></span>
                     </p>
@@ -40,7 +40,7 @@ use Joomla\CMS\Router\Route;
         <div class="col-md-4">
             <div class="card text-center">
                 <div class="card-body">
-                    <h5 class="card-title"><?php echo Text::_('COM_J2COMMERCE_DASHBOARD_ORDERS'); ?></h5>
+                    <h2 class="card-title fs-5"><?php echo Text::_('COM_J2COMMERCE_DASHBOARD_ORDERS'); ?></h2>
                     <p class="card-text">
                         <span class="badge bg-success fs-3"><?php echo (int) $this->ordersCount; ?></span>
                     </p>
@@ -54,7 +54,7 @@ use Joomla\CMS\Router\Route;
         <div class="col-md-4">
             <div class="card text-center">
                 <div class="card-body">
-                    <h5 class="card-title"><?php echo Text::_('COM_J2COMMERCE_DASHBOARD_CUSTOMERS'); ?></h5>
+                    <h2 class="card-title fs-5"><?php echo Text::_('COM_J2COMMERCE_DASHBOARD_CUSTOMERS'); ?></h2>
                     <p class="card-text">
                         <span class="badge bg-info fs-3"><?php echo (int) $this->customersCount; ?></span>
                     </p>
@@ -70,11 +70,11 @@ use Joomla\CMS\Router\Route;
         <div class="col-lg-12">
             <div class="card">
                 <div class="card-header">
-                    <h3><?php echo Text::_('COM_J2COMMERCE_MIGRATION_STATUS'); ?></h3>
+                    <h2><?php echo Text::_('COM_J2COMMERCE_MIGRATION_STATUS'); ?></h2>
                 </div>
                 <div class="card-body">
                     <div class="alert alert-info">
-                        <h4><?php echo Text::_('COM_J2COMMERCE_MIGRATION_WELCOME'); ?></h4>
+                        <h3><?php echo Text::_('COM_J2COMMERCE_MIGRATION_WELCOME'); ?></h3>
                         <p><?php echo Text::_('COM_J2COMMERCE_MIGRATION_DESC'); ?></p>
                         <a href="<?php echo Route::_('index.php?option=com_j2commerce&view=migration'); ?>" class="btn btn-warning">
                             <?php echo Text::_('COM_J2COMMERCE_START_MIGRATION'); ?>

--- a/components/com_j2commerce/tmpl/myprofile/default.php
+++ b/components/com_j2commerce/tmpl/myprofile/default.php
@@ -124,7 +124,7 @@ $menuParams = $this->menuItemParams;
     <div class="modal-dialog modal-xl modal-dialog-scrollable">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title" id="j2commerceOrderModalLabel"><?php echo Text::_('COM_J2COMMERCE_ORDER_PRINT'); ?></h5>
+                <h2 class="modal-title fs-5" id="j2commerceOrderModalLabel"><?php echo Text::_('COM_J2COMMERCE_ORDER_PRINT'); ?></h2>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="<?php echo Text::_('JCLOSE'); ?>"></button>
             </div>
             <div class="modal-body" id="j2commerceOrderModalBody">

--- a/components/com_j2commerce/tmpl/myprofile/default_payment_methods.php
+++ b/components/com_j2commerce/tmpl/myprofile/default_payment_methods.php
@@ -24,7 +24,7 @@ $csrfToken = Session::getFormToken();
 ?>
 
 <div class="j2commerce-payment-methods" data-csrf-token="<?php echo htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8'); ?>">
-    <h4 class="mb-4"><?php echo Text::_('COM_J2COMMERCE_PAYMENT_METHODS_TITLE'); ?></h4>
+    <h2 class="mb-4 fs-4"><?php echo Text::_('COM_J2COMMERCE_PAYMENT_METHODS_TITLE'); ?></h2>
 
     <?php if (empty($groupedMethods)) : ?>
         <div class="alert alert-info" role="alert">
@@ -56,13 +56,13 @@ $csrfToken = Session::getFormToken();
                                                 </div>
                                             <?php endif;?>
                                             <div>
-                                                <h6 class="mb-0"><?php echo htmlspecialchars(ucfirst($method->brand), ENT_QUOTES, 'UTF-8'); ?> <?php if($lastFour): echo Text::sprintf('COM_J2COMMERCE_PAYMENT_METHODS_ENDING_IN',$lastFour); endif;?>
+                                                <h3 class="mb-0 fs-6"><?php echo htmlspecialchars(ucfirst($method->brand), ENT_QUOTES, 'UTF-8'); ?> <?php if($lastFour): echo Text::sprintf('COM_J2COMMERCE_PAYMENT_METHODS_ENDING_IN',$lastFour); endif;?>
                                                 <?php if ($method->isDefault) : ?>
                                                     <span class="badge text-bg-info ms-2">
                                                         <?php echo Text::_('COM_J2COMMERCE_PAYMENT_METHODS_DEFAULT'); ?>
                                                     </span>
                                                 <?php endif; ?>
-                                                </h6>
+                                                </h3>
                                                 <?php if ($method->getFormattedExpiry()) : ?>
                                                     <small class="d-block">
                                                         <?php echo Text::sprintf('COM_J2COMMERCE_PAYMENT_METHODS_EXPIRES', $method->getFormattedExpiry()); ?>

--- a/plugins/j2commerce/app_bootstrap5/tmpl/categories_bootstrap5/default.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/categories_bootstrap5/default.php
@@ -80,10 +80,10 @@ $colsMd = match ($category_columns) {
                                         </div>
                                     </a>
                                     <?php endif; ?>
-                                    <h3 class="j2commerce-category-title d-flex w-100 pb-2 mb-1">
+                                    <h2 class="j2commerce-category-title d-flex w-100 pb-2 mb-1 fs-3">
                                         <a class="animate-underline animate-target d-inline text-truncate"
                                            href="<?php echo $categoryUrl; ?>"><?php echo $this->escape($category->title); ?></a>
-                                    </h3>
+                                    </h2>
                                     <?php if ($params->get('show_product_count', 1)) : ?>
                                     <span class="badge bg-secondary">
                                         <?php echo Text::plural('COM_J2COMMERCE_N_PRODUCTS', $category->product_count); ?>
@@ -148,10 +148,10 @@ $colsMd = match ($category_columns) {
                                         </div>
                                     </a>
                                     <?php endif; ?>
-                                    <h3 class="j2commerce-category-title d-flex w-100 pb-2 mb-1">
+                                    <h2 class="j2commerce-category-title d-flex w-100 pb-2 mb-1 fs-3">
                                         <a class="animate-underline animate-target d-inline text-truncate"
                                            href="<?php echo $categoryUrl; ?>"><?php echo $this->escape($category->title); ?></a>
-                                    </h3>
+                                    </h2>
                                     <?php if ($params->get('show_product_count', 1)) : ?>
                                     <span class="badge bg-secondary">
                                         <?php echo Text::plural('COM_J2COMMERCE_N_PRODUCTS', $category->product_count); ?>
@@ -200,10 +200,10 @@ $colsMd = match ($category_columns) {
                                         </div>
                                     </a>
                                     <?php endif; ?>
-                                    <h3 class="j2commerce-category-title d-flex w-100 pb-2 mb-1">
+                                    <h2 class="j2commerce-category-title d-flex w-100 pb-2 mb-1 fs-3">
                                         <a class="animate-underline animate-target d-inline text-truncate"
                                            href="<?php echo $categoryUrl; ?>"><?php echo $this->escape($category->title); ?></a>
-                                    </h3>
+                                    </h2>
                                     <?php if ($params->get('show_product_count', 1)) : ?>
                                     <span class="badge bg-secondary">
                                         <?php echo Text::plural('COM_J2COMMERCE_N_PRODUCTS', $category->product_count); ?>

--- a/plugins/j2commerce/app_flexivariable/tmpl/variable_variant.php
+++ b/plugins/j2commerce/app_flexivariable/tmpl/variable_variant.php
@@ -74,7 +74,7 @@ document.addEventListener('DOMContentLoaded', function() {
                             <div class="row">
                                 <!-- General Settings -->
                                 <div class="col-md-4">
-                                    <h5><?php echo Text::_('COM_J2COMMERCE_GENERAL'); ?></h5>
+                                    <h3 class="fs-5"><?php echo Text::_('COM_J2COMMERCE_GENERAL'); ?></h3>
 
                                     <input type="hidden" name="<?php echo $prefix; ?>[j2commerce_variant_id]" value="<?php echo (int) $variantId; ?>">
 
@@ -105,7 +105,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
                                 <!-- Shipping Settings -->
                                 <div class="col-md-4">
-                                    <h5><?php echo Text::_('COM_J2COMMERCE_SHIPPING'); ?></h5>
+                                    <h3 class="fs-5"><?php echo Text::_('COM_J2COMMERCE_SHIPPING'); ?></h3>
 
                                     <div class="mb-3">
                                         <label class="form-label"><?php echo Text::_('COM_J2COMMERCE_PRODUCT_ENABLE_SHIPPING'); ?></label>
@@ -132,7 +132,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
                                 <!-- Inventory Settings -->
                                 <div class="col-md-4">
-                                    <h5><?php echo Text::_('COM_J2COMMERCE_INVENTORY'); ?></h5>
+                                    <h3 class="fs-5"><?php echo Text::_('COM_J2COMMERCE_INVENTORY'); ?></h3>
 
                                     <div class="mb-3">
                                         <label class="form-label"><?php echo Text::_('COM_J2COMMERCE_PRODUCT_MANAGE_STOCK'); ?></label>

--- a/plugins/j2commerce/app_uikit/tmpl/categories_uikit/default.php
+++ b/plugins/j2commerce/app_uikit/tmpl/categories_uikit/default.php
@@ -77,9 +77,9 @@ $childWidth = match ($category_columns) {
                                 </div>
                                 <?php endif; ?>
                                 <div class="uk-card-body">
-                                    <h3 class="uk-card-title uk-text-truncate">
+                                    <h2 class="uk-card-title uk-text-truncate uk-h3">
                                         <a href="<?php echo $categoryUrl; ?>" class="uk-link-reset"><?php echo $this->escape($category->title); ?></a>
-                                    </h3>
+                                    </h2>
                                     <?php if ($params->get('show_product_count', 1)) : ?>
                                     <span class="uk-badge">
                                         <?php echo Text::plural('COM_J2COMMERCE_N_PRODUCTS', $category->product_count); ?>
@@ -143,9 +143,9 @@ $childWidth = match ($category_columns) {
                                 </div>
                                 <?php endif; ?>
                                 <div class="uk-card-body">
-                                    <h3 class="uk-card-title uk-text-truncate">
+                                    <h2 class="uk-card-title uk-text-truncate uk-h3">
                                         <a href="<?php echo $categoryUrl; ?>" class="uk-link-reset"><?php echo $this->escape($category->title); ?></a>
-                                    </h3>
+                                    </h2>
                                     <?php if ($params->get('show_product_count', 1)) : ?>
                                     <span class="uk-badge">
                                         <?php echo Text::plural('COM_J2COMMERCE_N_PRODUCTS', $category->product_count); ?>
@@ -192,9 +192,9 @@ $childWidth = match ($category_columns) {
                                 </div>
                                 <?php endif; ?>
                                 <div class="uk-card-body">
-                                    <h3 class="uk-card-title uk-text-truncate">
+                                    <h2 class="uk-card-title uk-text-truncate uk-h3">
                                         <a href="<?php echo $categoryUrl; ?>" class="uk-link-reset"><?php echo $this->escape($category->title); ?></a>
-                                    </h3>
+                                    </h2>
                                     <?php if ($params->get('show_product_count', 1)) : ?>
                                     <span class="uk-badge">
                                         <?php echo Text::plural('COM_J2COMMERCE_N_PRODUCTS', $category->product_count); ?>


### PR DESCRIPTION
## Summary

Part of #649 — fixes WCAG 2.4.10 (Section Headings) heading skips across the **frontend core** (component views + core plugin templates). Follows #660 which covered the admin. Non-core extension plugins (`app_reviews`, `app_subscriptionproduct`, `app_vendormanagement`, `app_productcompare`, etc.) will be handled in separate per-extension PRs.

## Problem

Frontend pages jumped from `<h1>` directly to `<h3>` or `<h5>` because Bootstrap card-titles (`h5.card-title`), modal titles (`h5.modal-title`), and category grid titles (`h3.card-title` / `h3.uk-card-title`) used fixed heading levels for visual sizing regardless of semantic depth.

## Fix Pattern

Change the semantic heading level; preserve visual size with a Bootstrap `fs-*` utility (or UIkit `uk-h*`).

```html
<!-- BEFORE -->
<h5 class="card-title">Products</h5>
<h3 class="uk-card-title">Category</h3>

<!-- AFTER (visually identical) -->
<h2 class="card-title fs-5">Products</h2>
<h2 class="uk-card-title uk-h3">Category</h2>
```

## Changes (6 files, 24/24 lines)

| File | Fix |
|---|---|
| `components/com_j2commerce/tmpl/dashboard/default.php` | 3× `h5.card-title` → `h2.card-title.fs-5`; migration block `h3/h4` aligned to `h2/h3` |
| `components/com_j2commerce/tmpl/myprofile/default.php` | Order print modal `h5.modal-title` → `h2.modal-title.fs-5` |
| `components/com_j2commerce/tmpl/myprofile/default_payment_methods.php` | Section `h4` → `h2.fs-4`; card-entry `h6` → `h3.fs-6` |
| `plugins/j2commerce/app_flexivariable/tmpl/variable_variant.php` | 3× settings section `h5` (General/Shipping/Inventory) → `h3.fs-5` (child of existing `h2.accordion-header`) |
| `plugins/j2commerce/app_bootstrap5/tmpl/categories_bootstrap5/default.php` | 3× `h3.j2commerce-category-title` → `h2.j2commerce-category-title.fs-3` (eliminates h1→h3 skip) |
| `plugins/j2commerce/app_uikit/tmpl/categories_uikit/default.php` | 3× `h3.uk-card-title` → `h2.uk-card-title.uk-h3` (UIkit variant) |

## Test Plan

- [ ] **My Dashboard** (frontend `my profile` → dashboard) — h1 (page heading) → h2.card-title stats cards → h2 migration status → h3 welcome. No skips.
- [ ] **My Profile** → click any order → "Print" modal — modal title is h2, not h5.
- [ ] **My Profile** → Payment Methods tab — section header h2, each saved card h3.
- [ ] **Edit a variable product frontend** (if flexivariable is enabled) — each variant accordion shows General/Shipping/Inventory as h3 children of the accordion h2.
- [ ] **Category listing page (bootstrap5 template)** — page h1, each category card title is h2. No h3 skip from the page heading.
- [ ] **Category listing page (uikit template)** — same, using UIkit styling.
- [ ] Run Lighthouse Accessibility audit on dashboard, my-profile, and a category page. "Heading elements appear in a sequentially-descending order" passes.
- [ ] Visual regression: all 6 pages render identically to before (the `fs-*` / `uk-h*` classes preserve appearance).

## Pre-Flight

- [x] PHP syntax check passed (`php -l` on all 6 files)
- [x] No secrets detected
- [x] No FOF remnants (only heading tag changes)
- [x] No language string changes
- [x] **Core files only** — verified against `build/build_package.php` allowlist: `app_bootstrap5`, `app_flexivariable`, `app_uikit` are core j2commerce plugins
- [x] Non-core plugin fixes (`app_reviews`, `app_subscriptionproduct`, etc.) deliberately excluded — those will land in separate per-extension PRs

## Scope Status for #649

- [x] **Phase B — Admin** (PR #660, 35 files)
- [x] **Phase A.1-core — Frontend core** (this PR, 6 files)
- [ ] Phase A.1-ext — Non-core extension plugin fixes (split per extension, separate PRs)
- [ ] Phase A.2 — Site layout fragments (checkout/cart/profile subtemplates, ~53 files)
- [ ] Phase C — Contributing guide for the heading-level rule

#649 remains open until the remaining phases ship.