### PR TITLE
Add stubs folder to file listing in j2commerce.xml

### DIFF
--- a/administrator/components/com_j2commerce/j2commerce.xml
+++ b/administrator/components/com_j2commerce/j2commerce.xml
@@ -73,6 +73,7 @@
             <folder>services</folder>
             <folder>sql</folder>
             <folder>src</folder>
+            <folder>stubs</folder>
             <folder>tmpl</folder>
         </files>
 


### PR DESCRIPTION
I just tested the cli for creating a plugin

I accepted the default to all questions

at the end the error message was
` [ERROR] Stub file not found: administrator/components/com_j2commerce/stubs/payment/manifest.xml.stub      `

the stubs are in the build package but they are not installed - this PR ensures that the stubs are installed