### PR TITLE
fix(products): deduplicate related product search and improve hover visibility

### DIFF
--- a/administrator/components/com_j2commerce/src/Controller/ProductsController.php
+++ b/administrator/components/com_j2commerce/src/Controller/ProductsController.php
@@ -372,7 +372,8 @@ class ProductsController extends AdminController
                 ' OR ' . $db->quoteName('v.sku') . ' LIKE ' . $db->quote($search) . ')'
             );
 
-            $query->order($db->quoteName('c.title') . ' ASC')
+            $query->group($db->quoteName('p.j2commerce_product_id'))
+                ->order($db->quoteName('c.title') . ' ASC')
                 ->setLimit(20);
 
             $db->setQuery($query);

--- a/administrator/components/com_j2commerce/tmpl/product/form_relations.php
+++ b/administrator/components/com_j2commerce/tmpl/product/form_relations.php
@@ -41,7 +41,8 @@ $style = <<<'CSS'
     transition: background-color 150ms;
 }
 .j2commerce-product-relations .autocomplete-item:hover {
-    background-color: var(--template-bg-dark-5, #f5f5f5);
+    background-color: var(--bs-dropdown-link-hover-bg, #e9ecef);
+    color: var(--bs-dropdown-link-hover-color, #1e2125);
 }
 .j2commerce-product-relations .autocomplete-item + .autocomplete-item {
     border-top: 1px solid var(--template-bg-dark-5, #f5f5f5);


### PR DESCRIPTION
## Summary
Fixes #674

## Changes
- Added `GROUP BY p.j2commerce_product_id` to related product search query — prevents duplicate results when LEFT JOIN on variants produces multiple rows
- Changed hover styling from barely-visible `--template-bg-dark-5` to Bootstrap's `--bs-dropdown-link-hover-bg` / `--bs-dropdown-link-hover-color` — auto-adapts to both light and dark mode

## Files Modified
| Type | Count |
|------|-------|
| PHP (controller) | 1 |
| PHP (template) | 1 |

## Testing
1. Edit any product → Relations tab → Upsells section
2. Type in "Search and Add Products" input
3. Verify: no duplicate results, hover is clearly visible
4. Switch to dark mode, verify hover still visible

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only (non-core excluded)