### PR TITLE
fix(email): bind language wildcard via variable to satisfy pass-by-reference

### DIFF
--- a/administrator/components/com_j2commerce/src/Helper/EmailHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/EmailHelper.php
@@ -2225,13 +2225,15 @@ class EmailHelper
                 ->bind(':context', $context);
         }
 
+        $langAll = '*';
+
         if ($language !== '') {
             $query->where($db->quoteName('language') . ' IN (:language, :languageAll)')
                 ->bind(':language', $language)
-                ->bind(':languageAll', '*');
+                ->bind(':languageAll', $langAll);
         } else {
             $query->where($db->quoteName('language') . ' = :languageAll')
-                ->bind(':languageAll', '*');
+                ->bind(':languageAll', $langAll);
         }
 
         $query->order($db->quoteName('ordering') . ' ASC');


### PR DESCRIPTION
## Summary
Fixes a bug in `EmailHelper` where binding the literal string `'*'` directly to a Joomla query parameter caused undefined behavior because `bind()` passes by reference.

## Changes
- Assign `'*'` to `$langAll` variable before binding in both the single-language and all-language query branches

## Files Changed
- `administrator/components/com_j2commerce/src/Helper/EmailHelper.php` — store wildcard in variable before `bind()`

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only