### PR TITLE
fix(installer): write install debug log to configured logs folder

### DIFF
--- a/administrator/components/com_j2commerce/script.j2commerce.php
+++ b/administrator/components/com_j2commerce/script.j2commerce.php
@@ -31,7 +31,7 @@ class Com_J2commerceInstallerScript extends InstallerScript
     private function debugLog(string $message): void
     {
         if (!$this->debugLogFile) {
-            $this->debugLogFile = JPATH_ROOT . '/tmp/j2commerce_install_debug.log';
+            $this->debugLogFile = Factory::getApplication()->get('log_path', JPATH_ADMINISTRATOR . '/logs') . '/j2commerce_install_debug.log';
         }
         file_put_contents($this->debugLogFile, date('[Y-m-d H:i:s] ') . $message . "\n", FILE_APPEND);
     }

--- a/build/script.pkg_j2commerce.php
+++ b/build/script.pkg_j2commerce.php
@@ -107,7 +107,7 @@ class Pkg_J2commerceInstallerScript extends InstallerScript
     private function debugLog(string $message): void
     {
         if (!$this->debugLogFile) {
-            $this->debugLogFile = JPATH_ROOT . '/tmp/j2commerce_install_debug.log';
+            $this->debugLogFile = Factory::getApplication()->get('log_path', JPATH_ADMINISTRATOR . '/logs') . '/j2commerce_install_debug.log';
         }
         file_put_contents($this->debugLogFile, date('[Y-m-d H:i:s] ') . $message . "\n", FILE_APPEND);
     }


### PR DESCRIPTION
## Summary
Fixes #764

## Changes
- Installer debug log now writes to the Joomla-configured `log_path` (defaults to `administrator/logs/`) instead of the hardcoded `tmp/` directory.

## Files Changed
- `administrator/components/com_j2commerce/script.j2commerce.php` — `debugLog()` uses `Factory::getApplication()->get('log_path')` with fallback to `JPATH_ADMINISTRATOR . '/logs'`
- `build/script.pkg_j2commerce.php` — same fix for package installer script

## Testing
1. Install or update the J2Commerce package
2. Confirm `administrator/logs/j2commerce_install_debug.log` is created
3. Confirm `/tmp/j2commerce_install_debug.log` is NOT created

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only