### PR TITLE
fix(cart): suppress unserialize warnings on legacy session payloads

### DIFF
--- a/administrator/components/com_j2commerce/src/Model/CartItemsModel.php
+++ b/administrator/components/com_j2commerce/src/Model/CartItemsModel.php
@@ -263,7 +263,7 @@ class CartItemsModel extends ListModel
             }
 
             // Now try to unserialize the data
-            $unserialized = unserialize($decoded, ['allowed_classes' => false]);
+            $unserialized = @unserialize($decoded, ['allowed_classes' => false]);
 
             if ($unserialized === false) {
                 // If unserialize fails, try to decode as JSON (fallback)


### PR DESCRIPTION
## Summary

`CartItemsModel::getItems()` reads cart payload data that may have been written years ago in inconsistent encodings (J2Store legacy sessions, partially-corrupt cart rows). Calling `unserialize()` on a malformed payload still emits an `E_WARNING` even though `allowed_classes => false` stops actual deserialization. That warning pollutes logs and breaks callers that escalate warnings to exceptions, even though the function already handles failure correctly via a JSON-decode fallback.

Add `@` to the single line so the explicit fallback chain runs cleanly:

```diff
-            $unserialized = unserialize($decoded, ['allowed_classes' => false]);
+            $unserialized = @unserialize($decoded, ['allowed_classes' => false]);
```

Behavior is unchanged: a `false` return still triggers the JSON fallback exactly as before, the surrounding try/catch still wins on hard exceptions. The change is *only* about not screaming on the probe call we already expect to sometimes fail.

## Files Modified

| File | Change |
| --- | --- |
| `administrator/components/com_j2commerce/src/Model/CartItemsModel.php` | 1 line (line 263 — suppress warning) |

## Pre-Flight

- [x] PHP syntax (`php -l`) clean
- [x] No FOF remnants, no `JFactory::`
- [x] Single-line scope; no semantic change

## Test plan

- [ ] Cart Items list view loads without populating logs with "unserialize(): Error at offset…" warnings on stores with legacy session data
- [ ] Cart items with valid serialized payloads still display correctly
- [ ] Cart items with valid JSON payloads still fall through and display correctly