### PR TITLE
fix(cli): preserve display_name in plugin scaffolder

### DIFF
--- a/administrator/components/com_j2commerce/src/CliCommands/PluginScaffolder.php
+++ b/administrator/components/com_j2commerce/src/CliCommands/PluginScaffolder.php
@@ -58,7 +58,9 @@ class PluginScaffolder
     {
         $name        = $this->name;
         $className   = $this->toPascalCase($name);
-        $displayName = $this->toDisplayName($name);
+        $displayName = !empty($this->options['display_name']) && \is_string($this->options['display_name'])
+            ? $this->options['display_name']
+            : $this->toDisplayName($name);
         $element     = $this->type . '_' . $name;
         $namespace   = 'J2Commerce\\Plugin\\J2Commerce\\' . ucfirst($this->type) . $className;
 
@@ -76,8 +78,11 @@ class PluginScaffolder
             'month'        => date('F'),
         ]);
 
-        // Set conditional flags
+        // Set conditional flags (skip non-boolean keys already handled above)
         foreach ($this->options as $key => $value) {
+            if ($key === 'display_name') {
+                continue;
+            }
             $this->processor->setReplacement($key, $value ? '1' : '');
         }
     }


### PR DESCRIPTION
## Summary
Fixes #688

The CLI scaffolder (`j2commerce:create:plugin`) generated language files where `{{display_name}}` was always `"1"`:

```ini
PLG_J2COMMERCE_SHIPPING_TEST999="1"
PLG_J2COMMERCE_SHIPPING_TEST999_DESC="Provides 1 shipping rates for J2Commerce."
PLG_J2COMMERCE_SHIPPING_TEST999_DEFAULT="1"
```

## Root Cause
`PluginScaffolder::setupReplacements()` loops over `$this->options` and coerces every value with `$value ? '1' : ''` to apply boolean conditional flags. Because `display_name` is a non-empty string (truthy), it was getting stomped with `"1"`. Additionally, user-entered display_name from the interactive prompt was ignored — the value was always recomputed from the plugin name.

## Changes
- Honor `$this->options['display_name']` when set, fall back to derived name otherwise
- Skip `display_name` key in the boolean conditional flag loop

## Testing
1. `php cli/joomla.php j2commerce:create:plugin shipping test999 --no-interaction --force`
2. Open `plugins/j2commerce/shipping_test999/language/en-GB/plg_j2commerce_shipping_test999.ini`
3. Verify: `PLG_J2COMMERCE_SHIPPING_TEST999="Test999"` (not `"1"`)
4. Repeat with `payment` type — both fixed.

## Files Changed
- `administrator/components/com_j2commerce/src/CliCommands/PluginScaffolder.php` — skip display_name in bool loop, honor options input