### PR TITLE
fix(product-options): match AJAX button classes to static counterparts (fixes #693)

### DIFF
--- a/administrator/components/com_j2commerce/tmpl/product/form_ajax_flexivariableoptions.php
+++ b/administrator/components/com_j2commerce/tmpl/product/form_ajax_flexivariableoptions.php
@@ -210,7 +210,7 @@ foreach ($variantList as $variant) :
             <?php endif; ?>
 
             <button type="button"
-                    class="btn btn-danger <?php echo $btnClass; ?> j2commerce-delete-variant"
+                    class="btn btn-soft-danger <?php echo $btnClass; ?> j2commerce-delete-variant"
                     data-variant-id="<?php echo $variantId; ?>"
                     aria-label="<?php echo $this->escape(Text::sprintf('COM_J2COMMERCE_DELETE_VARIANT_N', $variantId)); ?>">
                 <span class="icon icon-trash" aria-hidden="true"></span>

--- a/administrator/components/com_j2commerce/tmpl/product/form_variable_options.php
+++ b/administrator/components/com_j2commerce/tmpl/product/form_variable_options.php
@@ -165,7 +165,7 @@ document.addEventListener('DOMContentLoaded', () => {
     function buildOptionRow(poId, optionId, optionName, uniqueName, optionType, ordering) {
         const showSetValues = variantTypes.includes(optionType);
         const setValuesBtn = showSetValues
-            ? `<button type="button" class="small ms-2 btn btn-outline-primary btn-sm j2commerce-variable-option-values-link"
+            ? `<button type="button" class="small ms-2 ms-lg-3 btn btn-soft-dark btn-sm j2commerce-variable-option-values-link"
                     data-product-id="${productId}"
                     data-option-id="${poId}"
                     data-option-name="${escHtml(optionName)}">
@@ -186,7 +186,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 <input type="text" class="form-control" name="${formPrefix}[item_options][${poId}][ordering]" value="${ordering}">
             </td>
             <td class="text-end">
-                <span class="optionRemove btn btn-danger btn-sm"
+                <span class="optionRemove btn btn-soft-danger btn-sm"
                       data-option-id="${poId}"
                       role="button"
                       title="<?php echo Text::_('COM_J2COMMERCE_OPTION_REMOVE'); ?>">


### PR DESCRIPTION
## Summary
Fixes #693

AJAX-created buttons in product option/variant forms had different CSS classes than their static HTML counterparts, causing visual inconsistency.

## Changes
- `form_variable_options.php` — AJAX "Set Option Values" button: `btn-outline-primary` → `btn-soft-dark`, added missing `ms-lg-3`
- `form_variable_options.php` — AJAX "Remove option" button: `btn-danger` → `btn-soft-danger`
- `form_ajax_flexivariableoptions.php` — Delete variant button: `btn-danger` → `btn-soft-danger`

## Testing
1. Admin → Products → Edit a **variable** product
2. Options tab → add a new option via dropdown
3. Verify AJAX-created "Set Option Values" button matches existing dark-styled buttons
4. Verify AJAX-created remove (trash) button matches existing soft-danger styling
5. Admin → Products → Edit a **flexivariable** product
6. Generate variants → verify delete buttons use soft-danger style

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] Core files only (2 files)