### PR TITLE
fix(inventory): remove unreachable dead code block

### DIFF
--- a/administrator/components/com_j2commerce/tmpl/inventory/default.php
+++ b/administrator/components/com_j2commerce/tmpl/inventory/default.php
@@ -32,14 +32,6 @@ $wa->useScript('core')
 
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
-// Inventory view does not support manual ordering, so disable draggable functionality
-$saveOrder = false;
-
-if ($saveOrder && !empty($this->items)) {
-    $saveOrderingUrl = 'index.php?option=com_j2commerce&task=inventory.saveOrderAjax&tmpl=component&' . Session::getFormToken() . '=1';
-    HTMLHelper::_('draggablelist.draggable');
-}
-
 // Add custom CSS and JavaScript for inventory management
 $wa->addInlineStyle('
 .inventory-row { border-bottom: 1px solid #ddd; }


### PR DESCRIPTION
## Summary

Fixes #793

Removes dead code from the inventory template. `$saveOrder` was hardcoded `false` with a comment explaining that the inventory view does not support manual ordering — making the `if ($saveOrder && ...)` block that followed permanently unreachable.

## Changes

- Removed `$saveOrder = false` variable and its comment
- Removed the unreachable `if` block (draggableList setup)

## Testing

1. Navigate to J2Commerce > Inventory in admin
2. Verify page loads without errors
3. Confirm no draggable ordering UI appears

## Files Changed

- `administrator/components/com_j2commerce/tmpl/inventory/default.php` — removed 8 lines of unreachable dead code

## Pre-Flight

- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only