### PR TITLE
fix(reports): improve mobile layout for itemised and products reports

### DIFF
--- a/plugins/j2commerce/report_itemised/tmpl/report.php
+++ b/plugins/j2commerce/report_itemised/tmpl/report.php
@@ -42,7 +42,7 @@ $listDirn    = $vars->listDirn;
             <thead>
                 <tr>
                     <th scope="col" class="w-1 text-center">#</th>
-                    <th scope="col" class="w-5">
+                    <th scope="col" class="w-5 d-none d-md-table-cell">
                         <?php echo HTMLHelper::_('searchtools.sort',
                             'PLG_J2COMMERCE_REPORT_ITEMISED_COL_PRODUCT_ID',
                             'oi.product_id', $listDirn, $listOrder); ?>
@@ -83,7 +83,7 @@ $listDirn    = $vars->listDirn;
                         ?>
                         <tr>
                             <td class="text-center"><?php echo $i + 1; ?></td>
-                            <td><?php echo (int) $item->product_id; ?></td>
+                            <td class="d-none d-md-table-cell"><?php echo (int) $item->product_id; ?></td>
                             <td>
                                 <?php echo htmlspecialchars($item->orderitem_name, ENT_QUOTES, 'UTF-8'); ?>
                                 <?php if (!empty($item->orderitem_sku)) : ?>
@@ -110,7 +110,9 @@ $listDirn    = $vars->listDirn;
                         </tr>
                     <?php endforeach; ?>
                     <tr class="fw-bold">
-                        <td colspan="5"><?php echo Text::_('PLG_J2COMMERCE_REPORT_ITEMISED_TOTAL'); ?></td>
+                        <td colspan="3"><?php echo Text::_('PLG_J2COMMERCE_REPORT_ITEMISED_TOTAL'); ?></td>
+                        <td class="d-none d-md-table-cell"></td>
+                        <td class="d-none d-md-table-cell"></td>
                         <td class="text-end"><?php echo $qtyTotal; ?></td>
                         <td class="text-end"><?php echo $orderTotal; ?></td>
                     </tr>

--- a/plugins/j2commerce/report_products/tmpl/report.php
+++ b/plugins/j2commerce/report_products/tmpl/report.php
@@ -45,7 +45,7 @@ $listDirn    = $vars->listDirn;
                     <th scope="col">
                         <?php echo HTMLHelper::_('searchtools.sort', 'PLG_J2COMMERCE_REPORT_PRODUCTS_PRODUCT_NAME', 'orderitem_name', $listDirn, $listOrder); ?>
                     </th>
-                    <th scope="col" class="w-10">
+                    <th scope="col" class="w-10 d-none d-md-table-cell">
                         <?php echo HTMLHelper::_('searchtools.sort', 'PLG_J2COMMERCE_REPORT_PRODUCTS_TOTAL_QUANTITY', 'total_qty', $listDirn, $listOrder); ?>
                     </th>
                     <th scope="col" class="w-10 d-none d-md-table-cell">
@@ -84,7 +84,7 @@ $listDirn    = $vars->listDirn;
                                 <?php echo htmlspecialchars($product->orderitem_name, ENT_QUOTES, 'UTF-8'); ?>
                                 <small class="text-muted d-block lh-1"><?php echo Text::_('PLG_J2COMMERCE_REPORT_PRODUCTS_SKU'); ?>: <?php echo htmlspecialchars($product->orderitem_sku, ENT_QUOTES, 'UTF-8'); ?></small>
                             </td>
-                            <td class="text-start"><?php echo (int) $product->total_qty; ?></td>
+                            <td class="text-start d-none d-md-table-cell"><?php echo (int) $product->total_qty; ?></td>
                             <td class="text-start d-none d-md-table-cell"><?php echo $currency->format((float) $product->total_item_discount + (float) $product->total_item_discount_tax); ?></td>
                             <td class="text-start d-none d-md-table-cell"><?php echo $currency->format((float) $product->total_item_tax); ?></td>
                             <td class="text-start d-none d-lg-table-cell"><?php echo $currency->format((float) $product->total_final_price_without_tax); ?></td>
@@ -93,7 +93,7 @@ $listDirn    = $vars->listDirn;
                     <?php endforeach; ?>
                     <tr class="fw-bold">
                         <td><?php echo Text::_('PLG_J2COMMERCE_REPORT_PRODUCTS_TOTAL'); ?></td>
-                        <td class="text-start"><?php echo $qtyTotal; ?></td>
+                        <td class="text-start d-none d-md-table-cell"><?php echo $qtyTotal; ?></td>
                         <td class="text-start d-none d-md-table-cell"><?php echo $currency->format($discountTotal); ?></td>
                         <td class="text-start d-none d-md-table-cell"><?php echo $currency->format($totalTax); ?></td>
                         <td class="text-start d-none d-lg-table-cell"><?php echo $currency->format($totalWithoutTax); ?></td>


### PR DESCRIPTION
## Summary
Fixes #797

## Changes
- **Itemised report**: hide `product_id` column on mobile (`d-none d-md-table-cell`); fix totals row from broken `colspan="5"` to `colspan="3"` with explicit empty hidden cells matching the responsive column structure
- **Products report**: hide `total_qty` column on mobile so only Product Name and With Tax price are visible — ensures price data is always visible without horizontal scrolling

## Mobile result
- Itemised (mobile): `#` | Product Name | Qty | Purchases — totals row aligns correctly
- Products (mobile): Product Name | Price (with tax) — price always visible

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only

## Files Changed
- `plugins/j2commerce/report_itemised/tmpl/report.php`
- `plugins/j2commerce/report_products/tmpl/report.php`