### PR TITLE
Fix regression for download products (broken page) and improved image directory selection

### DIFF
--- a/administrator/components/com_j2commerce/src/Controller/MultiimageuploaderController.php
+++ b/administrator/components/com_j2commerce/src/Controller/MultiimageuploaderController.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace J2Commerce\Component\J2commerce\Administrator\Controller;
 
+use J2Commerce\Component\J2commerce\Administrator\Helper\ConfigHelper;
 use J2Commerce\Component\J2commerce\Administrator\Helper\ImageProcessorHelper;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
@@ -264,23 +265,7 @@ class MultiimageuploaderController extends BaseController
             return;
         }
 
-        $componentParams = ComponentHelper::getParams('com_j2commerce');
-        $directories     = $componentParams->get('image_directories', [(object) ['directory' => 'images']]);
-
-        if (\is_string($directories)) {
-            $directories = json_decode($directories);
-        }
-
-        $paths = [];
-        foreach ($directories as $dir) {
-            if (!empty($dir->directory)) {
-                $paths[] = $dir->directory;
-            }
-        }
-
-        if (empty($paths)) {
-            $paths[] = 'images';
-        }
+        $paths = ConfigHelper::getImageDirectoryPaths(['images']);
 
         $this->sendJson(true, '', $paths);
     }
@@ -489,15 +474,10 @@ class MultiimageuploaderController extends BaseController
         }
 
         // Protect configured root directories
