### PR TITLE
fix(print): equalise Print and Close button styles on invoice/packing slip

### DIFF
--- a/administrator/components/com_j2commerce/src/Controller/OrderController.php
+++ b/administrator/components/com_j2commerce/src/Controller/OrderController.php
@@ -521,8 +521,8 @@ class OrderController extends FormController
             . '<style>'
             . 'body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;margin:0;padding:20px;color:#333;background:#f8fafc;-webkit-print-color-adjust:exact;print-color-adjust:exact;}'
             . 'table{border-collapse:collapse;border-spacing:0;}img{max-width:100%;height:auto;border:0;}'
-            . '.no-print{margin-bottom:20px;text-align:center;}'
-            . '.no-print button{padding:10px 24px;border:1px solid #d1d5db;border-radius:6px;background:#fff;cursor:pointer;font-size:14px;}'
+            . '.no-print{margin-bottom:20px;display:flex;gap:8px;justify-content:center;align-items:center;}'
+            . '.no-print button{padding:10px 24px;border:1px solid #d1d5db;border-radius:6px;background:#fff;color:#333;cursor:pointer;font-size:14px;font-family:inherit;line-height:1.5;-webkit-appearance:none;appearance:none;}'
             . '.no-print button:hover{background:#f3f4f6;}'
             . $extractedStyles
             . ($customCss !== '' ? $customCss : '')
@@ -531,8 +531,8 @@ class OrderController extends FormController
             . '</head><body>'
             . '<div class="no-print">'
             . '<button onclick="window.print()">' . Text::_('COM_J2COMMERCE_PRINT') . '</button>'
-            . '<button onclick="window.close()" style="margin-left:8px;">' . Text::_('JCLOSE') . '</button>'
-            . '<span style="margin-left:16px;color:#6b7280;font-size:14px;">' . Text::sprintf('COM_J2COMMERCE_PRINT_PACKING_SLIPS_COUNT', \count($slipBodies)) . '</span>'
+            . '<button onclick="window.close()">' . Text::_('JCLOSE') . '</button>'
+            . '<span style="color:#6b7280;font-size:14px;">' . Text::sprintf('COM_J2COMMERCE_PRINT_PACKING_SLIPS_COUNT', \count($slipBodies)) . '</span>'
             . '</div>'
             . $body
             . '<script>window.onload=function(){window.print();};</script>'
@@ -576,8 +576,8 @@ class OrderController extends FormController
             . '<style>'
             . 'body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;margin:0;padding:20px;color:#333;background:#f8fafc;-webkit-print-color-adjust:exact;print-color-adjust:exact;}'
             . 'table{border-collapse:collapse;border-spacing:0;}img{max-width:100%;height:auto;border:0;}'
-            . '.no-print{margin-bottom:20px;text-align:center;}'
-            . '.no-print button{padding:10px 24px;border:1px solid #d1d5db;border-radius:6px;background:#fff;cursor:pointer;font-size:14px;}'
+            . '.no-print{margin-bottom:20px;display:flex;gap:8px;justify-content:center;}'
+            . '.no-print button{padding:10px 24px;border:1px solid #d1d5db;border-radius:6px;background:#fff;color:#333;cursor:pointer;font-size:14px;font-family:inherit;line-height:1.5;-webkit-appearance:none;appearance:none;}'
             . '.no-print button:hover{background:#f3f4f6;}'
             . $extractedStyles
             . ($customCss !== '' ? $customCss : '')
@@ -586,7 +586,7 @@ class OrderController extends FormController
             . '</head><body>'
             . '<div class="no-print">'
             . '<button onclick="window.print()">' . Text::_('COM_J2COMMERCE_PRINT') . '</button>'
-            . '<button onclick="window.close()" style="margin-left:8px;">' . Text::_('JCLOSE') . '</button>'
+            . '<button onclick="window.close()">' . Text::_('JCLOSE') . '</button>'
             . '</div>'
             . $bodyHtml
             . '<script>window.onload=function(){window.print();};</script>'

--- a/administrator/components/com_j2commerce/tmpl/order/invoice.php
+++ b/administrator/components/com_j2commerce/tmpl/order/invoice.php
@@ -72,14 +72,19 @@ $customCss = trim((string) $db->loadResult());
         img { max-width: 100%; height: auto; border: 0; }
 
         /* Print button bar */
