### PR TITLE
feat(report_itemised): register media/images folder in manifest XML

### DIFF
--- a/plugins/j2commerce/report_itemised/report_itemised.xml
+++ b/plugins/j2commerce/report_itemised/report_itemised.xml
@@ -61,6 +61,10 @@
         <language tag="zh-TW">zh-TW/plg_j2commerce_report_itemised.sys.ini</language>
     </languages>
 
+    <media folder="media" destination="plg_j2commerce_report_itemised">
+        <folder>images</folder>
+    </media>
+
     <config>
         <fields name="params"
                 addfieldprefix="J2Commerce\Plugin\J2Commerce\ReportItemised\Field">


### PR DESCRIPTION
## Core Update

### Changes
- Added `<media folder="media" destination="plg_j2commerce_report_itemised">` block to `report_itemised.xml` so the plugin's `media/images/` directory is correctly registered and installed.

### Files Modified
| Type | Count |
|------|-------|
| XML/Config | 1 |

### Pre-Flight
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only (non-core excluded)