### PR TITLE
Hide order status column on small screens for improved responsiveness

### DIFF
--- a/administrator/modules/mod_j2commerce_orders/tmpl/default.php
+++ b/administrator/modules/mod_j2commerce_orders/tmpl/default.php
@@ -32,7 +32,7 @@ if (empty($orders)) {
             <th scope="col"><?php echo Text::_('COM_J2COMMERCE_HEADING_ORDER'); ?></th>
             <th scope="col" class="d-none d-lg-table-cell"><?php echo Text::_('COM_J2COMMERCE_HEADING_DATE'); ?></th>
             <th scope="col"><?php echo Text::_('COM_J2COMMERCE_HEADING_CUSTOMER'); ?></th>
-            <th scope="col" class="text-center"><?php echo Text::_('COM_J2COMMERCE_HEADING_STATUS'); ?></th>
+            <th scope="col" class="d-none d-lg-table-cell text-center"><?php echo Text::_('COM_J2COMMERCE_HEADING_STATUS'); ?></th>
             <th scope="col" class="text-end"><?php echo Text::_('COM_J2COMMERCE_HEADING_TOTAL'); ?></th>
         </tr>
         </thead>
@@ -56,7 +56,7 @@ if (empty($orders)) {
                 <td>
                     <small><?php echo htmlspecialchars($customerName, ENT_QUOTES, 'UTF-8'); ?></small>
                 </td>
-                <td class="text-center">
+                <td class="d-none d-lg-table-cell text-center">
                     <span class="order-status-badge <?php echo htmlspecialchars($order->orderstatus_cssclass ?? 'badge text-bg-secondary', ENT_QUOTES, 'UTF-8'); ?>">
                         <?php echo Text::_($order->orderstatus_name ?? 'COM_J2COMMERCE_UNKNOWN'); ?>
                     </span>


### PR DESCRIPTION
## Before
<img width="699" height="764" alt="image" src="https://github.com/user-attachments/assets/71fce3ab-6cb0-4b0a-b6d5-17136cd1bd7c" />

## After

<img width="803" height="740" alt="image" src="https://github.com/user-attachments/assets/10be583a-4245-41dd-8a95-34e5e37af561" />
