### PR TITLE
fix(images): enable drag-and-drop onto product image upload zone

### DIFF
--- a/media/com_j2commerce/css/administrator/multiimageuploader.css
+++ b/media/com_j2commerce/css/administrator/multiimageuploader.css
@@ -630,7 +630,13 @@
     transition: border-color 0.15s ease, background-color 0.15s ease;
 }
 
-.uppymedia-empty-state:hover {
+.uppymedia-empty-state:hover,
+.uppymedia-empty-state.drag-over {
+    border-color: var(--bs-primary, #0d6efd);
+    background: #f0f4ff;
+}
+
+.uppymedia-add-more.drag-over {
     border-color: var(--bs-primary, #0d6efd);
     background: #f0f4ff;
 }

--- a/media/com_j2commerce/js/administrator/multiimageuploader.js
+++ b/media/com_j2commerce/js/administrator/multiimageuploader.js
@@ -37,6 +37,7 @@
             this.modalEl = null;
             this.bsModal = null;
             this.csrfToken = this.findCsrfToken();
+            this.pendingDropFiles = [];
 
             this.init();
         }
@@ -95,6 +96,7 @@
 
             this.setupModalHandlers();
             this.setupPreviewHandlers();
+            this.setupDropZone();
             this.renderSelectedImages();
 
             // Sync existing images to form inputs on load so saving
@@ -124,6 +126,18 @@
                     }
                 });
                 this.loadFolderContents(this.currentFolder);
+
+                // Add any files that were drag-and-dropped before the modal opened
+                if (this.pendingDropFiles.length > 0) {
+                    const filesToAdd = this.pendingDropFiles.splice(0);
+                    filesToAdd.forEach(file => {
+                        try {
+                            this.uppy.addFile({ name: file.name, type: file.type, data: file });
+                        } catch (err) {
+                            console.warn('Could not add dragged file to Uppy:', err);
+                        }
+                    });
+                }
             });
 
             // Clean up Uppy selections when modal closes without confirming
@@ -777,6 +791,65 @@
                     this.moveImage(index, direction);
                 }
             });
+        }
+
+        setupDropZone() {
+            const openModalWithFiles = (files, highlightEl) => {
+                highlightEl.classList.remove('drag-over');
+                if (!files.length) return;
+                this.pendingDropFiles = files;
+                bootstrap.Modal.getOrCreateInstance(this.modalEl).show();
+            };
+
+            const addListeners = (target) => {
+                ['dragenter', 'dragover'].forEach(evt => target.addEventListener(evt, (e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    target.classList.add('drag-over');
+                }));
+                target.addEventListener('dragleave', (e) => {
+                    if (!target.contains(e.relatedTarget)) {
+                        target.classList.remove('drag-over');
+                    }
+                });
+                target.addEventListener('drop', (e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    openModalWithFiles(Array.from(e.dataTransfer?.files ?? []), target);
+                });
+            };
+
+            const emptyState = this.element.querySelector('.uppymedia-empty-state');
+            if (emptyState) {
+                addListeners(emptyState);
+            }
+
+            // Delegate drag events for the dynamically-rendered "+" add-more card
+            const preview = this.element.querySelector('.uppymedia-preview');
+            if (preview) {
+                ['dragenter', 'dragover'].forEach(evt => {
+                    preview.addEventListener(evt, (e) => {
+                        const addMore = e.target.closest('.uppymedia-add-more');
+                        if (!addMore) return;
+                        e.preventDefault();
+                        e.stopPropagation();
+                        addMore.classList.add('drag-over');
+                    });
+                });
+                preview.addEventListener('dragleave', (e) => {
+                    const addMore = e.target.closest('.uppymedia-add-more');
+                    if (addMore && !addMore.contains(e.relatedTarget)) {
+                        addMore.classList.remove('drag-over');
+                    }
+                });
+                preview.addEventListener('drop', (e) => {
+                    const addMore = e.target.closest('.uppymedia-add-more');
+                    if (!addMore) return;
+                    e.preventDefault();
+                    e.stopPropagation();
+                    openModalWithFiles(Array.from(e.dataTransfer?.files ?? []), addMore);
+                });
+            }
         }
 
         /**


### PR DESCRIPTION
## Summary
Fixes #819

Dragging image files onto the dashed empty-state area (or the "+" add-more card when images already exist) now opens the upload modal and stages the dropped files directly in Uppy, ready for upload.

## Changes
- Added `setupDropZone()` method with `dragenter`/`dragover`/`dragleave`/`drop` listeners on `.uppymedia-empty-state` and (via delegation) `.uppymedia-add-more`
- On drop: stores files in `pendingDropFiles`, opens modal via `bootstrap.Modal.getOrCreateInstance()`
- In `shown.bs.modal` handler: adds pending files to Uppy via `uppy.addFile()` after init
- CSS: added `.drag-over` visual state (blue border + light background) for both drop targets

## Files Changed
- `media/com_j2commerce/js/administrator/multiimageuploader.js` — drop zone logic
- `media/com_j2commerce/css/administrator/multiimageuploader.css` — drag-over visual state

## Testing
1. Open any product in J2Commerce admin → Images tab
2. Drag an image from desktop onto the dashed purple bordered area
3. Verify: border highlights blue, modal opens, file appears staged in Uppy
4. Upload and confirm — image appears in preview
5. With images present: drag onto the "+" add-more card → same behavior

## Pre-Flight
- [x] No PHP files changed — no lint/cs-fixer needed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only