### PR TITLE
fix(sampledata): rotate product images per-category (fixes #717)

### DIFF
--- a/administrator/components/com_j2commerce/src/Helper/SampleDataHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/SampleDataHelper.php
@@ -1118,7 +1118,7 @@ final class SampleDataHelper
                 $db->insertObject('#__j2commerce_productquantities', $qty);
             }
 
-            $productIds[] = ['id' => $productId, 'variant_id' => $variantId, 'name' => $uniqueName, 'price' => $price, 'sku' => $sku, 'product_type' => $type];
+            $productIds[] = ['id' => $productId, 'variant_id' => $variantId, 'name' => $uniqueName, 'price' => $price, 'sku' => $sku, 'product_type' => $type, 'cat_key' => $catKey];
         }
 
         return $productIds;
@@ -1323,7 +1323,7 @@ final class SampleDataHelper
                 }
             }
 
-            $productIds[] = ['id' => $productId, 'variant_id' => $masterVariantId, 'name' => $productName, 'price' => $basePrice, 'sku' => $masterSku, 'product_type' => 'variable'];
+            $productIds[] = ['id' => $productId, 'variant_id' => $masterVariantId, 'name' => $productName, 'price' => $basePrice, 'sku' => $masterSku, 'product_type' => 'variable', 'cat_key' => $catKey];
         }
 
         return $productIds;
@@ -1801,30 +1801,28 @@ final class SampleDataHelper
 
         $db = $this->db;
 
-        // Build a lookup of product_id → category key using the catIds we created
-        $catKeyByIndex = [];
-        foreach ($catIds as $index => $catEntry) {
-            $catKeyByIndex[$index] = $catEntry['key'] ?? 'electronics';
-        }
-
         $imageBase   = 'media/plg_sampledata_j2commerce/images';
-        $categories  = ['electronics', 'clothing', 'home', 'sporting', 'books'];
+        $fallbackCat = 'electronics';
         $imageCount  = 5;
         $created     = 0;
 
-        foreach ($productIds as $index => $productData) {
+        // Per-category image rotation counter so every product in a category
+        // cycles independently through that category's 5 SVGs.
+        $perCatIndex = [];
+
+        foreach ($productIds as $productData) {
             $productId = (int) ($productData['id'] ?? 0);
 
             if ($productId <= 0) {
                 continue;
             }
 
-            // Determine category from rotation
-            $catCount = \count($catIds);
-            $catEntry = $catCount > 0 ? $catIds[$index % $catCount] : null;
-            $catKey   = $catEntry['key'] ?? $categories[$index % \count($categories)];
+            $catKey = $productData['cat_key'] ?? $fallbackCat;
 
-            $imageNum  = ($index % $imageCount) + 1;
+            $perCatIndex[$catKey] = ($perCatIndex[$catKey] ?? 0);
+            $imageNum             = ($perCatIndex[$catKey] % $imageCount) + 1;
+            $perCatIndex[$catKey]++;
+
             $imagePath = $imageBase . '/' . $catKey . '/' . $imageNum . '.svg';
 
             $img                              = new \stdClass();


### PR DESCRIPTION
## Summary
Fixes #717

`createProductImages()` was deriving both `catKey` and `imageNum` from the same global `$index % 5`. Because there are 5 categories *and* 5 SVGs per category, every product in a given category collapsed onto the same image. Variable products compounded the bug by looking up `catKey` via the merged productIds offset, landing on the wrong folder entirely ("category with more than 5 gets an image from a different category").

## Changes
- `createSimpleProducts()` — stamp each product entry with its own `cat_key`
- `createVariableProducts()` — same `cat_key` stamp for variable products
- `createProductImages()` — read `cat_key` directly from the product entry, rotate `1.svg..5.svg` via a per-category counter so every category cycles its own 5 SVGs independently

## Testing
1. `administrator/` → System → Install → Sample Data
2. Remove prior J2Commerce sample data if present
3. Run J2Commerce sample data steps 1-4
4. Content → Articles → filter by each of the 5 J2Commerce categories
5. Verify each category's products cycle through that category's `1.svg`..`5.svg` only
6. Verify categories with 6+ products wrap back to `1.svg` from the **same** category (no cross-category leakage)

## Files Changed
- `administrator/components/com_j2commerce/src/Helper/SampleDataHelper.php` — per-category image rotation