-        $componentParams = ComponentHelper::getParams('com_j2commerce');
-        $directories     = $componentParams->get('image_directories', [(object) ['directory' => 'images']]);
-
-        if (\is_string($directories)) {
-            $directories = json_decode($directories);
-        }
+        $directories = ConfigHelper::getImageDirectories();
 
         foreach ($directories as $dir) {
-            if (trim($dir->directory ?? '', '/') === $path) {
+            if (trim((string) ($dir['directory'] ?? ''), '/') === $path) {
                 $this->sendJson(false, 'Cannot delete a configured root directory');
                 return;
             }
@@ -862,24 +842,7 @@ class MultiimageuploaderController extends BaseController
         $path = trim($path, '/');
 
         // Build allowed roots from J2Commerce configured directories
-        $directories = ComponentHelper::getParams('com_j2commerce')
-            ->get('image_directories', [(object) ['directory' => 'images']]);
-
-        if (\is_string($directories)) {
-            $directories = json_decode($directories);
-        }
-
-        $allowedRoots = [];
-
-        foreach ($directories as $dir) {
-            if (!empty($dir->directory)) {
-                $allowedRoots[] = trim((string) $dir->directory, '/');
-            }
-        }
-
-        if (empty($allowedRoots)) {
-            $allowedRoots[] = 'images';
-        }
+        $allowedRoots = ConfigHelper::getImageDirectoryPaths(['images']);
 
         foreach ($allowedRoots as $root) {
             if ($path === $root || str_starts_with($path, $root . '/')) {

--- a/administrator/components/com_j2commerce/src/Field/ImageDirectoryField.php
+++ b/administrator/components/com_j2commerce/src/Field/ImageDirectoryField.php
@@ -14,6 +14,9 @@ namespace J2Commerce\Component\J2commerce\Administrator\Field;
 
 use Joomla\CMS\Form\Field\FolderlistField;
 use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\Filesystem\Path;
+use Joomla\Registry\Registry;
 
 \defined('_JEXEC') or die;
 
@@ -23,26 +26,124 @@ class ImageDirectoryField extends FolderlistField
 
     protected function getOptions(): array
     {
-        $this->directory  = 'images';
-        $this->recursive  = true;
-        $this->hideNone   = true;
+        $this->recursive = true;
+        $this->hideNone  = true;
 
-        $parentOptions = parent::getOptions();
+        $options = [];
+        $seen    = [];
 
-        $options = [
-            HTMLHelper::_('select.option', 'images', 'images'),
-        ];
-
-        foreach ($parentOptions as $option) {
-            if ($option->value === '' || $option->value === '-1') {
+        foreach ($this->getLocalRoots() as $root) {
+            if (isset($seen[$root])) {
                 continue;
             }
 
-            $option->value = 'images/' . $option->value;
-            $option->text  = 'images/' . $option->text;
-            $options[]     = $option;
+            $seen[$root] = true;
+            $options[]   = HTMLHelper::_('select.option', $root, $root);
+
+            $this->directory = $root;
+
+            foreach (parent::getOptions() as $option) {
+                if ($option->value === '' || $option->value === '-1') {
+                    continue;
+                }
+
+                $fullValue = $root . '/' . ltrim((string) $option->value, '/');
+
+                if (isset($seen[$fullValue])) {
+                    continue;
+                }
+
+                $seen[$fullValue] = true;
+                $option->value    = $fullValue;
+                $option->text     = $root . '/' . ltrim((string) $option->text, '/');
+                $options[]        = $option;
+            }
         }
 
         return $options;
+    }
+
+    /**
+     * Get available local filesystem roots from the Joomla local filesystem plugin.
+     */
+    private function getLocalRoots(): array
+    {
+        $roots = ['images', 'files'];
+
+        $plugin = PluginHelper::getPlugin('filesystem', 'local');
+
+        if (empty($plugin) || empty($plugin->params)) {
+            return $roots;
+        }
+
+        $params = new Registry($plugin->params);
+
+        $directories = $params->get('directories');
+
+        if (is_string($directories)) {
+            $decoded = json_decode($directories, true);
+            $directories = is_array($decoded) ? $decoded : $directories;
+        }
+
+        if (is_array($directories) || is_object($directories)) {
+            foreach ((array) $directories as $value) {
+                $this->appendRoot($roots, $value);
+            }
+        }
+
+        return array_values(array_unique($roots));
+    }
+
+    /**
+     * Normalize and append a root path if it points to an existing local directory.
+     */
+    private function appendRoot(array &$roots, mixed $value): void
+    {
+        if (is_array($value) || is_object($value)) {
+            $items = (array) $value;
+
+            if (isset($items['directory'])) {
+                $this->appendRoot($roots, $items['directory']);
+            }
+
+            foreach ($items as $item) {
+                if ($item === $value) {
+                    continue;
+                }
+
+                $this->appendRoot($roots, $item);
+            }
+
+            return;
+        }
+
+        if (!is_string($value) || trim($value) === '') {
+            return;
+        }
+
+        $candidate = str_replace('\\', '/', trim($value));
+
+        if (preg_match('#^[A-Za-z]:[/\\\\]#', $candidate) || str_starts_with($candidate, '/')) {
+            $rootPath   = str_replace('\\', '/', Path::clean((string) JPATH_ROOT));
+            $cleanValue = str_replace('\\', '/', Path::clean($candidate));
+
+            if (!str_starts_with($cleanValue, $rootPath . '/')) {
+                return;
+            }
+
+            $candidate = ltrim(substr($cleanValue, strlen($rootPath)), '/');
+        }
+
+        $candidate = trim($candidate, '/');
+
+        if ($candidate === '') {
+            return;
+        }
+
+        if (!is_dir(JPATH_ROOT . '/' . $candidate)) {
+            return;
+        }
+
+        $roots[] = $candidate;
     }
 }

--- a/administrator/components/com_j2commerce/src/Helper/ConfigHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/ConfigHelper.php
@@ -50,6 +50,60 @@ class ConfigHelper
         return self::getParams()->get($key, $default);
     }
 
+    /**
+     * Normalize the image_directories subform config into a predictable list.
+     *
+     * Joomla may return this field as a JSON string, array of arrays,
+     * array of objects, or a single associative row depending on context.
+     *
+     * @param   array<int, array<string, mixed>>  $default  Fallback rows when config is empty/invalid.
+     *
+     * @return  array<int, array{directory: string, thumbs: int}>
+     */
+    public static function getImageDirectories(array $default = [['directory' => 'images', 'thumbs' => 1]]): array
+    {
+        $normalized = self::normalizeImageDirectories(self::get('image_directories', $default));
+
+        if ($normalized !== []) {
+            return $normalized;
+        }
+
+        $fallback = self::normalizeImageDirectories($default);
+
+        return $fallback !== [] ? $fallback : [['directory' => 'images', 'thumbs' => 1]];
+    }
+
+    /**
+     * Return only the configured image directory paths.
+     *
+     * @param   array<int, string>  $default  Fallback directory paths.
+     *
+     * @return  array<int, string>
+     */
+    public static function getImageDirectoryPaths(array $default = ['images']): array
+    {
+        $defaultRows = [];
+
+        foreach ($default as $directory) {
+            $directory = trim((string) $directory, '/');
+
+            if ($directory !== '') {
+                $defaultRows[] = ['directory' => $directory, 'thumbs' => 1];
+            }
+        }
+
+        $directories = self::getImageDirectories($defaultRows ?: [['directory' => 'images', 'thumbs' => 1]]);
+        $paths = [];
+
+        foreach ($directories as $directory) {
+            if (!empty($directory['directory'])) {
+                $paths[] = $directory['directory'];
+            }
+        }
+
+        return $paths !== [] ? $paths : ($default ?: ['images']);
+    }
+
     /** Sets a value in memory only — does not persist. */
     public static function set(string $key, mixed $value): void
     {
@@ -64,6 +118,58 @@ class ConfigHelper
     public static function reset(): void
     {
         self::$params = null;
+    }
+
+    /**
+     * @return  array<int, array{directory: string, thumbs: int}>
+     */
+    private static function normalizeImageDirectories(mixed $value): array
+    {
+        if ($value instanceof Registry) {
+            $value = $value->toArray();
+        }
+
+        if (\is_string($value)) {
+            $decoded = json_decode($value, true);
+            $value   = \is_array($decoded) ? $decoded : [];
+        } elseif (\is_object($value)) {
+            $value = (array) $value;
+        }
+
+        if (!\is_array($value)) {
+            return [];
+        }
+
+        if (array_key_exists('directory', $value)) {
+            $value = [$value];
+        }
+
+        $normalized = [];
+
+        foreach ($value as $row) {
+            if ($row instanceof Registry) {
+                $row = $row->toArray();
+            } elseif (\is_object($row)) {
+                $row = (array) $row;
+            }
+
+            if (!\is_array($row)) {
+                continue;
+            }
+
+            $directory = trim((string) ($row['directory'] ?? ''), '/');
+
+            if ($directory === '') {
+                continue;
+            }
+
+            $normalized[] = [
+                'directory' => $directory,
+                'thumbs'    => (int) ($row['thumbs'] ?? 0),
+            ];
+        }
+
+        return $normalized;
     }
 
     // =========================================================================

--- a/administrator/components/com_j2commerce/tmpl/product/form_downloadablefiles.php
+++ b/administrator/components/com_j2commerce/tmpl/product/form_downloadablefiles.php
@@ -13,22 +13,29 @@
 
 use J2Commerce\Component\J2commerce\Administrator\Controller\MultiimageuploaderController;
 use J2Commerce\Component\J2commerce\Administrator\Field\MultiImageUploaderField;
+use J2Commerce\Component\J2commerce\Administrator\Helper\ConfigHelper;
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
-use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\FileLayout;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Uri\Uri;
 
-$item = $displayData['product'];
+$displayData = isset($displayData) && \is_array($displayData) ? $displayData : [];
+$item = isset($displayData['product']) && \is_object($displayData['product']) ? $displayData['product'] : new \stdClass();
 $formPrefix = $displayData['form_prefix'] ?? 'jform[attribs][j2commerce]';
 
 // Defaults for Joomla core layout fields to prevent PHP 8.4 undefined variable warnings
 $textFieldDefaults = ['value' => '', 'onchange' => '', 'disabled' => false, 'readonly' => false, 'dataAttribute' => '', 'hint' => '', 'required' => false, 'autofocus' => false, 'spellcheck' => false, 'addonBefore' => '', 'addonAfter' => '', 'dirname' => '', 'charcounter' => false, 'options' => []];
 
-$product_params = json_decode($item->params);
-$productId = $item->j2commerce_product_id ?? 0;
+$productParamsRaw = isset($item->params) ? (string) $item->params : '{}';
+$product_params = json_decode($productParamsRaw);
+
+if (!\is_object($product_params)) {
+    $product_params = new \stdClass();
+}
+
+$productId = (int) ($item->j2commerce_product_id ?? 0);
 
 // Load MultiImageUploader assets
 MultiImageUploaderField::loadAssetsStatic();
@@ -38,7 +45,9 @@ $filesData = [];
 $siteRoot = rtrim(Uri::root(), '/') . '/';
 
 // Strip repeated Uri::root() prefixes from a stored file path
-$stripBaseUrl = function (string $value) use ($siteRoot): string {
+$stripBaseUrl = function ($value) use ($siteRoot): string {
+    $value = (string) ($value ?? '');
+
     while (str_starts_with($value, $siteRoot)) {
         $value = substr($value, strlen($siteRoot));
     }
@@ -63,7 +72,7 @@ if ($productId) {
     $existingFiles = $db->loadObjectList();
 
     foreach ($existingFiles as $file) {
-        $path = $stripBaseUrl($file->product_file_save_name);
+        $path = $stripBaseUrl($file->product_file_save_name ?? '');
 
         $filesData[] = [
             'id'          => $file->j2commerce_productfile_id,
@@ -75,17 +84,19 @@ if ($productId) {
     }
 }
 
-// Resolve default upload directory from J2Commerce image_directories config
-$j2cParams      = ComponentHelper::getParams('com_j2commerce');
-$configuredDirs = $j2cParams->get('image_directories', []);
+// Resolve default upload directory from J2Commerce image_directories config.
+// This subform value is not guaranteed to come back as an array of objects;
+// normalize it first so the Files tab cannot break on config shape differences.
+$configuredDirs = ConfigHelper::getImageDirectories();
 
-if (\is_string($configuredDirs)) {
-    $configuredDirs = json_decode($configuredDirs, false) ?? [];
+$defaultUploadDir = 'images/downloads';
+
+foreach ($configuredDirs as $configuredDir) {
+    if (!empty($configuredDir['directory'])) {
+        $defaultUploadDir = $configuredDir['directory'];
+        break;
+    }
 }
-
-$defaultUploadDir = !empty($configuredDirs) && !empty($configuredDirs[0]->directory)
-    ? trim((string) $configuredDirs[0]->directory, '/')
-    : 'images/downloads';
 
 $layoutPath = JPATH_ADMINISTRATOR . '/components/com_j2commerce/layouts';
 ?>


### PR DESCRIPTION
The media files should be able to be downloaded/uploaded from directories other than the  /images default path.
Especially that in Joomla 6, Joomla offers /images and /files as default.
It is specifically needed for download products where a digital product could be located into a more appropriate location.
The improvements here allow the ImageDirectory field to handle all root folders specified in the Joomla filesystem plugin.
This improves flexibility and the setup is constrained to whatever folders have been approved as media files for the whole site.

<img width="910" height="287" alt="image" src="https://github.com/user-attachments/assets/9bfea38a-75fb-4029-9bf3-ccb6a1775cda" />

Configuration

<img width="646" height="458" alt="image" src="https://github.com/user-attachments/assets/9525f129-4c21-46f9-92b7-57b4b0e685c4" />

Seelection

<img width="680" height="448" alt="image" src="https://github.com/user-attachments/assets/9bd9fbf2-26d8-40a5-adca-ef3b7e553646" />

Download Product files


administrator/components/com_j2commerce/src/Field/ImageDirectoryField.php

- Reworked field options to support multiple roots instead of hardcoded images.
- Added local filesystem plugin root discovery via filesystem/local param directories.
- Added root normalization/validation (appendRoot) and includes default roots images + files.
- Options now include each root and recursive subfolders with dedupe.

administrator/components/com_j2commerce/src/Helper/ConfigHelper.php

- Added getImageDirectories() to normalize image_directories across shapes (JSON string / array / objects / single row).
- Added getImageDirectoryPaths() to return clean directory paths with fallback.
- Added private normalizeImageDirectories() helper for consistent parsing and typing.

administrator/components/com_j2commerce/src/Controller/MultiimageuploaderController.php

- Switched manual image_directories parsing to ConfigHelper methods.
- folders() now uses ConfigHelper::getImageDirectoryPaths(['images']).
- deleteFolder() root protection now reads normalized array rows ($dir['directory']).
- sanitizePath() allowed roots now come from ConfigHelper::getImageDirectoryPaths(['images']).

administrator/components/com_j2commerce/tmpl/product/form_downloadablefiles.php

- Switched config access to ConfigHelper::getImageDirectories().
- Hardened $displayData, $item, and $product_params initialization (safer defaults / PHP 8.4-friendly).
- Made $stripBaseUrl more defensive for null/missing values.
- Default upload directory now resolved from normalized config rows (array shape).