### PR TITLE
fix(advancedpricing): correct batch update item count

### DIFF
--- a/administrator/components/com_j2commerce/src/Controller/AdvancedpricingController.php
+++ b/administrator/components/com_j2commerce/src/Controller/AdvancedpricingController.php
@@ -45,8 +45,7 @@ class AdvancedpricingController extends AdminController
             return;
         }
 
-        $db      = Factory::getContainer()->get('DatabaseDriver');
-        $updated = 0;
+        $db = Factory::getContainer()->get('DatabaseDriver');
 
         try {
             $batchGroupId  = $this->input->post->getString('batch_customer_group_id', '');
@@ -63,7 +62,6 @@ class AdvancedpricingController extends AdminController
 
                 $db->setQuery($query);
                 $db->execute();
-                $updated += $db->getAffectedRows();
             }
 
             if ($batchDateFrom !== '') {
@@ -76,7 +74,6 @@ class AdvancedpricingController extends AdminController
 
                 $db->setQuery($query);
                 $db->execute();
-                $updated += $db->getAffectedRows();
             }
 
             if ($batchDateTo !== '') {
@@ -89,10 +86,9 @@ class AdvancedpricingController extends AdminController
 
                 $db->setQuery($query);
                 $db->execute();
-                $updated += $db->getAffectedRows();
             }
 
-            $this->setMessage(Text::sprintf('COM_J2COMMERCE_N_ITEMS_UPDATED', $updated));
+            $this->setMessage(Text::sprintf('COM_J2COMMERCE_N_ITEMS_UPDATED', count($cids)));
         } catch (\Exception $e) {
             $this->setMessage($e->getMessage(), 'error');
         }


### PR DESCRIPTION
## Summary
Fixes #733

## Changes
- `batch()` method was summing `getAffectedRows()` across up to 3 separate UPDATE queries (customer_group, date_from, date_to). Selecting 1 item and updating 2 fields produced "2 item(s) updated". Count now uses `count($cids)` — the number of selected records.

## Files Changed
| File | Change |
|------|--------|
| `administrator/components/com_j2commerce/src/Controller/AdvancedpricingController.php` | Replace `$updated` accumulator with `count($cids)` |

## Testing
1. Go to J2Commerce > Advanced Pricing
2. Select 1 price row
3. Click Batch Update — set both Date From and Date To
4. Submit
5. Verify message shows "1 item(s) updated" (not "2")

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only