### PR TITLE
fix(orders): populate customer_group and fix SQL injection in template filters

### DIFF
--- a/administrator/components/com_j2commerce/src/Helper/CartOrder.php
+++ b/administrator/components/com_j2commerce/src/Helper/CartOrder.php
@@ -14,6 +14,8 @@ namespace J2Commerce\Component\J2commerce\Administrator\Helper;
 
 \defined('_JEXEC') or die;
 
+use Joomla\CMS\Access\Access;
+use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\Database\DatabaseInterface;
@@ -1397,6 +1399,9 @@ class CartOrder
             'is_including_tax'      => $isIncludingTax,
             'customer_note'         => $this->customer_note,
             'customer_language'     => $app->getLanguage()->getTag(),
+            'customer_group'        => $userId > 0
+                ? implode(',', Access::getGroupsByUser($userId, false))
+                : (string) (int) ComponentHelper::getParams('com_users')->get('guest_usergroup', 1),
             'ip_address'            => $app->input->server->getString('REMOTE_ADDR', ''),
             'order_state_id'        => 5, // Incomplete
             'created_by'            => $userId,

--- a/administrator/components/com_j2commerce/src/Helper/EmailHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/EmailHelper.php
@@ -997,17 +997,25 @@ class EmailHelper
             ->bind(':orderstatus_id', $orderStateId, ParameterType::INTEGER)
             ->bind(':orderstatus_id2', $orderStateId, ParameterType::INTEGER);
 
-        // Customer group filter
+        // Customer group filter — parse to integers to prevent SQL injection
         if (!empty($customerGroup)) {
-            $query->where(
-                'CASE WHEN ' . $db->quoteName('group_id') . ' IN (' . $customerGroup . ')'
-                . ' THEN ' . $db->quoteName('group_id') . ' IN (' . $customerGroup . ')'
-                . ' ELSE ' . $db->quoteName('group_id') . ' = ' . $db->quote('*')
-                . ' OR ' . $db->quoteName('group_id') . ' = ' . $db->quote('1')
-                . ' OR ' . $db->quoteName('group_id') . ' = ' . $db->quote('')
-                . ' OR ' . $db->quoteName('group_id') . ' = ' . $db->quote('0')
-                . ' END'
-            );
+            $groupIds = array_values(array_filter(
+                array_map('intval', explode(',', $customerGroup)),
+                fn($id) => $id > 0
+            ));
+
+            if (!empty($groupIds)) {
+                $inList = implode(',', $groupIds);
+                $query->where(
+                    'CASE WHEN ' . $db->quoteName('group_id') . ' IN (' . $inList . ')'
+                    . ' THEN ' . $db->quoteName('group_id') . ' IN (' . $inList . ')'
+                    . ' ELSE ' . $db->quoteName('group_id') . ' = ' . $db->quote('*')
+                    . ' OR ' . $db->quoteName('group_id') . ' = ' . $db->quote('1')
+                    . ' OR ' . $db->quoteName('group_id') . ' = ' . $db->quote('')
+                    . ' OR ' . $db->quoteName('group_id') . ' = ' . $db->quote('0')
+                    . ' END'
+                );
+            }
         }
 
         // Payment method filter

--- a/administrator/components/com_j2commerce/src/Helper/InvoiceHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/InvoiceHelper.php
@@ -229,19 +229,27 @@ class InvoiceHelper
             ->bind(':orderstatus_id', $orderStateId)
             ->bind(':orderstatus_id2', $orderStateId);
 
