### PR TITLE
fix(cart): use ModuleHelper for ajaxmini rendering (fixes #640)

### DIFF
--- a/components/com_j2commerce/src/Controller/CartsController.php
+++ b/components/com_j2commerce/src/Controller/CartsController.php
@@ -22,6 +22,7 @@ use J2Commerce\Component\J2commerce\Administrator\Helper\UtilitiesHelper;
 use J2Commerce\Component\J2commerce\Administrator\Model\CartModel;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Helper\ModuleHelper;
 use Joomla\CMS\MVC\Controller\BaseController;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Router\Route;
@@ -775,7 +776,6 @@ class CartsController extends BaseController
         $this->startAjaxBuffer();
 
         $db       = Factory::getContainer()->get('DatabaseDriver');
-        $document = $this->app->getDocument();
         $language = $this->app->getLanguage()->getTag();
 
         $query = $db->getQuery(true);
@@ -800,15 +800,14 @@ class CartsController extends BaseController
             $modules = $db->loadObjectList();
         }
 
-        $renderer = $document->loadRenderer('module');
-        $json     = [];
+        $json = [];
 
         if (\count($modules) < 1) {
             $json['response'] = ' ';
         } else {
             foreach ($modules as $module) {
                 $this->app->setUserState('mod_j2commerce_mini_cart.isAjax', '1');
-                $json['response'][$module->id] = $renderer->render($module);
+                $json['response'][$module->id] = ModuleHelper::renderModule($module, ['style' => 'none']);
             }
         }
 

--- a/media/com_j2commerce/js/site/j2commerce.js
+++ b/media/com_j2commerce/js/site/j2commerce.js
@@ -234,35 +234,6 @@ const J2Commerce = {
         }
     },
 
-    /**
-     * Update mini cart module via AJAX
-     */
-    async doMiniCart() {
-        if (!this.baseUrl) this.baseUrl = this.getBaseUrl();
-        const url = `${this.baseUrl}index.php?option=com_j2commerce&view=carts&task=ajaxmini`;
-
-        try {
-            const response = await fetch(url, {
-                method: 'GET',
-                headers: {
-                    'Cache-Control': 'no-cache',
-                    'Content-Type': 'application/json; charset=utf-8'
-                }
-            });
-            const json = await response.json();
-
-            if (json?.response) {
-                Object.entries(json.response).forEach(([key, value]) => {
-                    document.querySelectorAll(`.j2commerce-cart-module-${key}`).forEach(el => {
-                        el.textContent = value;
-                    });
-                });
-            }
-        } catch (error) {
-            console.error('Mini cart error:', error);
-        }
-    },
-
     // =========================================================================
     // AJAX TASK EXECUTION
     // =========================================================================
@@ -1231,10 +1202,6 @@ const J2Commerce = {
 // =========================================================================
 // GLOBAL FUNCTIONS (Backwards Compatibility)
 // =========================================================================
-
-function doMiniCart() {
-    J2Commerce.doMiniCart();
-}
 
 
 function getCategoryFilterToggle() {


### PR DESCRIPTION
## Summary
Fixes #640

`ajaxmini()` used `$document->loadRenderer('module')` which fails with a 500 error when `format=raw` is in the URL, because `RawDocument` has no 'module' renderer. Replaced with `ModuleHelper::renderModule()` which works regardless of document type.

Also removed the dead `doMiniCart()` method and its global wrapper from `j2commerce.js` — the cart module's inline `refreshMiniCart()` handles all mini cart refreshes; nothing calls `doMiniCart()`.

## Changes
- `CartsController::ajaxmini()` — use `ModuleHelper::renderModule($module, ['style' => 'none'])` instead of `$document->loadRenderer('module')`
- `j2commerce.js` — remove unused `doMiniCart()` method and global wrapper

## Files Modified
| Type | Count |
|------|-------|
| PHP files | 1 |
| JS assets | 1 |

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only

## Testing
1. Publish `mod_j2commerce_cart` module on frontend
2. Add product to cart
3. Verify mini cart updates via AJAX — no 500 error
4. Check Network tab — `carts.ajaxmini&format=raw` returns 200
5. Check browser console — no errors