### PR TITLE
fix(report): add SKU column to itemised report CSV export

### DIFF
--- a/plugins/j2commerce/report_itemised/src/Extension/ReportItemised.php
+++ b/plugins/j2commerce/report_itemised/src/Extension/ReportItemised.php
@@ -322,6 +322,7 @@ final class ReportItemised extends CMSPlugin implements SubscriberInterface
 
         $productIdCol = Text::_('PLG_J2COMMERCE_REPORT_ITEMISED_COL_PRODUCT_ID');
         $nameCol      = Text::_('PLG_J2COMMERCE_REPORT_ITEMISED_COL_PRODUCT_NAME');
+        $skuCol       = Text::_('PLG_J2COMMERCE_REPORT_ITEMISED_COL_SKU');
         $optionsCol   = Text::_('PLG_J2COMMERCE_REPORT_ITEMISED_COL_OPTIONS');
         $categoryCol  = Text::_('PLG_J2COMMERCE_REPORT_ITEMISED_COL_CATEGORY');
         $qtyCol       = Text::_('PLG_J2COMMERCE_REPORT_ITEMISED_COL_QUANTITY');
@@ -351,6 +352,7 @@ final class ReportItemised extends CMSPlugin implements SubscriberInterface
             $csvRow                = new \stdClass();
             $csvRow->$productIdCol = $item->product_id;
             $csvRow->$nameCol      = $item->orderitem_name;
+            $csvRow->$skuCol       = $item->orderitem_sku ?? '';
             $csvRow->$optionsCol   = $optionStr;
             $csvRow->$categoryCol  = $item->category_name ?? '';
             $csvRow->$qtyCol       = $item->total_qty;
@@ -362,6 +364,7 @@ final class ReportItemised extends CMSPlugin implements SubscriberInterface
         $finalRow                = new \stdClass();
         $finalRow->$productIdCol = '';
         $finalRow->$nameCol      = Text::_('PLG_J2COMMERCE_REPORT_ITEMISED_TOTAL');
+        $finalRow->$skuCol       = '';
         $finalRow->$optionsCol   = '';
         $finalRow->$categoryCol  = '';
         $finalRow->$qtyCol       = $qtyTotal;


### PR DESCRIPTION
## Summary
Fixes #802

The on-screen itemised report displays the SKU below each product name, but the CSV export omitted it. This adds a SKU column between Product Name and Options in the exported file.

## Changes
- Added `$skuCol` variable in `buildExportData()` using the existing `PLG_J2COMMERCE_REPORT_ITEMISED_COL_SKU` language key
- Set `$csvRow->$skuCol = $item->orderitem_sku ?? ''` for each data row
- Set `$finalRow->$skuCol = ''` for the totals row

## Files Changed
- `plugins/j2commerce/report_itemised/src/Extension/ReportItemised.php` — 3 lines added

## Testing
1. Admin → J2Commerce → Reports → Itemised Report
2. Click Export CSV
3. Verify SKU column appears between "Product Name" and "Options" columns with correct values

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only