### PR TITLE
fix(overrides): remove tag badge with missing bg-purple class

### DIFF
--- a/administrator/components/com_j2commerce/tmpl/overrides/default_overrides.php
+++ b/administrator/components/com_j2commerce/tmpl/overrides/default_overrides.php
@@ -125,9 +125,6 @@ $wa->addInlineStyle($style);
                                                             <div class="d-flex align-items-start justify-content-between mb-2">
                                                                 <h3 class="card-title mb-0 fs-5">
                                                                     <?php echo $this->escape($file['displayName'] ?? $file['filename']); ?>
-                                                                    <?php if (($file['context'] ?? '') === 'tag') : ?>
-                                                                        <span class="ms-1 <?php echo J2htmlHelper::badgeClass('badge text-bg-purple'); ?>">Tag</span>
-                                                                    <?php endif; ?>
                                                                 </h3>
                                                                 <?php if ($file['hasOverride'] ?? false) : ?>
                                                                     <span class="<?php echo J2htmlHelper::badgeClass('badge text-bg-success'); ?> ms-2 flex-shrink-0">


### PR DESCRIPTION
## Summary
Fixes #763

## Changes
- Removed the "Tag" badge (`bg-purple` class) from layout cards in the Template Overrides view — `bg-purple` does not exist in `j2commerce_admin.css` (only `text-bg-purple` is defined), causing a broken/purple background in both light and dark mode

## Testing
1. Navigate to J2Commerce → Template Overrides (admin)
2. Expand any subtemplate accordion
3. Verify: no purple badge appears on any layout card title

## Files Changed
- `administrator/components/com_j2commerce/tmpl/overrides/default_overrides.php` — removed 3-line tag badge block

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only