### PR TITLE
Hide product thumbnail on small screens in product table view

### DIFF
--- a/administrator/components/com_j2commerce/tmpl/products/default.php
+++ b/administrator/components/com_j2commerce/tmpl/products/default.php
@@ -142,7 +142,7 @@ $canChangeState = $user->authorise('core.edit.state', 'com_content');
                                 <th scope="row">
                                     <div class="d-flex align-items-start">
                                         <?php if ($hasImage) : ?>
-                                            <div class="me-3 flex-shrink-0">
+                                            <div class="me-3 flex-shrink-0 d-none d-lg-inline-flex">
                                                 <img src="<?php echo Uri::root() . $thumbImage; ?>"
                                                      alt="<?php echo $this->escape($item->product_name); ?>"
                                                      class="img-fluid"


### PR DESCRIPTION
PLEASE check this - it works but I am not 100% I got the correct bootstrap class

## Before
<img width="766" height="710" alt="image" src="https://github.com/user-attachments/assets/62a6bf09-f60d-4448-b3d8-f413af0c487b" />

## After
<img width="656" height="785" alt="image" src="https://github.com/user-attachments/assets/90c6af20-f2a7-480f-ba8f-c61802f059f3" />
