### PR TITLE
fix(admin-css): dark mode dashboard — bg-white override and quickicon success colour

### DIFF
--- a/media/com_j2commerce/css/administrator/j2commerce_admin.css
+++ b/media/com_j2commerce/css/administrator/j2commerce_admin.css
@@ -229,7 +229,8 @@ html[data-bs-theme="dark"] body.com_j2commerce {
         background-color: var(--btn-primary-bg-hvr);
         border: var(--btn-primary-border-hvr);
     }
-    .variants-container {background-color: rgba(255, 255, 255, 0.1);border: none;}
+    .variants-container, .bg-white {background-color: rgba(255, 255, 255, 0.1)!important;border: none;}
+    .quick-icons .quickicon a.alert-success .quickicon-info .quickicon-icon {color: var(--success) !important;}
 }
 
 .j2commerce-social-share a[target="_blank"]:before {display:none;}


### PR DESCRIPTION
## Core Update

Dark mode CSS fixes for the J2Commerce admin dashboard.

### Changes
- Extend `.variants-container` dark-mode rule to also cover `.bg-white` elements (Bootstrap utility class used on dashboard cards) so white backgrounds are suppressed in dark theme
- Fix quickicon success icon colour to use `--success` CSS variable instead of the inherited light-mode colour

### Files Modified
| Type | Count |
|------|-------|
| CSS assets | 1 |

`media/com_j2commerce/css/administrator/j2commerce_admin.css`

### Pre-Flight
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only