### PR TITLE
chore(headers): add missing copyright headers to core PHP files

### DIFF
--- a/administrator/components/com_j2commerce/layouts/app/default.php
+++ b/administrator/components/com_j2commerce/layouts/app/default.php
@@ -1,10 +1,13 @@
 <?php
 /**
  * @package     J2Commerce
- * @subpackage  Layout
+ * @subpackage  com_j2commerce
  *
  * Layout variables:
  * @var array $displayData Array containing menu items and active page
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
 defined('_JEXEC') or die;

--- a/administrator/components/com_j2commerce/layouts/payment/default.php
+++ b/administrator/components/com_j2commerce/layouts/payment/default.php
@@ -1,10 +1,13 @@
 <?php
 /**
  * @package     J2Commerce
- * @subpackage  Layout
+ * @subpackage  com_j2commerce
  *
  * Layout variables:
  * @var array $displayData Array containing menu items and active page
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
 defined('_JEXEC') or die;

--- a/administrator/components/com_j2commerce/layouts/report/default.php
+++ b/administrator/components/com_j2commerce/layouts/report/default.php
@@ -1,10 +1,13 @@
 <?php
 /**
  * @package     J2Commerce
- * @subpackage  Layout
+ * @subpackage  com_j2commerce
  *
  * Layout variables:
  * @var array $displayData Array containing menu items and active page
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
 defined('_JEXEC') or die;

--- a/administrator/components/com_j2commerce/layouts/shipping/default.php
+++ b/administrator/components/com_j2commerce/layouts/shipping/default.php
@@ -1,10 +1,13 @@
 <?php
 /**
  * @package     J2Commerce
- * @subpackage  Layout
+ * @subpackage  com_j2commerce
  *
  * Layout variables:
  * @var array $displayData Array containing menu items and active page
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
 defined('_JEXEC') or die;

--- a/administrator/components/com_j2commerce/src/Builder/blocks/cart-form/view-edit.php
+++ b/administrator/components/com_j2commerce/src/Builder/blocks/cart-form/view-edit.php
@@ -1,4 +1,12 @@
 <?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
 \defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;

--- a/administrator/components/com_j2commerce/src/Builder/blocks/cart-form/view.php
+++ b/administrator/components/com_j2commerce/src/Builder/blocks/cart-form/view.php
@@ -1,4 +1,12 @@
 <?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
 \defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;

--- a/administrator/components/com_j2commerce/src/Builder/blocks/custom-banner/view-edit.php
+++ b/administrator/components/com_j2commerce/src/Builder/blocks/custom-banner/view-edit.php
@@ -1,4 +1,12 @@
 <?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
 \defined('_JEXEC') or die;
 
 extract($displayData);

--- a/administrator/components/com_j2commerce/src/Builder/blocks/custom-banner/view.php
+++ b/administrator/components/com_j2commerce/src/Builder/blocks/custom-banner/view.php
@@ -1,4 +1,12 @@
 <?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
 \defined('_JEXEC') or die;
 
 extract($displayData);

--- a/administrator/components/com_j2commerce/src/Builder/blocks/custom-divider/view-edit.php
+++ b/administrator/components/com_j2commerce/src/Builder/blocks/custom-divider/view-edit.php
@@ -1,4 +1,12 @@
 <?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
 \defined('_JEXEC') or die;
 
 extract($displayData);

--- a/administrator/components/com_j2commerce/src/Builder/blocks/custom-divider/view.php
+++ b/administrator/components/com_j2commerce/src/Builder/blocks/custom-divider/view.php
@@ -1,4 +1,12 @@
 <?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
 \defined('_JEXEC') or die;
 
 extract($displayData);

--- a/administrator/components/com_j2commerce/src/Builder/blocks/custom-html/view-edit.php
+++ b/administrator/components/com_j2commerce/src/Builder/blocks/custom-html/view-edit.php
@@ -1,4 +1,12 @@
 <?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
 \defined('_JEXEC') or die;
 
 extract($displayData);

--- a/administrator/components/com_j2commerce/src/Builder/blocks/custom-html/view.php
+++ b/administrator/components/com_j2commerce/src/Builder/blocks/custom-html/view.php
@@ -1,4 +1,12 @@
 <?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
 \defined('_JEXEC') or die;
 
 extract($displayData);

--- a/administrator/components/com_j2commerce/src/Builder/blocks/custom-text/view-edit.php
+++ b/administrator/components/com_j2commerce/src/Builder/blocks/custom-text/view-edit.php
@@ -1,4 +1,12 @@
 <?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
 \defined('_JEXEC') or die;
 
 extract($displayData);

--- a/administrator/components/com_j2commerce/src/Builder/blocks/custom-text/view.php
+++ b/administrator/components/com_j2commerce/src/Builder/blocks/custom-text/view.php
@@ -1,4 +1,12 @@
 <?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
 \defined('_JEXEC') or die;
 
 extract($displayData);

--- a/administrator/components/com_j2commerce/src/Builder/blocks/product-cart/view-edit.php
+++ b/administrator/components/com_j2commerce/src/Builder/blocks/product-cart/view-edit.php
@@ -1,4 +1,12 @@
 <?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
 \defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;

--- a/administrator/components/com_j2commerce/src/Builder/blocks/product-cart/view.php
+++ b/administrator/components/com_j2commerce/src/Builder/blocks/product-cart/view.php
@@ -1,4 +1,12 @@
 <?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
 \defined('_JEXEC') or die;
 
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;

--- a/administrator/components/com_j2commerce/src/Builder/blocks/product-description/view-edit.php
+++ b/administrator/components/com_j2commerce/src/Builder/blocks/product-description/view-edit.php
@@ -1,4 +1,12 @@
 <?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
 \defined('_JEXEC') or die;
 
 extract($displayData);

--- a/administrator/components/com_j2commerce/src/Builder/blocks/product-description/view.php
+++ b/administrator/components/com_j2commerce/src/Builder/blocks/product-description/view.php
@@ -1,4 +1,12 @@
 <?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
 \defined('_JEXEC') or die;
 
 extract($displayData);

--- a/administrator/components/com_j2commerce/src/Builder/blocks/product-image/view-edit.php
+++ b/administrator/components/com_j2commerce/src/Builder/blocks/product-image/view-edit.php
@@ -1,4 +1,12 @@
 <?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
 \defined('_JEXEC') or die;
 
 extract($displayData);

--- a/administrator/components/com_j2commerce/src/Builder/blocks/product-image/view.php
+++ b/administrator/components/com_j2commerce/src/Builder/blocks/product-image/view.php
@@ -1,4 +1,12 @@
 <?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
 \defined('_JEXEC') or die;
 
 use J2Commerce\Component\J2commerce\Administrator\Helper\ImageHelper;

--- a/administrator/components/com_j2commerce/src/Builder/blocks/product-options/view-edit.php
+++ b/administrator/components/com_j2commerce/src/Builder/blocks/product-options/view-edit.php
@@ -1,4 +1,12 @@
 <?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
 \defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;

--- a/administrator/components/com_j2commerce/src/Builder/blocks/product-options/view.php
+++ b/administrator/components/com_j2commerce/src/Builder/blocks/product-options/view.php
@@ -1,4 +1,12 @@
 <?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
 \defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;

--- a/administrator/components/com_j2commerce/src/Builder/blocks/product-price/view-edit.php
+++ b/administrator/components/com_j2commerce/src/Builder/blocks/product-price/view-edit.php
@@ -1,4 +1,12 @@
 <?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
 \defined('_JEXEC') or die;
 
 extract($displayData);

--- a/administrator/components/com_j2commerce/src/Builder/blocks/product-price/view.php
+++ b/administrator/components/com_j2commerce/src/Builder/blocks/product-price/view.php
@@ -1,4 +1,12 @@
 <?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
 \defined('_JEXEC') or die;
 
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;

--- a/administrator/components/com_j2commerce/src/Builder/blocks/product-quickview/view-edit.php
+++ b/administrator/components/com_j2commerce/src/Builder/blocks/product-quickview/view-edit.php
@@ -1,4 +1,12 @@
 <?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
 \defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;

--- a/administrator/components/com_j2commerce/src/Builder/blocks/product-quickview/view.php
+++ b/administrator/components/com_j2commerce/src/Builder/blocks/product-quickview/view.php
@@ -1,4 +1,12 @@
 <?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
 \defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;

--- a/administrator/components/com_j2commerce/src/Builder/blocks/product-sku/view-edit.php
+++ b/administrator/components/com_j2commerce/src/Builder/blocks/product-sku/view-edit.php
@@ -1,4 +1,12 @@
 <?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
 \defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;

--- a/administrator/components/com_j2commerce/src/Builder/blocks/product-sku/view.php
+++ b/administrator/components/com_j2commerce/src/Builder/blocks/product-sku/view.php
@@ -1,4 +1,12 @@
 <?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
 \defined('_JEXEC') or die;
 
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;

--- a/administrator/components/com_j2commerce/src/Builder/blocks/product-stock/view-edit.php
+++ b/administrator/components/com_j2commerce/src/Builder/blocks/product-stock/view-edit.php
@@ -1,4 +1,12 @@
 <?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
 \defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;

--- a/administrator/components/com_j2commerce/src/Builder/blocks/product-stock/view.php
+++ b/administrator/components/com_j2commerce/src/Builder/blocks/product-stock/view.php
@@ -1,4 +1,12 @@
 <?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
 \defined('_JEXEC') or die;
 
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;

--- a/administrator/components/com_j2commerce/src/Builder/blocks/product-title/view-edit.php
+++ b/administrator/components/com_j2commerce/src/Builder/blocks/product-title/view-edit.php
@@ -1,4 +1,12 @@
 <?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
 \defined('_JEXEC') or die;
 
 extract($displayData);

--- a/administrator/components/com_j2commerce/src/Builder/blocks/product-title/view.php
+++ b/administrator/components/com_j2commerce/src/Builder/blocks/product-title/view.php
@@ -1,4 +1,12 @@
 <?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
 \defined('_JEXEC') or die;
 
 extract($displayData);

--- a/components/com_j2commerce/layouts/app_bootstrap5/list/category/item_boxbuilder.php
+++ b/components/com_j2commerce/layouts/app_bootstrap5/list/category/item_boxbuilder.php
@@ -1,0 +1,11 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+\defined('_JEXEC') or die;

--- a/components/com_j2commerce/src/View/AdminAssetsTrait.php
+++ b/components/com_j2commerce/src/View/AdminAssetsTrait.php
@@ -1,1 +1,9 @@
 <?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */

