### PR TITLE
fix(cart): require explicit product_type, never default to 'simple'

### DIFF
--- a/administrator/components/com_j2commerce/src/Helper/CartOrder.php
+++ b/administrator/components/com_j2commerce/src/Helper/CartOrder.php
@@ -1484,6 +1484,17 @@ class CartOrder
         $now = Factory::getDate()->toSql();
 
         foreach ($this->items as $item) {
+            // product_type must come from the cartitem. Never default to 'simple' —
+            // that downgrades subscription / variable / configurable / etc. products
+            // and breaks AfterPayment routing (e.g. subscription rows never created).
+            $itemProductType = trim((string) ($item->product_type ?? ''));
+
+            if ($itemProductType === '') {
+                throw new \RuntimeException(
+                    'CartOrder::createOrderItems requires $item->product_type — refusing to write orderitem with default "simple"'
+                );
+            }
+
             $pricing           = $item->pricing ?? null;
             $quantity          = (int) ($item->product_qty ?? 1);
             $basePrice         = (float) ($pricing->price ?? $item->variant_price ?? 0);
@@ -1521,7 +1532,7 @@ class CartOrder
                 (int) ($this->cart_id),
                 (int) ($item->j2commerce_cartitem_id ?? $item->cartitem_id ?? 0),
                 (int) ($item->product_id ?? 0),
-                $db->quote($item->product_type ?? 'simple'),
+                $db->quote($itemProductType),
                 (int) ($item->variant_id ?? 0),
                 (int) ($item->vendor_id ?? 0),
                 $db->quote($item->sku ?? ''),

--- a/administrator/components/com_j2commerce/src/Model/CartModel.php
+++ b/administrator/components/com_j2commerce/src/Model/CartModel.php
@@ -180,6 +180,16 @@ class CartModel extends BaseDatabaseModel
             return false;
         }
 
+        // product_type must come from the caller (Cart{Type} behavior or reorder
+        // controller). Never default to 'simple' — that downgrades subscription /
+        // variable / configurable / etc. products and breaks downstream routing.
+        $itemProductType = trim((string) ($item->product_type ?? ''));
+
+        if ($itemProductType === '') {
+            $this->setError('CartModel::addItem requires $item->product_type — refusing to default to "simple"');
+            return false;
+        }
+
         $db  = $this->db;
         $app = Factory::getApplication();
 
@@ -245,7 +255,7 @@ class CartModel extends BaseDatabaseModel
             // Insert new cart item
             $productId   = (int) $item->product_id;
             $vendorId    = (int) ($item->vendor_id ?? 0);
-            $productType = $item->product_type ?? 'simple';
+            $productType = $itemProductType;
             $productQty  = (float) $item->product_qty;
 
             $insertQuery = $db->getQuery(true)

--- a/administrator/components/com_j2commerce/src/Table/CartitemTable.php
+++ b/administrator/components/com_j2commerce/src/Table/CartitemTable.php
@@ -86,8 +86,12 @@ class CartitemTable extends Table
             $this->vendor_id = 0;
         }
 
+        // product_type is required and must come from the caller. Never default to
+        // 'simple' — that silently downgrades subscription/variable/configurable
+        // products and breaks downstream AfterPayment routing.
         if (empty($this->product_type)) {
-            $this->product_type = 'simple';
+            $this->setError(Text::sprintf('COM_J2COMMERCE_ERR_FIELD_REQUIRED', 'Product Type'));
+            return false;
         }
 
         if (!isset($this->cartitem_params)) {

--- a/components/com_j2commerce/src/Controller/MyprofileController.php
+++ b/components/com_j2commerce/src/Controller/MyprofileController.php
@@ -722,13 +722,27 @@ class MyprofileController extends BaseController
                 continue;
             }
 
-            // Prepare item for cart
+            // product_type must propagate from the orderitem so CartModel::getItems()
+            // and CartOrder::createOrderItems route to the correct behavior on the
+            // next pass. Never silently fall back to 'simple' — that downgrades
+            // subscription/variable/etc. products and breaks AfterPayment routing.
+            $itemProductType = trim((string) ($item->product_type ?? ''));
+
+            if ($itemProductType === '') {
+                $errors[] = Text::sprintf('COM_J2COMMERCE_REORDER_FAILED_TO_ADD', $item->orderitem_name);
+                continue;
+            }
+
+            // product_options expects base64-serialized PHP array of option selections;
+            // orderitem_attributes is unrelated JSON (display attributes), so leave empty.
             $cartItem                  = new \stdClass();
             $cartItem->cart_id         = $cartId;
             $cartItem->product_id      = $productId;
             $cartItem->variant_id      = $variantId;
+            $cartItem->vendor_id       = (int) ($item->vendor_id ?? 0);
+            $cartItem->product_type    = $itemProductType;
             $cartItem->product_qty     = $quantity;
-            $cartItem->product_options = $item->orderitem_attributes;
+            $cartItem->product_options = '';
 
             // Add to cart
             $result = $cartModel->addItem($cartItem);


### PR DESCRIPTION
## Summary

Three core write paths were silently defaulting cartitem/orderitem `product_type` to `'simple'` when the caller forgot to set it. That masked a Reorder bug for weeks: subscription products reordered via `MyprofileController::reorder()` ended up as `product_type='simple'`, which made `AppSubscriptionproduct::onAfterPayment` skip them (its query filters on `IN ('subscriptionproduct','variablesubscriptionproduct')`) — so no subscription rows were ever created.

## Changes

| File | Change |
|---|---|
| `components/com_j2commerce/src/Controller/MyprofileController.php` | `reorder()` propagates `orderitem.product_type` and `vendor_id`; skips line with error if missing; stops copying `orderitem_attributes` JSON into `product_options` (wrong column shape) |
| `administrator/components/com_j2commerce/src/Model/CartModel.php` | `addItem()` requires non-empty `product_type`; `setError` + `return false` if missing |
| `administrator/components/com_j2commerce/src/Helper/CartOrder.php` | `createOrderItems()` throws `RuntimeException` when an item lacks `product_type` |
| `administrator/components/com_j2commerce/src/Table/CartitemTable.php` | `check()` returns false with field-required error when `product_type` empty |

## Rationale

Silent defaults at the data boundary downgraded subscription/variable/configurable/etc. products and broke downstream behavior routing. Loud failures here surface caller bugs immediately instead of producing corrupt data that only manifests at checkout (or worse — silently misses subscription creation).

## Test plan

- [ ] Click "Reorder/Buy Again" on a past subscription order → cartitem inserted with `product_type='subscriptionproduct'` (was `'simple'`)
- [ ] Frontend Add-to-cart for any non-simple product → cartitem `product_type` matches product
- [ ] Checkout → orderitem `product_type` matches cartitem (no silent downgrade)
- [ ] `j6_j2commerce_subscriptions` row created for subscription orders after `onJ2CommerceAfterPayment` fires
- [ ] Sanity: simple products still flow through unchanged

## Pre-flight
- [x] PHP syntax check passed (all 4 files)
- [x] No secrets detected
- [x] No FOF remnants / `JFactory::` usage
- [x] Core files only (4 files, no non-core touched)