### PR TITLE
fix(ui): dark mode support for product edit form (fixes #673)

### DIFF
--- a/administrator/components/com_j2commerce/tmpl/product/form_configoptions.php
+++ b/administrator/components/com_j2commerce/tmpl/product/form_configoptions.php
@@ -18,7 +18,7 @@ use Joomla\CMS\Language\Text;
 
 $wa = Factory::getApplication()->getDocument()->getWebAssetManager();
 
-$style = '.autocomplete-list{background: var(--form-control-bg);max-height: 200px;overflow-y: auto;width: 100%;}.autocomplete-list.autocomplete-active{border: var(--form-control-border);}.autocomplete-item{padding: 8px;cursor: pointer;font-size: .8rem;}.autocomplete-item:hover {background-color: #f0f0f0;}';
+$style = '.autocomplete-list{background: var(--form-control-bg);max-height: 200px;overflow-y: auto;width: 100%;}.autocomplete-list.autocomplete-active{border: var(--form-control-border);}.autocomplete-item{padding: 8px;cursor: pointer;font-size: .8rem;}.autocomplete-item:hover {background-color: var(--template-bg-dark-5, #f0f0f0);}';
 $wa->addInlineStyle($style, [], []);
 
 $item = $displayData['product'];

--- a/administrator/components/com_j2commerce/tmpl/product/form_filters.php
+++ b/administrator/components/com_j2commerce/tmpl/product/form_filters.php
@@ -24,7 +24,7 @@ use Joomla\CMS\Router\Route;
 
 $wa = Factory::getApplication()->getDocument()->getWebAssetManager();
 
-$style = '.autocomplete-list{background: var(--form-control-bg);max-height: 200px;overflow-y: auto;width: 100%;}.autocomplete-list.autocomplete-active{border: var(--form-control-border);}.autocomplete-item{padding: 8px;cursor: pointer;font-size: .8rem;}.autocomplete-item:hover {background-color: #f0f0f0;}';
+$style = '.autocomplete-list{background: var(--form-control-bg);max-height: 200px;overflow-y: auto;width: 100%;}.autocomplete-list.autocomplete-active{border: var(--form-control-border);}.autocomplete-item{padding: 8px;cursor: pointer;font-size: .8rem;}.autocomplete-item:hover {background-color: var(--template-bg-dark-5, #f0f0f0);}';
 $wa->addInlineStyle($style, [], []);
 
 

--- a/administrator/components/com_j2commerce/tmpl/product/form_options.php
+++ b/administrator/components/com_j2commerce/tmpl/product/form_options.php
@@ -18,7 +18,7 @@ use Joomla\CMS\Language\Text;
 
 $wa = Factory::getApplication()->getDocument()->getWebAssetManager();
 
-$style = '.autocomplete-list{background: var(--form-control-bg);max-height: 200px;overflow-y: auto;width: 100%;}.autocomplete-list.autocomplete-active{border: var(--form-control-border);}.autocomplete-item{padding: 8px;cursor: pointer;font-size: .8rem;}.autocomplete-item:hover {background-color: #f0f0f0;}';
+$style = '.autocomplete-list{background: var(--form-control-bg);max-height: 200px;overflow-y: auto;width: 100%;}.autocomplete-list.autocomplete-active{border: var(--form-control-border);}.autocomplete-item{padding: 8px;cursor: pointer;font-size: .8rem;}.autocomplete-item:hover {background-color: var(--template-bg-dark-5, #f0f0f0);}';
 $wa->addInlineStyle($style, [], []);
 
 $item = $displayData['product'];

--- a/media/com_j2commerce/css/administrator/editview.css
+++ b/media/com_j2commerce/css/administrator/editview.css
@@ -124,3 +124,101 @@
 }
 
 #subfieldList_jform_optionvalues {vertical-align: middle;}
