### PR TITLE
fix(products): variant deletion, null safety, toolbar & price hooks

### DIFF
--- a/administrator/components/com_j2commerce/src/Controller/ProductsController.php
+++ b/administrator/components/com_j2commerce/src/Controller/ProductsController.php
@@ -15,6 +15,7 @@ namespace J2Commerce\Component\J2commerce\Administrator\Controller;
 \defined('_JEXEC') or die;
 
 use J2Commerce\Component\J2commerce\Administrator\Helper\ConfigHelper;
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 use J2Commerce\Component\J2commerce\Administrator\Helper\ProductHelper;
 use Joomla\CMS\Application\CMSApplication;
 use Joomla\CMS\Application\CMSWebApplicationInterface;
@@ -2410,7 +2411,14 @@ class ProductsController extends AdminController
                 $product->lengths = $this->getLengthsList();
 
                 // Use the layout specified by the caller (variable vs flexivariable product type)
+                // Third-party plugins can register additional layouts via onJ2CommerceGetAllowedVariantLayouts
                 $allowedLayouts = ['form_ajax_avoptions', 'form_ajax_flexivariableoptions'];
+
+                $layoutEvent    = J2CommerceHelper::plugin()->event('GetAllowedVariantLayouts', [
+                    'layouts' => $allowedLayouts,
+                ]);
+                $allowedLayouts = $layoutEvent->getArgument('layouts', $allowedLayouts);
+
                 $variantLayout  = $app->getInput()->getCmd('variant_layout', 'form_ajax_avoptions');
                 if (!\in_array($variantLayout, $allowedLayouts, true)) {
                     $variantLayout = 'form_ajax_avoptions';
@@ -2730,32 +2738,8 @@ class ProductsController extends AdminController
             $db->setQuery($query);
             $db->execute();
 
-            // Get product optionvalue IDs
-            $query = $db->getQuery(true)
-                ->select($db->quoteName('product_optionvalue_ids'))
-                ->from($db->quoteName('#__j2commerce_product_variant_optionvalues'))
-                ->where($db->quoteName('variant_id') . ' = :variantId')
-                ->bind(':variantId', $variantId, ParameterType::INTEGER);
-
-            $db->setQuery($query);
-            $productOptionvalueIds = $db->loadResult();
-
-            if (!empty($productOptionvalueIds)) {
-                // Delete product optionvalues
-                $ids = array_map('intval', explode(',', $productOptionvalueIds));
-                $ids = array_filter($ids);
-
-                if (!empty($ids)) {
-                    $query = $db->getQuery(true)
-                        ->delete($db->quoteName('#__j2commerce_product_optionvalues'))
-                        ->whereIn($db->quoteName('j2commerce_product_optionvalue_id'), $ids);
-
-                    $db->setQuery($query);
-                    $db->execute();
-                }
-            }
-
-            // Delete variant optionvalues mapping
+            // Delete variant-to-optionvalue mapping (NOT the product_optionvalues
+            // themselves — those are product-level configuration shared across variants)
             $query = $db->getQuery(true)
                 ->delete($db->quoteName('#__j2commerce_product_variant_optionvalues'))
                 ->where($db->quoteName('variant_id') . ' = :variantId')

--- a/administrator/components/com_j2commerce/tmpl/product/form_flexivariablevariants.php
+++ b/administrator/components/com_j2commerce/tmpl/product/form_flexivariablevariants.php
@@ -255,7 +255,7 @@ $formPrefix = $displayData['form_prefix'];
                     accordion.innerHTML = data.html;
                     self.setupCheckboxHandlers();
                     initConfigToggles();
-                    document.dispatchEvent(new CustomEvent('joomla:updated'));
+                    try { document.dispatchEvent(new CustomEvent('joomla:updated')); } catch (e) { /* showon.js may throw when AJAX-injected fields reference missing controls */ }
                 }
                 if (typeof data.total !== 'undefined') {
                     self.updateVariantCount(data.total);

--- a/administrator/components/com_j2commerce/tmpl/product/form_inventory.php
+++ b/administrator/components/com_j2commerce/tmpl/product/form_inventory.php
@@ -44,7 +44,7 @@ $checkboxDefaults = ['disabled' => false, 'required' => false, 'autofocus' => fa
                     <label id="j2commerce-product-manage_stock-radio-group-lbl" for="j2commerce-product-manage_stock-radio-group"><?php echo Text::_('COM_J2COMMERCE_PRODUCT_MANAGE_STOCK');?></label>
                 </div>
                 <div class="controls">
-                    <?php echo LayoutHelper::render('joomla.form.field.radio.switcher', ['name'  => $formPrefix.'[manage_stock]','id'    => 'j2commerce-product-manage_stock-radio-group','value' => $item->variant->manage_stock,'options' => [(object) ['value' => 0, 'text' => Text::_('JNO')],(object) ['value' => 1, 'text' => Text::_('JYES')]]] + $switcherDefaults);?>
+                    <?php echo LayoutHelper::render('joomla.form.field.radio.switcher', ['name'  => $formPrefix.'[manage_stock]','id'    => 'j2commerce-product-manage_stock-radio-group','value' => $item->variant->manage_stock ?? 0,'options' => [(object) ['value' => 0, 'text' => Text::_('JNO')],(object) ['value' => 1, 'text' => Text::_('JYES')]]] + $switcherDefaults);?>
                 </div>
             </div>
 
@@ -53,7 +53,7 @@ $checkboxDefaults = ['disabled' => false, 'required' => false, 'autofocus' => fa
                     <label id="j2commerce-product-quantity_text-group-lbl" for="j2commerce-product-quantity_text-group"><?php echo Text::_('COM_J2COMMERCE_PRODUCT_QUANTITY');?></label>
                 </div>
                 <div class="controls">
-                    <input type="hidden" name="<?php echo $formPrefix;?>[quantity][j2commerce_productquantity_id]" class="input" value="<?php echo $item->variant->j2commerce_productquantity_id;?>">
+                    <input type="hidden" name="<?php echo $formPrefix;?>[quantity][j2commerce_productquantity_id]" class="input" value="<?php echo $item->variant->j2commerce_productquantity_id ?? 0;?>">
                     <?php echo LayoutHelper::render('joomla.form.field.text', ['name'  => $formPrefix.'[quantity][quantity]','id'    => 'j2commerce-product-quantity_text-group','value' => $item->variant->quantity ?? '','class' => 'form-control',] + $textFieldDefaults);?>
                 </div>
             </div>
@@ -63,7 +63,7 @@ $checkboxDefaults = ['disabled' => false, 'required' => false, 'autofocus' => fa
                     <label id="j2commerce-product-allow_backorder-select-group-lbl" for="j2commerce-product-allow_backorder-select-group"><?php echo Text::_('COM_J2COMMERCE_PRODUCT_ALLOW_BACKORDERS');?></label>
                 </div>
                 <div class="controls">
-                    <?php echo LayoutHelper::render('joomla.form.field.list-fancy-select', ['name'  => $formPrefix.'[allow_backorder]','id'    => 'j2commerce-product-allow_backorder-select-group','value' => $item->variant->allow_backorder,'options' => [(object) ['value' => 0, 'text' => Text::_('COM_J2COMMERCE_NO_ALLOW')],(object) ['value' => 1, 'text' => Text::_('COM_J2COMMERCE_ALLOW')],(object) ['value' => 2, 'text' => Text::_('COM_J2COMMERCE_ALLOW_BUT_NOTIFY')]]] + $fancySelectDefaults);?>
+                    <?php echo LayoutHelper::render('joomla.form.field.list-fancy-select', ['name'  => $formPrefix.'[allow_backorder]','id'    => 'j2commerce-product-allow_backorder-select-group','value' => $item->variant->allow_backorder ?? 0,'options' => [(object) ['value' => 0, 'text' => Text::_('COM_J2COMMERCE_NO_ALLOW')],(object) ['value' => 1, 'text' => Text::_('COM_J2COMMERCE_ALLOW')],(object) ['value' => 2, 'text' => Text::_('COM_J2COMMERCE_ALLOW_BUT_NOTIFY')]]] + $fancySelectDefaults);?>
                 </div>
             </div>
 
@@ -72,7 +72,7 @@ $checkboxDefaults = ['disabled' => false, 'required' => false, 'autofocus' => fa
                     <label id="j2commerce-product-stock-status-select-group-lbl" for="j2commerce-product-stock-status-select-group"><?php echo Text::_('COM_J2COMMERCE_PRODUCT_STOCK_STATUS');?></label>
                 </div>
                 <div class="controls">
-                    <?php echo LayoutHelper::render('joomla.form.field.list-fancy-select', ['name'  => $formPrefix.'[availability]','id'    => 'j2commerce-product-stock-status-select-group','value' => $item->variant->availability,'options' => [(object) ['value' => 0, 'text' => Text::_('COM_J2COMMERCE_STOCK_OUT_OF_STOCK')],(object) ['value' => 1, 'text' => Text::_('COM_J2COMMERCE_STOCK_IN_STOCK')]]] + $fancySelectDefaults);?>
+                    <?php echo LayoutHelper::render('joomla.form.field.list-fancy-select', ['name'  => $formPrefix.'[availability]','id'    => 'j2commerce-product-stock-status-select-group','value' => $item->variant->availability ?? 1,'options' => [(object) ['value' => 0, 'text' => Text::_('COM_J2COMMERCE_STOCK_OUT_OF_STOCK')],(object) ['value' => 1, 'text' => Text::_('COM_J2COMMERCE_STOCK_IN_STOCK')]]] + $fancySelectDefaults);?>
                 </div>
             </div>
 
@@ -88,7 +88,7 @@ $checkboxDefaults = ['disabled' => false, 'required' => false, 'autofocus' => fa
                         </div>
                         <div class="col-12">
                             <div class="qty_restriction">
-                                <?php echo LayoutHelper::render('joomla.form.field.checkbox', ['name'  => $formPrefix.'[use_store_config_notify_qty]','id'    => 'use_store_config_notify_qty','value' => $item->variant->use_store_config_notify_qty,'class' => 'storeconfig','checked' => (isset($item->variant->use_store_config_notify_qty) && $item->variant->use_store_config_notify_qty) ? 'checked' : ''] + $checkboxDefaults);?>
+                                <?php echo LayoutHelper::render('joomla.form.field.checkbox', ['name'  => $formPrefix.'[use_store_config_notify_qty]','id'    => 'use_store_config_notify_qty','value' => $item->variant->use_store_config_notify_qty ?? 0,'class' => 'storeconfig','checked' => (isset($item->variant->use_store_config_notify_qty) && $item->variant->use_store_config_notify_qty) ? 'checked' : ''] + $checkboxDefaults);?>
                                 <label for="use_store_config_notify_qty" class="lh-1 position-relative" style="top:-2px;"><?php echo Text::_('COM_J2COMMERCE_PRODUCT_USE_STORE_CONFIGURATION'); ?></label>
                             </div>
                         </div>
@@ -101,7 +101,7 @@ $checkboxDefaults = ['disabled' => false, 'required' => false, 'autofocus' => fa
                     <label id="j2commerce-product-quantity_restriction-radio-group-lbl" for="j2commerce-product-quantity_restriction-radio-group"><?php echo Text::_('COM_J2COMMERCE_PRODUCT_QUANTITY_RESTRICTION');?></label>
                 </div>
                 <div class="controls">
-                    <?php echo LayoutHelper::render('joomla.form.field.radio.switcher', ['name'  => $formPrefix.'[quantity_restriction]','id'    => 'j2commerce-product-quantity_restriction-radio-group','value' => $item->variant->quantity_restriction,'options' => [(object) ['value' => 0, 'text' => Text::_('JNO')],(object) ['value' => 1, 'text' => Text::_('JYES')]]] + $switcherDefaults);?>
+                    <?php echo LayoutHelper::render('joomla.form.field.radio.switcher', ['name'  => $formPrefix.'[quantity_restriction]','id'    => 'j2commerce-product-quantity_restriction-radio-group','value' => $item->variant->quantity_restriction ?? 0,'options' => [(object) ['value' => 0, 'text' => Text::_('JNO')],(object) ['value' => 1, 'text' => Text::_('JYES')]]] + $switcherDefaults);?>
                 </div>
             </div>
 
@@ -116,7 +116,7 @@ $checkboxDefaults = ['disabled' => false, 'required' => false, 'autofocus' => fa
                         </div>
                         <div class="col-12">
                             <div class="qty_restriction">
-                                <?php echo LayoutHelper::render('joomla.form.field.checkbox', ['name'  => $formPrefix.'[use_store_config_max_sale_qty]','id'    => 'use_store_config_max_sale_qty','value' => $item->variant->use_store_config_max_sale_qty,'class' => 'storeconfig','checked' => (isset($item->variant->use_store_config_max_sale_qty) && $item->variant->use_store_config_max_sale_qty) ? 'checked' : ''] + $checkboxDefaults);?>
+                                <?php echo LayoutHelper::render('joomla.form.field.checkbox', ['name'  => $formPrefix.'[use_store_config_max_sale_qty]','id'    => 'use_store_config_max_sale_qty','value' => $item->variant->use_store_config_max_sale_qty ?? 0,'class' => 'storeconfig','checked' => (isset($item->variant->use_store_config_max_sale_qty) && $item->variant->use_store_config_max_sale_qty) ? 'checked' : ''] + $checkboxDefaults);?>
                                 <label for="use_store_config_max_sale_qty" class="lh-1 position-relative" style="top:-2px;"><?php echo Text::_('COM_J2COMMERCE_PRODUCT_USE_STORE_CONFIGURATION'); ?></label>
                             </div>
                         </div>
@@ -135,7 +135,7 @@ $checkboxDefaults = ['disabled' => false, 'required' => false, 'autofocus' => fa
                         </div>
                         <div class="col-12">
                             <div class="qty_restriction">
-                                <?php echo LayoutHelper::render('joomla.form.field.checkbox', ['name'  => $formPrefix.'[use_store_config_min_sale_qty]','id'    => 'use_store_config_min_sale_qty','value' => $item->variant->use_store_config_min_sale_qty,'class' => 'storeconfig','checked' => (isset($item->variant->use_store_config_min_sale_qty) && $item->variant->use_store_config_min_sale_qty) ? 'checked' : ''] + $checkboxDefaults);?>
+                                <?php echo LayoutHelper::render('joomla.form.field.checkbox', ['name'  => $formPrefix.'[use_store_config_min_sale_qty]','id'    => 'use_store_config_min_sale_qty','value' => $item->variant->use_store_config_min_sale_qty ?? 0,'class' => 'storeconfig','checked' => (isset($item->variant->use_store_config_min_sale_qty) && $item->variant->use_store_config_min_sale_qty) ? 'checked' : ''] + $checkboxDefaults);?>
                                 <label for="use_store_config_min_sale_qty" class="lh-1 position-relative" style="top:-2px;"><?php echo Text::_('COM_J2COMMERCE_PRODUCT_USE_STORE_CONFIGURATION'); ?></label>
                             </div>
                         </div>

--- a/administrator/components/com_j2commerce/tmpl/product/form_shipping.php
+++ b/administrator/components/com_j2commerce/tmpl/product/form_shipping.php
@@ -96,7 +96,7 @@ $defaultWeightClassId = empty($item->variant->weight_class_id)
                     <label id="j2commerce-product-shipping-radio-group-lbl" for="j2commerce-product-shipping-radio-group"><?php echo Text::_('COM_J2COMMERCE_PRODUCT_ENABLE_SHIPPING');?></label>
                 </div>
                 <div class="controls">
-                    <?php echo LayoutHelper::render('joomla.form.field.radio.switcher', ['name'  => $formPrefix.'[shipping]','id'    => 'j2commerce-product-shipping-radio-group','value' => $item->variant->shipping,'options' => [(object) ['value' => 0, 'text' => Text::_('JNO')],(object) ['value' => 1, 'text' => Text::_('JYES')]]] + $switcherDefaults);?>
+                    <?php echo LayoutHelper::render('joomla.form.field.radio.switcher', ['name'  => $formPrefix.'[shipping]','id'    => 'j2commerce-product-shipping-radio-group','value' => $item->variant->shipping ?? 0,'options' => [(object) ['value' => 0, 'text' => Text::_('JNO')],(object) ['value' => 1, 'text' => Text::_('JYES')]]] + $switcherDefaults);?>
                 </div>
             </div>
 

--- a/administrator/components/com_j2commerce/tmpl/product/form_variable_variants.php
+++ b/administrator/components/com_j2commerce/tmpl/product/form_variable_variants.php
@@ -46,47 +46,45 @@ $csrfToken   = Session::getFormToken();
 
         <?php if ($hasOptions) : ?>
 
-            <?php if ($hasVariants) : ?>
-                <div class="d-flex justify-content-start align-items-center mb-3">
-                    <div class="form-check pt-0 me-2">
-                        <input class="form-check-input" type="checkbox" value="" id="toggleAllCheckboxes">
-                    </div>
-                    <button type="button" class="btn btn-soft-danger btn-sm me-2" id="deleteCheckedVariants"
-                            data-bs-toggle="tooltip" title="<?php echo Text::_('COM_J2COMMERCE_PRODUCT_VARIANTS_DELETE_CHECKED'); ?>"
-                            disabled>
-                        <span class="fas fa-solid fa-trash" aria-hidden="true"></span>
-                    </button>
-                    <button type="button" id="j2commerce-regenerate-variants"
-                            class="btn btn-sm btn-soft-info me-2"
-                            data-product-id="<?php echo (int) $item->j2commerce_product_id; ?>">
-                        <span class="fas fa-solid fa-recycle me-2" aria-hidden="true"></span>
-                        <?php echo Text::_('COM_J2COMMERCE_REGENERATE_VARIANTS'); ?>
-                    </button>
-                    <button type="button" id="j2commerce-delete-all-variants"
-                            class="btn btn-sm btn-soft-danger"
-                            data-product-id="<?php echo (int) $item->j2commerce_product_id; ?>">
-                        <span class="fas fa-solid fa-trash me-2" aria-hidden="true"></span>
-                        <?php echo Text::_('COM_J2COMMERCE_DELETE_ALL_VARIANTS'); ?>
-                    </button>
-                    <button type="button" id="openAll-panel" class="btn btn-soft-dark btn-sm ms-auto"
-                            onclick="setExpandAll();"
-                            data-bs-toggle="tooltip" title="<?php echo Text::_('COM_J2COMMERCE_OPEN_ALL'); ?>">
-                        <span class="fas fa-solid fa-chevron-down" aria-hidden="true"></span>
-                    </button>
-                    <button type="button" id="closeAll-panel" class="btn btn-soft-dark btn-sm ms-2"
-                            onclick="setCloseAll();"
-                            data-bs-toggle="tooltip" title="<?php echo Text::_('COM_J2COMMERCE_CLOSE_ALL'); ?>">
-                        <span class="fas fa-solid fa-chevron-up" aria-hidden="true"></span>
-                    </button>
+            <div class="<?php echo $hasVariants ? 'd-flex' : 'd-none'; ?> justify-content-start align-items-center mb-3" id="j2commerce-variant-toolbar">
+                <div class="form-check pt-0 me-2">
+                    <input class="form-check-input" type="checkbox" value="" id="toggleAllCheckboxes">
                 </div>
-            <?php else : ?>
-                <button type="button" id="j2commerce-generate-variants"
-                        class="btn btn-soft-success mb-3"
-                        data-product-id="<?php echo (int) $item->j2commerce_product_id; ?>">
-                    <span class="fas fa-solid fa-magic me-2" aria-hidden="true"></span>
-                    <?php echo Text::_('COM_J2COMMERCE_GENERATE_VARIANTS'); ?>
+                <button type="button" class="btn btn-soft-danger btn-sm me-2" id="deleteCheckedVariants"
+                        data-bs-toggle="tooltip" title="<?php echo Text::_('COM_J2COMMERCE_PRODUCT_VARIANTS_DELETE_CHECKED'); ?>"
+                        disabled>
+                    <span class="fas fa-solid fa-trash" aria-hidden="true"></span>
                 </button>
-            <?php endif; ?>
+                <button type="button" id="j2commerce-regenerate-variants"
+                        class="btn btn-sm btn-soft-info me-2"
+                        data-product-id="<?php echo (int) $item->j2commerce_product_id; ?>">
+                    <span class="fas fa-solid fa-recycle me-2" aria-hidden="true"></span>
+                    <?php echo Text::_('COM_J2COMMERCE_REGENERATE_VARIANTS'); ?>
+                </button>
+                <button type="button" id="j2commerce-delete-all-variants"
+                        class="btn btn-sm btn-soft-danger"
+                        data-product-id="<?php echo (int) $item->j2commerce_product_id; ?>">
+                    <span class="fas fa-solid fa-trash me-2" aria-hidden="true"></span>
+                    <?php echo Text::_('COM_J2COMMERCE_DELETE_ALL_VARIANTS'); ?>
+                </button>
+                <button type="button" id="openAll-panel" class="btn btn-soft-dark btn-sm ms-auto"
+                        onclick="setExpandAll();"
+                        data-bs-toggle="tooltip" title="<?php echo Text::_('COM_J2COMMERCE_OPEN_ALL'); ?>">
+                    <span class="fas fa-solid fa-chevron-down" aria-hidden="true"></span>
+                </button>
+                <button type="button" id="closeAll-panel" class="btn btn-soft-dark btn-sm ms-2"
+                        onclick="setCloseAll();"
+                        data-bs-toggle="tooltip" title="<?php echo Text::_('COM_J2COMMERCE_CLOSE_ALL'); ?>">
+                    <span class="fas fa-solid fa-chevron-up" aria-hidden="true"></span>
+                </button>
+            </div>
+            <button type="button" id="j2commerce-generate-variants"
+                    class="btn btn-soft-success mb-5"
+                    data-product-id="<?php echo (int) $item->j2commerce_product_id; ?>"
+                    style="<?php echo $hasVariants ? 'display:none' : ''; ?>">
+                <span class="fas fa-solid fa-magic me-2" aria-hidden="true"></span>
+                <?php echo Text::_('COM_J2COMMERCE_GENERATE_VARIANTS'); ?>
+            </button>
 
         <?php endif; ?>
 
@@ -277,6 +275,9 @@ $csrfToken   = Session::getFormToken();
                     variantItem.style.transition = 'opacity 0.3s ease-out';
                     variantItem.style.opacity = '0';
                     setTimeout(function() {
+                        if (typeof J2CommerceVariableVariants !== 'undefined') {
+                            J2CommerceVariableVariants.cleanupVariantSyncInputs(variantId);
+                        }
                         variantItem.remove();
 
                         if (typeof result.total !== 'undefined' && typeof J2CommerceVariableVariants !== 'undefined') {
@@ -355,15 +356,17 @@ $csrfToken   = Session::getFormToken();
         },
 
         updateToolbarVisibility: function (total) {
-            var toolbar = document.querySelector('#j2commerce-delete-all-variants');
-            if (toolbar) {
-                toolbar.style.display = total > 0 ? '' : 'none';
+            var toolbarWrapper = document.getElementById('j2commerce-variant-toolbar');
+            if (toolbarWrapper) {
+                if (total > 0) {
+                    toolbarWrapper.classList.remove('d-none');
+                    toolbarWrapper.classList.add('d-flex');
+                } else {
+                    toolbarWrapper.classList.remove('d-flex');
+                    toolbarWrapper.classList.add('d-none');
+                }
             }
-            var regenBtn = document.querySelector('#j2commerce-regenerate-variants');
-            if (regenBtn) {
-                regenBtn.style.display = total > 0 ? '' : 'none';
-            }
-            var genBtn = document.querySelector('#j2commerce-generate-variants');
+            var genBtn = document.getElementById('j2commerce-generate-variants');
             if (genBtn) {
                 genBtn.style.display = total === 0 ? '' : 'none';
             }
@@ -443,7 +446,7 @@ $csrfToken   = Session::getFormToken();
                         accordion.innerHTML = data.html;
                         self.setupCheckboxHandlers();
                         initVariantItemHandlers();
-                        document.dispatchEvent(new CustomEvent('joomla:updated'));
+                        try { document.dispatchEvent(new CustomEvent('joomla:updated')); } catch (e) { /* showon.js may throw when AJAX-injected fields reference missing controls */ }
                     }
                     if (typeof data.total !== 'undefined') {
                         self.updateVariantCount(data.total);
@@ -479,12 +482,13 @@ $csrfToken   = Session::getFormToken();
                         self.loadVariantList(0);
                     } else {
                         self.showMessage(data.message || '<?php echo Text::_('COM_J2COMMERCE_ERROR_GENERATING_VARIANTS'); ?>', 'error');
-                        self.setButtonLoading(btn, false);
                     }
                 })
                 .catch(function (error) {
                     console.error('Error generating variants:', error);
                     self.showMessage('<?php echo Text::_('COM_J2COMMERCE_ERROR_GENERATING_VARIANTS'); ?>', 'error');
+                })
+                .finally(function () {
                     self.setButtonLoading(btn, false);
                 });
         },
@@ -543,6 +547,7 @@ $csrfToken   = Session::getFormToken();
                 .then(function (response) { return response.json(); })
                 .then(function (data) {
                     if (data.success) {
+                        self.cleanupAllVariantSyncInputs();
                         var accordion = document.getElementById('accordion');
                         if (accordion) {
                             accordion.innerHTML = '<div class="alert alert-info"><?php echo Text::_('COM_J2COMMERCE_NO_VARIANTS'); ?></div>';
@@ -648,6 +653,28 @@ $csrfToken   = Session::getFormToken();
             if (deleteBtn) {
                 deleteBtn.disabled = !anyChecked;
             }
+        },
+
+        cleanupVariantSyncInputs: function(variantId) {
+            var form = document.querySelector('form[name="adminForm"]');
+            if (!form) return;
+            var prefix = this.config.formPrefix + '[variable][' + variantId + ']';
+            form.querySelectorAll('.uppymedia-sync-input').forEach(function(input) {
+                if (input.name && input.name.indexOf(prefix) === 0) {
+                    input.remove();
+                }
+            });
+        },
+
+        cleanupAllVariantSyncInputs: function() {
+            var form = document.querySelector('form[name="adminForm"]');
+            if (!form) return;
+            var prefix = this.config.formPrefix + '[variable]';
+            form.querySelectorAll('.uppymedia-sync-input').forEach(function(input) {
+                if (input.name && input.name.indexOf(prefix) === 0) {
+                    input.remove();
+                }
+            });
         },
 
         init: function () {

--- a/components/com_j2commerce/layouts/app_bootstrap5/list/category/item_price.php
+++ b/components/com_j2commerce/layouts/app_bootstrap5/list/category/item_price.php
@@ -41,9 +41,11 @@ $afterHtml = J2CommerceHelper::plugin()->eventWithHtml('AfterRenderingProductPri
 $basePrice = $pricing->base_price ?? 0;
 $salePrice = $pricing->price ?? 0;
 ?>
-<?php echo $beforeHtml; ?>
+
 
 <div class="j2commerce-product-price-container d-flex align-items-center gap-1">
+    <?php echo $beforeHtml; ?>
+
     <?php if ($showSpecialPrice && isset($pricing->price)): ?>
         <div class="sale-price lh-1 fs-5 fw-semibold">
             <?php echo $productHelper->displayPrice((float) $salePrice, $product, $params); ?>
@@ -56,6 +58,8 @@ $salePrice = $pricing->price ?? 0;
         </del>
     <?php endif; ?>
 
+    <?php echo $afterHtml; ?>
+
     <?php if ($showTaxInfo): ?>
         <div class="tax-text">
             <small class="fw-normal text-body-tertiary"><?php echo $productHelper->get_tax_text(); ?></small>
@@ -63,6 +67,6 @@ $salePrice = $pricing->price ?? 0;
     <?php endif; ?>
 </div>
 
-<?php echo $afterHtml; ?>
+
 
 

--- a/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/view_price.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/view_price.php
@@ -17,11 +17,13 @@ use Joomla\CMS\Language\Text;
 /** @var \J2Commerce\Component\J2commerce\Site\View\Product\HtmlView $this */
 
 ?>
-<?php echo J2CommerceHelper::plugin()->eventWithHtml('BeforeRenderingProductPrice', [$this->product, $this->context])->getArgument('html', ''); ?>
+
 
 <?php if ($this->params->get('item_show_product_base_price', 1) || $this->params->get('item_show_product_special_price', 1)) : ?>
     <div class="j2commerce-product-price-container mb-3">
         <div class="d-flex align-items-center">
+            <?php echo J2CommerceHelper::plugin()->eventWithHtml('BeforeRenderingProductPrice', [$this->product, $this->context])->getArgument('html', ''); ?>
+
             <?php if ($this->params->get('item_show_product_special_price', 1)) : ?>
                 <div class="sale-price lh-1 fs-3 fw-normal">
                     <?php if (isset($this->product->pricing->price)) {
@@ -38,6 +40,7 @@ use Joomla\CMS\Language\Text;
                     <?php echo $base_price; ?>
                 </del>
             <?php endif; ?>
+            <?php echo J2CommerceHelper::plugin()->eventWithHtml('AfterRenderingProductPrice', [$this->product, $this->context])->getArgument('html', ''); ?>
         </div>
         <?php if ($this->params->get('display_price_with_tax_info', 0)) : ?>
             <div class="tax-text d-block text-body-tertiary small mt-1">
@@ -47,6 +50,6 @@ use Joomla\CMS\Language\Text;
     </div>
 <?php endif; ?>
 
-<?php echo J2CommerceHelper::plugin()->eventWithHtml('AfterRenderingProductPrice', [$this->product, $this->context])->getArgument('html', ''); ?>
+
 
 


### PR DESCRIPTION
## Core Update

### Changes
- **ProductsController**: extensible variant layouts via `onJ2CommerceGetAllowedVariantLayouts` plugin event; stop deleting shared `product_optionvalues` when removing a single variant
- **form_inventory / form_shipping**: null coalescing (`??`) for variant properties preventing undefined errors on new products
- **form_variable_variants**: always render toolbar (CSS class toggle instead of PHP if/else), fix generate button loading state with `finally()`, cleanup Uppy sync inputs on variant delete, catch `showon.js` errors on AJAX-injected fields
- **form_flexivariablevariants**: catch `showon.js` errors on AJAX-injected fields
- **item_price / view_price**: move `BeforeRenderingProductPrice` / `AfterRenderingProductPrice` hooks inside price container div for correct layout integration

### Files Modified
| Type | Count |
|------|-------|
| PHP files | 7 |
| JS/CSS assets | 0 |
| Language files | 0 |
| XML/Config | 0 |

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Code style (php-cs-fixer) passed
- [x] Core files only (non-core excluded)