### PR TITLE
chore(version): bump core extension manifests to 6.2.2 (supersedes #859)

### DIFF
--- a/administrator/modules/mod_j2commerce_menu/mod_j2commerce_menu.xml
+++ b/administrator/modules/mod_j2commerce_menu/mod_j2commerce_menu.xml
@@ -7,7 +7,7 @@
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>support@j2commerce.com</authorEmail>
     <authorUrl>https://www.j2commerce.com</authorUrl>
-    <version>6.0.7</version>
+    <version>6.2.2</version>
     <description>MOD_J2COMMERCE_MENU_XML_DESCRIPTION</description>
     <namespace path="src">J2Commerce\Module\J2commerceMenu</namespace>
     <files>

--- a/administrator/modules/mod_j2commerce_orders/mod_j2commerce_orders.xml
+++ b/administrator/modules/mod_j2commerce_orders/mod_j2commerce_orders.xml
@@ -7,7 +7,7 @@
     <license>GNU General Public License v2 or later</license>
     <authorEmail>support@j2commerce.com</authorEmail>
     <authorUrl>https://www.j2commerce.com</authorUrl>
-    <version>6.0.7</version>
+    <version>6.2.2</version>
     <description>MOD_J2COMMERCE_ORDERS_XML_DESCRIPTION</description>
     <namespace path="src">J2Commerce\Module\Orders</namespace>
     <files>

--- a/administrator/modules/mod_j2commerce_quickicons/mod_j2commerce_quickicons.xml
+++ b/administrator/modules/mod_j2commerce_quickicons/mod_j2commerce_quickicons.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="module" client="administrator" method="upgrade">
     <name>MOD_J2COMMERCE_QUICKICONS</name>
-    <version>6.0.7</version>
+    <version>6.2.2</version>
     <description>MOD_J2COMMERCE_QUICKICONS_DESC</description>
     <namespace path="src">J2Commerce\Module\J2commerceQuickicons</namespace>
 

--- a/administrator/modules/mod_j2commerce_stats/mod_j2commerce_stats.xml
+++ b/administrator/modules/mod_j2commerce_stats/mod_j2commerce_stats.xml
@@ -7,7 +7,7 @@
     <license>GNU General Public License v2 or later</license>
     <authorEmail>support@j2commerce.com</authorEmail>
     <authorUrl>https://www.j2commerce.com</authorUrl>
-    <version>6.0.7</version>
+    <version>6.2.2</version>
     <description>MOD_J2COMMERCE_STATS_XML_DESCRIPTION</description>
     <namespace path="src">J2Commerce\Module\Stats</namespace>
     <files>

--- a/modules/mod_j2commerce_cart/mod_j2commerce_cart.xml
+++ b/modules/mod_j2commerce_cart/mod_j2commerce_cart.xml
@@ -7,7 +7,7 @@
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>support@j2commerce.com</authorEmail>
     <authorUrl>https://www.j2commerce.com</authorUrl>
-    <version>6.0.7</version>
+    <version>6.2.2</version>
     <description>MOD_J2COMMERCE_CART_DESC</description>
     <namespace path="src">J2Commerce\Module\Cart</namespace>
     <files>

--- a/modules/mod_j2commerce_currency/mod_j2commerce_currency.xml
+++ b/modules/mod_j2commerce_currency/mod_j2commerce_currency.xml
@@ -7,7 +7,7 @@
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>support@j2commerce.com</authorEmail>
     <authorUrl>https://www.j2commerce.com</authorUrl>
-    <version>6.0.7</version>
+    <version>6.2.2</version>
     <description>MOD_J2COMMERCE_CURRENCY_DESC</description>
     <namespace path="src">J2Commerce\Module\Currency</namespace>
     <files>

--- a/modules/mod_j2commerce_products/mod_j2commerce_products.xml
+++ b/modules/mod_j2commerce_products/mod_j2commerce_products.xml
@@ -5,7 +5,7 @@
     <authorUrl>https://www.j2commerce.com</authorUrl>
     <copyright>(C)2024-2026 J2Commerce, LLC. All rights reserved.</copyright>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
-    <version>6.0.7</version>
+    <version>6.2.2</version>
     <description>MOD_J2COMMERCE_PRODUCTS_DESC</description>
     <namespace path="src">J2Commerce\Module\Products</namespace>
 

--- a/modules/mod_j2commerce_relatedproducts/mod_j2commerce_relatedproducts.xml
+++ b/modules/mod_j2commerce_relatedproducts/mod_j2commerce_relatedproducts.xml
@@ -5,7 +5,7 @@
     <authorUrl>https://www.j2commerce.com</authorUrl>
     <copyright>(C)2024-2026 J2Commerce, LLC. All rights reserved.</copyright>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
-    <version>6.0.7</version>
+    <version>6.2.2</version>
     <description>MOD_J2COMMERCE_RELATEDPRODUCTS_DESC</description>
     <namespace path="src">J2Commerce\Module\RelatedProducts</namespace>
 

--- a/plugins/actionlog/j2commerce/j2commerce.xml
+++ b/plugins/actionlog/j2commerce/j2commerce.xml
@@ -5,7 +5,7 @@
     <creationDate>2026-02-07</creationDate>
     <copyright>(C)2024-2026 J2Commerce, LLC. All rights reserved.</copyright>
     <license>GNU General Public License version 2 or later</license>
-    <version>6.0.8</version>
+    <version>6.2.2</version>
     <description>PLG_ACTIONLOG_J2COMMERCE_DESCRIPTION</description>
     <namespace path="src">J2Commerce\Plugin\Actionlog\J2commerce</namespace>
     <files>

--- a/plugins/console/j2commerce/j2commerce.xml
+++ b/plugins/console/j2commerce/j2commerce.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="console" method="upgrade">
 	<name>PLG_CONSOLE_J2COMMERCE</name>
-	<version>6.0.0</version>
+	<version>6.2.2</version>
 	<creationDate>2026-02-27</creationDate>
 	<author>J2Commerce, LLC</author>
 	<authorEmail>support@j2commerce.com</authorEmail>

--- a/plugins/content/j2commerce/j2commerce.xml
+++ b/plugins/content/j2commerce/j2commerce.xml
@@ -7,7 +7,7 @@
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>support@j2commerce.com</authorEmail>
     <authorUrl>https://www.j2commerce.com</authorUrl>
-    <version>6.0.7</version>
+    <version>6.2.2</version>
     <description>PLG_CONTENT_J2COMMERCE_DESCRIPTION</description>
     <namespace path="src">J2Commerce\Plugin\Content\J2Commerce</namespace>
 

--- a/plugins/finder/j2commerce/j2commerce.xml
+++ b/plugins/finder/j2commerce/j2commerce.xml
@@ -7,7 +7,7 @@
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>support@j2commerce.com</authorEmail>
     <authorUrl>https://www.j2commerce.com</authorUrl>
-    <version>6.0.7</version>
+    <version>6.2.2</version>
     <description>PLG_FINDER_J2COMMERCE_XML_DESCRIPTION</description>
     <namespace path="src">J2Commerce\Plugin\Finder\J2commerce</namespace>
     <files>

--- a/plugins/j2commerce/app_bootstrap5/app_bootstrap5.xml
+++ b/plugins/j2commerce/app_bootstrap5/app_bootstrap5.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="j2commerce" method="upgrade">
     <name>PLG_J2COMMERCE_APP_BOOTSTRAP5</name>
-    <version>6.0.7</version>
+    <version>6.2.2</version>
     <creationDate>October 2025</creationDate>
     <author>J2Commerce, LLC</author>
     <copyright>Copyright (C) 2025 J2Commerce, LLC. All rights reserved.</copyright>

--- a/plugins/j2commerce/app_currencyupdater/app_currencyupdater.xml
+++ b/plugins/j2commerce/app_currencyupdater/app_currencyupdater.xml
@@ -7,7 +7,7 @@
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>support@j2commerce.com</authorEmail>
     <authorUrl>https://www.j2commerce.com</authorUrl>
-    <version>6.0.7.73</version>
+    <version>6.2.2</version>
     <description>PLG_J2COMMERCE_APP_CURRENCYUPDATER_XML_DESCRIPTION</description>
 
     <namespace path="src">J2Commerce\Plugin\J2Commerce\AppCurrencyupdater</namespace>

--- a/plugins/j2commerce/app_diagnostics/app_diagnostics.xml
+++ b/plugins/j2commerce/app_diagnostics/app_diagnostics.xml
@@ -7,7 +7,7 @@
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>support@j2commerce.com</authorEmail>
 	<authorUrl>https://www.j2commerce.com</authorUrl>
-	<version>6.0.7</version>
+	<version>6.2.2</version>
 	<namespace path="src">J2Commerce\Plugin\J2Commerce\AppDiagnostics</namespace>
 	<description>PLG_J2COMMERCE_APP_DIAGNOSTICS_DESCRIPTION</description>
 	<files>

--- a/plugins/j2commerce/app_flexivariable/app_flexivariable.xml
+++ b/plugins/j2commerce/app_flexivariable/app_flexivariable.xml
@@ -7,7 +7,7 @@
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>support@j2commerce.com</authorEmail>
     <authorUrl>https://www.j2commerce.com</authorUrl>
-    <version>6.0.7</version>
+    <version>6.2.2</version>
     <description>PLG_J2COMMERCE_APP_FLEXIVARIABLE_XML_DESCRIPTION</description>
 
     <namespace path="src">J2Commerce\Plugin\J2Commerce\AppFlexivariable</namespace>

--- a/plugins/j2commerce/app_localization_data/app_localization_data.xml
+++ b/plugins/j2commerce/app_localization_data/app_localization_data.xml
@@ -7,7 +7,7 @@
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>support@j2commerce.com</authorEmail>
 	<authorUrl>https://www.j2commerce.com</authorUrl>
-	<version>6.0.7</version>
+	<version>6.2.2</version>
 	<namespace path="src">J2Commerce\Plugin\J2Commerce\AppLocalizationData</namespace>
 	<description>PLG_J2COMMERCE_APP_LOCALIZATION_DATA_DESCRIPTION</description>
 	<files>

--- a/plugins/j2commerce/app_uikit/app_uikit.xml
+++ b/plugins/j2commerce/app_uikit/app_uikit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="j2commerce" method="upgrade">
     <name>PLG_J2COMMERCE_APP_UIKIT</name>
-    <version>6.0.7</version>
+    <version>6.2.2</version>
     <author>J2Commerce, LLC</author>
     <creationDate>2026-01</creationDate>
     <copyright>Copyright (C) 2024–2026 J2Commerce, LLC. All rights reserved.</copyright>

--- a/plugins/j2commerce/payment_banktransfer/payment_banktransfer.xml
+++ b/plugins/j2commerce/payment_banktransfer/payment_banktransfer.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="j2commerce" method="upgrade">
     <name>PLG_J2COMMERCE_PAYMENT_BANKTRANSFER</name>
-    <version>6.0.7</version>
+    <version>6.2.2</version>
     <creationDate>October 2025</creationDate>
     <author>J2Commerce, LLC</author>
     <copyright>Copyright (C) 2024–2026 J2Commerce, LLC. All rights reserved.</copyright>

--- a/plugins/j2commerce/payment_cash/payment_cash.xml
+++ b/plugins/j2commerce/payment_cash/payment_cash.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="j2commerce" method="upgrade">
     <name>PLG_J2COMMERCE_PAYMENT_CASH</name>
-    <version>6.0.7</version>
+    <version>6.2.2</version>
     <author>J2Commerce, LLC</author>
     <creationDate>2026-01</creationDate>
     <copyright>Copyright (C) 2024–2026 J2Commerce, LLC. All rights reserved.</copyright>

--- a/plugins/j2commerce/payment_moneyorder/payment_moneyorder.xml
+++ b/plugins/j2commerce/payment_moneyorder/payment_moneyorder.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="j2commerce" method="upgrade">
     <name>PLG_J2COMMERCE_PAYMENT_MONEYORDER</name>
-    <version>6.0.7</version>
+    <version>6.2.2</version>
     <author>J2Commerce, LLC</author>
     <creationDate>2026-01</creationDate>
     <copyright>Copyright (C) 2024–2026 J2Commerce, LLC. All rights reserved.</copyright>

--- a/plugins/j2commerce/report_itemised/report_itemised.xml
+++ b/plugins/j2commerce/report_itemised/report_itemised.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="j2commerce" method="upgrade">
     <name>PLG_J2COMMERCE_REPORT_ITEMISED</name>
-    <version>6.0.7</version>
+    <version>6.2.2</version>
     <author>J2Commerce, LLC</author>
     <creationDate>2026-02</creationDate>
     <copyright>Copyright (C) 2024–2026 J2Commerce, LLC. All rights reserved.</copyright>

--- a/plugins/j2commerce/report_products/report_products.xml
+++ b/plugins/j2commerce/report_products/report_products.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="j2commerce" method="upgrade">
     <name>PLG_J2COMMERCE_REPORT_PRODUCTS</name>
-    <version>6.0.7</version>
+    <version>6.2.2</version>
     <author>J2Commerce, LLC</author>
     <creationDate>2026-02</creationDate>
     <copyright>Copyright (C) 2024-2026 J2Commerce, LLC. All rights reserved.</copyright>

--- a/plugins/j2commerce/shipping_free/shipping_free.xml
+++ b/plugins/j2commerce/shipping_free/shipping_free.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="j2commerce" method="upgrade">
     <name>PLG_J2COMMERCE_SHIPPING_FREE</name>
-    <version>6.0.7</version>
+    <version>6.2.2</version>
     <author>J2Commerce, LLC</author>
     <creationDate>2026-02</creationDate>
     <copyright>Copyright (C) 2024-2026 J2Commerce, LLC. All rights reserved.</copyright>

--- a/plugins/j2commerce/shipping_standard/shipping_standard.xml
+++ b/plugins/j2commerce/shipping_standard/shipping_standard.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="j2commerce" method="upgrade">
     <name>PLG_J2COMMERCE_SHIPPING_STANDARD</name>
-    <version>6.0.7</version>
+    <version>6.2.2</version>
     <author>J2Commerce, LLC</author>
     <creationDate>2026-02</creationDate>
     <copyright>Copyright (C) 2024-2026 J2Commerce, LLC. All rights reserved.</copyright>

--- a/plugins/sampledata/j2commerce/j2commerce.xml
+++ b/plugins/sampledata/j2commerce/j2commerce.xml
@@ -7,7 +7,7 @@
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>support@j2commerce.com</authorEmail>
     <authorUrl>https://www.j2commerce.com</authorUrl>
-    <version>6.0.0</version>
+    <version>6.2.2</version>
     <description>PLG_SAMPLEDATA_J2COMMERCE_XML_DESCRIPTION</description>
     <namespace path="src">J2Commerce\Plugin\SampleData\J2Commerce</namespace>
     <files>

--- a/plugins/schemaorg/ecommerce/ecommerce.xml
+++ b/plugins/schemaorg/ecommerce/ecommerce.xml
@@ -7,7 +7,7 @@
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>support@j2commerce.com</authorEmail>
 	<authorUrl>https://www.j2commerce.com</authorUrl>
-	<version>6.0.7</version>
+	<version>6.2.2</version>
 	<description>PLG_SCHEMAORG_ECOMMERCE_XML_DESCRIPTION</description>
 	<namespace path="src">Joomla\Plugin\Schemaorg\Ecommerce</namespace>
 	<files>

--- a/plugins/system/j2commerce/j2commerce.xml
+++ b/plugins/system/j2commerce/j2commerce.xml
@@ -7,7 +7,7 @@
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>support@j2commerce.com</authorEmail>
     <authorUrl>https://www.j2commerce.com</authorUrl>
-    <version>6.0.7</version>
+    <version>6.2.2</version>
     <description>PLG_SYSTEM_J2COMMERCE_DESCRIPTION</description>
     <namespace path="src">J2Commerce\Plugin\System\J2Commerce</namespace>
 

--- a/plugins/task/j2commerce/j2commerce.xml
+++ b/plugins/task/j2commerce/j2commerce.xml
@@ -7,7 +7,7 @@
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>support@j2commerce.com</authorEmail>
     <authorUrl>https://www.j2commerce.com</authorUrl>
-    <version>6.0.7</version>
+    <version>6.2.2</version>
     <description>PLG_TASK_J2COMMERCE_XML_DESCRIPTION</description>
     <namespace path="src">J2Commerce\Plugin\Task\J2Commerce</namespace>
     <files>

--- a/plugins/user/j2commerce/j2commerce.xml
+++ b/plugins/user/j2commerce/j2commerce.xml
@@ -7,7 +7,7 @@
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>support@j2commerce.com</authorEmail>
     <authorUrl>https://www.j2commerce.com</authorUrl>
-    <version>6.0.7</version>
+    <version>6.2.2</version>
     <description>PLG_USER_J2COMMERCE_DESC</description>
 
     <namespace path="src">J2Commerce\Plugin\User\J2Commerce</namespace>

--- a/plugins/webservices/j2commerce/j2commerce.xml
+++ b/plugins/webservices/j2commerce/j2commerce.xml
@@ -7,7 +7,7 @@
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>support@j2commerce.com</authorEmail>
 	<authorUrl>https://www.j2commerce.com</authorUrl>
-	<version>6.0.7</version>
+	<version>6.2.2</version>
 	<description>PLG_WEBSERVICES_J2COMMERCE_XML_DESCRIPTION</description>
 	<namespace path="src">J2Commerce\Plugin\WebServices\J2Commerce</namespace>
 	<files>


### PR DESCRIPTION
## Summary

Supersedes #859 with @brianteeman's review applied: drops the `JFIELD_ALT_MODULE_LAYOUT_DESC` reference (removed from Joomla core in #849, should not be reintroduced).

Bumps the `<version>` field on **31** core extension manifests so they install/upgrade cleanly against the current 6.2.2 release. No other content changes — pure version field on every file.

## What changed vs #859

| File | Was (in #859) | Now |
| --- | --- | --- |
| `mod_j2commerce_orders.xml` | added `description="JFIELD_ALT_MODULE_LAYOUT_DESC"` on layout field | version bump only |
| `mod_j2commerce_stats.xml` | same as above | version bump only |
| `mod_j2commerce_cart.xml` | same as above | version bump only |
| (other 28 files) | unchanged | unchanged (version bump only) |

## Files Modified

| Group | Count |
| --- | --- |
| Admin modules | 4 |
| Site modules | 4 |
| Non-j2commerce-group plugins | 10 |
| j2commerce-group plugins | 13 |
| **Total** | **31** |

## Pre-Flight

- [x] No PHP files changed (manifest-only)
- [x] No secrets in diff
- [x] Core files only (verified against `build/build_package.php`)
- [x] No `JFIELD_ALT_MODULE_LAYOUT_DESC` reference (per @brianteeman in #859)
- [x] Excludes `payment_paypal.xml` (active feature work — separate PR will follow)

## Why a new PR

Branch ruleset on this repo blocks direct commits to feature branches once they exist; couldn't push the fix-up commit to #859's branch. Closing #859 in favour of this clean replacement preserves authorship and review history without partial state.

## Test plan

- [ ] Install/update each extension and verify it reports 6.2.2 in Extensions → Manage