+
+/* ── Dark mode overrides ── */
+html[data-bs-theme="dark"] .j2commerce-product-edit-form,
+html[data-bs-theme="dark"] #fieldset-schema {
+
+    .product-card-v3 {background: var(--bs-body-bg);}
+    .product-card-v3::before {background: linear-gradient(180deg, #818cf8 0%, #a78bfa 50%, #c084fc 100%);}
+
+    .product-card-v3 .header-left h4 {color: #a5b4fc;}
+    .product-card-v3 .product-name-v3 {color: var(--bs-body-color);}
+
+    .product-card-v3 .stock-indicator {background: #064e3b; border-color: #065f46;}
+    .product-card-v3 .stock-indicator .stock-text {color: #6ee7b7;}
+    .product-card-v3 .stock-indicator .stock-dot {background: #34d399;}
+    .product-card-v3 .stock-indicator.out-of-stock {background: #450a0a; border-color: #7f1d1d;}
+    .product-card-v3 .stock-indicator.out-of-stock .stock-text {color: #fca5a5;}
+    .product-card-v3 .stock-indicator.out-of-stock .stock-dot {background: #f87171;}
+    .product-card-v3 .stock-indicator.pre-order,
+    .product-card-v3 .stock-indicator.back-order {background: #451a03; border-color: #78350f;}
+    .product-card-v3 .stock-indicator.pre-order .stock-text,
+    .product-card-v3 .stock-indicator.back-order .stock-text {color: #fcd34d;}
+    .product-card-v3 .stock-indicator.pre-order .stock-dot,
+    .product-card-v3 .stock-indicator.back-order .stock-dot {background: #fbbf24;}
+
+    .product-card-v3 .image-frame {background: var(--bs-tertiary-bg, #2b3035); border-color: var(--bs-border-color);}
+    .product-card-v3 .image-frame::after {border-color: #818cf8;}
+    .product-card-v3 .image-meta {color: #9ca3af;}
+
+    .product-card-v3 .price-label-v3 {color: #9ca3af;}
+    .product-card-v3 .price-amount {color: var(--bs-body-color);}
+    .product-card-v3 .price-currency {color: #9ca3af;}
+
+    .product-card-v3 .data-item {border-bottom-color: var(--bs-border-color);}
+    .product-card-v3 .data-item:nth-child(odd) {border-right-color: var(--bs-border-color);}
+    .product-card-v3 .data-key {color: #9ca3af;}
+    .product-card-v3 .data-val {color: var(--bs-body-color);}
+    .product-card-v3 .data-val.empty {color: #6b7280;}
+
+    .product-card-v3 .description-area {border-top-color: var(--bs-border-color);}
+    .product-card-v3 .description-area h6 {color: #a5b4fc;}
+    .product-card-v3 .description-area p {color: #9ca3af;}
+
+    .product-card-v3 .notice-bar {background: #1e1b4b; border-left-color: #a78bfa;}
+    .product-card-v3 .notice-bar i {color: #c4b5fd;}
+    .product-card-v3 .notice-bar span {color: #e9d5ff;}
+
+    .product-card-v3 .variants-section {border-top-color: var(--bs-border-color);}
+    .product-card-v3 .variants-section h6 {color: #a5b4fc;}
+    .product-card-v3 .variants-section h6 .badge {background: #818cf8;}
+    .product-card-v3 .variants-table th {background: var(--bs-tertiary-bg, #2b3035); color: #9ca3af; border-bottom-color: var(--bs-border-color);}
+    .product-card-v3 .variants-table td {border-bottom-color: var(--bs-border-color); color: var(--bs-body-color);}
+    .product-card-v3 .variants-table tr:hover td {background: var(--bs-tertiary-bg, #2b3035);}
+    .product-card-v3 .variant-status.in-stock {background: #064e3b; color: #6ee7b7;}
+    .product-card-v3 .variant-status.out-of-stock {background: #450a0a; color: #fca5a5;}
+    .product-card-v3 .variant-status.back-order {background: #451a03; color: #fcd34d;}
+
+    .text-bg-success {color: #6ee7b7 !important; background: #064e3b !important; border-color: #065f46 !important;}
+    .text-bg-warning {color: #fcd34d !important; background: #451a03 !important; border-color: #78350f !important;}
+    .text-bg-danger {color: #fca5a5 !important; background: #450a0a !important; border-color: #7f1d1d !important;}
+    .text-bg-info {color: #93c5fd !important; background: #1e3a5f !important; border-color: #1e40af !important;}
+    .text-bg-purple {color: #c4b5fd !important; background: #2e1065 !important; border-color: #4c1d95 !important;}
+    .text-bg-dark {color: var(--bs-body-color) !important; background: var(--bs-tertiary-bg, #2b3035) !important; border-color: var(--bs-border-color) !important;}
+
+    .btn-soft-success {color: #6ee7b7; background: #064e3b; border-color: #065f46;}
+    .btn-soft-success:hover {background: #065f46 !important;}
+    .btn-soft-warning {color: #fcd34d; background: #451a03; border-color: #78350f;}
+    .btn-soft-warning:hover {background: #78350f !important;}
+    .btn-soft-danger {color: #fca5a5; background: #450a0a; border-color: #7f1d1d;}
+    .btn-soft-danger:hover {background: #7f1d1d !important;}
+    .btn-soft-info {color: #93c5fd; background: #1e3a5f; border-color: #1e40af;}
+    .btn-soft-info:hover {background: #1e40af !important;}
+    .btn-soft-primary {color: #c4b5fd !important; background: #2e1065 !important; border-color: #4c1d95;}
+    .btn-soft-primary:hover {background: #4c1d95 !important;}
+    .btn-soft-dark {color: var(--bs-body-color); background: var(--bs-tertiary-bg, #2b3035); border-color: var(--bs-border-color);}
+    .btn-soft-dark:hover {background: var(--bs-secondary-bg, #343a40);}
+
+    joomla-tab > div[role="tablist"] {border-block-end-color: #4c1d95;}
+    joomla-tab > div[role="tablist"] > button[role="tab"][aria-selected="true"] {background: #2e1065 !important; color: #fff !important;}
+    joomla-tab > div[role="tablist"] > button[role="tab"][aria-selected="true"],
+    joomla-tab > div[role="tablist"] > button[role="tab"]:focus,
+    joomla-tab > div[role="tablist"] > button[role="tab"]:hover {color: #c4b5fd;}
+    joomla-tab > div[role="tablist"] > button[role="tab"][aria-selected="true"]:after,
+    joomla-tab > div[role="tablist"] > button[role="tab"]:focus:after,
+    joomla-tab > div[role="tablist"] > button[role="tab"]:hover:after {background-color: #a78bfa;}
+
+    .j2commerce-product-files .uppymedia-image .uppymedia-file-name {color: #9ca3af;}
+    .uppymedia-add-more, .uppymedia-empty-state {background: #2e1065; border-color: #4c1d95; color: #c4b5fd;}
+    .uppymedia-add-more:hover, .uppymedia-empty-state:hover {background: #2e1065; border-color: #7c3aed; color: #c4b5fd;}
+    .uppymedia-add-more .uppymedia-add-more-icon {color: #c4b5fd;}
+    .uppymedia-image input:focus {color: #c4b5fd; background: #2e1065;}
+
+    .j2commerce-product-relations .j2c-relations-search {background: rgba(255, 255, 255, 0.1) !important;}
+
+    #fieldset-j2commerce-product-settings {.accordion-button:not(.collapsed) {background-color: rgba(255, 255, 255, 0.1);}}
+
+    .variant-item .accordion-header .icon-featured,
+    .variant-item .accordion-header .fa-star {color: #a78bfa;}
+}

--- a/media/com_j2commerce/css/administrator/j2commerce_admin.css
+++ b/media/com_j2commerce/css/administrator/j2commerce_admin.css
@@ -201,7 +201,7 @@ body.com_j2commerce #content, #fieldset-j2commerce-product-settings, .j2commerce
 
 
     .subform-repeatable-group .control-group {margin-bottom:0;}
-    .progress {background-color: #eef1f6 !important;}
+    .progress {background-color: var(--bs-secondary-bg, #eef1f6) !important;}
     .box-shadow-none {box-shadow:none!important;}
 
     .j2commerce-variant-inventory .form-check {padding-block-start: 3px;}
@@ -293,7 +293,7 @@ html[data-bs-theme="dark"] body.com_j2commerce {
     .modal .btn.j2commerce-set-default-btn, .modal .btn.j2commerce-delete-optionvalue-btn {border-color:transparent;border-radius:0;background:transparent;box-shadow:none;}
 
     #appsTab, joomla-tab-element {padding-left:0;padding-right:0;}
-    .accordion-button:not(.collapsed) {background-color:#fff;}
+    .accordion-button:not(.collapsed) {background-color:var(--bs-body-bg, #fff);}
     .accordion-button:focus {box-shadow:none;}
     .j2commerce-app-image {width: 140px;}
 }


### PR DESCRIPTION
## Summary
Fixes #673

## Changes
- Add `[data-bs-theme="dark"]` overrides to `editview.css` covering product card v3, badges, soft buttons, tabs, stock indicators, variants table, uppymedia areas, and relations search
- Replace hardcoded `#fff` in accordion button and `#eef1f6` in progress bar with CSS vars in `j2commerce_admin.css`
- Fix inline `#f0f0f0` hover color in 3 autocomplete templates with `var(--template-bg-dark-5, #f0f0f0)`

## Files Changed
- `media/com_j2commerce/css/administrator/editview.css` — dark mode override block (97 lines)
- `media/com_j2commerce/css/administrator/j2commerce_admin.css` — accordion + progress bar CSS vars
- `administrator/.../tmpl/product/form_configoptions.php` — autocomplete hover var
- `administrator/.../tmpl/product/form_options.php` — autocomplete hover var
- `administrator/.../tmpl/product/form_filters.php` — autocomplete hover var

## Testing
1. Open admin → Articles → edit any J2Commerce product article
2. Toggle dark mode via Joomla theme switcher
3. Verify: product card, badges, tabs, stock indicators, buttons all readable with proper contrast
4. Toggle back to light mode — verify unchanged appearance

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] Core files only