### PR TITLE
fix(inventory): improve variants dark mode contrast (fixes #675)

### DIFF
--- a/administrator/components/com_j2commerce/tmpl/inventory/default.php
+++ b/administrator/components/com_j2commerce/tmpl/inventory/default.php
@@ -306,7 +306,7 @@ document.addEventListener("DOMContentLoaded", function() {
                                 </th>
                                 <td class="text-start j2commerce-inventory-sku">
                                     <?php if ($isVariantProduct) : ?>
-                                        <button type="button" class="btn btn-sm btn-outline-info position-relative" data-bs-toggle="collapse" data-bs-target="#variants-<?php echo $item->j2commerce_product_id; ?>" aria-expanded="false">
+                                        <button type="button" class="btn btn-sm btn-outline-primary position-relative" data-bs-toggle="collapse" data-bs-target="#variants-<?php echo $item->j2commerce_product_id; ?>" aria-expanded="false">
                                             <?php echo Text::_('COM_J2COMMERCE_VARIANTS'); ?>
                                             <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-secondary"><?php echo count($item->variants ?? []); ?><span class="visually-hidden"><?php echo Text::_('COM_J2COMMERCE_VARIANT_COUNT');?></span></span>
                                         </button>

--- a/media/com_j2commerce/css/administrator/j2commerce_admin.css
+++ b/media/com_j2commerce/css/administrator/j2commerce_admin.css
@@ -229,6 +229,7 @@ html[data-bs-theme="dark"] body.com_j2commerce {
         background-color: var(--btn-primary-bg-hvr);
         border: var(--btn-primary-border-hvr);
     }
+    .variants-container {background-color: rgba(255, 255, 255, 0.1);border: none;}
 }
 
 .j2commerce-social-share a[target="_blank"]:before {display:none;}


### PR DESCRIPTION
## Summary
- Change variant toggle button from `btn-outline-info` to `btn-outline-primary` for better dark mode visibility
- Add dark mode background and border styling for `.variants-container`

Fixes #675

## Test plan
- [ ] Open Inventory view with variable products in light mode — verify variants button looks correct
- [ ] Switch to dark mode — verify variants button has good contrast
- [ ] Expand a variant row in dark mode — verify `.variants-container` background is visible but subtle