### PR TITLE
fix(order): remove duplicate print buttons from sidebar action area

### DIFF
--- a/administrator/components/com_j2commerce/tmpl/order/view_sidebar.php
+++ b/administrator/components/com_j2commerce/tmpl/order/view_sidebar.php
@@ -28,16 +28,6 @@ if ($orderInfo) {
 ?>
 <?php echo J2CommerceHelper::plugin()->eventWithHtml('BeforeAdminOrderButtons', array($item))->getArgument('html', ''); ?>
 <div class="j2c-action-buttons d-flex flex-wrap gap-2 mb-3">
-    <a href="<?php echo Route::_('index.php?option=com_j2commerce&view=order&layout=invoice&tmpl=component&id=' . (int) $item->j2commerce_order_id); ?>"
-       class="btn btn-sm btn-primary" target="_blank">
-        <span class="icon-print" aria-hidden="true"></span> <?php echo Text::_('COM_J2COMMERCE_PRINT_ORDER'); ?>
-    </a>
-    <?php if (!empty($this->hasPackingSlip)) : ?>
-    <a href="<?php echo Route::_('index.php?option=com_j2commerce&task=order.packingSlip&id=' . (int) $item->j2commerce_order_id); ?>"
-       class="btn btn-sm btn-primary" target="_blank">
-        <span class="icon-list" aria-hidden="true"></span> <?php echo Text::_('COM_J2COMMERCE_PRINT_PACKING_SLIP'); ?>
-    </a>
-    <?php endif; ?>
     <button type="button" class="btn btn-sm btn-dark" id="resendEmailBtn"
             data-order-id="<?php echo (int) $item->j2commerce_order_id; ?>">
         <span class="icon-envelope" aria-hidden="true"></span> <?php echo Text::_('COM_J2COMMERCE_RESEND_EMAIL'); ?>


### PR DESCRIPTION
## Summary
Fixes #714

The `.j2c-action-buttons` sidebar in the admin order view contained **Print Order** and **Print Packing Slip** buttons that duplicate the toolbar buttons. Both buttons linked to the same URLs as their toolbar counterparts, creating confusing redundancy with inconsistent labels ("Print Order" vs "Print Invoice").

## Changes
- Removed the **Print Order** anchor button from `.j2c-action-buttons` in `view_sidebar.php`
- Removed the **Print Packing Slip** anchor button from `.j2c-action-buttons` in `view_sidebar.php`
- Both print actions remain available in the toolbar (canonical location)
- **Resend Email** button remains in the sidebar as it has no toolbar equivalent

## Testing
1. Open Admin → J2Commerce → Orders
2. Click any order to open the order view
3. Verify: no "Print Order" or "Print Packing Slip" buttons appear in the sidebar action area
4. Verify: "Print Invoice" and "Print Packing Slip" toolbar buttons are still present and functional
5. Verify: "Resend Email" button is still present in the sidebar

## Files Changed
- `administrator/components/com_j2commerce/tmpl/order/view_sidebar.php` — removed 10 lines (two print button anchors)

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only