### PR TITLE
fix(search): sku: prefix uses exact match instead of LIKE (fixes #710)

### DIFF
--- a/administrator/components/com_j2commerce/src/Model/ProductsModel.php
+++ b/administrator/components/com_j2commerce/src/Model/ProductsModel.php
@@ -325,8 +325,8 @@ class ProductsModel extends ListModel
                 $query->where($db->quoteName('a.j2commerce_product_id') . ' = :searchId')
                     ->bind(':searchId', $searchId, ParameterType::INTEGER);
             } elseif (stripos($search, 'sku:') === 0) {
-                $searchSku = '%' . substr($search, 4) . '%';
-                $query->where($db->quoteName('v.sku') . ' LIKE :searchSku')
+                $searchSku = trim(substr($search, 4));
+                $query->where($db->quoteName('v.sku') . ' = :searchSku')
                     ->bind(':searchSku', $searchSku);
             } else {
                 $search = '%' . trim($search) . '%';

--- a/administrator/components/com_j2commerce/src/Model/ShippingtroublesModel.php
+++ b/administrator/components/com_j2commerce/src/Model/ShippingtroublesModel.php
@@ -137,9 +137,9 @@ class ShippingtroublesModel extends ListModel
                 $query->where($db->quoteName('p.j2commerce_product_id') . ' = :id')
                     ->bind(':id', $search, ParameterType::INTEGER);
             } elseif (stripos($search, 'sku:') === 0) {
-                $search = '%' . str_replace(' ', '%', $db->escape(trim(substr($search, 4)), true)) . '%';
-                $query->where($db->quoteName('v.sku') . ' LIKE :sku')
-                    ->bind(':sku', $search);
+                $searchSku = trim(substr($search, 4));
+                $query->where($db->quoteName('v.sku') . ' = :sku')
+                    ->bind(':sku', $searchSku);
             } else {
                 $search = '%' . str_replace(' ', '%', $db->escape(trim($search), true)) . '%';
                 $query->where(


### PR DESCRIPTION
The `sku:` search prefix in ProductsModel and ShippingtroublesModel
was wrapping the value with wildcards and using LIKE, contradicting
the documented "exact match" behavior. Changed to = comparison
with trim() for whitespace safety.

fixes #710 