### PR TITLE
fix(strapper): native Joomla 6 calendar for product-option date/datetime fields

### DIFF
--- a/administrator/components/com_j2commerce/src/Helper/StrapperHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/StrapperHelper.php
@@ -17,6 +17,7 @@ namespace J2Commerce\Component\J2commerce\Administrator\Helper;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Event\GenericEvent;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Language\Text;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Database\ParameterType;
@@ -397,6 +398,182 @@ class StrapperHelper
         }
         return $filesize . " bytes";
 
+    }
+
+    /**
+     * Promote a text input to a Joomla 6 native calendar field (`field.calendar`).
+     *
+     * Wraps the existing `<input>` (located by class name) in the same DOM
+     * structure rendered by `Joomla\CMS\Form\Field\CalendarField`, registers
+     * the core `field.calendar` script/style, and lets Joomla's auto-init
+     * handler upgrade it on `DOMContentLoaded` / `joomla:updated`.
+     *
+     * @param string                $element     Element class name (no leading dot)
+     * @param array|string|Registry $jsonOptions Option parameters (JSON, array, or Registry)
+     * @since 6.0.0
+     */
+    public function addDatePicker(
+        string $element,
+        $jsonOptions = null,
+        string $iconClass = 'icon-calendar',
+        array $iconAttrs = []
+    ): void {
+        $this->addCalendarPicker($element, false, $jsonOptions, $iconClass, $iconAttrs);
+    }
+
+    /**
+     * Promote a text input to a Joomla 6 native calendar field with time selector.
+     *
+     * @param string                $element     Element class name (no leading dot)
+     * @param array|string|Registry $jsonOptions Option parameters (JSON, array, or Registry)
+     * @param string                $iconClass   CSS class for the trigger icon (e.g. `fa-solid fa-calendar`)
+     * @param array<string,string>  $iconAttrs   Extra attributes on the icon span (e.g. `['uk-icon' => 'calendar']`)
+     * @since 6.0.0
+     */
+    public function addDateTimePicker(
+        string $element,
+        $jsonOptions = null,
+        string $iconClass = 'icon-calendar',
+        array $iconAttrs = []
+    ): void {
+        $this->addCalendarPicker($element, true, $jsonOptions, $iconClass, $iconAttrs);
+    }
+
+    /**
+     * Shared implementation that wires an existing input into Joomla 6's native
+     * `field.calendar` widget — registers assets, queues the gregorian helper,
+     * pushes the `Text::script()` strings the calendar consumes at runtime, and
+     * emits a vanilla-JS IIFE that wraps the input + appends the trigger button.
+     *
+     * @param string                $element     Element class name
+     * @param bool                  $showTime    Whether to enable the time selector
+     * @param array|string|Registry $jsonOptions Option parameters
+     * @since 6.0.0
+     */
+    protected function addCalendarPicker(
+        string $element,
+        bool $showTime,
+        $jsonOptions = null,
+        string $iconClass = 'icon-calendar',
+        array $iconAttrs = []
+    ): void {
+        if ($this->wa === null || $this->app === null || !preg_match('/^[A-Za-z0-9_-]+$/', $element)) {
+            return;
+        }
+
+        $params = $jsonOptions instanceof Registry
+            ? $jsonOptions
+            : new Registry($jsonOptions);
+
+        $format = (string) $params->get(
+            'date_format_strftime',
+            $showTime ? '%Y-%m-%d %H:%M' : '%Y-%m-%d'
+        );
+        // Joomla calendar treats min/max year as OFFSETS from current year (calendar.js: minYear = today + dataset.minYear).
+        $minYear = (int) $params->get('hide_pastdates', 1) === 1 ? 0 : -1900;
+        $maxYear = 200;
+        $showTimeAttr = $showTime ? '1' : '0';
+
+        if (empty($this->scriptsLoaded['field.calendar'])) {
+            $document = $this->app->getDocument();
+            $lang     = $this->app->getLanguage();
+            $calendar = $lang->getCalendar();
+            $direction = strtolower($document->getDirection());
+
+            $helperPath = 'system/fields/calendar-locales/date/gregorian/date-helper.min.js';
+            if ($calendar && is_dir(JPATH_ROOT . '/media/system/js/fields/calendar-locales/date/' . strtolower($calendar))) {
+                $helperPath = 'system/fields/calendar-locales/date/' . strtolower($calendar) . '/date-helper.min.js';
+            }
+
+            $this->wa
+                ->registerAndUseScript('field.calendar.helper', $helperPath, [], ['defer' => true])
+                ->useStyle('field.calendar' . ($direction === 'rtl' ? '-rtl' : ''))
+                ->useScript('field.calendar');
+
+            foreach ([
+                'SUNDAY', 'MONDAY', 'TUESDAY', 'WEDNESDAY', 'THURSDAY', 'FRIDAY', 'SATURDAY',
+                'SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT',
+                'JANUARY', 'FEBRUARY', 'MARCH', 'APRIL', 'MAY', 'JUNE',
+                'JULY', 'AUGUST', 'SEPTEMBER', 'OCTOBER', 'NOVEMBER', 'DECEMBER',
+                'JANUARY_SHORT', 'FEBRUARY_SHORT', 'MARCH_SHORT', 'APRIL_SHORT', 'MAY_SHORT', 'JUNE_SHORT',
+                'JULY_SHORT', 'AUGUST_SHORT', 'SEPTEMBER_SHORT', 'OCTOBER_SHORT', 'NOVEMBER_SHORT', 'DECEMBER_SHORT',
+                'JCLOSE', 'JCLEAR', 'JLIB_HTML_BEHAVIOR_TODAY',
+                'JLIB_HTML_BEHAVIOR_WK',
+                'JLIB_HTML_BEHAVIOR_AM', 'JLIB_HTML_BEHAVIOR_PM',
+                'JLIB_HTML_BEHAVIOR_OPEN_CALENDAR',
+            ] as $key) {
+                Text::script($key);
+            }
+
+            $this->scriptsLoaded['field.calendar'] = true;
+        }
+
+        $firstDay     = (int) $this->app->getLanguage()->getFirstDay();
+        $weekend      = preg_replace('/[^0-9,]/', '', (string) $this->app->getLanguage()->getWeekEnd()) ?: '0,6';
+        $jsonFlags    = JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_UNESCAPED_SLASHES;
+        $formatJs     = json_encode($format, $jsonFlags);
+        $labelJs      = json_encode(Text::_('JLIB_HTML_BEHAVIOR_OPEN_CALENDAR'), $jsonFlags);
+        $iconClassJs  = json_encode($iconClass, $jsonFlags);
+        $iconAttrsJs  = json_encode((object) $iconAttrs, $jsonFlags);
+
+        $js = <<<JS
+(function(){
+    function init(){
+        var input=document.querySelector('.{$element}');
+        if(!input||input.dataset.j2cCal)return;
+        input.dataset.j2cCal='1';
+        if(!input.id)input.id='{$element}_input';
+        var inputId=input.id;
+        var btnId=inputId+'_btn';
+        if(!input.hasAttribute('data-alt-value'))input.setAttribute('data-alt-value',input.value||'');
+        input.setAttribute('autocomplete','off');
+        var parent=input.parentNode;
+        var anchor=input.nextSibling;
+        var openLabel={$labelJs};
+        var btn=document.createElement('button');
+        btn.type='button';
+        btn.className='btn btn-primary';
+        btn.id=btnId;
+        btn.title=openLabel;
+        btn.setAttribute('data-inputfield',inputId);
+        btn.setAttribute('data-button',btnId);
+        btn.setAttribute('data-date-format',{$formatJs});
+        btn.setAttribute('data-firstday','{$firstDay}');
+        btn.setAttribute('data-weekend','{$weekend}');
+        btn.setAttribute('data-today-btn','1');
+        btn.setAttribute('data-week-numbers','0');
+        btn.setAttribute('data-show-time','{$showTimeAttr}');
+        btn.setAttribute('data-show-others','1');
+        btn.setAttribute('data-time24','24');
+        btn.setAttribute('data-only-months-nav','0');
+        btn.setAttribute('data-min-year','{$minYear}');
+        btn.setAttribute('data-max-year','{$maxYear}');
+        btn.setAttribute('data-date-type','gregorian');
+        var icon=document.createElement('span');
+        var iconClass={$iconClassJs};
+        if(iconClass)icon.className=iconClass;
+        icon.setAttribute('aria-hidden','true');
+        var iconAttrs={$iconAttrsJs};
+        for(var k in iconAttrs){if(Object.prototype.hasOwnProperty.call(iconAttrs,k))icon.setAttribute(k,iconAttrs[k]);}
+        btn.appendChild(icon);
+        var sr=document.createElement('span');
+        sr.className='visually-hidden';
+        sr.textContent=openLabel;
+        btn.appendChild(sr);
+        var inputGroup=document.createElement('div');
+        inputGroup.className='input-group';
+        inputGroup.appendChild(input);
+        inputGroup.appendChild(btn);
+        var fieldCal=document.createElement('div');
+        fieldCal.className='field-calendar';
+        fieldCal.appendChild(inputGroup);
+        parent.insertBefore(fieldCal,anchor);
+    }
+    if(document.readyState==='loading'){document.addEventListener('DOMContentLoaded',init,{once:true});}else{init();}
+})();
+JS;
+
+        $this->wa->addInlineScript($js);
     }
 
     /**

--- a/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/view_configurableoptions.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/view_configurableoptions.php
@@ -220,7 +220,7 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
                     class="<?php echo $element_date; ?>" />
             </div>
             <br>
-            <?php J2CommerceHelper::strapper()->addDatePicker($element_date, $option['option_params']); ?>
+            <?php J2CommerceHelper::strapper()->addDatePicker($element_date, $option['option_params'], 'fa-solid fa-calendar'); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] == 'datetime') : ?>
@@ -237,7 +237,7 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
                     class="<?php echo $element_datetime; ?>" />
             </div>
             <br>
-            <?php J2CommerceHelper::strapper()->addDateTimePicker($element_datetime, $option['option_params']); ?>
+            <?php J2CommerceHelper::strapper()->addDateTimePicker($element_datetime, $option['option_params'], 'fa-solid fa-calendar'); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] == 'time') : ?>

--- a/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/view_options.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/view_options.php
@@ -201,7 +201,7 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
                     value="<?php echo $esc($option['optionvalue'] ?? ''); ?>"
                     class="form-control <?php echo $element_date; ?>" />
             </div>
-            <?php J2CommerceHelper::strapper()->addDatePicker($element_date, $option['option_params']); ?>
+            <?php J2CommerceHelper::strapper()->addDatePicker($element_date, $option['option_params'], 'fa-solid fa-calendar'); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] == 'datetime') : ?>
@@ -217,7 +217,7 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
                     value="<?php echo $esc($option['optionvalue'] ?? ''); ?>"
                     class="form-control <?php echo $element_datetime; ?>" />
             </div>
-            <?php J2CommerceHelper::strapper()->addDateTimePicker($element_datetime, $option['option_params']); ?>
+            <?php J2CommerceHelper::strapper()->addDateTimePicker($element_datetime, $option['option_params'], 'fa-solid fa-calendar'); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] == 'time') : ?>

--- a/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/view_variableoptions.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/view_variableoptions.php
@@ -259,7 +259,7 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
                        name="product_option[<?php echo (int) $option['productoption_id']; ?>]"
                        value="<?php echo $esc($option['optionvalue'] ?? ''); ?>" />
             </div>
-            <?php J2CommerceHelper::strapper()->addDatePicker($element_date, $option['option_params']); ?>
+            <?php J2CommerceHelper::strapper()->addDatePicker($element_date, $option['option_params'], 'fa-solid fa-calendar'); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] === 'datetime') : ?>
@@ -277,7 +277,7 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
                        name="product_option[<?php echo (int) $option['productoption_id']; ?>]"
                        value="<?php echo $esc($option['optionvalue'] ?? ''); ?>" />
             </div>
-            <?php J2CommerceHelper::strapper()->addDateTimePicker($element_datetime, $option['option_params']); ?>
+            <?php J2CommerceHelper::strapper()->addDateTimePicker($element_datetime, $option['option_params'], 'fa-solid fa-calendar'); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] === 'time') : ?>

--- a/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/view_configurableoptions.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/view_configurableoptions.php
@@ -220,7 +220,7 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
                     class="<?php echo $element_date; ?>" />
             </div>
             <br>
-            <?php J2CommerceHelper::strapper()->addDatePicker($element_date, $option['option_params']); ?>
+            <?php J2CommerceHelper::strapper()->addDatePicker($element_date, $option['option_params'], 'fa-solid fa-calendar'); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] == 'datetime') : ?>
@@ -237,7 +237,7 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
                     class="<?php echo $element_datetime; ?>" />
             </div>
             <br>
-            <?php J2CommerceHelper::strapper()->addDateTimePicker($element_datetime, $option['option_params']); ?>
+            <?php J2CommerceHelper::strapper()->addDateTimePicker($element_datetime, $option['option_params'], 'fa-solid fa-calendar'); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] == 'time') : ?>

--- a/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/view_options.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/view_options.php
@@ -200,7 +200,7 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
                     value="<?php echo $esc($option['optionvalue'] ?? ''); ?>"
                     class="form-control <?php echo $element_date; ?>" />
             </div>
-            <?php J2CommerceHelper::strapper()->addDatePicker($element_date, $option['option_params']); ?>
+            <?php J2CommerceHelper::strapper()->addDatePicker($element_date, $option['option_params'], 'fa-solid fa-calendar'); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] == 'datetime') : ?>
@@ -216,7 +216,7 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
                     value="<?php echo $esc($option['optionvalue'] ?? ''); ?>"
                     class="form-control <?php echo $element_datetime; ?>" />
             </div>
-            <?php J2CommerceHelper::strapper()->addDateTimePicker($element_datetime, $option['option_params']); ?>
+            <?php J2CommerceHelper::strapper()->addDateTimePicker($element_datetime, $option['option_params'], 'fa-solid fa-calendar'); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] == 'time') : ?>

--- a/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/view_variableoptions.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/view_variableoptions.php
@@ -259,7 +259,7 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
                        name="product_option[<?php echo $option['productoption_id']; ?>]"
                        value="<?php echo $esc($option['optionvalue'] ?? ''); ?>" />
             </div>
-            <?php J2CommerceHelper::strapper()->addDatePicker($element_date, $option['option_params']); ?>
+            <?php J2CommerceHelper::strapper()->addDatePicker($element_date, $option['option_params'], 'fa-solid fa-calendar'); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] === 'datetime') : ?>
@@ -277,7 +277,7 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
                        name="product_option[<?php echo $option['productoption_id']; ?>]"
                        value="<?php echo $esc($option['optionvalue'] ?? ''); ?>" />
             </div>
-            <?php J2CommerceHelper::strapper()->addDateTimePicker($element_datetime, $option['option_params']); ?>
+            <?php J2CommerceHelper::strapper()->addDateTimePicker($element_datetime, $option['option_params'], 'fa-solid fa-calendar'); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] === 'time') : ?>

--- a/plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_configurableoptions.php
+++ b/plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_configurableoptions.php
@@ -218,7 +218,7 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
                     name="product_option[<?php echo $option['productoption_id']; ?>]"
                     value="<?php echo $option['optionvalue']; ?>" />
             </div>
-            <?php J2CommerceHelper::strapper()->addDatePicker($element_date, $option['option_params']); ?>
+            <?php J2CommerceHelper::strapper()->addDatePicker($element_date, $option['option_params'], '', ['uk-icon' => 'calendar']); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] == 'datetime') : ?>
@@ -233,7 +233,7 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
                     name="product_option[<?php echo $option['productoption_id']; ?>]"
                     value="<?php echo $option['optionvalue']; ?>" />
             </div>
-            <?php J2CommerceHelper::strapper()->addDateTimePicker($element_datetime, $option['option_params']); ?>
+            <?php J2CommerceHelper::strapper()->addDateTimePicker($element_datetime, $option['option_params'], '', ['uk-icon' => 'calendar']); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] == 'time') : ?>

--- a/plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_options.php
+++ b/plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_options.php
@@ -189,7 +189,7 @@ $ajax_url = Route::_('index.php', false);
                     name="product_option[<?php echo $option['productoption_id']; ?>]"
                     value="<?php echo $option['optionvalue']; ?>" />
             </div>
-            <?php J2CommerceHelper::strapper()->addDatePicker($element_date, $option['option_params']); ?>
+            <?php J2CommerceHelper::strapper()->addDatePicker($element_date, $option['option_params'], '', ['uk-icon' => 'calendar']); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] == 'datetime') : ?>
@@ -204,7 +204,7 @@ $ajax_url = Route::_('index.php', false);
                     name="product_option[<?php echo $option['productoption_id']; ?>]"
                     value="<?php echo $option['optionvalue']; ?>" />
             </div>
-            <?php J2CommerceHelper::strapper()->addDateTimePicker($element_datetime, $option['option_params']); ?>
+            <?php J2CommerceHelper::strapper()->addDateTimePicker($element_datetime, $option['option_params'], '', ['uk-icon' => 'calendar']); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] == 'time') : ?>

--- a/plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_variableoptions.php
+++ b/plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_variableoptions.php
@@ -254,7 +254,7 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
                        name="product_option[<?php echo $option['productoption_id']; ?>]"
                        value="<?php echo $esc($option['optionvalue'] ?? ''); ?>" />
             </div>
-            <?php J2CommerceHelper::strapper()->addDatePicker($element_date, $option['option_params']); ?>
+            <?php J2CommerceHelper::strapper()->addDatePicker($element_date, $option['option_params'], '', ['uk-icon' => 'calendar']); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] === 'datetime') : ?>
@@ -272,7 +272,7 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
                        name="product_option[<?php echo $option['productoption_id']; ?>]"
                        value="<?php echo $esc($option['optionvalue'] ?? ''); ?>" />
             </div>
-            <?php J2CommerceHelper::strapper()->addDateTimePicker($element_datetime, $option['option_params']); ?>
+            <?php J2CommerceHelper::strapper()->addDateTimePicker($element_datetime, $option['option_params'], '', ['uk-icon' => 'calendar']); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] === 'time') : ?>

--- a/plugins/j2commerce/app_uikit/tmpl/uikit/view_configurableoptions.php
+++ b/plugins/j2commerce/app_uikit/tmpl/uikit/view_configurableoptions.php
@@ -218,7 +218,7 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
                     name="product_option[<?php echo $option['productoption_id']; ?>]"
                     value="<?php echo $option['optionvalue']; ?>" />
             </div>
-            <?php J2CommerceHelper::strapper()->addDatePicker($element_date, $option['option_params']); ?>
+            <?php J2CommerceHelper::strapper()->addDatePicker($element_date, $option['option_params'], '', ['uk-icon' => 'calendar']); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] == 'datetime') : ?>
@@ -233,7 +233,7 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
                     name="product_option[<?php echo $option['productoption_id']; ?>]"
                     value="<?php echo $option['optionvalue']; ?>" />
             </div>
-            <?php J2CommerceHelper::strapper()->addDateTimePicker($element_datetime, $option['option_params']); ?>
+            <?php J2CommerceHelper::strapper()->addDateTimePicker($element_datetime, $option['option_params'], '', ['uk-icon' => 'calendar']); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] == 'time') : ?>

--- a/plugins/j2commerce/app_uikit/tmpl/uikit/view_options.php
+++ b/plugins/j2commerce/app_uikit/tmpl/uikit/view_options.php
@@ -189,7 +189,7 @@ $ajax_url = Route::_('index.php', false);
                     name="product_option[<?php echo $option['productoption_id']; ?>]"
                     value="<?php echo $option['optionvalue']; ?>" />
             </div>
-            <?php J2CommerceHelper::strapper()->addDatePicker($element_date, $option['option_params']); ?>
+            <?php J2CommerceHelper::strapper()->addDatePicker($element_date, $option['option_params'], '', ['uk-icon' => 'calendar']); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] == 'datetime') : ?>
@@ -204,7 +204,7 @@ $ajax_url = Route::_('index.php', false);
                     name="product_option[<?php echo $option['productoption_id']; ?>]"
                     value="<?php echo $option['optionvalue']; ?>" />
             </div>
-            <?php J2CommerceHelper::strapper()->addDateTimePicker($element_datetime, $option['option_params']); ?>
+            <?php J2CommerceHelper::strapper()->addDateTimePicker($element_datetime, $option['option_params'], '', ['uk-icon' => 'calendar']); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] == 'time') : ?>

--- a/plugins/j2commerce/app_uikit/tmpl/uikit/view_variableoptions.php
+++ b/plugins/j2commerce/app_uikit/tmpl/uikit/view_variableoptions.php
@@ -255,7 +255,7 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
                        name="product_option[<?php echo $option['productoption_id']; ?>]"
                        value="<?php echo $esc($option['optionvalue'] ?? ''); ?>" />
             </div>
-            <?php J2CommerceHelper::strapper()->addDatePicker($element_date, $option['option_params']); ?>
+            <?php J2CommerceHelper::strapper()->addDatePicker($element_date, $option['option_params'], '', ['uk-icon' => 'calendar']); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] === 'datetime') : ?>
@@ -273,7 +273,7 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
                        name="product_option[<?php echo $option['productoption_id']; ?>]"
                        value="<?php echo $esc($option['optionvalue'] ?? ''); ?>" />
             </div>
-            <?php J2CommerceHelper::strapper()->addDateTimePicker($element_datetime, $option['option_params']); ?>
+            <?php J2CommerceHelper::strapper()->addDateTimePicker($element_datetime, $option['option_params'], '', ['uk-icon' => 'calendar']); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] === 'time') : ?>


### PR DESCRIPTION
## Summary

Plugin templates were calling `J2CommerceHelper::strapper()->addDatePicker()` / `addDateTimePicker()` on `view_options.php`, `view_configurableoptions.php`, and `view_variableoptions.php` (in both `bootstrap5`/`uikit` template variants and their `tag_*` siblings), but those methods did not exist on `StrapperHelper`. Every product page exposing a date or datetime option threw:

```
Call to undefined method J2Commerce\Component\J2commerce\Administrator\Helper\StrapperHelper::addDatePicker()
```

## Implementation

Pure Joomla 6 — **no jQuery UI, no third-party calendar libs, no `j2store` legacy assets**.

`addDatePicker()` / `addDateTimePicker()` now:

1. Register the core `field.calendar` script + style and the locale-aware `field.calendar.helper` (gregorian fallback) via the Web Asset Manager — exactly mirroring `layouts/joomla/form/field/calendar.php`.
2. Push the same `Text::script()` keys the calendar widget consumes at runtime.
3. Emit a vanilla-JS IIFE through `addInlineScript` that, on `DOMContentLoaded`, wraps the pre-rendered `<input class=\"\$element\">` in:

   ```html
   <div class=\"field-calendar\">
     <div class=\"input-group\">
       <input … data-alt-value=\"…\" autocomplete=\"off\">
       <button class=\"btn btn-primary\" data-inputfield … data-date-format … data-show-time …>
         <span class=\"…icon…\" aria-hidden=\"true\"></span>
       </button>
     </div>
   </div>
   ```

4. Joomla's own `media/system/js/fields/calendar.js` auto-init handler (its DOMContentLoaded listener) upgrades the wrapped element on its next pass.

### Notable defenses

- **DOM construction is gated behind a readyState check** — `addInlineScript` lands the IIFE in `<head>` before the input exists in `<body>`, so a synchronous `querySelector` would no-op silently.
- **`data-min-year` / `data-max-year` use Joomla's RELATIVE-OFFSET semantics** (`calendar.js`: `params.minYear = currentYear + dataset.minYear`). Use `0` for \"today\" when `hide_pastdates=1`, otherwise `-1900` / `200` to mirror `CalendarField` defaults. Passing absolute years rendered the calendar at year 4052.
- **No manual `joomla:updated` dispatch** — the deferred core script registers its own DOMContentLoaded listener, so manual dispatch races and is unreliable.
- **Injection hardening:** `\$element` regex-validated `^[A-Za-z0-9_-]+\$`; `\$weekend` filtered to `[0-9,]` with `0,6` fallback; `\$format` + open-calendar label emitted via `json_encode(…, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_UNESCAPED_SLASHES)` to defeat `</script>` breakouts.
- **Idempotent:** `input.dataset.j2cCal` flag blocks double-wrap; asset registration gated on `\$this->scriptsLoaded['field.calendar']`.

### Framework-aware icons

Both methods accept optional `\$iconClass` (default `icon-calendar`) and `\$iconAttrs` array. The IIFE applies the class then iterates the attributes via `setAttribute` — no `innerHTML`, works for either framework:

| Template | Call signature |
| --- | --- |
| `app_bootstrap5/tmpl/{bootstrap5,tag_bootstrap5}/*` | `addDatePicker(\$el, \$params, 'fa-solid fa-calendar')` |
| `app_uikit/tmpl/{uikit,tag_uikit}/*` | `addDatePicker(\$el, \$params, '', ['uk-icon' => 'calendar'])` |

## Files Modified (13)

| Type | Count |
| --- | --- |
| PHP helper | 1 (`StrapperHelper.php`) |
| Bootstrap 5 templates | 6 |
| UIkit templates | 6 |

## Pre-Flight

- [x] PHP syntax (`php -l`) on all 13 files — clean
- [x] No secrets / API keys in diff
- [x] No FOF remnants (`F0FModel`, `F0FController`, `F0FTable`, `JFactory::`)
- [x] Core files only (verified against `build/build_package.php`; non-core extensions excluded)
- [x] Reviewed by `joomla6-code-reviewer` — C1 (head-injection ordering), H1 (deferred-script race), M1 (`</script>` injection), M2 (FQN imports) all addressed before commit

## Test plan

- [ ] Open a product detail page with a date-type option in `app_bootstrap5/bootstrap5` template — calendar renders, current year displays, picker opens on click
- [ ] Same on `app_bootstrap5/tag_bootstrap5` (tag/category list views)
- [ ] Same on `app_uikit/uikit` and `app_uikit/tag_uikit` — `uk-icon` calendar trigger renders correctly
- [ ] datetime-type option shows time selector; date-only option does not
- [ ] `hide_pastdates=1` configurations limit selection to current year onward