### PR TITLE
Add custom delimiter, enclosure, and escape to fputcsv calls

### DIFF
--- a/administrator/components/com_j2commerce/src/Controller/ReportpluginController.php
+++ b/administrator/components/com_j2commerce/src/Controller/ReportpluginController.php
@@ -161,6 +161,9 @@ class ReportpluginController extends BaseController
         // Output CSV
         $output = fopen('php://output', 'w');
 
+        // Add UTF-8 BOM for Excel ensures currency symbols and other characters display correctly
+        fprintf($output, chr(0xEF) . chr(0xBB) . chr(0xBF));
+
         if (!empty($items)) {
             // Header row from object keys
             $firstItem = reset($items);

--- a/administrator/components/com_j2commerce/src/Controller/ReportpluginController.php
+++ b/administrator/components/com_j2commerce/src/Controller/ReportpluginController.php
@@ -165,7 +165,7 @@ class ReportpluginController extends BaseController
             // Header row from object keys
             $firstItem = reset($items);
             $keys      = array_keys((array) $firstItem);
-            fputcsv($output, $keys);
+            fputcsv($output, $keys, ',', '"', '\\');
 
             // Data rows
             foreach ($items as $item) {
@@ -183,7 +183,7 @@ class ReportpluginController extends BaseController
                     $row[] = $value;
                 }
 
-                fputcsv($output, $row);
+                fputcsv($output, $row, ',', '"', '\\');
             }
         }
 


### PR DESCRIPTION
resolves a php 8.4 deprecation

https://php.watch/versions/8.4/csv-functions-escape-parameter

fixes #735 

additionaly sets the encoding to utf8 to ensure that currency symbols are displayed correctly in excel on import