### PR TITLE
fix(cart-module): respect view basket toggle and improve button styling

### DIFF
--- a/modules/mod_j2commerce_cart/tmpl/default.php
+++ b/modules/mod_j2commerce_cart/tmpl/default.php
@@ -48,7 +48,6 @@ $ajaxUrl        = (string) ($ajaxUrl ?? '');
 $isAjax         = !empty($isAjax ?? false);
 $items          = $items ?? [];
 $order          = $order ?? null;
-$linkType       = $params->get('link_type', 'link');
 $title          = $params->get('cart_module_title', '');
 $moduleClassSfx = htmlspecialchars($params->get('moduleclass_sfx', ''), ENT_QUOTES, 'UTF-8');
 
@@ -219,38 +218,21 @@ try {
 
     <!-- Footer buttons (only when cart has items) -->
     <?php if ($productCount > 0 && ($showCheckout || $showViewCart)) : ?>
+        <?php $viewCartClass = ($showCheckout && $showViewCart) ? 'btn btn-link' : 'btn btn-success'; ?>
         <div class="j2commerce-minicart-button d-grid gap-2 mt-2">
             <?php if ($showCheckout) : ?>
                 <a class="btn btn-success"
-                   href="<?php echo htmlspecialchars($checkoutUrl, ENT_QUOTES, 'UTF-8'); ?>">
+                   href="<?php echo htmlspecialchars($checkoutUrl, ENT_QUOTES, 'UTF-8'); ?>"
+                   role="button"
+                   aria-label="<?php echo htmlspecialchars(Text::_('MOD_J2COMMERCE_CART_CHECKOUT'), ENT_QUOTES, 'UTF-8'); ?>">
                     <?php echo Text::_('MOD_J2COMMERCE_CART_CHECKOUT'); ?>
                 </a>
             <?php endif; ?>
             <?php if ($showViewCart) : ?>
-                <?php if ($linkType === 'link') : ?>
-                    <a class="j2commerce-view-cart-link text-center"
-                       href="<?php echo htmlspecialchars($cartUrl, ENT_QUOTES, 'UTF-8'); ?>">
-                        <?php echo Text::_('MOD_J2COMMERCE_CART_VIEW_CART'); ?>
-                    </a>
-                <?php else : ?>
-                    <a class="btn btn-outline-secondary"
-                       href="<?php echo htmlspecialchars($cartUrl, ENT_QUOTES, 'UTF-8'); ?>">
-                        <?php echo Text::_('MOD_J2COMMERCE_CART_VIEW_CART'); ?>
-                    </a>
-                <?php endif; ?>
-            <?php endif; ?>
-        </div>
-    <?php elseif ($productCount > 0) : ?>
-        <!-- Fallback: show View Cart if no button params configured but cart has items -->
-        <div class="j2commerce-minicart-button mt-2">
-            <?php if ($linkType === 'link') : ?>
-                <a class="j2commerce-view-cart-link"
-                   href="<?php echo htmlspecialchars($cartUrl, ENT_QUOTES, 'UTF-8'); ?>">
-                    <?php echo Text::_('MOD_J2COMMERCE_CART_VIEW_CART'); ?>
-                </a>
-            <?php else : ?>
-                <a class="btn btn-primary j2commerce-view-cart-btn"
-                   href="<?php echo htmlspecialchars($cartUrl, ENT_QUOTES, 'UTF-8'); ?>">
+                <a class="<?php echo $viewCartClass; ?>"
+                   href="<?php echo htmlspecialchars($cartUrl, ENT_QUOTES, 'UTF-8'); ?>"
+                   role="button"
+                   aria-label="<?php echo htmlspecialchars(Text::_('MOD_J2COMMERCE_CART_VIEW_CART'), ENT_QUOTES, 'UTF-8'); ?>">
                     <?php echo Text::_('MOD_J2COMMERCE_CART_VIEW_CART'); ?>
                 </a>
             <?php endif; ?>

--- a/modules/mod_j2commerce_cart/tmpl/detailcartonhover.php
+++ b/modules/mod_j2commerce_cart/tmpl/detailcartonhover.php
@@ -76,7 +76,7 @@ $panelId = 'j2commerce-cart-detail-' . $moduleId;
                 <span class="j2commerce-cart-text">
                     <?php echo htmlspecialchars(Text::sprintf('MOD_J2COMMERCE_CART_TOTAL', $productCount, $formattedTotal), ENT_QUOTES, 'UTF-8'); ?>
                 </span>
-                <?php if (!empty($cartUrl)) : ?>
+                <?php if ($showViewCart && !empty($cartUrl)) : ?>
                     <a class="j2commerce-view-cart-link ms-2" href="<?php echo htmlspecialchars($cartUrl, ENT_QUOTES, 'UTF-8'); ?>">
                         <?php echo Text::_('MOD_J2COMMERCE_CART_VIEW_CART'); ?>
                     </a>
@@ -97,7 +97,7 @@ $panelId = 'j2commerce-cart-detail-' . $moduleId;
                         <?php echo Text::_('MOD_J2COMMERCE_CART_EMPTY'); ?>
                     <?php endif; ?>
                 </div>
-                <?php if ($productCount > 0) : ?>
+                <?php if ($showViewCart && $productCount > 0) : ?>
                     <a class="text-decoration-none" href="<?php echo htmlspecialchars($cartUrl, ENT_QUOTES, 'UTF-8'); ?>">
                         <?php echo Text::_('MOD_J2COMMERCE_CART_VIEW_CART'); ?>
                     </a>
@@ -169,15 +169,22 @@ $panelId = 'j2commerce-cart-detail-' . $moduleId;
             </ul>
 
             <?php if ($showCheckout || $showViewCart) : ?>
+            <?php $viewCartClass = ($showCheckout && $showViewCart) ? 'btn btn-link' : 'btn btn-success'; ?>
             <!-- Footer buttons -->
             <div class="card-footer d-grid gap-2">
                 <?php if ($showCheckout) : ?>
-                    <a class="btn btn-success" href="<?php echo htmlspecialchars($checkoutUrl, ENT_QUOTES, 'UTF-8'); ?>">
+                    <a class="btn btn-success"
+                       href="<?php echo htmlspecialchars($checkoutUrl, ENT_QUOTES, 'UTF-8'); ?>"
+                       role="button"
+                       aria-label="<?php echo htmlspecialchars(Text::_('MOD_J2COMMERCE_CART_CHECKOUT'), ENT_QUOTES, 'UTF-8'); ?>">
                         <?php echo Text::_('MOD_J2COMMERCE_CART_CHECKOUT'); ?>
                     </a>
                 <?php endif; ?>
                 <?php if ($showViewCart) : ?>
-                    <a class="btn btn-outline-secondary" href="<?php echo htmlspecialchars($cartUrl, ENT_QUOTES, 'UTF-8'); ?>">
+                    <a class="<?php echo $viewCartClass; ?>"
+                       href="<?php echo htmlspecialchars($cartUrl, ENT_QUOTES, 'UTF-8'); ?>"
+                       role="button"
+                       aria-label="<?php echo htmlspecialchars(Text::_('MOD_J2COMMERCE_CART_VIEW_CART'), ENT_QUOTES, 'UTF-8'); ?>">
                         <?php echo Text::_('MOD_J2COMMERCE_CART_VIEW_CART'); ?>
                     </a>
                 <?php endif; ?>


### PR DESCRIPTION
## Summary
Fixes #676

## Changes
- Removed fallback block in `default.php` that forced "View Cart" link even when `enable_view_cart=No`
- Gated `detailcartonhover.php` "View Cart" links behind `$showViewCart` parameter
- Unified button styling: `btn btn-link` when paired with checkout, `btn btn-success` when standalone
- Added `role="button"` and `aria-label` accessibility attributes to both checkout and view cart buttons
- Removed unused `$linkType` variable

## Files Changed
- `modules/mod_j2commerce_cart/tmpl/default.php` — removed fallback, new button logic, accessibility
- `modules/mod_j2commerce_cart/tmpl/detailcartonhover.php` — view cart gating, new button logic, accessibility

## Pre-Flight
- [x] PHP syntax check passed
- [x] Core files only
- [x] No language file changes

## Testing
1. Set `enable_view_cart=No`, `enable_checkout=No` → no buttons appear
2. Set `enable_view_cart=Yes` only → green `btn-success` view cart button
3. Set both `enable_view_cart=Yes` and `enable_checkout=Yes` → green checkout + link-style view cart
4. Test with `detailcartonhover` layout — same behavior