### PR TITLE
fix(productprice): persist create flash across reload

### DIFF
--- a/administrator/components/com_j2commerce/tmpl/productprice/productpricing.php
+++ b/administrator/components/com_j2commerce/tmpl/productprice/productpricing.php
@@ -61,9 +61,22 @@ document.addEventListener('DOMContentLoaded', function() {
         variantId: {$variantId},
 
         init: function() {
+            this.renderPendingFlash();
             this.bindCreateButton();
             this.bindSaveAllButton();
             this.bindRemoveButtons();
+        },
+
+        renderPendingFlash: function() {
+            const raw = sessionStorage.getItem('j2commerce.productprice.flash');
+            if (!raw) return;
+            sessionStorage.removeItem('j2commerce.productprice.flash');
+            try {
+                const flash = JSON.parse(raw);
+                if (flash && flash.type && flash.text) {
+                    Joomla.renderMessages({[flash.type]: [flash.text]});
+                }
+            } catch (e) {}
         },
 
         bindCreateButton: function() {
@@ -114,7 +127,10 @@ document.addEventListener('DOMContentLoaded', function() {
             .then(data => {
                 this.hideLoading();
                 if (data.success) {
-                    Joomla.renderMessages({success: [data.message || 'Price created successfully']});
+                    sessionStorage.setItem('j2commerce.productprice.flash', JSON.stringify({
+                        type: 'success',
+                        text: data.message || 'Price created successfully'
+                    }));
                     location.reload();
                 } else {
                     Joomla.renderMessages({error: [data.message || 'Error creating price']});


### PR DESCRIPTION
## Summary
Fixes #748

The "Price created." success toast on the Set Additional Pricing tab flashes for a split second then disappears. Root cause: `createPrice()` rendered the message via `Joomla.renderMessages()` and then immediately called `location.reload()`, wiping it before the user could read it.

## Changes
- Stash the success flash in `sessionStorage` (`j2commerce.productprice.flash`) before `location.reload()`
- New `renderPendingFlash()` helper runs first in `init()`, pops the stored key, and renders the toast on the reloaded page
- `saveAllPrices()` and `removePrice()` unchanged — they don't reload

## Testing
1. Admin > Components > J2Commerce > Products > edit any product
2. Open the Pricing tab (Set Additional Pricing)
3. Fill a new price row and click Create
4. Verify the "Price created." toast stays visible after the page reloads
5. Sanity-check Save All and Remove buttons still render their toasts normally

## Files Changed
- `administrator/components/com_j2commerce/tmpl/productprice/productpricing.php` — sessionStorage flash persistence