### PR TITLE
fix(content-plugin): remove constructor to prevent fatal on install

### DIFF
--- a/plugins/content/j2commerce/src/Extension/J2Commerce.php
+++ b/plugins/content/j2commerce/src/Extension/J2Commerce.php
@@ -35,7 +35,6 @@ use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Session\Session;
 use Joomla\Database\DatabaseAwareTrait;
 use Joomla\Database\ParameterType;
-use Joomla\Event\DispatcherInterface;
 use Joomla\Event\SubscriberInterface;
 use Joomla\Registry\Registry;
 
@@ -106,15 +105,6 @@ final class J2Commerce extends CMSPlugin implements SubscriberInterface
     private function clearArticleCache(int $articleId): void
     {
         unset(self::$articleCache[$articleId]);
-    }
-
-    /** @since 6.0.0 */
-    public function __construct(DispatcherInterface $dispatcher, array $config = [])
-    {
-        parent::__construct($dispatcher, $config);
-
-        // Load component language for COM_J2COMMERCE_* strings used in product form templates
-        Factory::getApplication()->getLanguage()->load('com_j2commerce', JPATH_ADMINISTRATOR . '/components/com_j2commerce');
     }
 
     /** @since 6.0.0 */


### PR DESCRIPTION
## Summary
Fixes #826

During J2Commerce package installation, `Factory::getApplication()->getLanguage()` returns null because the installer runs in a degraded application context. This caused a fatal "Call to a member function load() on null" in the content plugin constructor.

The constructor's language preload was redundant — `injectArticleForm()` and `injectCategoryForm()` both already load `com_j2commerce` language immediately before they need it. Removing the constructor eliminates the fatal with no functional change.

## Changes
- Removed custom `__construct()` from `plg_content_j2commerce` Extension class
- Removed unused `DispatcherInterface` import

## Files Changed
- `plugins/content/j2commerce/src/Extension/J2Commerce.php` — removed redundant constructor

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only

## Testing
1. Install J2Commerce 6 package on a Joomla site with J2Store 4.x / "Content - J2Store" plugin present
2. Verify install completes with no fatal errors
3. Open an article — confirm J2Commerce tab present and all language strings display correctly