### PR TITLE
feat(payment_paypal): scaffold PayPal subscription service + Smart Button template

### DIFF
--- a/plugins/j2commerce/payment_paypal/src/Service/PayPalSubscriptions.php
+++ b/plugins/j2commerce/payment_paypal/src/Service/PayPalSubscriptions.php
@@ -1,0 +1,381 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  plg_j2commerce_payment_paypal
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Plugin\J2Commerce\PaymentPaypal\Service;
+
+\defined('_JEXEC') or die;
+
+use Joomla\CMS\Log\Log;
+
+/**
+ * PayPal Billing v1 / Catalogs v1 / Subscriptions v1 wrapper.
+ *
+ * Provides REST-only subscription primitives backed by the existing
+ * PayPalClient (OAuth + retry transport). All methods return arrays
+ * shaped like {success: bool, ...} so the calling extension can map
+ * directly to the J2Commerce renewal-event outcome contract.
+ *
+ * @since  6.1.0
+ */
+final class PayPalSubscriptions
+{
+    public function __construct(
+        private readonly PayPalClient $client
+    ) {
+    }
+
+    /**
+     * Resolve or create a Catalogs Product representing this J2Commerce product.
+     *
+     * @param  array{product_name?: string, catalog_prefix?: string}  $context
+     */
+    public function getOrCreateCatalogProduct(object $subscription, array $context = []): string
+    {
+        $name        = (string) ($context['product_name'] ?? 'Subscription');
+        $localId     = (int) ($subscription->product_id ?? 0);
+        $prefix      = (string) ($context['catalog_prefix'] ?? 'j2c');
+        $referenceId = $prefix . '-product-' . $localId;
+
+        $existing = $this->client->request('GET', '/v1/catalogs/products/' . urlencode($referenceId));
+
+        if (($existing['status'] ?? 0) === 200 && !empty($existing['body']['id'])) {
+            return (string) $existing['body']['id'];
+        }
+
+        $body = [
+            'id'          => $referenceId,
+            'name'        => substr($name, 0, 127),
+            'description' => 'J2Commerce subscription product #' . $localId,
+            'type'        => 'SERVICE',
+            'category'    => 'SOFTWARE',
+        ];
+
+        $created = $this->client->requestWithRetry('POST', '/v1/catalogs/products', $body);
+
+        if (($created['status'] ?? 0) >= 300) {
+            throw new \RuntimeException(
+                'PayPal catalog product create failed: HTTP ' . ($created['status'] ?? 0)
+                . ' — ' . ($created['body']['message'] ?? 'unknown error')
+            );
+        }
+
+        return (string) ($created['body']['id'] ?? $referenceId);
+    }
+
+    /**
+     * Create a Billing Plan derived from a J2Commerce subscription record.
+     *
+     * Required context keys: brand_name, product_name, currency_code.
+     * Optional: plan_name_template, catalog_prefix.
+     *
+     * @param  array{brand_name: string, product_name: string, currency_code: string, plan_name_template?: string, catalog_prefix?: string}  $context
+     */
+    public function createBillingPlan(object $subscription, object $order, array $context): string
+    {
+        $productId = $this->getOrCreateCatalogProduct($subscription, $context);
+
+        $period       = strtoupper((string) ($subscription->period ?? 'MONTH'));
+        $intervalUnit = match ($period) {
+            'DAY', 'D'    => 'DAY',
+            'WEEK', 'W'   => 'WEEK',
+            'YEAR', 'Y'   => 'YEAR',
+            default       => 'MONTH',
+        };
+
+        $intervalCount = max(1, (int) ($subscription->period_units ?? 1));
+        // total_cycles=0 means "infinite" per PayPal. That matches J2Commerce's
+        // convention for open-ended subscriptions. NOTE: if a future change adds
+        // trial/setup-fee cycles, PayPal requires infinite cycles to be the LAST
+        // entry in billing_cycles[] — extend this array accordingly.
+        $totalCycles   = max(0, (int) ($subscription->subscription_length ?? 0));
+        $renewalAmount = $this->formatAmount(
+            (float) ($subscription->renewal_amount ?? $order->order_total ?? 0),
+            (string) $context['currency_code']
+        );
+        $sitename      = (string) $context['brand_name'];
+        $productName   = (string) $context['product_name'];
+
+        $planName = !empty($context['plan_name_template'])
+            ? strtr((string) $context['plan_name_template'], [
+                '{site}'         => $sitename,
+                '{product_name}' => $productName,
+            ])
+            : ($sitename . ' — ' . $productName);
+
+        $body = [
+            'product_id'   => $productId,
+            'name'         => substr($planName, 0, 127),
+            'description'  => 'J2Commerce subscription #' . (int) ($subscription->id ?? 0),
+            'status'       => 'ACTIVE',
+            'billing_cycles' => [
+                [
+                    'frequency' => [
+                        'interval_unit'  => $intervalUnit,
+                        'interval_count' => $intervalCount,
+                    ],
+                    'tenure_type'  => 'REGULAR',
+                    'sequence'     => 1,
+                    'total_cycles' => $totalCycles,
+                    'pricing_scheme' => [
+                        'fixed_price' => [
+                            'value'         => $renewalAmount,
+                            'currency_code' => strtoupper((string) $context['currency_code']),
+                        ],
+                    ],
+                ],
+            ],
+            'payment_preferences' => [
+                'auto_bill_outstanding'     => true,
+                'setup_fee_failure_action'  => 'CONTINUE',
+                'payment_failure_threshold' => 3,
+            ],
+        ];
+
+        $response = $this->client->requestWithRetry('POST', '/v1/billing/plans', $body);
+
+        if (($response['status'] ?? 0) >= 300) {
+            throw new \RuntimeException(
+                'PayPal billing plan create failed: HTTP ' . ($response['status'] ?? 0)
+                . ' — ' . ($response['body']['message'] ?? 'unknown error')
+            );
+        }
+
+        return (string) ($response['body']['id'] ?? '');
+    }
+
+    /**
+     * Create a Subscription against an existing Plan.
+     *
+     * Required context keys: subscriber_given_name, subscriber_surname, subscriber_email,
+     * brand_name, return_url, cancel_url.
+     *
+     * @param  array{subscriber_given_name: string, subscriber_surname: string, subscriber_email: string, brand_name: string, return_url: string, cancel_url: string}  $context
+     */
+    public function createSubscription(string $planId, object $subscription, array $context): array
+    {
+        $given   = trim((string) $context['subscriber_given_name']);
+        $surname = trim((string) $context['subscriber_surname']);
+        $email   = trim((string) $context['subscriber_email']);
+
+        if ($given === '' || $surname === '' || $email === '') {
+            return [
+                'success' => false,
+                'error'   => 'PayPal subscription create failed: subscriber name and email are required',
+            ];
+        }
+
+        $body = [
+            'plan_id' => $planId,
+            'subscriber' => [
+                'name' => [
+                    'given_name' => $given,
+                    'surname'    => $surname,
+                ],
+                'email_address' => $email,
+            ],
+            'application_context' => [
+                'brand_name'         => substr((string) $context['brand_name'], 0, 127),
+                'locale'             => 'en-US',
+                'shipping_preference' => 'NO_SHIPPING',
+                'user_action'        => 'SUBSCRIBE_NOW',
+                'payment_method'     => [
+                    'payer_selected'              => 'PAYPAL',
+                    'payee_preferred'             => 'IMMEDIATE_PAYMENT_REQUIRED',
+                ],
+                'return_url' => (string) $context['return_url'],
+                'cancel_url' => (string) $context['cancel_url'],
+            ],
+            'custom_id' => 'j2c-sub-' . (int) ($subscription->id ?? 0),
+        ];
+
+        $response = $this->client->requestWithRetry('POST', '/v1/billing/subscriptions', $body);
+
+        if (($response['status'] ?? 0) >= 300) {
+            return [
+                'success' => false,
+                'error'   => 'PayPal subscription create failed: HTTP ' . ($response['status'] ?? 0)
+                    . ' — ' . ($response['body']['message'] ?? 'unknown error'),
+            ];
+        }
+
+        $approveUrl = '';
+
+        foreach ($response['body']['links'] ?? [] as $link) {
+            if (($link['rel'] ?? '') === 'approve') {
+                $approveUrl = (string) ($link['href'] ?? '');
+                break;
+            }
+        }
+
+        return [
+            'success'     => true,
+            'id'          => (string) ($response['body']['id'] ?? ''),
+            'status'      => (string) ($response['body']['status'] ?? ''),
+            'approve_url' => $approveUrl,
+        ];
+    }
+
+    /**
+     * Charge the next billing cycle on a stored subscription.
+     *
+     * PayPal exposes /v1/billing/subscriptions/{id}/capture for on-demand
+     * charges against an active subscription. Returns one of:
+     *   ['status' => 'success',     'gateway_response' => …]
+     *   ['status' => 'failed',      'gateway_response' => …, 'error' => …]
+     *   ['status' => 'no_response', 'gateway_response' => …, 'error' => …]
+     */
+    /**
+     * Charge the next billing cycle on a stored subscription.
+     *
+     * NOTE: PayPal's preferred renewal path is its own auto-billing schedule
+     * (PAYMENT.SALE.COMPLETED webhooks drive renewal state via the PayPalWebhooks
+     * handlers). This synchronous capture is for cron/debug flows and takes two
+     * separate HTTP calls (GET then POST) — there is a small race window where
+     * PayPal could cancel/suspend the subscription between the two. Acceptable
+     * for the cron path; documented here so callers know the trade-off.
+     */
+    public function captureRenewalPayment(object $subscription, object $order, string $paypalSubscriptionId): array
+    {
+        $details = $this->client->request('GET', '/v1/billing/subscriptions/' . urlencode($paypalSubscriptionId));
+
+        if (($details['status'] ?? 0) === 0 || ($details['status'] ?? 0) >= 500) {
+            return [
+                'status'           => 'no_response',
+                'gateway_response' => $details['body'] ?? [],
+                'error'            => 'PayPal subscription lookup unreachable',
+            ];
+        }
+
+        if (($details['status'] ?? 0) >= 300) {
+            return [
+                'status'           => 'failed',
+                'gateway_response' => $details['body'] ?? [],
+                'error'            => $details['body']['message'] ?? 'PayPal subscription lookup failed',
+            ];
+        }
+
+        $remoteStatus = strtoupper((string) ($details['body']['status'] ?? ''));
+
+        if ($remoteStatus !== 'ACTIVE') {
+            return [
+                'status'           => 'failed',
+                'gateway_response' => $details['body'] ?? [],
+                'error'            => 'PayPal subscription not active (status: ' . $remoteStatus . ')',
+            ];
+        }
+
+        $currency = strtoupper((string) ($order->currency_code ?? 'USD'));
+        $amount   = $this->formatAmount((float) ($subscription->renewal_amount ?? $order->order_total ?? 0), $currency);
+        $body     = [
+            'note'                => 'J2Commerce renewal — Order #' . ($order->order_id ?? ''),
+            'capture_type'        => 'OUTSTANDING_BALANCE',
+            'amount' => [
+                'value'         => $amount,
+                'currency_code' => $currency,
+            ],
+        ];
+
+        $captured = $this->client->requestWithRetry(
+            'POST',
+            '/v1/billing/subscriptions/' . urlencode($paypalSubscriptionId) . '/capture',
+            $body
+        );
+
+        $statusCode = (int) ($captured['status'] ?? 0);
+
+        if ($statusCode === 0 || ($statusCode >= 500 && $statusCode <= 599)) {
+            return [
+                'status'           => 'no_response',
+                'gateway_response' => $captured['body'] ?? [],
+                'error'            => 'PayPal capture endpoint unreachable',
+            ];
+        }
+
+        if ($statusCode >= 200 && $statusCode < 300) {
+            return [
+                'status'           => 'success',
+                'gateway_response' => $captured['body'] ?? [],
+                'transaction_id'   => (string) ($captured['body']['id'] ?? ''),
+            ];
+        }
+
+        return [
+            'status'           => 'failed',
+            'gateway_response' => $captured['body'] ?? [],
+            'error'            => $captured['body']['message'] ?? 'PayPal capture failed',
+        ];
+    }
+
+    public function cancelSubscription(string $paypalSubscriptionId, string $reason): bool
+    {
+        $response = $this->client->request(
+            'POST',
+            '/v1/billing/subscriptions/' . urlencode($paypalSubscriptionId) . '/cancel',
+            ['reason' => substr($reason, 0, 127)]
+        );
+
+        $status = (int) ($response['status'] ?? 0);
+
+        if ($status >= 200 && $status < 300) {
+            return true;
+        }
+
+        // PayPal returns 422 SUBSCRIPTION_STATUS_INVALID when the subscription is already
+        // in a terminal state. That is the desired outcome — treat as idempotent success.
+        if ($status === 422) {
+            $details = $this->getSubscriptionDetails($paypalSubscriptionId);
+            $remote  = strtoupper((string) ($details['body']['status'] ?? ''));
+
+            if (\in_array($remote, ['CANCELLED', 'EXPIRED'], true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Format a monetary amount using PayPal's decimal rules.
+     * JPY/KRW/TWD/HUF use 0 decimals; everything else 2.
+     */
+    private function formatAmount(float $amount, string $currency): string
+    {
+        $zeroDecimal = ['JPY', 'KRW', 'TWD', 'HUF', 'CLP', 'ISK'];
+        $decimals    = \in_array(strtoupper($currency), $zeroDecimal, true) ? 0 : 2;
+
+        return number_format($amount, $decimals, '.', '');
+    }
+
+    public function suspendSubscription(string $paypalSubscriptionId, string $reason): bool
+    {
+        $response = $this->client->request(
+            'POST',
+            '/v1/billing/subscriptions/' . urlencode($paypalSubscriptionId) . '/suspend',
+            ['reason' => substr($reason, 0, 127)]
+        );
+
+        return ($response['status'] ?? 0) >= 200 && ($response['status'] ?? 0) < 300;
+    }
+
+    public function getSubscriptionDetails(string $paypalSubscriptionId): array
+    {
+        $response = $this->client->request(
+            'GET',
+            '/v1/billing/subscriptions/' . urlencode($paypalSubscriptionId)
+        );
+
+        return [
+            'status'   => (int) ($response['status'] ?? 0),
+            'body'     => $response['body'] ?? [],
+        ];
+    }
+}

--- a/plugins/j2commerce/payment_paypal/tmpl/prepayment_subscription.php
+++ b/plugins/j2commerce/payment_paypal/tmpl/prepayment_subscription.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  Plugin.J2Commerce.PaymentPaypal
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later
+ */
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Uri\Uri;
+
+/** @var array $displayData */
+$vars     = $displayData['vars'];
+$sandbox  = $vars->sandbox ?? false;
+$clientId = $vars->client_id ?? '';
+// Note: renewal amount is baked into the PayPal Billing Plan server-side
+// in PayPalSubscriptions::createBillingPlan, so we do NOT emit a data-amount
+// attribute here. The JS only hands back a subscription_id to the approval flow.
+?>
+
+<div class="j2commerce-payment-paypal note note-<?php echo htmlspecialchars($vars->orderpayment_type, ENT_QUOTES, 'UTF-8'); ?>">
+
+    <?php if (!empty($vars->display_image)) : ?>
+        <span class="j2commerce-payment-image">
+            <img class="payment-plugin-image payment_paypal" src="<?php echo Uri::root() . htmlspecialchars($vars->display_image, ENT_QUOTES, 'UTF-8'); ?>" alt="<?php echo htmlspecialchars($vars->display_name, ENT_QUOTES, 'UTF-8'); ?>" />
+        </span>
+    <?php endif; ?>
+
+    <p class="j2commerce-payment-display-name">
+        <strong><?php echo htmlspecialchars(Text::_($vars->display_name), ENT_QUOTES, 'UTF-8'); ?></strong>
+        <span class="badge bg-info text-dark ms-2"><?php echo htmlspecialchars(Text::_('PLG_J2COMMERCE_PAYMENT_PAYPAL_SUBSCRIPTION_BADGE'), ENT_QUOTES, 'UTF-8'); ?></span>
+    </p>
+</div>
+
+<div id="paypal-subscription-button-container"
+     data-order-id="<?php echo htmlspecialchars($vars->order_id, ENT_QUOTES, 'UTF-8'); ?>"
+     data-order-token="<?php echo htmlspecialchars($vars->order_token ?? '', ENT_QUOTES, 'UTF-8'); ?>"
+     data-create-subscription-url="<?php echo htmlspecialchars($vars->create_subscription_url, ENT_QUOTES, 'UTF-8'); ?>"
+     data-approve-subscription-url="<?php echo htmlspecialchars($vars->approve_subscription_url, ENT_QUOTES, 'UTF-8'); ?>"
+     data-return-url="<?php echo htmlspecialchars($vars->return_url, ENT_QUOTES, 'UTF-8'); ?>"
+     data-csrf-token="<?php echo htmlspecialchars($vars->csrf_token, ENT_QUOTES, 'UTF-8'); ?>"
+     data-currency="<?php echo htmlspecialchars($vars->currency_code, ENT_QUOTES, 'UTF-8'); ?>"
+     data-sandbox="<?php echo $sandbox ? 'true' : 'false'; ?>"
+     data-client-id="<?php echo htmlspecialchars($clientId, ENT_QUOTES, 'UTF-8'); ?>"
+     data-debug="<?php echo ($vars->debug ?? 0) ? 'true' : 'false'; ?>"
+></div>
+
+<div id="paypal-subscription-error" class="alert alert-danger d-none" role="alert"></div>
+<div id="paypal-subscription-processing" class="alert alert-info d-none" role="alert">
+    <?php echo Text::_('PLG_J2COMMERCE_PAYMENT_PAYPAL_PROCESSING'); ?>
+</div>


### PR DESCRIPTION
## Summary

Adds two new scaffolding files to `plugins/j2commerce/payment_paypal/` that lay the REST-layer groundwork for PayPal subscription support per PRD §7.3 (`docs/prd/apps/app_subscriptionproduct_subscriptions.md`). Neither file is wired into the existing `PaymentPaypal` extension yet — they ship as standalone scaffolding so the REST plumbing can be reviewed on its own, and a follow-up PR will land the extension-side wiring (event subscribers, AJAX handlers, webhook routes, XML params, language strings, JS button init).

## Why split the work

The full Track B port (12 sub-tasks in the PRD) mutates many existing files: the extension adds ~400 lines of event handlers, the webhook service adds 8 new `BILLING.SUBSCRIPTION.*` routes, the XML grows a subscriptions fieldset, and the checkout JS gets a parallel Smart Subscription Button init path. Bundling all of that into a single PR makes review painful and any revert risks pulling the REST layer out with the rest.

This PR isolates the clean, additive, non-wired layer. No existing file is modified. No existing behavior changes. The files are dead code until a follow-up PR references them.

## Files added

| File | Purpose |
|------|---------|
| `plugins/j2commerce/payment_paypal/src/Service/PayPalSubscriptions.php` | REST wrapper over PayPal Billing Plans v1, Catalogs v1, and Subscriptions v1 |
| `plugins/j2commerce/payment_paypal/tmpl/prepayment_subscription.php` | Smart Subscription Button template (paypal.Buttons createSubscription/onApprove) |

## `PayPalSubscriptions` service

Constructor-promoted `PayPalClient` dependency — matches the existing `PayPalOrders` / `PayPalRefunds` / `PayPalWebhooks` convention (lazy getter pattern, not DI container binding). No `services/provider.php` edit needed.

Public API:

- `getOrCreateCatalogProduct(object $subscription, array $context): string` — idempotent Catalogs v1 product create keyed on `{catalog_prefix}-product-{id}`
- `createBillingPlan(object $subscription, object $order, array $context): string` — Billing Plans v1 with period/period_units/subscription_length mapped to PayPal intervalUnit/intervalCount/totalCycles
- `createSubscription(string $planId, object $subscription, array $context): array` — validates required context (subscriber name/email are mandatory per PayPal Subscriptions v1) and returns `['success', 'id', 'status', 'approve_url']`
- `captureRenewalPayment(object $subscription, object $order, string $paypalSubscriptionId): array` — on-demand `POST /v1/billing/subscriptions/{id}/capture`, returns `['status' => 'success'|'failed'|'no_response', 'gateway_response' => …]` shaped to match J2Commerce's renewal outcome contract
- `cancelSubscription(string $paypalSubscriptionId, string $reason): bool` — handles PayPal's 422 `SUBSCRIPTION_STATUS_INVALID` as idempotent success (looks up the remote status; if `CANCELLED` or `EXPIRED`, returns true — so cancelling an already-cancelled subscription does not report a failure to the caller)
- `suspendSubscription(string $paypalSubscriptionId, string $reason): bool`
- `getSubscriptionDetails(string $paypalSubscriptionId): array`

Design notes baked into the code:

1. **Context-array API instead of order-object reads.** Every public method takes an `array $context` with explicit keys (`subscriber_given_name`, `subscriber_surname`, `subscriber_email`, `brand_name`, `product_name`, `currency_code`, `return_url`, `cancel_url`, `plan_name_template`, `catalog_prefix`). This avoids reaching for fields that do not exist on `#__j2commerce_orders` — billing addresses live on `#__j2commerce_orderinfos`, sitename comes from Joomla config, product name comes from `#__j2commerce_orderitems`. The caller loads each piece from the right table once and passes them in, so this service stays schema-agnostic.
2. **Currency decimal rules.** `formatAmount(float, string)` handles PayPal's rule that JPY/KRW/TWD/HUF/CLP/ISK amounts must have zero decimals. Hardcoding `number_format(…, 2)` would produce `INVALID_PARAMETER_VALUE` errors in those currencies.
3. **Infinite billing cycles.** `createBillingPlan` sets `total_cycles = 0` when `subscription_length = 0`, matching J2Commerce's convention for open-ended subscriptions. A code comment warns that PayPal requires infinite cycles to be the LAST entry in `billing_cycles[]`, so future trial/setup-fee work must extend the array in the right order.
4. **GET→POST race in capture.** `captureRenewalPayment` does a `GET /v1/billing/subscriptions/{id}` before `POST .../capture` to verify the subscription is still `ACTIVE`. A docblock documents the small race window where PayPal could cancel the subscription between the two calls — acceptable for cron/debug flows, not ideal for high-traffic. The docblock recommends PayPal webhooks as the preferred renewal driver.
5. **Idempotency headers.** `createBillingPlan` and `createSubscription` use `PayPalClient::requestWithRetry` which already attaches `PayPal-Request-Id` headers for idempotent retries. `cancelSubscription` / `suspendSubscription` use plain `request()` because retry on a destructive op is not desirable.

## `prepayment_subscription.php` template

Renders an empty div with data attributes that a follow-up JS module will read:

```html
<div id="paypal-subscription-button-container"
     data-order-id="…"
     data-order-token="…"
     data-client-id="…"
     data-sandbox="…"
     data-csrf-token="…"
     data-currency="…"
     data-create-subscription-url="…"
     data-approve-subscription-url="…"
     data-return-url="…"
     data-debug="…"
></div>
```

A leading comment in the template explicitly documents why `data-amount` is NOT emitted — the renewal amount is baked into the PayPal Billing Plan server-side in `PayPalSubscriptions::createBillingPlan`, so the browser never sees or sends it. That matters because a decorative `data-amount` attribute on a subscription button would mislead any future reader who thinks they can override the amount client-side.

The template uses `htmlspecialchars(ENT_QUOTES, 'UTF-8')` on every attribute, so nothing attacker-controlled can break out of the data context.

## What this PR does NOT do

- Does NOT subscribe to `onJ2CommerceProcessRenewalPayment`, `onJ2CommerceCreateNewSubscriptionOrderForRenewal`, `onJ2CommerceAcceptSubscriptionPaymentWithTrial`, or any other subscription event — the extension class is untouched
- Does NOT gate `onAcceptSubscriptionPayment` on an `enable_subscriptions` param — that param does not exist yet
- Does NOT add webhook routes for `BILLING.SUBSCRIPTION.*` or `PAYMENT.SALE.COMPLETED` — `PayPalWebhooks` is untouched
- Does NOT wire `_prePaymentForSubscription` into `_prePayment` — the existing one-shot flow is unchanged
- Does NOT add the Smart Subscription Button JS init — `paypal-checkout.js` is untouched
- Does NOT add language strings for the button template — follow-up PR
- Does NOT bump `payment_paypal.xml` version — follow-up PR

Nothing calls either new file after this PR merges. They become live only when the follow-up lands.

## Pre-Flight

- [x] `php -l` passes on both files
- [x] No secrets detected (`password`, `secret`, `api_key`, `ghp_` grep clean)
- [x] No FOF remnants (`F0FModel`, `F0FController`, `F0FTable`, `JFactory::` grep clean)
- [x] Core files only (both under `plugins/j2commerce/payment_paypal/` which is on the core allowlist)
- [x] No `SELECT *` (service does no SQL at all — pure REST client)
- [x] `declare(strict_types=1);` + `\defined('_JEXEC') or die;` on both files
- [x] Namespace matches path: `J2Commerce\Plugin\J2Commerce\PaymentPaypal\Service`
- [x] Copyright header matches project convention
- [x] Constructor promotion used
- [x] Match expression used where appropriate (`intervalUnit` mapping)
- [x] Minimal docblocks (load-bearing comments only — currency rules, race window, infinite-cycles rule)
- [x] No dead code in new files
- [ ] `php-cs-fixer` not run — `build/php-cs-fixer.phar` is not present in the repo; PSR-12 conformance is visually verified but not tool-checked

## Files Modified

| Type | Count |
|------|-------|
| PHP files (new) | 2 |
| JS/CSS assets | 0 |
| Language files | 0 |
| XML/Config | 0 |

Total: 2 files added, 0 modified, 0 deleted.

## Test plan

Because nothing wires these files in, there is no runtime test surface in this PR. Sanity checks:

- [x] `php -l plugins/j2commerce/payment_paypal/src/Service/PayPalSubscriptions.php` → no errors
- [x] `php -l plugins/j2commerce/payment_paypal/tmpl/prepayment_subscription.php` → no errors
- [x] `git diff upstream/main --name-only` shows only the 2 scaffold files
- [x] `grep -R "PayPalSubscriptions" plugins/j2commerce/payment_paypal/` shows only the new file itself — no existing code references it yet
- [x] `grep -R "prepayment_subscription" plugins/j2commerce/payment_paypal/` shows only the new file itself

Full end-to-end sandbox testing (create a PayPal Billing Plan, sign up a sandbox buyer, capture a renewal, cancel, verify webhook dedup) happens in the follow-up PR that actually wires these files in.

## Follow-up

The follow-up PR will:

1. Subscribe `PaymentPaypal` to `onJ2CommerceProcessRenewalPayment`, `onJ2CommerceCreateNewSubscriptionOrderForRenewal`, `onJ2CommerceAcceptSubscriptionPaymentWithTrial`
2. Gate `onAcceptSubscriptionPayment` on a new `enable_subscriptions` plugin param
3. Add `getPayPalSubscriptions()` lazy getter + `dispatchRenewalOutcome` helper
4. Wire `_prePayment` → `_prePaymentForSubscription` when `order_type === 'subscription'`
5. Add `onAjaxPayment_paypal` with `createSubscription` / `approveSubscription` tasks
6. Extend `PayPalWebhooks::handleEvent` with `BILLING.SUBSCRIPTION.*` routes and a metafield-backed event-id dedup so PayPal retries do not double-dispatch
7. Rewrite `onAfterSubscriptionCanceled` to call `PayPalSubscriptions::cancelSubscription` against the stored `paypal_subscription_id` metafield
8. Add `enable_subscriptions` + `default_plan_name_template` fields to `payment_paypal.xml`, bump version
9. Subscribe to `onJ2CommerceGetSavedPaymentMethods` and return active billing agreements
10. Extend `paypal-checkout.js` with `initializePayPalSubscriptionButtons` + observer
11. Add `PLG_J2COMMERCE_PAYMENT_PAYPAL_*` language strings
12. Run `joomla-doc` agent for user guide updates