### PR TITLE
fix(downloadables): surface upload rejections and tighten file-type restriction

### DIFF
--- a/administrator/components/com_j2commerce/tmpl/product/form_downloadablefiles.php
+++ b/administrator/components/com_j2commerce/tmpl/product/form_downloadablefiles.php
@@ -11,6 +11,7 @@
 \defined('_JEXEC') or die;
 // phpcs:enable PSR1.Files.SideEffects
 
+use J2Commerce\Component\J2commerce\Administrator\Controller\MultiimageuploaderController;
 use J2Commerce\Component\J2commerce\Administrator\Field\MultiImageUploaderField;
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 use Joomla\CMS\Component\ComponentHelper;
@@ -105,25 +106,15 @@ $layoutPath = JPATH_ADMINISTRATOR . '/components/com_j2commerce/layouts';
                         'value'    => $filesData,
                         'options'  => [
                             'maxFileSize'      => 100 * 1024 * 1024, // 100MB for downloadable files
-                            'allowedFileTypes' => [
-                                'audio/*', 'video/*',
-                                'image/jpeg', 'image/png', 'image/gif', 'image/webp', 'image/avif', 'image/tiff', 'image/bmp',
-                                'application/pdf', 'application/epub+zip', 'application/x-mobipocket-ebook',
-                                'application/zip', 'application/x-7z-compressed', 'application/x-rar-compressed',
-                                'application/x-tar', 'application/gzip',
-                                'application/msword',
-                                'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-                                'application/vnd.ms-excel',
-                                'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-                                'application/vnd.ms-powerpoint',
-                                'application/vnd.openxmlformats-officedocument.presentationml.presentation',
-                                'application/vnd.oasis.opendocument.text',
-                                'application/vnd.oasis.opendocument.spreadsheet',
-                                'application/vnd.oasis.opendocument.presentation',
-                                'text/plain', 'text/csv', 'text/markdown', 'text/rtf',
-                                'font/ttf', 'font/otf', 'font/woff', 'font/woff2',
-                                'application/octet-stream',
-                            ],
+                            // Mirror the server's FILE_ALLOWLIST as dotted extensions so the
+                            // browser's file picker defaults to these formats and Uppy's
+                            // client-side restriction rejects anything the server would also
+                            // reject — no more `application/octet-stream` catch-all that let
+                            // .exe/.bin slip past client validation.
+                            'allowedFileTypes' => array_values(array_map(
+                                static fn (string $ext): string => '.' . $ext,
+                                MultiimageuploaderController::FILE_ALLOWLIST
+                            )),
                             'enableCompression' => false,
                             'enableImageEditor' => false,
                             'autoThumbnail'     => false,

--- a/media/com_j2commerce/js/administrator/multiimageuploader.js
+++ b/media/com_j2commerce/js/administrator/multiimageuploader.js
@@ -290,26 +290,22 @@
                 allowedMetaFields: allowedMeta,
                 headers: { 'Accept': 'application/json' },
                 getResponseData: (xhr) => {
+                    let json;
                     try {
-                        const text = xhr.responseText;
-                        const json = JSON.parse(text);
-
-                        if (!json.success) {
-                            console.error('[MultiImageUploader] Server error:', json.message);
-                            return {};
-                        }
-
-                        const inner = json.data;
-                        if (!inner) {
-                            return {};
-                        }
-
-                        // inner is { name, path, url, ... }
-                        return inner;
+                        json = JSON.parse(xhr.responseText);
                     } catch (e) {
-                        console.error('[MultiImageUploader] getResponseData error:', e);
-                        return {};
+                        throw new Error(this.getText('COM_J2COMMERCE_MULTIIMAGEUPLOADER_UPLOAD_ERROR'));
                     }
+
+                    // Server-side validation rejected the file (forbidden extension,
+                    // dangerous MIME, etc.). Throwing here makes Uppy treat it as a
+                    // failed upload so `upload-error` fires with the real message
+                    // and the file never lands in the success grid.
+                    if (!json.success) {
+                        throw new Error(json.message || this.getText('COM_J2COMMERCE_MULTIIMAGEUPLOADER_UPLOAD_ERROR'));
+                    }
+
+                    return json.data || {};
                 },
             });
 


### PR DESCRIPTION
## Summary

Fixes #760

When an admin tries to upload a forbidden file (e.g. `.exe`) from the Downloadable Files tab, the server correctly blocks it but the UI showed the upload as successful. The file never lands on disk, which is only noticed later when reopening the product and finding it missing.

Two issues caused this:

1. `multiimageuploader.js` `getResponseData()` returned `{}` when the server replied `{success:false, message:\"…\"}`. Uppy treated the empty object as a successful upload — fired `upload-success`, added the file to the grid, then showed the green "Upload successful" toast. The server's rejection reason was only `console.error`-logged.
2. `form_downloadablefiles.php` passed Uppy a loose MIME list that included `application/octet-stream` — the generic binary type that browsers report for `.exe`/`.bin` — so Uppy's client-side restriction never caught executables before the upload attempt. The list also drifted away from the server's `FILE_ALLOWLIST`.

## Changes

- `multiimageuploader.js`: `getResponseData()` now `throw`s on `json.success === false`. Uppy fires `upload-error` instead of `upload-success`, the existing `Joomla.renderMessages({error:[…]})` handler displays the server's real message, and the file never hits the grid. The green "Upload successful" toast only fires when at least one file genuinely succeeded, which was already the case.
- `form_downloadablefiles.php`: `allowedFileTypes` is now derived from `MultiimageuploaderController::FILE_ALLOWLIST` as dotted extensions (`.mp3`, `.pdf`, `.zip`, …). The browser's file picker defaults to these formats, Uppy's client-side restriction rejects anything else with a clear message, and the client/server allowlists can't drift apart again.

## Testing

1. Open a downloadable product in the J2Commerce admin, go to the **Files** tab, and click **Add Product Files**. The file picker defaults to the allowlisted extensions.
2. Switch the picker's filter to "All files" and choose an `.exe` — Uppy rejects it client-side with "You can only upload: .mp3, .wav, …". No upload attempt, no file in grid.
3. Rename `evil.exe` → `evil.mp3.exe` to bypass client validation. Server rejects, the Joomla message bar shows "File type not allowed for security reasons", and the file does **not** appear in the grid. The green "Upload successful" toast does **not** appear.
4. Upload a real `.pdf` — succeeds, persists after reopening the product.
5. Regression: Product Images tab still rejects non-image uploads cleanly with the server message surfaced to the UI.

## Files Changed

- `administrator/components/com_j2commerce/tmpl/product/form_downloadablefiles.php` — derive `allowedFileTypes` from `FILE_ALLOWLIST` as dotted extensions.
- `media/com_j2commerce/js/administrator/multiimageuploader.js` — throw in `getResponseData()` on `success:false` so `upload-error` fires with the real message.