### PR TITLE
fix(product-filters): align autocomplete dropdown with input field

### DIFF
--- a/administrator/components/com_j2commerce/tmpl/product/form_ajax_avfilter.php
+++ b/administrator/components/com_j2commerce/tmpl/product/form_ajax_avfilter.php
@@ -40,43 +40,43 @@ $productFilters = (new ProductfiltersModel)->getFiltersByProduct($item->j2commer
 
 <input type="hidden" name="<?php echo $formPrefix.'[productfilter_ids]';?>" value="" />
 
-<div class="table-responsive">
-    <table id="product_filters_table" class="table itemList j2commerce">
-        <thead>
+<table id="product_filters_table" class="table itemList j2commerce">
+    <thead>
+    <tr>
+        <th scope="col"><?php echo Text::_('COM_J2COMMERCE_PRODUCT_FILTER_VALUE');?></th>
+        <th scope="col" class="w-1 text-center"><?php echo Text::_('COM_J2COMMERCE_REMOVE');?></th>
+    </tr>
+    </thead>
+    <tbody>
+    <?php if(isset($productFilters) && count($productFilters)): ?>
+        <?php foreach($productFilters as $group_id=>$filters):?>
             <tr>
-                <th scope="col"><?php echo Text::_('COM_J2COMMERCE_PRODUCT_FILTER_VALUE');?></th>
-                <th scope="col" class="w-1 text-center"><?php echo Text::_('COM_J2COMMERCE_REMOVE');?></th>
+                <td colspan="2"><h4 class="mb-0"><?php echo Text::_($this->escape($filters['group_name'])); ?></h4></td>
             </tr>
-        </thead>
-        <tbody>
-        <?php if(isset($productFilters) && count($productFilters)): ?>
-            <?php foreach($productFilters as $group_id=>$filters):?>
-                <tr>
-                    <td colspan="2"><h4 class="mb-0"><?php echo Text::_($this->escape($filters['group_name'])); ?></h4></td>
-                </tr>
-                <?php foreach($filters['filters'] as $filter):
-                    ?>
-                    <tr id="product_filter_current_option_<?php echo $filter->filter_id;?>">
-                        <td class="addedFilter">
-                            <?php echo $this->escape($filter->filter_name) ;?>
-                        </td>
-                        <td class="text-center">
+            <?php foreach($filters['filters'] as $filter):
+                ?>
+                <tr id="product_filter_current_option_<?php echo $filter->filter_id;?>">
+                    <td class="addedFilter">
+                        <?php echo $this->escape($filter->filter_name) ;?>
+                    </td>
+                    <td class="text-center">
                                 <span class="filterRemove" onclick="removeFilter(<?php echo $filter->filter_id; ?>, <?php echo $item->j2commerce_product_id; ?>);">
                                     <span class="icon icon-trash text-danger"></span>
                                 </span>
-                            <input type="hidden" value="<?php echo $filter->filter_id;?>" name="<?php echo $formPrefix.'[productfilter_ids]' ;?>[]" />
-                        </td>
-                    </tr>
-                <?php endforeach;?>
+                        <input type="hidden" value="<?php echo $filter->filter_id;?>" name="<?php echo $formPrefix.'[productfilter_ids]' ;?>[]" />
+                    </td>
+                </tr>
             <?php endforeach;?>
-        <?php endif;?>
-        <tr class="j2commerce_a_filter">
-            <td colspan="2">
-                <small><strong><?php echo Text::_('COM_J2COMMERCE_SEARCH_AND_PRODUCT_FILTERS');?></strong></small>
-                <?php echo LayoutHelper::render('joomla.form.field.text', ['name'  => 'productfilter','id'    => 'J2CommerceproductFilter','value' => '','class' => 'form-control ms-2',] + $textFieldDefaults);?>
-            </td>
-        </tr>
-        </tbody>
-    </table>
-</div>
+        <?php endforeach;?>
+    <?php endif;?>
+    <tr class="j2commerce_a_filter">
+        <td colspan="2">
+            <small><strong><?php echo Text::_('COM_J2COMMERCE_SEARCH_AND_PRODUCT_FILTERS');?></strong></small>
+            <div class="d-inline-block position-relative ms-2">
+                <?php echo LayoutHelper::render('joomla.form.field.text', ['name'  => 'productfilter','id'    => 'J2CommerceproductFilter','value' => '','class' => 'form-control',] + $textFieldDefaults);?>
+            </div>
+        </td>
+    </tr>
+    </tbody>
+</table>
 


### PR DESCRIPTION
## Summary

Fixes #782

The filter search autocomplete dropdown was misaligned — appearing at the label's left edge instead of below the input field. Two issues combined to cause this:

1. The `table-responsive` wrapper's `overflow: auto` was clipping the absolutely-positioned dropdown
2. No `position: relative` ancestor existed near the input, so the autocomplete anchored to a distant ancestor (the left edge of the table/form column, where the label sits)

## Changes

- Removed `<div class="table-responsive">` wrapper to allow the dropdown to render outside the table scroll boundary
- Wrapped the filter search input in `<div class="d-inline-block position-relative ms-2">` to provide a local positioning context directly adjacent to the input
- Moved `ms-2` spacing from the input's class to the wrapper div

## Testing

1. Edit any product → Filters / Specifications tab
2. Type 2+ characters in the "Search and Add Product Filters" input
3. Verify: autocomplete dropdown appears directly below and left-aligned with the input field

## Files Changed

- `administrator/components/com_j2commerce/tmpl/product/form_ajax_avfilter.php` — removed table-responsive, added position-relative wrapper