### PR TITLE
fix(inventory): align Save button to center to match Actions header

### DIFF
--- a/administrator/components/com_j2commerce/tmpl/inventory/default.php
+++ b/administrator/components/com_j2commerce/tmpl/inventory/default.php
@@ -381,7 +381,7 @@ document.addEventListener("DOMContentLoaded", function() {
                                             </select>
                                         <?php endif; ?>
                                     </td>
-                                    <td class="text-end inventory-actions">
+                                    <td class="text-center inventory-actions">
                                         <button type="button" class="btn btn-sm btn-primary save-btn" onclick="saveInventoryItem(<?php echo $item->j2commerce_product_id; ?>, <?php echo $item->j2commerce_variant_id ?: 0; ?>)">
                                             <?php echo Text::_('COM_J2COMMERCE_SAVE'); ?>
                                         </button>


### PR DESCRIPTION
## Summary
Fixes #775

## Changes
- Changed `text-end` to `text-center` on the Save button `<td>` in inventory list view so it aligns with the Actions column header

## Files Changed
- `administrator/components/com_j2commerce/tmpl/inventory/default.php` — CSS class fix

## Testing
1. Open J2Commerce → Inventory in the admin
2. Verify the Save button is centered under the Actions header

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only