-        .no-print { margin-bottom: 20px; text-align: center; }
+        .no-print { margin-bottom: 20px; display: flex; gap: 8px; justify-content: center; }
         .no-print button {
             padding: 10px 24px;
             border: 1px solid #d1d5db;
             border-radius: 6px;
             background: #fff;
+            color: #333;
             cursor: pointer;
             font-size: 14px;
+            font-family: inherit;
+            line-height: 1.5;
+            -webkit-appearance: none;
+            appearance: none;
         }
         .no-print button:hover { background: #f3f4f6; }
 
@@ -101,7 +106,7 @@ $customCss = trim((string) $db->loadResult());
 <body>
     <div class="no-print">
         <button onclick="window.print()"><?php echo Text::_('COM_J2COMMERCE_PRINT'); ?></button>
-        <button onclick="window.close()" style="margin-left: 8px;"><?php echo Text::_('JCLOSE'); ?></button>
+        <button onclick="window.close()"><?php echo Text::_('JCLOSE'); ?></button>
     </div>
     <?php echo $bodyHtml; ?>
     <script>window.onload = function() { window.print(); };</script>

--- a/administrator/components/com_j2commerce/tmpl/order/packingslip.php
+++ b/administrator/components/com_j2commerce/tmpl/order/packingslip.php
@@ -72,14 +72,19 @@ $customCss = trim((string) $db->loadResult());
         img { max-width: 100%; height: auto; border: 0; }
 
         /* Print button bar */
-        .no-print { margin-bottom: 20px; text-align: center; }
+        .no-print { margin-bottom: 20px; display: flex; gap: 8px; justify-content: center; }
         .no-print button {
             padding: 10px 24px;
             border: 1px solid #d1d5db;
             border-radius: 6px;
             background: #fff;
+            color: #333;
             cursor: pointer;
             font-size: 14px;
+            font-family: inherit;
+            line-height: 1.5;
+            -webkit-appearance: none;
+            appearance: none;
         }
         .no-print button:hover { background: #f3f4f6; }
 
@@ -101,7 +106,7 @@ $customCss = trim((string) $db->loadResult());
 <body>
     <div class="no-print">
         <button onclick="window.print()"><?php echo Text::_('COM_J2COMMERCE_PRINT'); ?></button>
-        <button onclick="window.close()" style="margin-left: 8px;"><?php echo Text::_('JCLOSE'); ?></button>
+        <button onclick="window.close()"><?php echo Text::_('JCLOSE'); ?></button>
     </div>
     <?php echo $bodyHtml; ?>
     <script>window.onload = function() { window.print(); };</script>


### PR DESCRIPTION
## Summary
Fixes #715

The Print and Close buttons on invoice and packing slip print pages rendered inconsistently because:
- Close button had an inline `style="margin-left:8px;"` creating a CSS specificity difference
- `.no-print button` lacked browser UA resets (`appearance:none`, `color`, `font-family`, `line-height`)
- The actual render path for `task=order.packingSlip` is inline HTML in `OrderController`, not the tmpl file — both were fixed

## Changes
- `tmpl/order/invoice.php` — flexbox gap replaces `text-align:center`, full button CSS reset
- `tmpl/order/packingslip.php` — same
- `src/Controller/OrderController.php` — same fix applied to `renderPackingSlipHtml()` and `printPackingSlips()` (the live render path)

## Testing
1. Open any order in admin → click **Print Invoice**
2. Verify Print and Close buttons look identical (same border, background, size, font)
3. Allow print dialog to open → close it → buttons still identical
4. Repeat for **Print Packing Slip** via `task=order.packingSlip&id=X`

## Files Changed
| File | Change |
|------|--------|
| `tmpl/order/invoice.php` | Button CSS reset + flexbox gap |
| `tmpl/order/packingslip.php` | Button CSS reset + flexbox gap |
| `src/Controller/OrderController.php` | Same fix in 2 inline HTML methods |

## Pre-Flight
- [x] PHP syntax check passed (all 3 files)
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only