### PR TITLE
fix(content-plugin): disable product record when article toggled off as product

### DIFF
--- a/administrator/components/com_j2commerce/tmpl/product/form.php
+++ b/administrator/components/com_j2commerce/tmpl/product/form.php
@@ -140,7 +140,7 @@ $wa->addInlineScript($submitButtonJs);
                                         (object) ['value' => 0, 'text' => Text::_('JNO')],
                                         (object) ['value' => 1, 'text' => Text::_('JYES')]
                                     ],
-                                    'onchange' => 'this.form.submit();',
+                                    'onchange' => "Joomla.submitbutton('article.apply');",
                                     'label' => Text::_('COM_J2COMMERCE_TREAT_AS_PRODUCT'),
                                     'disabled' => false,
                                     'readonly' => false,

--- a/plugins/content/j2commerce/src/Extension/J2Commerce.php
+++ b/plugins/content/j2commerce/src/Extension/J2Commerce.php
@@ -388,14 +388,30 @@ final class J2Commerce extends CMSPlugin implements SubscriberInterface
 
         $j2data = $attribs->j2commerce;
 
-        // Check if product is enabled and has a product type
-        if (empty($j2data->enabled) || empty($j2data->product_type)) {
+        // Check if product already exists for this article
+        $existingProduct = $this->getProductBySource('com_content', $articleId);
+
+        // If being disabled, update existing product record and stop
+        if (empty($j2data->enabled)) {
+            if ($existingProduct && !empty($existingProduct->j2commerce_product_id)) {
+                $db        = $this->getDatabase();
+                $productId = (int) $existingProduct->j2commerce_product_id;
+                $query     = $db->getQuery(true)
+                    ->update($db->quoteName('#__j2commerce_products'))
+                    ->set($db->quoteName('enabled') . ' = 0')
+                    ->where($db->quoteName('j2commerce_product_id') . ' = :productId')
+                    ->bind(':productId', $productId, ParameterType::INTEGER);
+                $db->setQuery($query)->execute();
+            }
+
             return;
         }
 
-        // Check if product already exists for this article
-        $existingProduct = $this->getProductBySource('com_content', $articleId);
-        $alreadyExists   = ($existingProduct && !empty($existingProduct->enabled));
+        if (empty($j2data->product_type)) {
+            return;
+        }
+
+        $alreadyExists = ($existingProduct && !empty($existingProduct->enabled));
 
         // Only save if enabled or already exists
         if ($j2data->enabled != 1 && !$alreadyExists) {


### PR DESCRIPTION
## Summary

Fixes #779

Two bugs prevented an article from being returned to a simple (non-product) article:

1. **Article closed immediately on toggle** — the enabled switcher used `this.form.submit()` as its `onchange` handler, which bypassed `Joomla.submitbutton` and submitted the form without `task=article.apply`, causing Joomla to redirect to the article list instead of staying on the edit page.

2. **Product still shown as active** — `onContentAfterSave` returned early when `enabled=0` before checking whether a product record existed. The existing product row in `#__j2commerce_products` stayed `enabled=1`, so re-opening the article showed the product as still active.

## Changes

- `administrator/components/com_j2commerce/tmpl/product/form.php` — change enabled-switcher `onchange` from `this.form.submit()` to `Joomla.submitbutton('article.apply')` so the article saves in place and stays open
- `plugins/content/j2commerce/src/Extension/J2Commerce.php` — move `getProductBySource()` call before the enabled check; when `enabled=0` and a product record exists, run `UPDATE ... SET enabled=0` then return

## Testing

1. Open any article that has a J2Commerce product configured
2. In the J2Commerce tab, toggle "Use as a product" from Yes → No
3. Verify: article stays open (no redirect to list)
4. Save the article via Joomla's Save button
5. Re-open the article → J2Commerce tab should show switcher at "No"

## Files Changed

- `administrator/components/com_j2commerce/tmpl/product/form.php` — switcher onchange fix
- `plugins/content/j2commerce/src/Extension/J2Commerce.php` — disable product on toggle-off

## Pre-Flight

- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only