### PR TITLE
fix(templates): add missing default values to params->get() calls

### DIFF
--- a/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/default_sortfilter.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/default_sortfilter.php
@@ -52,7 +52,7 @@ $currentSefPath = Uri::getInstance()->getPath();
         </div>
 
         <div class="d-flex align-items-center gap-2 j2commerce-sortbar-filter-right">
-            <?php if ($this->params->get('list_show_filter_search')) : ?>
+            <?php if ($this->params->get('list_show_filter_search', 1)) : ?>
                 <div class="input-group">
                     <input type="text" name="search" id="j2commerce-search" class="form-control j2commerce-product-search-input" value="<?php echo $search; ?>" placeholder="<?php echo Text::_('COM_J2COMMERCE_FILTER_SEARCH'); ?>" />
                     <button type="submit" class="btn btn-primary" title="<?php echo Text::_('COM_J2COMMERCE_FILTER_GO'); ?>">
@@ -64,7 +64,7 @@ $currentSefPath = Uri::getInstance()->getPath();
                 </div>
             <?php endif; ?>
 
-            <?php if ($this->params->get('list_show_filter_sorting')) : ?>
+            <?php if ($this->params->get('list_show_filter_sorting', 1)) : ?>
                 <?php
                 $sortOptions = $this->filters['sorting'] ?? [];
                 $currentSort = $this->state->sortby ?? '';