--- a/libraries/j2commerce/csvexport/src/ExportCsv.php
+++ b/libraries/j2commerce/csvexport/src/ExportCsv.php
@@ -1,5 +1,13 @@
 <?php
 
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
 namespace J2Commerce\Library\ExportCsv;
 
 class ExportCsv


### PR DESCRIPTION
## Summary
Fixes #718

Adds the standard J2Commerce copyright/license docblock to 35 core PHP files that were missing it.

## Changes
- 4 admin layout files (`layouts/app|payment|report|shipping/default.php`) — had partial docblock (`@package`/`@subpackage`) missing `@copyright` and `@license`; also normalised `@subpackage Layout` → `@subpackage com_j2commerce`
- 28 Builder block view files (`src/Builder/blocks/*/view*.php`) — no docblock at all
- `components/com_j2commerce/src/View/AdminAssetsTrait.php` — missing docblock
- `components/com_j2commerce/layouts/app_bootstrap5/list/category/item_boxbuilder.php` — was 0 bytes; now has `<?php` + copyright + `\defined('_JEXEC') or die`
- `libraries/j2commerce/csvexport/src/ExportCsv.php` — missing docblock

**Note:** 15 extension plugin files (`app_giftwrapping`, `app_productcompare`, `app_quantityprice`, `app_subscriptionexcluderenewalinventory`) are gitignored in this repo and will need the same fix applied in the extensions repo.

## Files Changed
| Path | Count |
|------|-------|
| `administrator/components/com_j2commerce/layouts/` | 4 |
| `administrator/components/com_j2commerce/src/Builder/blocks/` | 28 |
| `components/com_j2commerce/` | 2 |
| `libraries/j2commerce/csvexport/src/` | 1 |
| **Total** | **35** |

## Pre-Flight
- [x] PHP syntax check passed (all 35 files)
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only
- [x] No language files changed