### PR TITLE
fix(checkout): strip stray output from JSON responses

### DIFF
--- a/components/com_j2commerce/src/Controller/CheckoutController.php
+++ b/components/com_j2commerce/src/Controller/CheckoutController.php
@@ -74,8 +74,15 @@ class CheckoutController extends BaseController
 
     protected function jsonResponse(array $json): void
     {
-        header('Content-Type: application/json; charset=utf-8');
-        header('Cache-Control: no-store, no-cache, must-revalidate');
+        while (ob_get_level() > 0) {
+            ob_end_clean();
+        }
+
+        if (!headers_sent()) {
+            header('Content-Type: application/json; charset=utf-8');
+            header('Cache-Control: no-store, no-cache, must-revalidate');
+        }
+
         echo json_encode($json);
         $this->app->close();
     }


### PR DESCRIPTION
## Core Update

### Changes
Hardens `CheckoutController::jsonResponse()` so stray PHP output (warnings, notices, HTML) cannot corrupt the JSON body sent to checkout AJAX endpoints.

### Problem
Returning customers logging in on `/new-checkout` intermittently see:
`Unexpected server response. Please reload the page and try again.`

Root cause: legacy `plg_system_j2store` still loads `libraries/f0f/` on every request (project is dual-mode J2Store + J2Commerce during migration). FOF 2 predates PHP 8.2/8.4 and emits `Deprecated: Implicitly marking parameter as nullable` and `Creation of dynamic property F0FUtilsObject::$limit` notices. With `debug=true` and `error_reporting=maximum`, those notices render as HTML and prepend to the JSON response body. Client `JSON.parse(text)` throws, fallback warning fires.

### Fix
In `components/com_j2commerce/src/Controller/CheckoutController.php::jsonResponse()`:
- `while (ob_get_level() > 0) ob_end_clean()` — discard every active output buffer before emitting JSON
- `headers_sent()` guard around `header()` calls — avoids our own warning if something already flushed
- `echo json_encode($json)` and `$this->app->close()` unchanged

Defense in depth: protects every checkout AJAX endpoint (`loginValidate`, `registerValidate`, `billingAddress`, `shippingAddress`, `shippingMethod`, `paymentMethod`, `confirmOrder`, etc.) against current and future stray output. Does not touch FOF, does not change HTML paths.

### Files Modified
| Type | Count |
|------|-------|
| PHP files | 1 |
| JS/CSS assets | 0 |
| Language files | 0 |
| XML/Config | 0 |

### Pre-Flight
- [x] PHP syntax check passed (`php -l`)
- [x] No secrets detected
- [x] No FOF remnants
- [x] Code style (php-cs-fixer) passed
- [x] Core files only