-        // Customer group filter (only on frontend/site)
+        // Customer group filter (only on frontend/site) — parse to integers to prevent SQL injection
         if (!empty($customerGroup)) {
             $app = Factory::getApplication();
 
             if ($app->isClient('site')) {
-                $query->where(
-                    'CASE WHEN ' . $db->quoteName('group_id') . ' IN (' . $customerGroup . ')'
-                    . ' THEN ' . $db->quoteName('group_id') . ' IN (' . $customerGroup . ')'
-                    . ' ELSE ' . $db->quoteName('group_id') . ' = ' . $db->quote('*')
-                    . ' OR ' . $db->quoteName('group_id') . ' = ' . $db->quote('1')
-                    . ' OR ' . $db->quoteName('group_id') . ' = ' . $db->quote('')
-                    . ' END'
-                );
+                $groupIds = array_values(array_filter(
+                    array_map('intval', explode(',', $customerGroup)),
+                    fn($id) => $id > 0
+                ));
+
+                if (!empty($groupIds)) {
+                    $inList = implode(',', $groupIds);
+                    $query->where(
+                        'CASE WHEN ' . $db->quoteName('group_id') . ' IN (' . $inList . ')'
+                        . ' THEN ' . $db->quoteName('group_id') . ' IN (' . $inList . ')'
+                        . ' ELSE ' . $db->quoteName('group_id') . ' = ' . $db->quote('*')
+                        . ' OR ' . $db->quoteName('group_id') . ' = ' . $db->quote('1')
+                        . ' OR ' . $db->quoteName('group_id') . ' = ' . $db->quote('')
+                        . ' END'
+                    );
+                }
             }
         }
 

--- a/administrator/components/com_j2commerce/src/Helper/SampleDataHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/SampleDataHelper.php
@@ -14,6 +14,7 @@ namespace J2Commerce\Component\J2commerce\Administrator\Helper;
 
 \defined('_JEXEC') or die;
 
+use Joomla\CMS\Access\Access;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Table\Table;
 use Joomla\Database\DatabaseInterface;
@@ -1571,7 +1572,7 @@ final class SampleDataHelper
             $order->is_including_tax       = 0;
             $order->customer_note          = '';
             $order->customer_language      = 'en-GB';
-            $order->customer_group         = 'Registered';
+            $order->customer_group         = implode(',', Access::getGroupsByUser((int) $customer['id'], false));
             $order->order_state_id         = $statusId;
             $order->order_state            = $statusName;
             $order->order_params           = '{}';


### PR DESCRIPTION
## Summary

Fixes #830

`customer_group` was never set during J2Commerce checkout, leaving it empty for all new orders. Sample data hard-coded `'Registered'` (a group name, not an ID), which was concatenated directly into a SQL `IN()` clause — MySQL threw *Unknown column 'Registered' in where clause*, silently killing email template lookup. With `send_default_email_template` defaulting to `0`, the result was always `success: false, "No email templates found"` on **Resend Email** and **Notify Customer**.

## Root Cause

`EmailHelper::getEmailTemplates()` and `InvoiceHelper::getInvoiceTemplates()` both build:
```sql
CASE WHEN `group_id` IN (Registered) ...
```
The unquoted identifier caused a DB error caught silently — returning no templates.

## Changes

- **`CartOrder::saveOrder()`** — now writes `customer_group` on every new order: registered users get their actual Joomla group IDs via `Access::getGroupsByUser()`; guests get the configured `guest_usergroup` ID from `com_users` params (default: 1/Public)
- **`EmailHelper::getEmailTemplates()`** — parses `customer_group` as integers before building `IN()` list; non-numeric values (e.g. `'Registered'`) filter to empty → clause skipped safely, templates load normally
- **`InvoiceHelper::getInvoiceTemplates()`** — same integer-parse guard applied
- **`SampleDataHelper`** — replaces hard-coded `'Registered'` with `Access::getGroupsByUser()` on the created user, storing the correct integer group ID (e.g. `'2'`)

## Files Changed

| File | Change |
|------|--------|
| `administrator/components/com_j2commerce/src/Helper/CartOrder.php` | Add `customer_group` to order data on checkout |
| `administrator/components/com_j2commerce/src/Helper/EmailHelper.php` | Fix SQL injection in customer group filter |
| `administrator/components/com_j2commerce/src/Helper/InvoiceHelper.php` | Fix SQL injection in customer group filter |
| `administrator/components/com_j2commerce/src/Helper/SampleDataHelper.php` | Use integer group IDs instead of group name |

## Testing

1. Load sample data — open any sample order — click **Resend Email** → success toast or SMTP error, NOT "No email templates found"
2. Change order status with **Notify Customer** checked → same result
3. Place a new order as a registered user — confirm `customer_group` column shows `'2'` (or user's actual groups)
4. Place a guest order — confirm `customer_group` shows configured guest group ID (default `'1'`)

## Pre-Flight

- [x] PHP syntax check passed (all 4 files)
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only (4 Helper files, all in `com_j2commerce`)