### PR TITLE
fix(vouchers): add migration for missing valid_from / valid_to columns

### DIFF
--- a/administrator/components/com_j2commerce/sql/updates/mysql/6.2.2-2026-04-20.sql
+++ b/administrator/components/com_j2commerce/sql/updates/mysql/6.2.2-2026-04-20.sql
@@ -1,0 +1,11 @@
+--
+-- Add valid_from and valid_to columns to vouchers table.
+-- These were missing from early install SQL so upgraders never got them.
+-- Fresh installs already have them; ALTER will no-op on those sites.
+--
+
+ALTER TABLE `#__j2commerce_vouchers`
+    ADD COLUMN `valid_from` datetime DEFAULT NULL AFTER `email_body`;
+
+ALTER TABLE `#__j2commerce_vouchers`
+    ADD COLUMN `valid_to` datetime DEFAULT NULL AFTER `valid_from`;


### PR DESCRIPTION
## Core Update

### Problem
Sites that installed J2Commerce before `valid_from` and `valid_to` were added to the vouchers install SQL received a 500 error when visiting the Vouchers admin list:

```
Unknown column 'a.valid_from' in 'SELECT'
```

The `VouchersModel` selects these columns in every query, but no upgrade migration existed to add them to existing installations.

### Changes
- Added `sql/updates/mysql/6.2.2-2026-04-20.sql` — adds `valid_from` and `valid_to` to `#__j2commerce_vouchers` for upgraders

### Files Modified
| Type | Count |
|------|-------|
| SQL migration | 1 |

### Pre-Flight
- [x] PHP syntax check passed (SQL file only)
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only (`build/build_pkg_j2connections.php` excluded)