### PR TITLE
chore(vendors): always show vendor status in build output

### DIFF
--- a/build/check_vendors.php
+++ b/build/check_vendors.php
@@ -145,11 +145,14 @@ function runBuildCheck(): void
         return;
     }
 
-    $outdated = [];
+    $outdated  = [];
+    $upToDate  = [];
+    $total     = count($manifest['vendors']);
 
     foreach ($manifest['vendors'] as $vendor) {
         $latest = fetchLatestVersion($vendor['npm']);
         if ($latest === null || $latest === $vendor['version']) {
+            $upToDate[] = $vendor['name'];
             continue;
         }
         $outdated[] = sprintf(
@@ -160,16 +163,24 @@ function runBuildCheck(): void
         );
     }
 
+    $line = str_repeat('─', 62);
+
     if (empty($outdated)) {
+        $checked = count($upToDate);
+        echo "Vendors: {$checked}/{$total} up to date\n";
         return;
     }
 
-    $line = str_repeat('─', 62);
+    $upToDateCount = count($upToDate);
     echo "\n┌{$line}┐\n";
     echo "│  ⚠  VENDOR LIBRARIES HAVE UPDATES AVAILABLE" . str_repeat(' ', 16) . "│\n";
     echo "├{$line}┤\n";
     foreach ($outdated as $row) {
         echo "│" . str_pad($row, 62) . "│\n";
+    }
+    if ($upToDateCount > 0) {
+        $okLine = "  {$upToDateCount} other " . ($upToDateCount === 1 ? 'library' : 'libraries') . " up to date";
+        echo "│" . str_pad($okLine, 62) . "│\n";
     }
     echo "├{$line}┤\n";
     echo "│  To update, run:                                             │\n";


### PR DESCRIPTION
## Summary

Follow-up to #811 (merged).

`--build-check` was silent when all vendors were up to date, so running `package j2commerce` gave no indication the check had run.

## Change

`build/check_vendors.php --build-check` now always prints a one-line summary:

```
Vendors: 9/9 up to date
```

When updates are available, it still prints the full warning box with the outdated list and update instructions.

## Files Changed

- `build/check_vendors.php` — always emit vendor status line in `--build-check` mode

## Pre-Flight

- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only