### PR TITLE
feat(schema): multi-token paymentprofiles

### DIFF
--- a/administrator/components/com_j2commerce/sql/updates/mysql/6.2.2-2026-04-16.sql
+++ b/administrator/components/com_j2commerce/sql/updates/mysql/6.2.2-2026-04-16.sql
@@ -1,0 +1,19 @@
+--
+-- Extend paymentprofiles to support multiple stored payment tokens per user.
+-- Adds payment_token (e.g. Square card_id), token_label (display string), and
+-- is_renewal_default flag. The customer-anchor row keeps payment_token = ''.
+-- A unique key on (user_id, provider, environment, payment_token) enforces one
+-- customer row per user and one row per distinct card token.
+--
+
+ALTER TABLE `#__j2commerce_paymentprofiles`
+    ADD COLUMN `payment_token`      VARCHAR(100) NOT NULL DEFAULT ''
+        AFTER `customer_profile_id`,
+    ADD COLUMN `token_label`        VARCHAR(100) NOT NULL DEFAULT ''
+        AFTER `payment_token`,
+    ADD COLUMN `is_renewal_default` TINYINT UNSIGNED NOT NULL DEFAULT 0
+        AFTER `token_label`;
+
+ALTER TABLE `#__j2commerce_paymentprofiles`
+    ADD UNIQUE KEY `uq_user_provider_env_token`
+        (`user_id`, `provider`, `environment`, `payment_token`);

--- a/administrator/components/com_j2commerce/sql/updates/mysql/6.2.2-2026-04-17.sql
+++ b/administrator/components/com_j2commerce/sql/updates/mysql/6.2.2-2026-04-17.sql
@@ -1,0 +1,20 @@
+--
+-- Multi-token paymentprofiles cleanup.
+-- 1. Backfill any NULL payment_token values to '' so customer-anchor rows match
+--    the `payment_token = ''` filter used by payment plugins.
+-- 2. Force payment_token to NOT NULL DEFAULT '' (matches 6.2.2-2026-04-16.sql intent;
+--    the earlier migration left it nullable on installs that pre-dated the change).
+-- 3. Drop the legacy 3-column unique index `idx_user_provider_env`; the 4-column
+--    `uq_user_provider_env_token` replaces it and allows one customer-anchor row
+--    plus N card-token rows per (user, provider, environment).
+--
+
+UPDATE `#__j2commerce_paymentprofiles`
+    SET `payment_token` = ''
+    WHERE `payment_token` IS NULL;
+
+ALTER TABLE `#__j2commerce_paymentprofiles`
+    MODIFY `payment_token` VARCHAR(100) NOT NULL DEFAULT '';
+
+ALTER TABLE `#__j2commerce_paymentprofiles`
+    DROP INDEX `idx_user_provider_env`;


### PR DESCRIPTION
## Summary
- Add `payment_token`, `token_label`, `is_renewal_default` columns to `#__j2commerce_paymentprofiles` — one user can now store multiple cards per provider while keeping a customer-anchor row.
- Replace 3-column `idx_user_provider_env` with 4-column `uq_user_provider_env_token` unique index.
- Backfill NULL `payment_token` to `''` and force `NOT NULL DEFAULT ''`.

Split out of #788 so the schema lands independently of the unrelated plugin infra changes that may be reverted.

## Test plan
- [ ] Apply `6.2.2-2026-04-16.sql` then `6.2.2-2026-04-17.sql` on an existing 6.2.2 database
- [ ] Confirm `payment_token`, `token_label`, `is_renewal_default` columns exist
- [ ] Confirm `uq_user_provider_env_token` unique index exists and `idx_user_provider_env` is gone
- [ ] Confirm any pre-existing NULL `payment_token` rows are now `''`