--- a/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/view_accordions.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/view_accordions.php
@@ -30,8 +30,8 @@ if ($wa->assetExists('script', 'bootstrap.esm')) {
 
 $wa->registerAndUseScript('bootstrap.collapse',Uri::base().'media/com_j2commerce/js/site/vendor/bootstrap/collapse.min.js',[],['type' => 'module'],$deps);
 HTMLHelper::_('bootstrap.collapse', '.accordion-button', []);
-$hasShortDesc = $this->params->get('item_show_sdesc') && !empty(trim(strip_tags($this->product->product_short_desc ?? '')));
-$hasLongDesc  = $this->params->get('item_show_ldesc') && !empty(trim(strip_tags($this->product->product_long_desc ?? '')));
+$hasShortDesc = $this->params->get('item_show_sdesc', 1) && !empty(trim(strip_tags($this->product->product_short_desc ?? '')));
+$hasLongDesc  = $this->params->get('item_show_ldesc', 1) && !empty(trim(strip_tags($this->product->product_long_desc ?? '')));
 $hasDescription = $hasShortDesc || $hasLongDesc;
 $set_specification_active = !$hasDescription;
 ?>
@@ -50,7 +50,7 @@ $set_specification_active = !$hasDescription;
             </div>
         </div>
     <?php endif;?>
-    <?php if($this->params->get('item_show_product_specification')):?>
+    <?php if($this->params->get('item_show_product_specification', 0)):?>
         <div class="accordion-item border-0 mb-2">
             <div class="accordion-header fs-4" id="headingSpecs">
                 <button type="button" class="accordion-button" data-bs-toggle="collapse" data-bs-target="#specs" aria-expanded="false" aria-controls="specs">

--- a/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/view_configurable.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/view_configurable.php
@@ -56,7 +56,7 @@ use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
                 </div>
             </div>
 
-            <?php if($this->params->get('item_show_sdesc')):?>
+            <?php if($this->params->get('item_show_sdesc', 1)):?>
                 <?php echo $this->loadTemplate('sdesc'); ?>
             <?php endif; ?>
 

--- a/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/view_flexivariable.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/view_flexivariable.php
@@ -65,7 +65,7 @@ if ($this->params->get('item_show_product_stock', 1) && J2CommerceHelper::produc
 
             <?php echo J2CommerceHelper::plugin()->eventWithHtml('BeforeProductDescription', [$this->product, $this->context])->getArgument('html', ''); ?>
 
-            <?php if($this->params->get('item_show_sdesc')):?>
+            <?php if($this->params->get('item_show_sdesc', 1)):?>
                 <?php echo $this->loadTemplate('sdesc'); ?>
             <?php endif; ?>
 

--- a/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/view_notabs.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/view_notabs.php
@@ -19,14 +19,14 @@ $productfilters = $this->product->productfilters ?? [];
 ?>
 <div class="row">
     <div class="col-sm-12">
-        <?php if ($this->params->get('item_show_ldesc')) : ?>
+        <?php if ($this->params->get('item_show_ldesc', 1)) : ?>
             <div class="product-description mt-5 pt-4 border-top">
                 <h3 class="text-center mb-4"><?php echo Text::_('COM_J2COMMERCE_PRODUCT_DESCRIPTION'); ?></h3>
                 <?php echo $this->loadTemplate('ldesc'); ?>
             </div>
         <?php endif; ?>
 
-        <?php if ($this->params->get('item_show_product_specification')) : ?>
+        <?php if ($this->params->get('item_show_product_specification', 0)) : ?>
             <div class="product-specs mt-5 pt-4 border-top">
                 <h3 class="text-center mb-4"><?php echo Text::_('COM_J2COMMERCE_PRODUCT_SPECIFICATIONS'); ?></h3>
                 <?php echo $this->loadTemplate('specs'); ?>

--- a/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/view_simple.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/view_simple.php
@@ -70,7 +70,7 @@ use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 
             <?php echo J2CommerceHelper::plugin()->eventWithHtml('BeforeProductDescription', [$this->product, $this->context])->getArgument('html', ''); ?>
 
-            <?php if($this->params->get('item_show_sdesc')):?>
+            <?php if($this->params->get('item_show_sdesc', 1)):?>
                 <?php echo $this->loadTemplate('sdesc'); ?>
             <?php endif; ?>
 

--- a/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/view_tabs.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/view_tabs.php
@@ -20,8 +20,8 @@ use Joomla\CMS\Language\Text;
 HTMLHelper::_('bootstrap.tab', '#j2commerce-product-detail-tab', []);
 
 $productfilters = $this->product->productfilters ?? [];
-$hasShortDesc = $this->params->get('item_show_sdesc') && !empty(trim(strip_tags($this->product->product_short_desc ?? '')));
-$hasLongDesc  = $this->params->get('item_show_ldesc') && !empty(trim(strip_tags($this->product->product_long_desc ?? '')));
+$hasShortDesc = $this->params->get('item_show_sdesc', 1) && !empty(trim(strip_tags($this->product->product_short_desc ?? '')));
+$hasLongDesc  = $this->params->get('item_show_ldesc', 1) && !empty(trim(strip_tags($this->product->product_long_desc ?? '')));
 $hasDescription = $hasShortDesc || $hasLongDesc;
 $set_specification_active = !$hasDescription;
 ?>
@@ -35,7 +35,7 @@ $set_specification_active = !$hasDescription;
             </li>
         <?php endif; ?>
 
-        <?php if ($this->params->get('item_show_product_specification')) : ?>
+        <?php if ($this->params->get('item_show_product_specification', 0)) : ?>
             <li class="nav-item">
                 <a href="#specs" class="nav-link rounded-0 <?php echo $set_specification_active ? 'active' : ''; ?>" data-bs-toggle="tab"><?php echo Text::_('COM_J2COMMERCE_PRODUCT_SPECIFICATIONS'); ?></a>
             </li>
@@ -45,13 +45,13 @@ $set_specification_active = !$hasDescription;
     </ul>
 
     <div class="tab-content border-0 rounded-0 box-shadow-none px-1">
-        <?php if ($this->params->get('item_show_ldesc')) : ?>
+        <?php if ($this->params->get('item_show_ldesc', 1)) : ?>
             <div class="tab-pane fade show active" id="description">
                 <?php echo $this->loadTemplate('ldesc'); ?>
             </div>
         <?php endif; ?>
 
-        <?php if ($this->params->get('item_show_product_specification')) : ?>
+        <?php if ($this->params->get('item_show_product_specification', 0)) : ?>
             <div class="tab-pane fade show <?php echo $set_specification_active ? 'active' : ''; ?>" id="specs">
                 <?php echo $this->loadTemplate('specs'); ?>
             </div>

--- a/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/view_variable.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/view_variable.php
@@ -60,7 +60,7 @@ if ($this->params->get('item_show_product_stock', 1) && J2CommerceHelper::produc
                 </div>
             </div>
 
-            <?php if($this->params->get('item_show_sdesc')):?>
+            <?php if($this->params->get('item_show_sdesc', 1)):?>
                 <?php echo $this->loadTemplate('sdesc'); ?>
             <?php endif; ?>
 

--- a/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/default_sortfilter.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/default_sortfilter.php
@@ -47,7 +47,7 @@ $currentSefPath = Uri::getInstance()->getPath();
         </div>
 
         <div class="d-flex align-items-center gap-2 j2commerce-sortbar-filter-right">
-            <?php if ($this->params->get('list_show_filter_search')) : ?>
+            <?php if ($this->params->get('list_show_filter_search', 1)) : ?>
                 <div class="input-group">
                     <input type="text" name="search" id="j2commerce-search" class="form-control j2commerce-product-search-input" value="<?php echo $search; ?>" placeholder="<?php echo Text::_('COM_J2COMMERCE_FILTER_SEARCH'); ?>" />
                     <button type="submit" class="btn btn-primary" title="<?php echo Text::_('COM_J2COMMERCE_FILTER_GO'); ?>">
@@ -59,7 +59,7 @@ $currentSefPath = Uri::getInstance()->getPath();
                 </div>
             <?php endif; ?>
 
-            <?php if ($this->params->get('list_show_filter_sorting')) : ?>
+            <?php if ($this->params->get('list_show_filter_sorting', 1)) : ?>
                 <?php
                 $sortOptions = $this->filters['sorting'] ?? [];
                 $currentSort = $this->state->sortby ?? '';

--- a/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/view_accordions.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/view_accordions.php
@@ -30,8 +30,8 @@ if ($wa->assetExists('script', 'bootstrap.esm')) {
 
 $wa->registerAndUseScript('bootstrap.collapse',Uri::base().'media/com_j2commerce/js/site/vendor/bootstrap/collapse.min.js',[],['type' => 'module'],$deps);
 HTMLHelper::_('bootstrap.collapse', '.accordion-button', []);
-$hasShortDesc = $this->params->get('item_show_sdesc') && !empty(trim(strip_tags($this->product->product_short_desc ?? '')));
-$hasLongDesc  = $this->params->get('item_show_ldesc') && !empty(trim(strip_tags($this->product->product_long_desc ?? '')));
+$hasShortDesc = $this->params->get('item_show_sdesc', 1) && !empty(trim(strip_tags($this->product->product_short_desc ?? '')));
+$hasLongDesc  = $this->params->get('item_show_ldesc', 1) && !empty(trim(strip_tags($this->product->product_long_desc ?? '')));
 $hasDescription = $hasShortDesc || $hasLongDesc;
 $set_specification_active = !$hasDescription;
 ?>
@@ -50,7 +50,7 @@ $set_specification_active = !$hasDescription;
             </div>
         </div>
     <?php endif;?>
-    <?php if($this->params->get('item_show_product_specification')):?>
+    <?php if($this->params->get('item_show_product_specification', 0)):?>
         <div class="accordion-item border-0 mb-2">
             <div class="accordion-header fs-4" id="headingSpecs">
                 <button type="button" class="accordion-button" data-bs-toggle="collapse" data-bs-target="#specs" aria-expanded="false" aria-controls="specs">

--- a/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/view_configurable.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/view_configurable.php
@@ -56,7 +56,7 @@ use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
                 </div>
             </div>
 
-            <?php if($this->params->get('item_show_sdesc')):?>
+            <?php if($this->params->get('item_show_sdesc', 1)):?>
                 <?php echo $this->loadTemplate('sdesc'); ?>
             <?php endif; ?>
 

--- a/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/view_flexivariable.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/view_flexivariable.php
@@ -61,7 +61,7 @@ if ($this->params->get('item_show_product_stock', 1) && J2CommerceHelper::produc
                 </div>
             </div>
 
-            <?php if($this->params->get('item_show_sdesc')):?>
+            <?php if($this->params->get('item_show_sdesc', 1)):?>
                 <?php echo $this->loadTemplate('sdesc'); ?>
             <?php endif; ?>
 

--- a/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/view_notabs.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/view_notabs.php
@@ -19,14 +19,14 @@ $productfilters = $this->product->productfilters ?? [];
 ?>
 <div class="row">
     <div class="col-sm-12">
-        <?php if ($this->params->get('item_show_ldesc')) : ?>
+        <?php if ($this->params->get('item_show_ldesc', 1)) : ?>
             <div class="product-description mt-5 pt-4 border-top">
                 <h3 class="text-center mb-4"><?php echo Text::_('COM_J2COMMERCE_PRODUCT_DESCRIPTION'); ?></h3>
                 <?php echo $this->loadTemplate('ldesc'); ?>
             </div>
         <?php endif; ?>
 
-        <?php if ($this->params->get('item_show_product_specification')) : ?>
+        <?php if ($this->params->get('item_show_product_specification', 0)) : ?>
             <div class="product-specs mt-5 pt-4 border-top">
                 <h3 class="text-center mb-4"><?php echo Text::_('COM_J2COMMERCE_PRODUCT_SPECIFICATIONS'); ?></h3>
                 <?php echo $this->loadTemplate('specs'); ?>

--- a/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/view_simple.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/view_simple.php
@@ -57,7 +57,7 @@ use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
                 </div>
             </div>
 
-            <?php if($this->params->get('item_show_sdesc')):?>
+            <?php if($this->params->get('item_show_sdesc', 1)):?>
                 <?php echo $this->loadTemplate('sdesc'); ?>
             <?php endif; ?>
 

--- a/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/view_tabs.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/view_tabs.php
@@ -20,8 +20,8 @@ use Joomla\CMS\Language\Text;
 HTMLHelper::_('bootstrap.tab', '#j2commerce-product-detail-tab', []);
 
 $productfilters = $this->product->productfilters ?? [];
-$hasShortDesc = $this->params->get('item_show_sdesc') && !empty(trim(strip_tags($this->product->product_short_desc ?? '')));
-$hasLongDesc  = $this->params->get('item_show_ldesc') && !empty(trim(strip_tags($this->product->product_long_desc ?? '')));
+$hasShortDesc = $this->params->get('item_show_sdesc', 1) && !empty(trim(strip_tags($this->product->product_short_desc ?? '')));
+$hasLongDesc  = $this->params->get('item_show_ldesc', 1) && !empty(trim(strip_tags($this->product->product_long_desc ?? '')));
 $hasDescription = $hasShortDesc || $hasLongDesc;
 $set_specification_active = !$hasDescription;
 ?>
@@ -34,7 +34,7 @@ $set_specification_active = !$hasDescription;
             </li>
         <?php endif; ?>
 
-        <?php if ($this->params->get('item_show_product_specification')) : ?>
+        <?php if ($this->params->get('item_show_product_specification', 0)) : ?>
             <li class="nav-item">
                 <a href="#specs" class="nav-link rounded-0 <?php echo $set_specification_active ? 'active' : ''; ?>" data-bs-toggle="tab"><?php echo Text::_('COM_J2COMMERCE_PRODUCT_SPECIFICATIONS'); ?></a>
             </li>
@@ -44,13 +44,13 @@ $set_specification_active = !$hasDescription;
     </ul>
 
     <div class="tab-content border-0 rounded-0 box-shadow-none px-1">
-        <?php if ($this->params->get('item_show_ldesc')) : ?>
+        <?php if ($this->params->get('item_show_ldesc', 1)) : ?>
             <div class="tab-pane fade show active" id="description">
                 <?php echo $this->loadTemplate('ldesc'); ?>
             </div>
         <?php endif; ?>
 
-        <?php if ($this->params->get('item_show_product_specification')) : ?>
+        <?php if ($this->params->get('item_show_product_specification', 0)) : ?>
             <div class="tab-pane fade show <?php echo $set_specification_active ? 'active' : ''; ?>" id="specs">
                 <?php echo $this->loadTemplate('specs'); ?>
             </div>

--- a/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/view_variable.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/view_variable.php
@@ -60,7 +60,7 @@ if ($this->params->get('item_show_product_stock', 1) && J2CommerceHelper::produc
                 </div>
             </div>
 
-            <?php if($this->params->get('item_show_sdesc')):?>
+            <?php if($this->params->get('item_show_sdesc', 1)):?>
                 <?php echo $this->loadTemplate('sdesc'); ?>
             <?php endif; ?>
 

--- a/plugins/j2commerce/app_uikit/tmpl/tag_uikit/default_sortfilter.php
+++ b/plugins/j2commerce/app_uikit/tmpl/tag_uikit/default_sortfilter.php
@@ -47,7 +47,7 @@ $currentSefPath = Uri::getInstance()->getPath();
         </div>
 
         <div class="uk-flex uk-flex-middle j2commerce-sortbar-filter-right" style="gap:.5rem;">
-            <?php if ($this->params->get('list_show_filter_search')) : ?>
+            <?php if ($this->params->get('list_show_filter_search', 1)) : ?>
                 <div class="uk-inline">
                     <input type="text" name="search" id="j2commerce-search" class="uk-input j2commerce-product-search-input" value="<?php echo $search; ?>" placeholder="<?php echo Text::_('COM_J2COMMERCE_FILTER_SEARCH'); ?>" />
                     <button type="submit" class="uk-button uk-button-primary" title="<?php echo Text::_('COM_J2COMMERCE_FILTER_GO'); ?>">
@@ -59,7 +59,7 @@ $currentSefPath = Uri::getInstance()->getPath();
                 </div>
             <?php endif; ?>
 
-            <?php if ($this->params->get('list_show_filter_sorting')) : ?>
+            <?php if ($this->params->get('list_show_filter_sorting', 1)) : ?>
                 <?php
                 $sortOptions = $this->filters['sorting'] ?? [];
                 $currentSort = $this->state->sortby ?? '';

--- a/plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_configurable.php
+++ b/plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_configurable.php
@@ -56,7 +56,7 @@ use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
                 </div>
             </div>
 
-            <?php if ($this->params->get('item_show_sdesc')) : ?>
+            <?php if ($this->params->get('item_show_sdesc', 1)) : ?>
                 <?php echo $this->loadTemplate('sdesc'); ?>
             <?php endif; ?>
 

--- a/plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_flexivariable.php
+++ b/plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_flexivariable.php
@@ -59,7 +59,7 @@ if ($this->params->get('item_show_product_stock', 1) && J2CommerceHelper::produc
                 </div>
             </div>
 
-            <?php if ($this->params->get('item_show_sdesc')) : ?>
+            <?php if ($this->params->get('item_show_sdesc', 1)) : ?>
                 <?php echo $this->loadTemplate('sdesc'); ?>
             <?php endif; ?>
 

--- a/plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_notabs.php
+++ b/plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_notabs.php
@@ -15,8 +15,8 @@
 	<div class="uk-grid" uk-grid>
 		<div class="uk-width-1-1">
 				<?php
-			$hasShortDesc = $this->params->get('item_show_sdesc') && !empty(trim(strip_tags($this->item->product_short_desc ?? '')));
-			$hasLongDesc  = $this->params->get('item_show_ldesc') && !empty(trim(strip_tags($this->item->product_long_desc ?? '')));
+			$hasShortDesc = $this->params->get('item_show_sdesc', 1) && !empty(trim(strip_tags($this->item->product_short_desc ?? '')));
+			$hasLongDesc  = $this->params->get('item_show_ldesc', 1) && !empty(trim(strip_tags($this->item->product_long_desc ?? '')));
 			?>
 			<?php if($hasShortDesc || $hasLongDesc):?>
 				<div class="product-description">
@@ -25,7 +25,7 @@
 				</div>
 				<?php endif;?>
 
-				<?php if($this->params->get('item_show_product_specification')):?>
+				<?php if($this->params->get('item_show_product_specification', 0)):?>
 					<div class="product-specs">
 						<?php echo $this->loadTemplate('specs'); ?>
 					</div>

--- a/plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_simple.php
+++ b/plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_simple.php
@@ -55,7 +55,7 @@ use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
                 </div>
             </div>
 
-            <?php if ($this->params->get('item_show_sdesc')) : ?>
+            <?php if ($this->params->get('item_show_sdesc', 1)) : ?>
                 <?php echo $this->loadTemplate('sdesc'); ?>
             <?php endif; ?>
 

--- a/plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_tabs.php
+++ b/plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_tabs.php
@@ -17,8 +17,8 @@ use Joomla\CMS\Language\Text;
 	<div class="uk-grid" uk-grid>
 		<div class="uk-width-1-1">
 			<?php
-				$hasShortDesc = $this->params->get('item_show_sdesc') && !empty(trim(strip_tags($this->item->product_short_desc ?? '')));
-				$hasLongDesc  = $this->params->get('item_show_ldesc') && !empty(trim(strip_tags($this->item->product_long_desc ?? '')));
+				$hasShortDesc = $this->params->get('item_show_sdesc', 1) && !empty(trim(strip_tags($this->item->product_short_desc ?? '')));
+				$hasLongDesc  = $this->params->get('item_show_ldesc', 1) && !empty(trim(strip_tags($this->item->product_long_desc ?? '')));
 				$hasDescription = $hasShortDesc || $hasLongDesc;
 				$set_specification_active = !$hasDescription;
 			?>
@@ -27,7 +27,7 @@ use Joomla\CMS\Language\Text;
 					<li class="uk-active"><a href="#"><?php echo Text::_('COM_J2COMMERCE_PRODUCT_DESCRIPTION')?></a></li>
 				<?php endif; ?>
 
-				<?php if($this->params->get('item_show_product_specification')): ?>
+				<?php if($this->params->get('item_show_product_specification', 0)): ?>
 					<li<?php echo isset($set_specification_active) && $set_specification_active ? ' class="uk-active"' : ''; ?>><a href="#"><?php echo Text::_('COM_J2COMMERCE_PRODUCT_SPECIFICATIONS')?></a></li>
 				<?php endif; ?>
 			</ul>
@@ -40,7 +40,7 @@ use Joomla\CMS\Language\Text;
 				</li>
 				<?php endif; ?>
 
-				<?php if($this->params->get('item_show_product_specification')): ?>
+				<?php if($this->params->get('item_show_product_specification', 0)): ?>
 				<li<?php echo isset($set_specification_active) && $set_specification_active ? ' class="uk-active"' : ''; ?>>
 					<?php echo $this->loadTemplate('specs'); ?>
 				</li>

--- a/plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_variable.php
+++ b/plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_variable.php
@@ -59,7 +59,7 @@ if ($this->params->get('item_show_product_stock', 1) && J2CommerceHelper::produc
                 </div>
             </div>
 
-            <?php if ($this->params->get('item_show_sdesc')) : ?>
+            <?php if ($this->params->get('item_show_sdesc', 1)) : ?>
                 <?php echo $this->loadTemplate('sdesc'); ?>
             <?php endif; ?>
 

--- a/plugins/j2commerce/app_uikit/tmpl/uikit/default_sortfilter.php
+++ b/plugins/j2commerce/app_uikit/tmpl/uikit/default_sortfilter.php
@@ -52,7 +52,7 @@ $currentSefPath = Uri::getInstance()->getPath();
         </div>
 
         <div class="uk-flex uk-flex-middle j2commerce-sortbar-filter-right" style="gap:.5rem;">
-            <?php if ($this->params->get('list_show_filter_search')) : ?>
+            <?php if ($this->params->get('list_show_filter_search', 1)) : ?>
                 <div class="uk-inline">
                     <input type="text" name="search" id="j2commerce-search" class="uk-input j2commerce-product-search-input" value="<?php echo $search; ?>" placeholder="<?php echo Text::_('COM_J2COMMERCE_FILTER_SEARCH'); ?>" />
                     <button type="submit" class="uk-button uk-button-primary" title="<?php echo Text::_('COM_J2COMMERCE_FILTER_GO'); ?>">
@@ -64,7 +64,7 @@ $currentSefPath = Uri::getInstance()->getPath();
                 </div>
             <?php endif; ?>
 
-            <?php if ($this->params->get('list_show_filter_sorting')) : ?>
+            <?php if ($this->params->get('list_show_filter_sorting', 1)) : ?>
                 <?php
                 $sortOptions = $this->filters['sorting'] ?? [];
                 $currentSort = $this->state->sortby ?? '';

--- a/plugins/j2commerce/app_uikit/tmpl/uikit/view_accordions.php
+++ b/plugins/j2commerce/app_uikit/tmpl/uikit/view_accordions.php
@@ -16,8 +16,8 @@ use Joomla\CMS\Language\Text;
 
 /** @var \J2Commerce\Component\J2commerce\Site\View\Product\HtmlView $this */
 
-$hasShortDesc = $this->params->get('item_show_sdesc') && !empty(trim(strip_tags($this->product->product_short_desc ?? '')));
-$hasLongDesc  = $this->params->get('item_show_ldesc') && !empty(trim(strip_tags($this->product->product_long_desc ?? '')));
+$hasShortDesc = $this->params->get('item_show_sdesc', 1) && !empty(trim(strip_tags($this->product->product_short_desc ?? '')));
+$hasLongDesc  = $this->params->get('item_show_ldesc', 1) && !empty(trim(strip_tags($this->product->product_long_desc ?? '')));
 $hasDescription = $hasShortDesc || $hasLongDesc;
 $set_specification_active = !$hasDescription;
 ?>
@@ -32,7 +32,7 @@ $set_specification_active = !$hasDescription;
             </div>
         </li>
     <?php endif; ?>
-    <?php if ($this->params->get('item_show_product_specification')) : ?>
+    <?php if ($this->params->get('item_show_product_specification', 0)) : ?>
         <li<?php echo isset($set_specification_active) && $set_specification_active ? ' class="uk-open"' : ''; ?>>
             <a class="uk-accordion-title" href="#">
                 <span class="uk-text-capitalize uk-text-bold"><?php echo Text::_('COM_J2COMMERCE_PRODUCT_SPECIFICATIONS'); ?></span>

--- a/plugins/j2commerce/app_uikit/tmpl/uikit/view_configurable.php
+++ b/plugins/j2commerce/app_uikit/tmpl/uikit/view_configurable.php
@@ -56,7 +56,7 @@ use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
                 </div>
             </div>
 
-            <?php if ($this->params->get('item_show_sdesc')) : ?>
+            <?php if ($this->params->get('item_show_sdesc', 1)) : ?>
                 <?php echo $this->loadTemplate('sdesc'); ?>
             <?php endif; ?>
 

--- a/plugins/j2commerce/app_uikit/tmpl/uikit/view_flexivariable.php
+++ b/plugins/j2commerce/app_uikit/tmpl/uikit/view_flexivariable.php
@@ -61,7 +61,7 @@ if ($this->params->get('item_show_product_stock', 1) && J2CommerceHelper::produc
                 </div>
             </div>
 
-            <?php if ($this->params->get('item_show_sdesc')) : ?>
+            <?php if ($this->params->get('item_show_sdesc', 1)) : ?>
                 <?php echo $this->loadTemplate('sdesc'); ?>
             <?php endif; ?>
 

--- a/plugins/j2commerce/app_uikit/tmpl/uikit/view_notabs.php
+++ b/plugins/j2commerce/app_uikit/tmpl/uikit/view_notabs.php
@@ -19,14 +19,14 @@ $productfilters = $this->product->productfilters ?? [];
 ?>
 <div class="uk-grid" uk-grid>
     <div class="uk-width-1-1">
-        <?php if ($this->params->get('item_show_ldesc')) : ?>
+        <?php if ($this->params->get('item_show_ldesc', 1)) : ?>
             <div class="product-description uk-margin-large-top uk-padding-small uk-border-top">
                 <h3 class="uk-text-center uk-margin-bottom"><?php echo Text::_('COM_J2COMMERCE_PRODUCT_DESCRIPTION'); ?></h3>
                 <?php echo $this->loadTemplate('ldesc'); ?>
             </div>
         <?php endif; ?>
 
-        <?php if ($this->params->get('item_show_product_specification')) : ?>
+        <?php if ($this->params->get('item_show_product_specification', 0)) : ?>
             <div class="product-specs uk-margin-large-top uk-padding-small uk-border-top">
                 <h3 class="uk-text-center uk-margin-bottom"><?php echo Text::_('COM_J2COMMERCE_PRODUCT_SPECIFICATIONS'); ?></h3>
                 <?php echo $this->loadTemplate('specs'); ?>

--- a/plugins/j2commerce/app_uikit/tmpl/uikit/view_simple.php
+++ b/plugins/j2commerce/app_uikit/tmpl/uikit/view_simple.php
@@ -55,7 +55,7 @@ use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
                 </div>
             </div>
 
-            <?php if ($this->params->get('item_show_sdesc')) : ?>
+            <?php if ($this->params->get('item_show_sdesc', 1)) : ?>
                 <?php echo $this->loadTemplate('sdesc'); ?>
             <?php endif; ?>
 

--- a/plugins/j2commerce/app_uikit/tmpl/uikit/view_tabs.php
+++ b/plugins/j2commerce/app_uikit/tmpl/uikit/view_tabs.php
@@ -17,8 +17,8 @@ use Joomla\CMS\Language\Text;
 /** @var \J2Commerce\Component\J2commerce\Site\View\Product\HtmlView $this */
 
 $productfilters = $this->product->productfilters ?? [];
-$hasShortDesc = $this->params->get('item_show_sdesc') && !empty(trim(strip_tags($this->product->product_short_desc ?? '')));
-$hasLongDesc  = $this->params->get('item_show_ldesc') && !empty(trim(strip_tags($this->product->product_long_desc ?? '')));
+$hasShortDesc = $this->params->get('item_show_sdesc', 1) && !empty(trim(strip_tags($this->product->product_short_desc ?? '')));
+$hasLongDesc  = $this->params->get('item_show_ldesc', 1) && !empty(trim(strip_tags($this->product->product_long_desc ?? '')));
 $hasDescription = $hasShortDesc || $hasLongDesc;
 $set_specification_active = !$hasDescription;
 ?>
@@ -29,7 +29,7 @@ $set_specification_active = !$hasDescription;
             <li class="uk-active"><a href="#"><?php echo Text::_('COM_J2COMMERCE_PRODUCT_DESCRIPTION'); ?></a></li>
         <?php endif; ?>
 
-        <?php if ($this->params->get('item_show_product_specification')) : ?>
+        <?php if ($this->params->get('item_show_product_specification', 0)) : ?>
             <li<?php echo $set_specification_active ? ' class="uk-active"' : ''; ?>><a href="#"><?php echo Text::_('COM_J2COMMERCE_PRODUCT_SPECIFICATIONS'); ?></a></li>
         <?php endif; ?>
 
@@ -37,13 +37,13 @@ $set_specification_active = !$hasDescription;
     </ul>
 
     <ul class="uk-switcher uk-margin">
-        <?php if ($this->params->get('item_show_ldesc')) : ?>
+        <?php if ($this->params->get('item_show_ldesc', 1)) : ?>
             <li>
                 <?php echo $this->loadTemplate('ldesc'); ?>
             </li>
         <?php endif; ?>
 
-        <?php if ($this->params->get('item_show_product_specification')) : ?>
+        <?php if ($this->params->get('item_show_product_specification', 0)) : ?>
             <li>
                 <?php echo $this->loadTemplate('specs'); ?>
             </li>

--- a/plugins/j2commerce/app_uikit/tmpl/uikit/view_variable.php
+++ b/plugins/j2commerce/app_uikit/tmpl/uikit/view_variable.php
@@ -60,7 +60,7 @@ if ($this->params->get('item_show_product_stock', 1) && J2CommerceHelper::produc
                 </div>
             </div>
 
-            <?php if ($this->params->get('item_show_sdesc')) : ?>
+            <?php if ($this->params->get('item_show_sdesc', 1)) : ?>
                 <?php echo $this->loadTemplate('sdesc'); ?>
             <?php endif; ?>
 


### PR DESCRIPTION
## Summary
Fixes #704

Menu item filter and display settings show incorrect state on the frontend when menu items are created via the wizard but not yet saved. The XML form defines `default="1"` (or `"0"`) attributes, but Joomla only applies these when rendering the admin form — on the frontend, `params->get('param_name')` without a fallback returns `null`, which hides elements that should be visible by default.

## Changes
- Added default value arguments to all `params->get()` calls in app_bootstrap5 and app_uikit plugin templates (31 files)
- **`list_show_filter_search`**: default `1` (show search box)
- **`list_show_filter_sorting`**: default `1` (show sort dropdown)
- **`item_show_sdesc`**: default `1` (show short description)
- **`item_show_ldesc`**: default `1` (show long description)
- **`item_show_product_specification`**: default `0` (hide specification tab)

All defaults match the corresponding XML `default` attributes in `default.xml`.

## Testing
1. Create a category list menu item via the wizard — do **not** save it
2. Visit the menu item on the frontend
3. Verify: search box and sort dropdown are visible in the top filter bar
4. Create a product detail menu item via the wizard — do **not** save it
5. Visit on the frontend
6. Verify: short description and long description are visible; specification tab is hidden
7. Save both menu items without changes — revisit and confirm same behavior

## Files Changed
- `plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/` — 8 files
- `plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/` — 8 files
- `plugins/j2commerce/app_uikit/tmpl/uikit/` — 8 files
- `plugins/j2commerce/app_uikit/tmpl/tag_uikit/` — 7 files