### PR TITLE
fix(schema): remove blind DROP INDEX that breaks 6.2.2 install

### DIFF
--- a/administrator/components/com_j2commerce/sql/install.mysql.utf8.sql
+++ b/administrator/components/com_j2commerce/sql/install.mysql.utf8.sql
@@ -949,12 +949,15 @@ CREATE TABLE IF NOT EXISTS `#__j2commerce_paymentprofiles` (
   `user_id` int NOT NULL,
   `provider` varchar(50) NOT NULL DEFAULT 'authorizenet',
   `customer_profile_id` varchar(50) NOT NULL,
+  `payment_token` varchar(100) NOT NULL DEFAULT '',
+  `token_label` varchar(100) NOT NULL DEFAULT '',
+  `is_renewal_default` tinyint unsigned NOT NULL DEFAULT 0,
   `environment` varchar(10) NOT NULL DEFAULT 'production',
   `is_default` tinyint unsigned NOT NULL DEFAULT 0,
   `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
-  KEY `idx_user_id` (`user_id`),
+  UNIQUE KEY `uq_user_provider_env_token` (`user_id`,`provider`,`environment`,`payment_token`),
   KEY `idx_customer_profile_id` (`customer_profile_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
 

--- a/administrator/components/com_j2commerce/sql/updates/mysql/6.2.2-2026-04-17.sql
+++ b/administrator/components/com_j2commerce/sql/updates/mysql/6.2.2-2026-04-17.sql
@@ -1,20 +1,6 @@
---
--- Multi-token paymentprofiles cleanup.
--- 1. Backfill any NULL payment_token values to '' so customer-anchor rows match
---    the `payment_token = ''` filter used by payment plugins.
--- 2. Force payment_token to NOT NULL DEFAULT '' (matches 6.2.2-2026-04-16.sql intent;
---    the earlier migration left it nullable on installs that pre-dated the change).
--- 3. Drop the legacy 3-column unique index `idx_user_provider_env`; the 4-column
---    `uq_user_provider_env_token` replaces it and allows one customer-anchor row
---    plus N card-token rows per (user, provider, environment).
---
-
 UPDATE `#__j2commerce_paymentprofiles`
     SET `payment_token` = ''
     WHERE `payment_token` IS NULL;
 
 ALTER TABLE `#__j2commerce_paymentprofiles`
     MODIFY `payment_token` VARCHAR(100) NOT NULL DEFAULT '';
-
-ALTER TABLE `#__j2commerce_paymentprofiles`
-    DROP INDEX `idx_user_provider_env`;


### PR DESCRIPTION
## Summary

The `6.2.2-2026-04-17.sql` migration contained an unguarded `DROP INDEX idx_user_provider_env` on `#__j2commerce_paymentprofiles`. That index was never created by any released migration or `install.mysql.utf8.sql`. As a result, every install/update to 6.2.2 fails with:

```
JInstaller::Install: Error SQL Can't DROP INDEX `idx_user_provider_env`; check that it exists
```

## Root Cause

- `6.2.2-2026-04-16.sql` (the prior migration in this series) creates the new 4-column `uq_user_provider_env_token` directly via `ADD UNIQUE KEY` — it does not first create `idx_user_provider_env`.
- `install.mysql.utf8.sql` has never created `idx_user_provider_env` either.
- Git history confirmed via `git log -p -S 'idx_user_provider_env'` — the index only ever appears in the drop statement, never in a create statement.

The 04-17 migration comment referenced "an earlier migration" that simply does not exist.

## Fix

1. **`6.2.2-2026-04-17.sql`** — removed the bogus `DROP INDEX`. Kept the idempotent `UPDATE` + `MODIFY payment_token` as a safety net on databases where an intermediate dev build may have left `payment_token` nullable.
2. **`install.mysql.utf8.sql`** — synced `#__j2commerce_paymentprofiles` `CREATE TABLE` with the post-migration state:
   - Added `payment_token`, `token_label`, `is_renewal_default` columns.
   - Added the 4-column `uq_user_provider_env_token` unique key.
   - Dropped `idx_user_id` because the new unique key already covers `user_id` as the leftmost prefix.

## Recovery Path

Existing sites stuck on the failed install: `#__schemas.version_id` remains at `6.2.2-2026-04-16` because Joomla only stamps the schema version after a migration file completes without error. Re-running the installer with this fix applies 04-17 cleanly (`UPDATE` + `MODIFY` are idempotent). No manual SQL required.

## Test Plan

- [x] Fresh install on empty Joomla 6 DB — `#__j2commerce_paymentprofiles` created with new columns + unique key
- [x] Existing 6.2.1 install upgraded to 6.2.2 — no error; `payment_token = ''` backfill confirmed
- [x] Re-running installer is idempotent (no duplicate-column / duplicate-key errors on the 04-17 file)
- [x] PHP syntax clean on all changed files
- [x] No non-core files included