### PR TITLE
fix(onboarding): dark mode support for product type cards and buttons

### DIFF
--- a/administrator/components/com_j2commerce/tmpl/dashboard/default_onboarding.php
+++ b/administrator/components/com_j2commerce/tmpl/dashboard/default_onboarding.php
@@ -703,7 +703,7 @@ $e = fn(string $s): string => htmlspecialchars($s, ENT_QUOTES, 'UTF-8');
           <div id="ob-sampledata-prompt" class="d-none">
             <div class="alert alert-info text-center mb-0">
               <p class="mb-2"><?php echo Text::_('COM_J2COMMERCE_ONBOARDING_SAMPLEDATA_PROMPT'); ?></p>
-              <button type="button" class="btn btn-outline-primary btn-sm me-2" data-action="load-sampledata">
+              <button type="button" class="btn btn-primary btn-sm me-2" data-action="load-sampledata">
                 <span class="fa-solid fa-database me-1" aria-hidden="true"></span>
                 <?php echo Text::_('COM_J2COMMERCE_ONBOARDING_SAMPLEDATA_LOAD'); ?>
               </button>
@@ -727,7 +727,7 @@ $e = fn(string $s): string => htmlspecialchars($s, ENT_QUOTES, 'UTF-8');
               </a>
             </div>
             <div class="col-md-3">
-              <button type="button" class="btn btn-outline-primary w-100 shadow-none" data-action="close-onboarding">
+              <button type="button" class="btn btn-primary w-100 shadow-none" data-action="close-onboarding">
                 <span class="fa-solid fa-gauge-high me-1" aria-hidden="true"></span>
                 <?php echo Text::_('COM_J2COMMERCE_ONBOARDING_READY_DASHBOARD'); ?>
               </button>

--- a/media/com_j2commerce/css/administrator/onboarding.css
+++ b/media/com_j2commerce/css/administrator/onboarding.css
@@ -247,6 +247,30 @@
     border-color: var(--bs-danger);
 }
 
+/* ---- Dark mode ---- */
+[data-bs-theme="dark"] .card.j2c-product-type-card {
+    border-color: var(--bs-border-color);
+    background-color: var(--bs-secondary-bg);
+}
+
+[data-bs-theme="dark"] .card.j2c-product-type-card:hover {
+    border-color: var(--template-link-color);
+}
+
+[data-bs-theme="dark"] .card.j2c-product-type-card.selected {
+    border-color: var(--template-link-color);
+    background-color: var(--bs-tertiary-bg);
+}
+
+[data-bs-theme="dark"] .j2c-onboarding-footer .btn:focus-visible,
+[data-bs-theme="dark"] .j2c-step .btn:focus-visible,
+[data-bs-theme="dark"] .j2c-step a.btn:focus-visible,
+[data-bs-theme="dark"] .j2c-step button:focus-visible,
+[data-bs-theme="dark"] .card.j2c-product-type-card:focus-visible {
+    outline-color: var(--template-link-color, var(--bs-primary));
+    box-shadow: 0 0 0 0.25rem rgba(111, 191, 219, 0.35);
+}
+
 /* ---- Responsive ---- */
 @media (max-width: 767.98px) {
     .j2c-step-label { display: none; }


### PR DESCRIPTION
## Summary
Fixes #669

## Changes
- Added `[data-bs-theme="dark"]` CSS overrides for onboarding product type cards — border, background, selected state, and focus rings now use Bootstrap semantic vars that adapt to dark mode
- Changed step 6 `btn-outline-primary` buttons to `btn-primary` for better tab navigation visibility in both light and dark mode

## Files Changed
- `media/com_j2commerce/css/administrator/onboarding.css` — dark mode card styles
- `administrator/components/com_j2commerce/tmpl/dashboard/default_onboarding.php` — button class update

## Testing
1. Open admin → J2Commerce Dashboard
2. Toggle dark mode (Atum template setting)
3. Trigger onboarding wizard
4. Verify product type cards have dark backgrounds with visible borders
5. Select a card — should show subtle highlight, not white
6. Navigate to step 6, tab through buttons — all clearly visible
7. Switch to light mode — verify no regressions

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only (non-core excluded)