### PR TITLE
fix(product): correct inventory warning config link (fixes #691)

### DIFF
--- a/administrator/components/com_j2commerce/tmpl/product/form_ajax_avoptions.php
+++ b/administrator/components/com_j2commerce/tmpl/product/form_ajax_avoptions.php
@@ -299,7 +299,7 @@ foreach ($variantList as $variant) :
                                     <div class="alert alert-warning d-flex align-items-center" role="alert">
                                         <span class="fa-solid fa-exclamation-triangle flex-shrink-0 me-2" aria-hidden="true"></span>
                                         <div>
-                                            <?php echo Text::sprintf('COM_J2COMMERCE_PRODUCT_INVENTORY_WARNING', Route::_('index.php?option=com_j2commerce&view=configuration')); ?>
+                                            <?php echo Text::sprintf('COM_J2COMMERCE_PRODUCT_INVENTORY_WARNING', Route::_('index.php?option=com_config&view=component&component=com_j2commerce')); ?>
                                         </div>
                                     </div>
                                 <?php endif; ?>

--- a/administrator/components/com_j2commerce/tmpl/product/form_ajax_flexivariableoptions.php
+++ b/administrator/components/com_j2commerce/tmpl/product/form_ajax_flexivariableoptions.php
@@ -298,7 +298,7 @@ foreach ($variantList as $variant) :
                                     <div class="alert alert-warning d-flex align-items-center" role="alert">
                                         <span class="fa-solid fa-exclamation-triangle flex-shrink-0 me-2" aria-hidden="true"></span>
                                         <div>
-                                            <?php echo Text::sprintf('COM_J2COMMERCE_PRODUCT_INVENTORY_WARNING',Route::_('index.php?option=com_j2commerce&view=configuration')); ?>
+                                            <?php echo Text::sprintf('COM_J2COMMERCE_PRODUCT_INVENTORY_WARNING',Route::_('index.php?option=com_config&view=component&component=com_j2commerce')); ?>
                                         </div>
                                     </div>
                                 <?php endif; ?>


### PR DESCRIPTION
## Summary
Fixes #691

The variant product inventory warning linked to a non-existent
`com_j2commerce&view=configuration` URL. Updated to the Joomla component
config URL.

## Changes
- `form_ajax_avoptions.php` — fix Route target
- `form_ajax_flexivariableoptions.php` — fix Route target

## Testing
1. Admin → System → Global Config → J2Commerce → disable inventory management
2. Edit an Advanced Variable or Flexible Variable product → Variants tab
3. Click the warning link
4. Verify it lands on `index.php?option=com_config&view=component&component=com_j2commerce`

## Files Changed
- `administrator/components/com_j2commerce/tmpl/product/form_ajax_avoptions.php`
- `administrator/components/com_j2commerce/tmpl/product/form_ajax_flexivariableoptions.php`