### PR TITLE
fix(cart-module): add showon conditions to layout-specific fields

### DIFF
--- a/modules/mod_j2commerce_cart/mod_j2commerce_cart.xml
+++ b/modules/mod_j2commerce_cart/mod_j2commerce_cart.xml
@@ -87,6 +87,7 @@
                     type="text"
                     label="MOD_J2COMMERCE_CART_TITLE"
                     description="MOD_J2COMMERCE_CART_TITLE_DESC"
+                    showon="layout:_:default,_:detailcartonhover"
                 />
                 <field
                     name="link_type"
@@ -95,6 +96,7 @@
                     label="MOD_J2COMMERCE_CART_LINK_TYPE"
                     description="MOD_J2COMMERCE_CART_LINK_TYPE_DESC"
                     class="form-select"
+                    showon="layout:_:default,_:detailcartonhover"
                 >
                     <option value="link">MOD_J2COMMERCE_CART_LINK_TYPE_LINK</option>
                     <option value="button">MOD_J2COMMERCE_CART_LINK_TYPE_BUTTON</option>
@@ -114,6 +116,7 @@
                     description="MOD_J2COMMERCE_CART_CHECKOUT_MENU_ITEM_DESC"
                     class="form-select"
                     default=""
+                    showon="layout:_:default,_:detailcartonhover"
                 />
                 <field
                     name="check_empty"
@@ -146,6 +149,7 @@
                     type="note"
                     label="MOD_J2COMMERCE_CART_DETAIL_HEADING"
                     class="alert alert-info"
+                    showon="layout:_:default,_:detailcartonhover"
                 />
                 <field
                     name="show_thumbimage"
@@ -155,6 +159,7 @@
                     default="0"
                     label="MOD_J2COMMERCE_CART_SHOW_THUMBNAIL"
                     description="MOD_J2COMMERCE_CART_SHOW_THUMBNAIL_DESC"
+                    showon="layout:_:default,_:detailcartonhover"
                 >
                     <option value="0">JNO</option>
                     <option value="1">JYES</option>
@@ -167,6 +172,7 @@
                     default="0"
                     label="MOD_J2COMMERCE_CART_SHOW_QUANTITY"
                     description="MOD_J2COMMERCE_CART_SHOW_QUANTITY_DESC"
+                    showon="layout:_:default,_:detailcartonhover"
                 >
                     <option value="0">JNO</option>
                     <option value="1">JYES</option>
@@ -179,6 +185,7 @@
                     default="0"
                     label="MOD_J2COMMERCE_CART_SHOW_REMOVE"
                     description="MOD_J2COMMERCE_CART_SHOW_REMOVE_DESC"
+                    showon="layout:_:default,_:detailcartonhover"
                 >
                     <option value="0">JNO</option>
                     <option value="1">JYES</option>
@@ -191,6 +198,7 @@
                     default="0"
                     label="MOD_J2COMMERCE_CART_SHOW_CHECKOUT"
                     description="MOD_J2COMMERCE_CART_SHOW_CHECKOUT_DESC"
+                    showon="layout:_:default,_:detailcartonhover"
                 >
                     <option value="0">JNO</option>
                     <option value="1">JYES</option>
@@ -203,6 +211,7 @@
                     default="0"
                     label="MOD_J2COMMERCE_CART_SHOW_VIEW_CART"
                     description="MOD_J2COMMERCE_CART_SHOW_VIEW_CART_DESC"
+                    showon="layout:_:default,_:detailcartonhover"
                 >
                     <option value="0">JNO</option>
                     <option value="1">JYES</option>
@@ -214,6 +223,7 @@
                     type="note"
                     label="MOD_J2COMMERCE_CART_MINICART_HEADING"
                     class="alert alert-info"
+                    showon="layout:_:minicart"
                 />
                 <field
                     name="minicart_cart_icon_class"
@@ -221,6 +231,7 @@
                     default="fa-solid fa-shopping-cart"
                     label="MOD_J2COMMERCE_CART_ICON_CLASS"
                     description="MOD_J2COMMERCE_CART_ICON_CLASS_DESC"
+                    showon="layout:_:minicart"
                 />
 
                 <!-- Custom CSS -->


### PR DESCRIPTION
## Summary
Fixes #677

Adds `showon` attributes to cart module XML config so fields only display when their relevant layout is selected.

## Changes
- 10 fields get `showon="layout:_:default,_:detailcartonhover"` (detail-only: title, link type, checkout menu item, detail heading, thumbnails, qty, remove, checkout, view cart)
- 2 fields get `showon="layout:_:minicart"` (minicart-only: icon class heading, icon class)
- 5 fields unchanged — common to all layouts (cart menu item, hide when empty, quantity count, custom CSS)

## Files Modified
| Type | Count |
|------|-------|
| XML/Config | 1 |

## Testing
1. Admin → Content → Site Modules → edit Shopping Cart module
2. Select **Default** layout → detail fields visible, minicart fields hidden
3. Select **Minicart** → minicart fields visible, detail fields hidden
4. Select **Detail Cart On Hover** → same as Default

## Pre-Flight
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only