### PR TITLE
Add aria-label to customer note textarea for accessibility

### DIFF
--- a/administrator/components/com_j2commerce/tmpl/order/view_sidebar.php
+++ b/administrator/components/com_j2commerce/tmpl/order/view_sidebar.php
@@ -41,7 +41,7 @@ if ($orderInfo) {
         <h2 class="card-title mb-0 fs-5"><?php echo Text::_('COM_J2COMMERCE_CUSTOMER_NOTE'); ?></h2>
     </div>
     <div class="card-body">
-        <textarea class="form-control" id="customerNote" rows="2" readonly><?php echo $this->escape($item->customer_note ?? ''); ?></textarea>
+        <textarea class="form-control" id="customerNote" rows="2" readonly aria-label="<?php echo Text::_('COM_J2COMMERCE_CUSTOMER_NOTE'); ?>"><?php echo $this->escape($item->customer_note ?? ''); ?></textarea>
     </div>
 </div>
 <?php echo J2CommerceHelper::plugin()->eventWithHtml('AfterAdminOrderNote', array($item))->getArgument('html', ''); ?>


### PR DESCRIPTION
Form fields must have associated labels even if they are disabled

<img width="1037" height="852" alt="image" src="https://github.com/user-attachments/assets/a2229472-7fcd-41a8-949d-cccf32dd56f2" />
