### PR TITLE
Remove layout description attribute from module XML field definitions

### DIFF
--- a/administrator/modules/mod_j2commerce_orders/mod_j2commerce_orders.xml
+++ b/administrator/modules/mod_j2commerce_orders/mod_j2commerce_orders.xml
@@ -91,7 +91,6 @@
                     class="form-select"
                     type="modulelayout"
                     label="JFIELD_ALT_LAYOUT_LABEL"
-                    description="JFIELD_ALT_MODULE_LAYOUT_DESC"
                 />
                 <field
                     name="moduleclass_sfx"

--- a/administrator/modules/mod_j2commerce_stats/mod_j2commerce_stats.xml
+++ b/administrator/modules/mod_j2commerce_stats/mod_j2commerce_stats.xml
@@ -81,7 +81,6 @@
                     class="form-select"
                     type="modulelayout"
                     label="JFIELD_ALT_LAYOUT_LABEL"
-                    description="JFIELD_ALT_MODULE_LAYOUT_DESC"
                 />
                 <field
                     name="moduleclass_sfx"

--- a/modules/mod_j2commerce_cart/mod_j2commerce_cart.xml
+++ b/modules/mod_j2commerce_cart/mod_j2commerce_cart.xml
@@ -73,7 +73,6 @@
                     type="modulelayout"
                     class="form-select"
                     label="JFIELD_ALT_LAYOUT_LABEL"
-                    description="JFIELD_ALT_MODULE_LAYOUT_DESC"
                 />
                 <field
                     name="cart_module_title"


### PR DESCRIPTION
this description was removed from joomla core with 4.0 its pretty useless imho but you could add a new striing if you want