### PR TITLE
fix(productprice): register JS delete confirm string (fixes #747)

### DIFF
--- a/administrator/components/com_j2commerce/tmpl/productprice/productpricing.php
+++ b/administrator/components/com_j2commerce/tmpl/productprice/productpricing.php
@@ -34,6 +34,8 @@ $currencyDecimals = CurrencyHelper::getDecimalPlace();
 // Initialize tooltips
 HTMLHelper::_('bootstrap.tooltip', '[data-bs-toggle="tooltip"]', ['placement' => 'top']);
 
+Text::script('COM_J2COMMERCE_CONFIRM_DELETE');
+
 // Get Web Asset Manager
 $wa = $app->getDocument()->getWebAssetManager();
 $wa->useScript('form.validate')


### PR DESCRIPTION
## Summary
Fixes #747

JS `confirm(Joomla.Text._('COM_J2COMMERCE_CONFIRM_DELETE'))` on the Set Additional Pricing tab rendered the raw language key because the key was never registered server-side.

## Changes
- Add `Text::script('COM_J2COMMERCE_CONFIRM_DELETE')` in `productpricing.php` so the JS `Joomla.Text._()` lookup resolves the translated string.

## Testing
1. Admin -> J2Commerce -> Products -> edit a product
2. Open the "Set Additional Pricing" tab
3. Click Remove on a price row
4. Verify the browser confirm dialog shows the translated delete message, not `COM_J2COMMERCE_CONFIRM_DELETE`

## Files Changed
- `administrator/components/com_j2commerce/tmpl/productprice/productpricing.php` - register the JS language key via `Text::script()`