### PR TITLE
fix(downloads): allow configured image_directories for downloadable product file uploads

### DIFF
--- a/administrator/components/com_j2commerce/src/Controller/MultiimageuploaderController.php
+++ b/administrator/components/com_j2commerce/src/Controller/MultiimageuploaderController.php
@@ -861,11 +861,33 @@ class MultiimageuploaderController extends BaseController
         $path = preg_replace('#/+#', '/', $path);
         $path = trim($path, '/');
 
-        if (!str_starts_with($path, 'images')) {
-            return 'images';
+        // Build allowed roots from J2Commerce configured directories
+        $directories = ComponentHelper::getParams('com_j2commerce')
+            ->get('image_directories', [(object) ['directory' => 'images']]);
+
+        if (\is_string($directories)) {
+            $directories = json_decode($directories);
         }
 
-        return $path;
+        $allowedRoots = [];
+
+        foreach ($directories as $dir) {
+            if (!empty($dir->directory)) {
+                $allowedRoots[] = trim((string) $dir->directory, '/');
+            }
+        }
+
+        if (empty($allowedRoots)) {
+            $allowedRoots[] = 'images';
+        }
+
+        foreach ($allowedRoots as $root) {
+            if ($path === $root || str_starts_with($path, $root . '/')) {
+                return $path;
+            }
+        }
+
+        return $allowedRoots[0];
     }
 
     /** Verify a resolved path is within JPATH_ROOT to prevent traversal attacks. */

--- a/administrator/components/com_j2commerce/tmpl/product/form_downloadablefiles.php
+++ b/administrator/components/com_j2commerce/tmpl/product/form_downloadablefiles.php
@@ -13,6 +13,7 @@
 
 use J2Commerce\Component\J2commerce\Administrator\Field\MultiImageUploaderField;
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
+use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\FileLayout;
@@ -73,6 +74,18 @@ if ($productId) {
     }
 }
 
+// Resolve default upload directory from J2Commerce image_directories config
+$j2cParams      = ComponentHelper::getParams('com_j2commerce');
+$configuredDirs = $j2cParams->get('image_directories', []);
+
+if (\is_string($configuredDirs)) {
+    $configuredDirs = json_decode($configuredDirs, false) ?? [];
+}
+
+$defaultUploadDir = !empty($configuredDirs) && !empty($configuredDirs[0]->directory)
+    ? trim((string) $configuredDirs[0]->directory, '/')
+    : 'images/downloads';
+
 $layoutPath = JPATH_ADMINISTRATOR . '/components/com_j2commerce/layouts';
 ?>
 
@@ -114,7 +127,7 @@ $layoutPath = JPATH_ADMINISTRATOR . '/components/com_j2commerce/layouts';
                             'enableCompression' => false,
                             'enableImageEditor' => false,
                             'autoThumbnail'     => false,
-                            'directory'         => 'images/downloads',
+                            'directory'         => $defaultUploadDir,
                             'multiple'          => true,
                             'endpoint'          => 'index.php?option=com_j2commerce&task=multiimageuploader.upload&format=json',
                             'formPrefix'        => $formPrefix,


### PR DESCRIPTION
## Summary

Fixes #778

Downloadable product file uploads were hardcoded to only accept paths starting with `images/`, blocking any custom directory a user configured in J2Commerce. The folder dropdown (already driven by `image_directories` config) showed configured directories correctly, but uploads and file browsing silently fell back to `images`.

## Changes

- `MultiimageuploaderController::sanitizePath()` — replaced hardcoded `str_starts_with($path, 'images')` guard with a dynamic check against `image_directories` from J2Commerce component params. Paths outside any configured root fall back to the first configured root.
- `form_downloadablefiles.php` — replaced hardcoded `'directory' => 'images/downloads'` with the first configured directory from `image_directories` (fallback: `'images/downloads'` when unconfigured).

The `folders()` task already returned configured directories to the JS dropdown — uploads and browsing now respect the same configuration.

## Testing

1. Go to **Components > J2Commerce > Configuration**, add a directory (e.g. `downloads`) under Image Directories
2. Edit a downloadable product and open the **Files** tab
3. Verify the folder selector defaults to `downloads`
4. Upload a file — confirm it lands in `downloads/` on disk
5. **Regression:** with no custom directory configured, upload should still work to `images`

## Files Changed

| File | Change |
|------|--------|
| `administrator/components/com_j2commerce/src/Controller/MultiimageuploaderController.php` | `sanitizePath()` validates against configured dirs |
| `administrator/components/com_j2commerce/tmpl/product/form_downloadablefiles.php` | Default upload dir from component config |

## Pre-Flight

- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only