### PR TITLE
feat(payment_paypal): NVP client + test buttons field

### DIFF
--- a/plugins/j2commerce/payment_paypal/language/en-GB/plg_j2commerce_payment_paypal.ini
+++ b/plugins/j2commerce/payment_paypal/language/en-GB/plg_j2commerce_payment_paypal.ini
@@ -27,9 +27,42 @@ PLG_J2COMMERCE_PAYMENT_PAYPAL_WEBHOOK_ID_DESC="Webhook ID from PayPal dashboard 
 PLG_J2COMMERCE_PAYMENT_PAYPAL_SANDBOX_WEBHOOK_ID="Sandbox Webhook ID"
 PLG_J2COMMERCE_PAYMENT_PAYPAL_SANDBOX_WEBHOOK_ID_DESC="Sandbox Webhook ID from PayPal dashboard (optional but recommended for testing)."
 
+; Configuration - Subscription mode toggle
+PLG_J2COMMERCE_PAYMENT_PAYPAL_SUBSCRIPTION_MODE_LABEL="Subscription creation mode"
+PLG_J2COMMERCE_PAYMENT_PAYPAL_SUBSCRIPTION_MODE_DESC="<strong>Controls how NEW subscriptions are created at checkout.</strong> Renewals always route by metakey so subs created in either mode keep working when this toggle is changed.<br><br><strong>Modern REST</strong> (default): customer uses Smart Buttons popup → PayPal-side recurring schedule → app cron force-charges via /v1/billing/subscriptions/{id}/capture. Stored as paypal_subscription_id metakey.<br><br><strong>Legacy NVP</strong> (J2Store-compatible): customer redirects to classic PayPal Express Checkout → BAID returned → app cron charges via DoReferenceTransaction. Stored as billing_agreement_id metakey. Use this when migrating from J2Store with the intent that a migration tool will later convert legacy BAIDs to modern paypal_subscription_id values."
+PLG_J2COMMERCE_PAYMENT_PAYPAL_SUBSCRIPTION_MODE_REST="Modern REST Subscriptions API (Smart Buttons)"
+PLG_J2COMMERCE_PAYMENT_PAYPAL_SUBSCRIPTION_MODE_NVP="Legacy NVP / Express Checkout (J2Store-compatible)"
+
+; Configuration - NVP credentials (legacy J2Store BAID renewals — Path C hybrid)
+PLG_J2COMMERCE_PAYMENT_PAYPAL_NVP_SECTION_LABEL="NVP API Credentials (legacy renewals only)"
+PLG_J2COMMERCE_PAYMENT_PAYPAL_NVP_SECTION_DESC="<strong>Required ONLY when migrated J2Store subscriptions exist (rows in #__j2commerce_metafields with metakey=billing_agreement_id).</strong> PayPal stopped issuing NVP credentials to new merchants in 2023 — if you are a new merchant, leave these blank; subscriptions from this point forward use the modern REST flow. Existing J2Store merchants: locate api_username, api_password, and api_signature in PayPal → Account Settings → Account access → API access → NVP/SOAP API integration → Manage API credentials."
+PLG_J2COMMERCE_PAYMENT_PAYPAL_NVP_API_USERNAME="NVP API Username (live)"
+PLG_J2COMMERCE_PAYMENT_PAYPAL_NVP_API_USERNAME_DESC="Live NVP api_username from PayPal Manage API credentials."
+PLG_J2COMMERCE_PAYMENT_PAYPAL_NVP_API_PASSWORD="NVP API Password (live)"
+PLG_J2COMMERCE_PAYMENT_PAYPAL_NVP_API_PASSWORD_DESC="Live NVP api_password from PayPal Manage API credentials."
+PLG_J2COMMERCE_PAYMENT_PAYPAL_NVP_API_SIGNATURE="NVP API Signature (live)"
+PLG_J2COMMERCE_PAYMENT_PAYPAL_NVP_API_SIGNATURE_DESC="Live NVP api_signature from PayPal Manage API credentials."
+PLG_J2COMMERCE_PAYMENT_PAYPAL_NVP_SANDBOX_API_USERNAME="NVP API Username (sandbox)"
+PLG_J2COMMERCE_PAYMENT_PAYPAL_NVP_SANDBOX_API_USERNAME_DESC="Sandbox NVP api_username for testing legacy BAID renewals."
+PLG_J2COMMERCE_PAYMENT_PAYPAL_NVP_SANDBOX_API_PASSWORD="NVP API Password (sandbox)"
+PLG_J2COMMERCE_PAYMENT_PAYPAL_NVP_SANDBOX_API_PASSWORD_DESC="Sandbox NVP api_password."
+PLG_J2COMMERCE_PAYMENT_PAYPAL_NVP_SANDBOX_API_SIGNATURE="NVP API Signature (sandbox)"
+PLG_J2COMMERCE_PAYMENT_PAYPAL_NVP_SANDBOX_API_SIGNATURE_DESC="Sandbox NVP api_signature."
+
 ; Configuration - Debug
 PLG_J2COMMERCE_PAYMENT_PAYPAL_DEBUG_LABEL="Debug Mode"
 PLG_J2COMMERCE_PAYMENT_PAYPAL_DEBUG_DESC="Enable debug logging for PayPal transactions. Logs are written to administrator/logs/payment_paypal.php and browser console. Disable in production."
+
+; Sandbox subscription test harness (admin-only, sandbox-mode-only)
+PLG_J2COMMERCE_PAYMENT_PAYPAL_SANDBOX_TEST_LABEL="Sandbox Subscription Test Harness"
+PLG_J2COMMERCE_PAYMENT_PAYPAL_SANDBOX_TEST_DESC="<strong>1. Test Credentials</strong> — verifies sandbox client_id + secret obtain a valid OAuth token.<br><strong>2. Create Subscription</strong> — builds a real catalog product, billing plan ($1.00/day × 5 cycles), and subscription in your sandbox. Returns an Approve URL — click it, log in with a sandbox PERSONAL account, approve.<br><strong>3. Check Status</strong> — paste the I-XXXX subscription id and confirm remote_status flipped to ACTIVE after approval.<br><strong>4. Cancel</strong> — clean up the test subscription so it doesn't keep billing the sandbox account."
+PLG_J2COMMERCE_PAYMENT_PAYPAL_SANDBOX_TEST_CREDS="1. Test Credentials"
+PLG_J2COMMERCE_PAYMENT_PAYPAL_SANDBOX_TEST_CREATE="2. Create Test Subscription"
+PLG_J2COMMERCE_PAYMENT_PAYPAL_SANDBOX_TEST_CHECK="3. Check Status"
+PLG_J2COMMERCE_PAYMENT_PAYPAL_SANDBOX_TEST_CANCEL="4. Cancel Test Subscription"
+PLG_J2COMMERCE_PAYMENT_PAYPAL_SANDBOX_TEST_NVP="5. Test NVP Credentials"
+PLG_J2COMMERCE_PAYMENT_PAYPAL_SANDBOX_TEST_SUBID_LABEL="PayPal Subscription ID"
+PLG_J2COMMERCE_PAYMENT_PAYPAL_SANDBOX_TEST_SUBID_HELP="Auto-filled after step 2. Used by Check Status / Cancel."
 
 ; Frontend Messages
 PLG_J2COMMERCE_PAYMENT_PAYPAL_ORDER_NOT_FOUND="Order not found."

--- a/plugins/j2commerce/payment_paypal/media/js/paypal-checkout.js
+++ b/plugins/j2commerce/payment_paypal/media/js/paypal-checkout.js
@@ -88,8 +88,11 @@
         const amount = container.dataset.amount;
         const sandbox = container.dataset.sandbox === 'true';
         const clientId = container.dataset.clientId;
+        const isSubscription = container.dataset.isSubscription === 'true';
+        const subscriptionMode = container.dataset.subscriptionMode || 'rest';
+        const isNvpMode = isSubscription && subscriptionMode === 'nvp';
 
-        debugLog('Configuration:', { orderId, currency, amount, sandbox });
+        debugLog('Configuration:', { orderId, currency, amount, sandbox, isSubscription, subscriptionMode });
 
         const errorContainer = document.getElementById('paypal-error-message');
         const processingContainer = document.getElementById('paypal-processing-message');
@@ -127,8 +130,63 @@
             }
         };
 
+        // Legacy NVP Express Checkout flow: no Smart Buttons SDK. Render a single
+        // "Subscribe via PayPal" button that POSTs to createOrderUrl, gets back a
+        // redirect_url, sends the customer to classic PayPal Express Checkout.
+        if (isNvpMode) {
+            container.dataset.paypalInitialized = 'true';
+            buttonsRendered = true;
+
+            const nvpButton = document.createElement('button');
+            nvpButton.type = 'button';
+            nvpButton.className = 'btn btn-primary btn-lg w-100';
+            nvpButton.textContent = 'Subscribe via PayPal';
+            nvpButton.style.minHeight = '45px';
+
+            nvpButton.addEventListener('click', async () => {
+                nvpButton.disabled = true;
+                hideMessages();
+                showProcessing();
+                debugLog('NVP express checkout: requesting redirect URL');
+
+                try {
+                    const response = await fetch(createOrderUrl, {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({
+                            order_id: orderId,
+                            currency: currency,
+                            amount: amount,
+                            mode: 'nvp',
+                            [csrfToken]: '1'
+                        })
+                    });
+                    const data = await response.json();
+                    debugLog('NVP express checkout response:', { status: response.status, data });
+
+                    if (!response.ok || !data.success || !data.redirect_url) {
+                        throw new Error(data.error || 'Failed to start PayPal Express Checkout');
+                    }
+
+                    window.location.href = data.redirect_url;
+                } catch (err) {
+                    console.error('[PayPal NVP] start error:', err);
+                    showError(err.message || 'Failed to start PayPal Express Checkout. Please try again.');
+                    nvpButton.disabled = false;
+                }
+            });
+
+            container.appendChild(nvpButton);
+            debugLog('NVP express checkout button rendered');
+            return;
+        }
+
         const baseUrl = sandbox ? 'https://www.sandbox.paypal.com/sdk/js' : 'https://www.paypal.com/sdk/js';
-        const sdkUrl = `${baseUrl}?client-id=${encodeURIComponent(clientId)}&currency=${encodeURIComponent(currency)}&intent=capture&components=buttons`;
+        // Subscriptions require vault=true + intent=subscription on the SDK URL.
+        // One-off Orders v2 carts use vault=false + intent=capture.
+        const sdkUrl = isSubscription
+            ? `${baseUrl}?client-id=${encodeURIComponent(clientId)}&vault=true&intent=subscription&components=buttons`
+            : `${baseUrl}?client-id=${encodeURIComponent(clientId)}&currency=${encodeURIComponent(currency)}&intent=capture&components=buttons`;
 
         container.dataset.paypalInitialized = 'true';
         buttonsRendered = true;
@@ -139,18 +197,102 @@
                     throw new Error('PayPal SDK loaded but paypal object not available');
                 }
 
-                debugLog('Rendering PayPal buttons');
+                debugLog('Rendering PayPal buttons (' + (isSubscription ? 'subscription' : 'one-off') + ')');
 
-                return paypal.Buttons({
+                const buttonConfig = {
                     style: {
                         layout: 'vertical',
                         color: 'gold',
                         shape: 'rect',
-                        label: 'paypal',
+                        label: isSubscription ? 'subscribe' : 'paypal',
                         height: 45
                     },
 
-                    createOrder: async () => {
+                    onCancel: () => {
+                        debugLog('onCancel: Payment cancelled by user');
+                        showError('Payment was cancelled. You can try again or choose a different payment method.');
+                    },
+
+                    onError: (err) => {
+                        console.error('[PayPal] Button error:', err);
+                        const msg = err?.message || (typeof err === 'string' ? err : 'Unknown error');
+                        showError('PayPal error: ' + msg);
+                    }
+                };
+
+                if (isSubscription) {
+                    buttonConfig.createSubscription = async () => {
+                        try {
+                            debugLog('createSubscription: Starting subscription creation');
+                            hideMessages();
+
+                            const requestBody = {
+                                order_id: orderId,
+                                currency: currency,
+                                amount: amount,
+                                [csrfToken]: '1'
+                            };
+
+                            const response = await fetch(createOrderUrl, {
+                                method: 'POST',
+                                headers: { 'Content-Type': 'application/json' },
+                                body: JSON.stringify(requestBody)
+                            });
+
+                            const data = await response.json();
+
+                            debugLog('createSubscription: Response:', { status: response.status, data });
+
+                            if (!response.ok || !data.success || !data.paypal_subscription_id) {
+                                throw new Error(data.error || 'Failed to create PayPal subscription');
+                            }
+
+                            debugLog('createSubscription: PayPal subscription ID:', data.paypal_subscription_id);
+                            return data.paypal_subscription_id;
+                        } catch (error) {
+                            console.error('[PayPal] createSubscription error:', error);
+                            showError(error.message || 'Failed to initialize subscription. Please try again.');
+                            throw error;
+                        }
+                    };
+
+                    buttonConfig.onApprove = async (data) => {
+                        try {
+                            debugLog('onApprove (subscription): Approving subscription:', data.subscriptionID);
+                            showProcessing();
+
+                            const requestBody = {
+                                paypal_subscription_id: data.subscriptionID,
+                                order_id: orderId,
+                                [csrfToken]: '1'
+                            };
+
+                            const response = await fetch(captureOrderUrl, {
+                                method: 'POST',
+                                headers: { 'Content-Type': 'application/json' },
+                                body: JSON.stringify(requestBody)
+                            });
+
+                            const result = await response.json();
+
+                            debugLog('onApprove (subscription): Finalize response:', { status: response.status, result });
+
+                            if (!response.ok || !result.success) {
+                                throw new Error(result.error || 'Subscription approval failed');
+                            }
+
+                            if (result.redirect) {
+                                window.location.href = result.redirect;
+                            } else {
+                                showError('Subscription approved but redirect URL is missing.');
+                            }
+                        } catch (error) {
+                            console.error('[PayPal] onApprove (subscription) error:', error);
+                            showError(error.message || 'Subscription approval failed. Please contact support.');
+                        }
+                    };
+                } else {
+                    buttonConfig.createOrder = async () => {
                         try {
                             debugLog('createOrder: Starting order creation');
                             hideMessages();
@@ -184,9 +326,9 @@
                             showError(error.message || 'Failed to initialize payment. Please try again.');
                             throw error;
                         }
-                    },
+                    };
 
-                    onApprove: async (data) => {
+                    buttonConfig.onApprove = async (data) => {
                         try {
                             debugLog('onApprove: Capturing payment for order:', data.orderID);
                             showProcessing();
@@ -225,19 +367,10 @@
                             console.error('[PayPal] onApprove error:', error);
                             showError(error.message || 'Payment processing failed. Please contact support.');
                         }
-                    },
+                    };
+                }
 
-                    onCancel: () => {
-                        debugLog('onCancel: Payment cancelled by user');
-                        showError('Payment was cancelled. You can try again or choose a different payment method.');
-                    },
-
-                    onError: (err) => {
-                        console.error('[PayPal] Button error:', err);
-                        const msg = err?.message || (typeof err === 'string' ? err : 'Unknown error');
-                        showError('PayPal error: ' + msg);
-                    }
-                }).render('#paypal-button-container');
+                return paypal.Buttons(buttonConfig).render('#paypal-button-container');
             })
             .catch((err) => {
                 console.error('[PayPal] Initialization failed:', err);

--- a/plugins/j2commerce/payment_paypal/payment_paypal.xml
+++ b/plugins/j2commerce/payment_paypal/payment_paypal.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="j2commerce" method="upgrade">
     <name>PLG_J2COMMERCE_PAYMENT_PAYPAL</name>
-    <version>6.0.7</version>
+    <version>6.2.2</version>
     <author>J2Commerce, LLC</author>
     <creationDate>2026-02</creationDate>
     <copyright>Copyright (C) 2024–2026 J2Commerce, LLC. All rights reserved.</copyright>
@@ -148,6 +148,73 @@
                     size="70"
                     label="PLG_J2COMMERCE_PAYMENT_PAYPAL_SANDBOX_WEBHOOK_ID"
                     description="PLG_J2COMMERCE_PAYMENT_PAYPAL_SANDBOX_WEBHOOK_ID_DESC"
+                />
+
+                <field type="spacer" />
+
+                <field
+                    name="subscription_mode"
+                    type="radio"
+                    layout="joomla.form.field.radio.switcher"
+                    label="PLG_J2COMMERCE_PAYMENT_PAYPAL_SUBSCRIPTION_MODE_LABEL"
+                    description="PLG_J2COMMERCE_PAYMENT_PAYPAL_SUBSCRIPTION_MODE_DESC"
+                    default="rest"
+                >
+                    <option value="rest">PLG_J2COMMERCE_PAYMENT_PAYPAL_SUBSCRIPTION_MODE_REST</option>
+                    <option value="nvp">PLG_J2COMMERCE_PAYMENT_PAYPAL_SUBSCRIPTION_MODE_NVP</option>
+                </field>
+
+                <field
+                    name="nvp_section_note"
+                    type="note"
+                    label="PLG_J2COMMERCE_PAYMENT_PAYPAL_NVP_SECTION_LABEL"
+                    description="PLG_J2COMMERCE_PAYMENT_PAYPAL_NVP_SECTION_DESC"
+                />
+
+                <field
+                    name="api_username"
+                    type="text"
+                    size="70"
+                    label="PLG_J2COMMERCE_PAYMENT_PAYPAL_NVP_API_USERNAME"
+                    description="PLG_J2COMMERCE_PAYMENT_PAYPAL_NVP_API_USERNAME_DESC"
+                />
+                <field
+                    name="api_password"
+                    type="text"
+                    size="70"
+                    label="PLG_J2COMMERCE_PAYMENT_PAYPAL_NVP_API_PASSWORD"
+                    description="PLG_J2COMMERCE_PAYMENT_PAYPAL_NVP_API_PASSWORD_DESC"
+                />
+                <field
+                    name="api_signature"
+                    type="text"
+                    size="70"
+                    label="PLG_J2COMMERCE_PAYMENT_PAYPAL_NVP_API_SIGNATURE"
+                    description="PLG_J2COMMERCE_PAYMENT_PAYPAL_NVP_API_SIGNATURE_DESC"
+                />
+
+                <field type="spacer" />
+
+                <field
+                    name="sandbox_api_username"
+                    type="text"
+                    size="70"
+                    label="PLG_J2COMMERCE_PAYMENT_PAYPAL_NVP_SANDBOX_API_USERNAME"
+                    description="PLG_J2COMMERCE_PAYMENT_PAYPAL_NVP_SANDBOX_API_USERNAME_DESC"
+                />
+                <field
+                    name="sandbox_api_password"
+                    type="text"
+                    size="70"
+                    label="PLG_J2COMMERCE_PAYMENT_PAYPAL_NVP_SANDBOX_API_PASSWORD"
+                    description="PLG_J2COMMERCE_PAYMENT_PAYPAL_NVP_SANDBOX_API_PASSWORD_DESC"
+                />
+                <field
+                    name="sandbox_api_signature"
+                    type="text"
+                    size="70"
+                    label="PLG_J2COMMERCE_PAYMENT_PAYPAL_NVP_SANDBOX_API_SIGNATURE"
+                    description="PLG_J2COMMERCE_PAYMENT_PAYPAL_NVP_SANDBOX_API_SIGNATURE_DESC"
                 />
 
                 <field type="spacer" />
@@ -339,6 +406,22 @@
                     <option value="0">JNO</option>
                     <option value="1">JYES</option>
                 </field>
+
+                <field
+                    name="sandbox_test_note"
+                    type="note"
+                    label="PLG_J2COMMERCE_PAYMENT_PAYPAL_SANDBOX_TEST_LABEL"
+                    description="PLG_J2COMMERCE_PAYMENT_PAYPAL_SANDBOX_TEST_DESC"
+                    showon="sandbox:1"
+                />
+
+                <field
+                    name="sandbox_test_buttons"
+                    type="paypaltestbuttons"
+                    addfieldprefix="J2Commerce\Plugin\J2Commerce\PaymentPaypal\Field"
+                    label=" "
+                    showon="sandbox:1"
+                />
             </fieldset>
         </fields>
     </config>

--- a/plugins/j2commerce/payment_paypal/src/Extension/PaymentPaypal.php
+++ b/plugins/j2commerce/payment_paypal/src/Extension/PaymentPaypal.php
@@ -18,8 +18,10 @@ use J2Commerce\Component\J2commerce\Administrator\Library\Plugins\Payment;
 use J2Commerce\Component\J2commerce\Administrator\Library\Plugins\PluginLayoutTrait;
 use J2Commerce\Plugin\J2Commerce\PaymentPaypal\Helper\PayPalCurrencyHelper;
 use J2Commerce\Plugin\J2Commerce\PaymentPaypal\Service\PayPalClient;
+use J2Commerce\Plugin\J2Commerce\PaymentPaypal\Service\PayPalNvpClient;
 use J2Commerce\Plugin\J2Commerce\PaymentPaypal\Service\PayPalOrders;
 use J2Commerce\Plugin\J2Commerce\PaymentPaypal\Service\PayPalRefunds;
+use J2Commerce\Plugin\J2Commerce\PaymentPaypal\Service\PayPalSubscriptions;
 use J2Commerce\Plugin\J2Commerce\PaymentPaypal\Service\PayPalWebhooks;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Language;
@@ -70,6 +72,10 @@ final class PaymentPaypal extends CMSPlugin implements SubscriberInterface
 
     private ?PayPalRefunds $paypalRefunds = null;
 
+    private ?PayPalSubscriptions $paypalSubscriptions = null;
+
+    private ?PayPalNvpClient $paypalNvp = null;
+
     private static bool $loggerAdded = false;
 
     public function __construct(
@@ -116,14 +122,17 @@ final class PaymentPaypal extends CMSPlugin implements SubscriberInterface
             'onJ2CommerceGetPaymentPlugins'         => 'onGetPaymentPlugins',
             'onJ2CommercePrePayment'                => 'onPrePayment',
             'onJ2CommercePostPayment'               => 'onPostPayment',
+            'onJ2CommerceAfterPayment'              => ['onAfterPayment', -100],
             'onJ2CommerceProcessWebhook'            => 'onProcessWebhook',
             'onJ2CommerceRefundPayment'             => 'onRefundPayment',
             'onJ2CommerceAfterSubscriptionCanceled' => 'onAfterSubscriptionCanceled',
+            'onJ2CommerceProcessRenewalPayment'     => 'onProcessRenewalPayment',
             'onJ2CommercePaymentCreateOrder'        => 'onPaymentCreateOrder',
             'onJ2CommercePaymentCaptureOrder'       => 'onPaymentCaptureOrder',
             'onJ2CommerceCheckoutStart'             => 'onCheckoutStart',
             'onJ2CommerceGetQuickIcons'             => 'onGetQuickIcons',
             'onJ2CommerceGetDashboardMessages'      => 'onGetDashboardMessages',
+            'onAjaxPayment_paypal'                  => 'onAjaxHandler',
         ];
     }
 
@@ -411,7 +420,802 @@ final class PaymentPaypal extends CMSPlugin implements SubscriberInterface
             return;
         }
 
-        $event->setArgument('result', ['status' => 'subscription_cancellation_registered']);
+        $subscriptionId = (int) ($args[1] ?? 0);
+        $reason         = (string) ($args[2] ?? 'Cancelled via J2Commerce admin');
+
+        if ($subscriptionId <= 0) {
+            $event->setArgument('result', ['status' => 'subscription_cancellation_registered']);
+            return;
+        }
+
+        $legacyBaid  = $this->loadLegacyBillingAgreementId($subscriptionId);
+        $paypalSubId = $this->loadPayPalSubscriptionId($subscriptionId);
+
+        if ($legacyBaid !== '') {
+            $event->setArgument('result', $this->cancelNvpBaid($subscriptionId, $legacyBaid, $reason));
+            return;
+        }
+
+        if ($paypalSubId !== '') {
+            $event->setArgument('result', $this->cancelModernSubscription($subscriptionId, $paypalSubId, $reason));
+            return;
+        }
+
+        $this->log('onAfterSubscriptionCanceled: no PayPal credential meta for sub #' . $subscriptionId, Log::WARNING);
+        $event->setArgument('result', ['status' => 'subscription_cancellation_registered', 'paypal_remote' => 'no-id']);
+    }
+
+    /**
+     * @return  array<string, mixed>
+     */
+    private function cancelNvpBaid(int $subscriptionId, string $baid, string $reason): array
+    {
+        $nvp = $this->getPayPalNvp();
+
+        if (!$nvp->isConfigured()) {
+            $this->log(sprintf(
+                'onAfterSubscriptionCanceled: sub=%d has BAID=%s but NVP credentials not configured — manual cancellation required at PayPal',
+                $subscriptionId,
+                $baid
+            ), Log::WARNING);
+
+            return [
+                'status'                 => 'subscription_cancellation_registered',
+                'paypal_remote'          => 'nvp-creds-missing',
+                'legacy_baid'            => $baid,
+                'manual_cancel_required' => true,
+            ];
+        }
+
+        try {
+            $response = $nvp->billAgreementUpdate($baid, 'Cancel', $reason);
+            $ok       = PayPalNvpClient::isSuccess($response);
+
+            $this->log(sprintf(
+                'onAfterSubscriptionCanceled: sub=%d nvp_baid=%s remote_cancel=%s',
+                $subscriptionId,
+                $baid,
+                $ok ? 'ok' : 'failed'
+            ));
+
+            return [
+                'status'        => 'subscription_cancellation_registered',
+                'paypal_remote' => $ok ? 'cancelled-nvp' : 'failed-nvp',
+                'legacy_baid'   => $baid,
+                'gateway_error' => $ok ? null : PayPalNvpClient::getErrorMessage($response),
+            ];
+        } catch (\Throwable $e) {
+            $this->log('NVP BillAgreementUpdate exception: ' . $e->getMessage(), Log::ERROR);
+            return [
+                'status'        => 'subscription_cancellation_registered',
+                'paypal_remote' => 'exception-nvp',
+                'error'         => $e->getMessage(),
+            ];
+        }
+    }
+
+    /**
+     * @return  array<string, mixed>
+     */
+    private function cancelModernSubscription(int $subscriptionId, string $paypalSubId, string $reason): array
+    {
+        try {
+            $ok = $this->getPayPalSubscriptions()->cancelSubscription($paypalSubId, $reason);
+            $this->log(sprintf(
+                'onAfterSubscriptionCanceled: sub=%d paypal=%s remote_cancel=%s',
+                $subscriptionId,
+                $paypalSubId,
+                $ok ? 'ok' : 'failed'
+            ));
+            return [
+                'status'        => 'subscription_cancellation_registered',
+                'paypal_remote' => $ok ? 'cancelled' : 'failed',
+            ];
+        } catch (\Throwable $e) {
+            $this->log('Modern cancelSubscription exception: ' . $e->getMessage(), Log::ERROR);
+            return [
+                'status'        => 'subscription_cancellation_registered',
+                'paypal_remote' => 'exception',
+                'error'         => $e->getMessage(),
+            ];
+        }
+    }
+
+    /**
+     * Subscription rows are created by app_subscriptionproduct in its own
+     * onJ2CommerceAfterPayment listener. The Smart Buttons subscription branch
+     * stashes the PayPal subscription id in the order's transaction_details
+     * JSON (key `paypal_subscription_id`). This handler runs at priority -100,
+     * after the subscription row exists, and writes the metakey that links
+     * the local sub to the PayPal subscription resource.
+     */
+    public function onAfterPayment(Event $event): void
+    {
+        $args  = $event->getArguments();
+        $order = $args[0] ?? null;
+
+        if (!$order || empty($order->order_id)) {
+            return;
+        }
+
+        if (((string) ($order->orderpayment_type ?? '')) !== $this->_name) {
+            return;
+        }
+
+        $userId = (int) ($order->user_id ?? 0);
+
+        if ($userId <= 0) {
+            return;
+        }
+
+        $details = json_decode((string) ($order->transaction_details ?? ''), true);
+
+        if (!\is_array($details)) {
+            return;
+        }
+
+        $paypalSubId   = trim((string) ($details['paypal_subscription_id'] ?? ''));
+        $legacyBaid    = trim((string) ($details['billing_agreement_id'] ?? ''));
+
+        if ($legacyBaid !== '') {
+            try {
+                $this->linkMetakeyToOrder((string) $order->order_id, $userId, 'billing_agreement_id', $legacyBaid);
+            } catch (\Throwable $e) {
+                $this->log('onAfterPayment NVP-link exception for order ' . $order->order_id . ': ' . $e->getMessage(), Log::ERROR);
+            }
+            return;
+        }
+
+        if ($paypalSubId === '') {
+            // Not a subscription order — no link to write. Normal one-off Orders v2 capture.
+            return;
+        }
+
+        try {
+            $this->linkPayPalSubscriptionToOrder((string) $order->order_id, $userId, $paypalSubId);
+        } catch (\Throwable $e) {
+            $this->log('onAfterPayment link exception for order ' . $order->order_id . ': ' . $e->getMessage(), Log::ERROR);
+        }
+    }
+
+    /**
+     * Generic metakey writer used by the NVP path to stamp billing_agreement_id
+     * onto every local sub matching this order. Mirrors linkPayPalSubscriptionToOrder
+     * but with the metakey/metavalue passed in.
+     */
+    private function linkMetakeyToOrder(string $orderIdString, int $userId, string $metakey, string $metavalue): void
+    {
+        $db    = $this->getDatabase();
+        $query = $db->getQuery(true)
+            ->select($db->quoteName('id'))
+            ->from($db->quoteName('#__j2commerce_subscriptions'))
+            ->where($db->quoteName('order_id') . ' = :oid')
+            ->where($db->quoteName('user_id') . ' = :uid')
+            ->bind(':oid', $orderIdString)
+            ->bind(':uid', $userId, ParameterType::INTEGER);
+        $db->setQuery($query);
+        $localSubs = $db->loadColumn();
+
+        if (empty($localSubs)) {
+            $this->log('linkMetakeyToOrder(' . $metakey . '): no local subs for order ' . $orderIdString . ' user ' . $userId, Log::WARNING);
+            return;
+        }
+
+        $namespace = 'subscription';
+        $resource  = 'subscriptions';
+        $now       = date('Y-m-d H:i:s');
+        $valuetype = 'string';
+        $scope     = '';
+        $desc      = '';
+
+        foreach ($localSubs as $subId) {
+            $subIdInt = (int) $subId;
+
+            $existing = $db->setQuery(
+                $db->getQuery(true)
+                    ->select($db->quoteName('id'))
+                    ->from($db->quoteName('#__j2commerce_metafields'))
+                    ->where($db->quoteName('owner_id') . ' = :sid')
+                    ->where($db->quoteName('owner_resource') . ' = :res')
+                    ->where($db->quoteName('namespace') . ' = :ns')
+                    ->where($db->quoteName('metakey') . ' = :metakey')
+                    ->bind(':sid', $subIdInt, ParameterType::INTEGER)
+                    ->bind(':res', $resource)
+                    ->bind(':ns', $namespace)
+                    ->bind(':metakey', $metakey)
+            )->loadResult();
+
+            if ($existing !== null) {
+                $db->setQuery(
+                    $db->getQuery(true)
+                        ->update($db->quoteName('#__j2commerce_metafields'))
+                        ->set($db->quoteName('metavalue') . ' = :val')
+                        ->where($db->quoteName('id') . ' = :id')
+                        ->bind(':val', $metavalue)
+                        ->bind(':id', (int) $existing, ParameterType::INTEGER)
+                )->execute();
+            } else {
+                $db->setQuery(
+                    $db->getQuery(true)
+                        ->insert($db->quoteName('#__j2commerce_metafields'))
+                        ->columns($db->quoteName(['metakey', 'namespace', 'scope', 'metavalue', 'valuetype', 'description', 'owner_id', 'owner_resource', 'created_at', 'updated_at']))
+                        ->values(':metakey, :ns, :scope, :val, :vtype, :desc, :sid, :res, :now1, :now2')
+                        ->bind(':metakey', $metakey)
+                        ->bind(':ns', $namespace)
+                        ->bind(':scope', $scope)
+                        ->bind(':val', $metavalue)
+                        ->bind(':vtype', $valuetype)
+                        ->bind(':desc', $desc)
+                        ->bind(':sid', $subIdInt, ParameterType::INTEGER)
+                        ->bind(':res', $resource)
+                        ->bind(':now1', $now)
+                        ->bind(':now2', $now)
+                )->execute();
+            }
+        }
+
+        $this->log(sprintf(
+            'linkMetakeyToOrder: wrote %s=%s on %d local sub(s)',
+            $metakey,
+            $metavalue,
+            \count($localSubs)
+        ));
+    }
+
+    /**
+     * createOrder branch for subscription_mode=nvp + subscription cart. Calls
+     * SetExpressCheckout to obtain a TOKEN, stashes the TOKEN in the order's
+     * transaction_details, and returns a redirect URL the JS sends the
+     * customer to. After approval, PayPal redirects back with TOKEN+PayerID
+     * in query params; the capture step calls completeNvpExpressCheckoutForOrder.
+     */
+    public function createNvpExpressCheckoutForOrder(array $data): array
+    {
+        try {
+            $orderId = (string) ($data['order_id'] ?? '');
+
+            if ($orderId === '') {
+                return ['success' => false, 'error' => 'Missing order_id'];
+            }
+
+            $orderTable = Factory::getApplication()
+                ->bootComponent('com_j2commerce')
+                ->getMVCFactory()
+                ->createTable('Order', 'Administrator');
+
+            if (!$orderTable->load(['order_id' => $orderId])) {
+                return ['success' => false, 'error' => Text::_('PLG_J2COMMERCE_PAYMENT_PAYPAL_ORDER_NOT_FOUND')];
+            }
+
+            $nvp = $this->getPayPalNvp();
+
+            if (!$nvp->isConfigured()) {
+                return [
+                    'success' => false,
+                    'error'   => 'NVP credentials not configured. Switch subscription_mode to "rest" or fill api_username/password/signature in plugin params.',
+                ];
+            }
+
+            $currency = $this->getCurrency($orderTable);
+            $amount   = (float) ($orderTable->order_total ?? 0);
+
+            $returnUrl = Route::_(
+                'index.php?option=com_j2commerce&task=checkout.confirmPayment'
+                . '&orderpayment_type=' . $this->_name . '&paction=display'
+                . '&order_id=' . urlencode($orderId)
+                . '&nvp=1',
+                false,
+                Route::TLS_IGNORE,
+                true
+            );
+            $cancelUrl = Route::_(
+                'index.php?option=com_j2commerce&view=checkout',
+                false,
+                Route::TLS_IGNORE,
+                true
+            );
+
+            $brand = (string) Factory::getApplication()->get('sitename', 'J2Commerce');
+
+            $response = $nvp->setExpressCheckout(
+                amount:             $amount,
+                currencyCode:       $currency,
+                returnUrl:          $returnUrl,
+                cancelUrl:          $cancelUrl,
+                invoiceNumber:      $orderId,
+                billingDescription: $brand . ' subscription',
+                custom:             $orderId
+            );
+
+            if (!PayPalNvpClient::isSuccess($response)) {
+                return [
+                    'success'         => false,
+                    'error'           => PayPalNvpClient::getErrorMessage($response),
+                    'gateway_response' => $response,
+                ];
+            }
+
+            $token = (string) ($response['TOKEN'] ?? '');
+
+            if ($token === '') {
+                return ['success' => false, 'error' => 'PayPal SetExpressCheckout returned no TOKEN'];
+            }
+
+            $details = json_decode((string) ($orderTable->transaction_details ?? '{}'), true);
+
+            if (!\is_array($details)) {
+                $details = [];
+            }
+
+            $details['nvp_express_token'] = $token;
+            $details['mode']               = 'nvp_express';
+            $details['created_at']         = date('Y-m-d H:i:s');
+
+            $orderTable->transaction_details = json_encode($details);
+            $orderTable->store();
+
+            $approveUrl = $nvp->getApprovalUrl($token);
+
+            $this->log(sprintf(
+                'createNvpExpressCheckoutForOrder: order=%s token=%s approve=%s',
+                $orderId,
+                $token,
+                $approveUrl
+            ));
+
+            return [
+                'success'      => true,
+                'mode'         => 'nvp',
+                'redirect_url' => $approveUrl,
+                'token'        => $token,
+            ];
+        } catch (\Throwable $e) {
+            $this->log('createNvpExpressCheckoutForOrder exception: ' . $e->getMessage(), Log::ERROR);
+
+            return ['success' => false, 'error' => $e->getMessage()];
+        }
+    }
+
+    /**
+     * Capture-step branch for the NVP Express Checkout return flow. Customer
+     * has approved at PayPal and bounced back with TOKEN+PayerID in URL params.
+     * This calls DoExpressCheckoutPayment, extracts the BILLINGAGREEMENTID
+     * (BAID), and stashes it in transaction_details so onAfterPayment writes
+     * the billing_agreement_id metakey.
+     */
+    public function completeNvpExpressCheckoutForOrder(string $orderIdString, string $token, string $payerId): array
+    {
+        try {
+            if ($orderIdString === '' || $token === '' || $payerId === '') {
+                return ['success' => false, 'error' => 'Missing order_id, nvp_token, or nvp_payer_id'];
+            }
+
+            $orderTable = Factory::getApplication()
+                ->bootComponent('com_j2commerce')
+                ->getMVCFactory()
+                ->createTable('Order', 'Administrator');
+
+            if (!$orderTable->load(['order_id' => $orderIdString])) {
+                return ['success' => false, 'error' => Text::_('PLG_J2COMMERCE_PAYMENT_PAYPAL_ORDER_NOT_FOUND')];
+            }
+
+            $nvp = $this->getPayPalNvp();
+
+            if (!$nvp->isConfigured()) {
+                return ['success' => false, 'error' => 'NVP credentials not configured'];
+            }
+
+            $currency = $this->getCurrency($orderTable);
+            $amount   = (float) ($orderTable->order_total ?? 0);
+
+            $response = $nvp->doExpressCheckoutPayment(
+                token:         $token,
+                payerId:       $payerId,
+                amount:        $amount,
+                currencyCode:  $currency,
+                invoiceNumber: $orderIdString,
+                custom:        $orderIdString
+            );
+
+            if (!PayPalNvpClient::isSuccess($response)) {
+                return [
+                    'success'         => false,
+                    'error'           => PayPalNvpClient::getErrorMessage($response),
+                    'gateway_response' => $response,
+                ];
+            }
+
+            $baid    = (string) ($response['BILLINGAGREEMENTID'] ?? '');
+            $transId = (string) ($response['PAYMENTINFO_0_TRANSACTIONID'] ?? '');
+
+            if ($baid === '') {
+                $this->log('completeNvpExpressCheckoutForOrder: NO BAID returned in DoExpressCheckoutPayment response', Log::ERROR);
+                return [
+                    'success' => false,
+                    'error'   => 'PayPal did not return a BILLINGAGREEMENTID. Subscription will not be able to renew.',
+                    'gateway_response' => $response,
+                ];
+            }
+
+            $confirmedStateId = (int) $this->params->get('payment_status', 1);
+
+            $details = json_decode((string) ($orderTable->transaction_details ?? '{}'), true) ?: [];
+            $details['billing_agreement_id'] = $baid;
+            $details['transaction_id']       = $transId;
+            $details['mode']                  = 'nvp_express';
+            $details['completed_at']         = date('Y-m-d H:i:s');
+
+            $orderTable->orderpayment_type   = $this->_name;
+            $orderTable->order_state_id      = $confirmedStateId;
+            $orderTable->transaction_id      = $transId;
+            $orderTable->transaction_status  = 'Completed';
+            $orderTable->transaction_details = json_encode($details);
+            $orderTable->store();
+
+            OrderHistoryHelper::add(
+                orderId: (string) $orderTable->order_id,
+                comment: Text::sprintf(
+                    'COM_J2COMMERCE_ORDER_HISTORY_PAYMENT_RECEIVED',
+                    Text::_('PLG_J2COMMERCE_PAYMENT_PAYPAL')
+                ) . ' (NVP Express, BAID ' . $baid . ', TRANS ' . $transId . ')',
+                orderStateId: $confirmedStateId,
+            );
+
+            $this->log(sprintf(
+                'completeNvpExpressCheckoutForOrder: order=%s baid=%s transId=%s',
+                $orderIdString,
+                $baid,
+                $transId
+            ));
+
+            return [
+                'success'              => true,
+                'mode'                 => 'nvp',
+                'billing_agreement_id' => $baid,
+                'transaction_id'       => $transId,
+                'redirect'             => Route::_(
+                    'index.php?option=com_j2commerce&view=checkout&task=checkout.confirmPayment'
+                    . '&orderpayment_type=' . $this->_name . '&paction=display',
+                    false
+                ),
+            ];
+        } catch (\Throwable $e) {
+            $this->log('completeNvpExpressCheckoutForOrder exception: ' . $e->getMessage(), Log::ERROR);
+
+            return ['success' => false, 'error' => $e->getMessage()];
+        }
+    }
+
+    /**
+     * Cron / debug-button trigger: read paypal_subscription_id from metafields,
+     * call PayPal's /v1/billing/subscriptions/{id}/capture, dispatch the
+     * Success / Failed / NoResponse follow-up event so app_subscriptionproduct
+     * flips the local subscription status.
+     *
+     * Note: PayPal renewals primarily flow via webhooks (BILLING.SUBSCRIPTION.* /
+     * PAYMENT.SALE.COMPLETED). This handler is for manual force-charge from the
+     * subscription debug fieldset and edge cases where the cron job runs faster
+     * than the webhook.
+     */
+    public function onProcessRenewalPayment(Event $event): void
+    {
+        $element      = (string) $event->getArgument('payment_method', '');
+        $subscription = $event->getArgument('subscription');
+        $order        = $event->getArgument('order');
+
+        if ($element !== $this->_name || $subscription === null || $order === null) {
+            return;
+        }
+
+        $result      = $event->getArgument('result', []);
+        $localSubId  = (int) ($subscription->id ?? 0);
+
+        // Path C hybrid — branch on which metakey the sub has:
+        //  1. billing_agreement_id (legacy J2Store NVP)         → DoReferenceTransaction
+        //  2. paypal_subscription_id (modern Subscriptions API) → /v1/billing/subscriptions/{id}/capture
+        //  3. neither                                           → fail with clear error
+        $legacyBaid  = $this->loadLegacyBillingAgreementId($localSubId);
+        $paypalSubId = $this->loadPayPalSubscriptionId($localSubId);
+
+        if ($legacyBaid !== '') {
+            [$status, $error, $extra] = $this->renewViaNvpReference($legacyBaid, $subscription, $order);
+        } elseif ($paypalSubId !== '') {
+            [$status, $error, $extra] = $this->renewViaModernSubscriptionsApi($paypalSubId, $subscription, $order);
+        } else {
+            $result[] = ['success' => false, 'error' => 'No PayPal payment credential stored — neither billing_agreement_id (legacy NVP) nor paypal_subscription_id (modern REST) metakey exists for this subscription.'];
+            $event->setArgument('result', $result);
+            $this->dispatchRenewalOutcome('onJ2CommerceFailedRenewalPayment', $subscription, $order);
+            return;
+        }
+
+        $result[] = array_merge([
+            'success' => $status === 'success',
+            'error'   => $error,
+            'outcome' => $status,
+        ], $extra);
+        $event->setArgument('result', $result);
+
+        $followUp = match ($status) {
+            'success'     => 'onJ2CommerceSuccessRenewalPayment',
+            'no_response' => 'onJ2CommerceNoResponseForRenewalPayment',
+            default       => 'onJ2CommerceFailedRenewalPayment',
+        };
+
+        $this->dispatchRenewalOutcome($followUp, $subscription, $order, $status === 'success' ? true : null);
+    }
+
+    /**
+     * NVP DoReferenceTransaction — charges a saved BAID for a J2Commerce
+     * renewal order. Mirrors the legacy J2Store byReference() pattern.
+     *
+     * @return  array{0: string, 1: ?string, 2: array<string, mixed>}  [status, error, extra]
+     *          status is 'success' | 'failed' | 'no_response'
+     */
+    private function renewViaNvpReference(string $baid, object $subscription, object $order): array
+    {
+        $nvp = $this->getPayPalNvp();
+
+        if (!$nvp->isConfigured()) {
+            return [
+                'failed',
+                'Subscription #' . ($subscription->id ?? '?') . ' uses a legacy J2Store BAID (' . $baid . ') but NVP credentials (api_username/password/signature) are not configured in payment_paypal plugin params. Either configure NVP credentials or have the customer re-authorize.',
+                ['needs_nvp_credentials' => true],
+            ];
+        }
+
+        try {
+            $response = $nvp->doReferenceTransaction(
+                referenceId:    $baid,
+                amount:         (float) ($subscription->renewal_amount ?? $order->order_total ?? 0),
+                currencyCode:   strtoupper((string) ($order->currency_code ?? 'USD')),
+                invoiceNumber:  (string) ($order->order_id ?? ''),
+                description:    'J2Commerce subscription renewal #' . ($subscription->id ?? '')
+            );
+        } catch (\Throwable $e) {
+            $this->log('NVP DoReferenceTransaction exception: ' . $e->getMessage(), Log::ERROR);
+            return ['no_response', $e->getMessage(), []];
+        }
+
+        if (PayPalNvpClient::isSuccess($response)) {
+            $transId = (string) ($response['TRANSACTIONID'] ?? '');
+            $this->finalizeNvpRenewalOrder($order, $transId, $response);
+            return ['success', null, ['transaction_id' => $transId, 'gateway_response' => $response]];
+        }
+
+        $code = (string) ($response['L_ERRORCODE0'] ?? '');
+
+        // Per legacy J2Store: 10412 = duplicate INVNUM. Treat as no_response so
+        // the retry counter advances without flipping the sub to 'failed'.
+        if ($code === '10412') {
+            return ['no_response', PayPalNvpClient::getErrorMessage($response), ['gateway_response' => $response]];
+        }
+
+        // 11451 = BAID already canceled, 11452 = BAID expired — terminal failures.
+        return ['failed', PayPalNvpClient::getErrorMessage($response), ['gateway_response' => $response]];
+    }
+
+    private function finalizeNvpRenewalOrder(object $order, string $transactionId, array $nvpResponse): void
+    {
+        try {
+            $orderTable = Factory::getApplication()
+                ->bootComponent('com_j2commerce')
+                ->getMVCFactory()
+                ->createTable('Order', 'Administrator');
+
+            if (!$orderTable->load(['order_id' => (string) ($order->order_id ?? '')])) {
+                return;
+            }
+
+            $orderTable->transaction_id     = $transactionId;
+            $orderTable->transaction_status  = 'Completed';
+            $orderTable->orderpayment_type   = $this->_name;
+            $orderTable->order_state_id      = (int) $this->params->get('payment_status', 1);
+            $orderTable->transaction_details = json_encode([
+                'transaction_id' => $transactionId,
+                'paymentinfo'    => $nvpResponse['PAYMENTINFO_0_TRANSACTIONID'] ?? null,
+                'pending_reason' => $nvpResponse['PENDINGREASON'] ?? null,
+                'reason_code'    => $nvpResponse['REASONCODE'] ?? null,
+                'type'           => 'renewal_nvp',
+                'completed_at'   => date('Y-m-d H:i:s'),
+            ]);
+            $orderTable->store();
+
+            OrderHistoryHelper::add(
+                orderId: (string) $orderTable->order_id,
+                comment: Text::sprintf(
+                    'COM_J2COMMERCE_ORDER_HISTORY_PAYMENT_RECEIVED',
+                    Text::_('PLG_J2COMMERCE_PAYMENT_PAYPAL')
+                ) . ' (NVP DoReferenceTransaction ' . $transactionId . ')',
+                orderStateId: (int) $orderTable->order_state_id,
+            );
+        } catch (\Throwable $e) {
+            $this->log('finalizeNvpRenewalOrder exception: ' . $e->getMessage(), Log::ERROR);
+        }
+    }
+
+    /**
+     * Modern REST Subscriptions API renewal — for subs created post-migration.
+     * Wraps the existing PayPalSubscriptions::captureRenewalPayment() shape so
+     * onProcessRenewalPayment can route uniformly.
+     *
+     * @return  array{0: string, 1: ?string, 2: array<string, mixed>}  [status, error, extra]
+     */
+    private function renewViaModernSubscriptionsApi(string $paypalSubId, object $subscription, object $order): array
+    {
+        try {
+            $outcome = $this->getPayPalSubscriptions()->captureRenewalPayment($subscription, $order, $paypalSubId);
+        } catch (\Throwable $e) {
+            $this->log('Modern subscription capture exception: ' . $e->getMessage(), Log::ERROR);
+            return ['no_response', $e->getMessage(), []];
+        }
+
+        return [
+            (string) ($outcome['status'] ?? 'failed'),
+            isset($outcome['error']) ? (string) $outcome['error'] : null,
+            ['gateway_response' => $outcome['gateway_response'] ?? null, 'transaction_id' => $outcome['transaction_id'] ?? null],
+        ];
+    }
+
+    private function dispatchRenewalOutcome(string $eventName, object $subscription, object $order, ?bool $updateRenewalDate = null): void
+    {
+        $args = ['subscription' => $subscription, 'order' => $order];
+
+        if ($updateRenewalDate !== null) {
+            $args['updateRenewalDate'] = $updateRenewalDate;
+        }
+
+        Factory::getApplication()->getDispatcher()->dispatch($eventName, new Event($eventName, $args));
+    }
+
+    /**
+     * Read the PayPal subscription id from metafields linked to a local sub.
+     */
+    private function loadPayPalSubscriptionId(int $subscriptionId): string
+    {
+        if ($subscriptionId <= 0) {
+            return '';
+        }
+
+        $db        = $this->getDatabase();
+        $metakey   = 'paypal_subscription_id';
+        $namespace = 'subscription';
+        $resource  = 'subscriptions';
+
+        $query = $db->getQuery(true)
+            ->select($db->quoteName('metavalue'))
+            ->from($db->quoteName('#__j2commerce_metafields'))
+            ->where($db->quoteName('owner_id') . ' = :sid')
+            ->where($db->quoteName('owner_resource') . ' = :res')
+            ->where($db->quoteName('namespace') . ' = :ns')
+            ->where($db->quoteName('metakey') . ' = :metakey')
+            ->bind(':sid', $subscriptionId, ParameterType::INTEGER)
+            ->bind(':res', $resource)
+            ->bind(':ns', $namespace)
+            ->bind(':metakey', $metakey)
+            ->setLimit(1);
+
+        $db->setQuery($query);
+
+        return (string) ($db->loadResult() ?? '');
+    }
+
+    /**
+     * Detect a legacy J2Store paypal `billing_agreement_id` metakey on this sub.
+     * Used by renewal/cancel flows to emit a clear "needs re-authorization"
+     * outcome instead of silently failing — the BAID was issued via PayPal NVP
+     * (deprecated) and is incompatible with the REST Subscriptions API used by
+     * this plugin.
+     */
+    private function loadLegacyBillingAgreementId(int $subscriptionId): string
+    {
+        if ($subscriptionId <= 0) {
+            return '';
+        }
+
+        $db        = $this->getDatabase();
+        $metakey   = 'billing_agreement_id';
+        $namespace = 'subscription';
+        $resource  = 'subscriptions';
+
+        $query = $db->getQuery(true)
+            ->select($db->quoteName('metavalue'))
+            ->from($db->quoteName('#__j2commerce_metafields'))
+            ->where($db->quoteName('owner_id') . ' = :sid')
+            ->where($db->quoteName('owner_resource') . ' = :res')
+            ->where($db->quoteName('namespace') . ' = :ns')
+            ->where($db->quoteName('metakey') . ' = :metakey')
+            ->bind(':sid', $subscriptionId, ParameterType::INTEGER)
+            ->bind(':res', $resource)
+            ->bind(':ns', $namespace)
+            ->bind(':metakey', $metakey)
+            ->setLimit(1);
+
+        $db->setQuery($query);
+
+        return (string) ($db->loadResult() ?? '');
+    }
+
+    /**
+     * Link a PayPal subscription resource id to all local subs sharing this order.
+     * Writes the paypal_subscription_id metafield so renewal/cancel flows can find it.
+     */
+    private function linkPayPalSubscriptionToOrder(string $orderIdString, int $userId, string $paypalSubId): void
+    {
+        $db    = $this->getDatabase();
+        $query = $db->getQuery(true)
+            ->select($db->quoteName('id'))
+            ->from($db->quoteName('#__j2commerce_subscriptions'))
+            ->where($db->quoteName('order_id') . ' = :oid')
+            ->where($db->quoteName('user_id') . ' = :uid')
+            ->bind(':oid', $orderIdString)
+            ->bind(':uid', $userId, ParameterType::INTEGER);
+        $db->setQuery($query);
+        $localSubs = $db->loadColumn();
+
+        if (empty($localSubs)) {
+            $this->log('linkPayPalSubscriptionToOrder: no local subs for order ' . $orderIdString . ' user ' . $userId, Log::WARNING);
+            return;
+        }
+
+        $metakey   = 'paypal_subscription_id';
+        $namespace = 'subscription';
+        $resource  = 'subscriptions';
+        $now       = date('Y-m-d H:i:s');
+        $valuetype = 'string';
+        $scope     = '';
+        $desc      = '';
+
+        foreach ($localSubs as $subId) {
+            $subIdInt = (int) $subId;
+
+            $existing = $db->setQuery(
+                $db->getQuery(true)
+                    ->select($db->quoteName('id'))
+                    ->from($db->quoteName('#__j2commerce_metafields'))
+                    ->where($db->quoteName('owner_id') . ' = :sid')
+                    ->where($db->quoteName('owner_resource') . ' = :res')
+                    ->where($db->quoteName('namespace') . ' = :ns')
+                    ->where($db->quoteName('metakey') . ' = :metakey')
+                    ->bind(':sid', $subIdInt, ParameterType::INTEGER)
+                    ->bind(':res', $resource)
+                    ->bind(':ns', $namespace)
+                    ->bind(':metakey', $metakey)
+            )->loadResult();
+
+            if ($existing !== null) {
+                $db->setQuery(
+                    $db->getQuery(true)
+                        ->update($db->quoteName('#__j2commerce_metafields'))
+                        ->set($db->quoteName('metavalue') . ' = :val')
+                        ->where($db->quoteName('id') . ' = :id')
+                        ->bind(':val', $paypalSubId)
+                        ->bind(':id', (int) $existing, ParameterType::INTEGER)
+                )->execute();
+            } else {
+                $db->setQuery(
+                    $db->getQuery(true)
+                        ->insert($db->quoteName('#__j2commerce_metafields'))
+                        ->columns($db->quoteName(['metakey', 'namespace', 'scope', 'metavalue', 'valuetype', 'description', 'owner_id', 'owner_resource', 'created_at', 'updated_at']))
+                        ->values(':metakey, :ns, :scope, :val, :vtype, :desc, :sid, :res, :now1, :now2')
+                        ->bind(':metakey', $metakey)
+                        ->bind(':ns', $namespace)
+                        ->bind(':scope', $scope)
+                        ->bind(':val', $paypalSubId)
+                        ->bind(':vtype', $valuetype)
+                        ->bind(':desc', $desc)
+                        ->bind(':sid', $subIdInt, ParameterType::INTEGER)
+                        ->bind(':res', $resource)
+                        ->bind(':now1', $now)
+                        ->bind(':now2', $now)
+                )->execute();
+            }
+        }
+
+        $this->log(sprintf(
+            'linkPayPalSubscriptionToOrder: linked PayPal sub %s to %d local sub(s)',
+            $paypalSubId,
+            \count($localSubs)
+        ));
     }
 
     public function onPaymentCreateOrder(Event $event): void
@@ -424,10 +1228,32 @@ final class PaymentPaypal extends CMSPlugin implements SubscriberInterface
             return;
         }
 
-        $this->log('onPaymentCreateOrder: Starting PayPal order creation for order_id: ' . ($data['order_id'] ?? 'N/A'));
+        $orderId = (string) ($data['order_id'] ?? '');
 
-        $result = $this->createPayPalOrder($data);
+        if ($this->isSubscriptionOrder($orderId)) {
+            $mode = $this->getSubscriptionMode();
+            $this->log('onPaymentCreateOrder: subscription detected for order_id: ' . $orderId . ' — mode=' . $mode);
+
+            $result = $mode === 'nvp'
+                ? $this->createNvpExpressCheckoutForOrder($data)
+                : $this->createPayPalSubscriptionForOrder($data);
+        } else {
+            $this->log('onPaymentCreateOrder: Starting PayPal order creation for order_id: ' . ($data['order_id'] ?? 'N/A'));
+            $result = $this->createPayPalOrder($data);
+        }
+
         $event->setArgument('result', $result);
+    }
+
+    /**
+     * Effective subscription creation mode for new checkouts.
+     * Returns 'nvp' or 'rest'. Defaults to 'rest'.
+     */
+    private function getSubscriptionMode(): string
+    {
+        $mode = strtolower((string) $this->params->get('subscription_mode', 'rest'));
+
+        return $mode === 'nvp' ? 'nvp' : 'rest';
     }
 
     public function onPaymentCaptureOrder(Event $event): void
@@ -440,11 +1266,346 @@ final class PaymentPaypal extends CMSPlugin implements SubscriberInterface
             return;
         }
 
-        $paypalOrderId = $data['paypal_order_id'] ?? '';
-        $orderId       = $data['order_id'] ?? '';
+        $orderId              = (string) ($data['order_id'] ?? '');
+        $paypalOrderId        = (string) ($data['paypal_order_id'] ?? '');
+        $paypalSubscriptionId = (string) ($data['paypal_subscription_id'] ?? '');
+        $nvpToken             = (string) ($data['nvp_token'] ?? '');
+        $nvpPayerId           = (string) ($data['nvp_payer_id'] ?? '');
 
-        $result = $this->capturePayPalOrder($paypalOrderId, $orderId);
+        if ($nvpToken !== '' || (string) ($data['mode'] ?? '') === 'nvp') {
+            $this->log('onPaymentCaptureOrder: completing NVP Express Checkout for order_id: ' . $orderId);
+            $result = $this->completeNvpExpressCheckoutForOrder($orderId, $nvpToken, $nvpPayerId);
+        } elseif ($paypalSubscriptionId !== '' || $this->isSubscriptionOrder($orderId)) {
+            $this->log('onPaymentCaptureOrder: subscription detected for order_id: ' . $orderId . ' — finalizing via subscription approval');
+            $result = $this->finalizePayPalSubscriptionApproval($orderId, $paypalSubscriptionId);
+        } else {
+            $result = $this->capturePayPalOrder($paypalOrderId, $orderId);
+        }
+
         $event->setArgument('result', $result);
+    }
+
+    /**
+     * True when the cart for this order contains at least one subscription product.
+     * Detected via orderitems.product_type IN (subscriptionproduct, variablesubscriptionproduct).
+     */
+    private function isSubscriptionOrder(string $orderIdString): bool
+    {
+        if ($orderIdString === '') {
+            return false;
+        }
+
+        $db    = $this->getDatabase();
+        $type1 = 'subscriptionproduct';
+        $type2 = 'variablesubscriptionproduct';
+
+        $query = $db->getQuery(true)
+            ->select('COUNT(*)')
+            ->from($db->quoteName('#__j2commerce_orderitems'))
+            ->where($db->quoteName('order_id') . ' = :oid')
+            ->where($db->quoteName('product_type') . ' IN (:t1, :t2)')
+            ->bind(':oid', $orderIdString)
+            ->bind(':t1', $type1)
+            ->bind(':t2', $type2);
+
+        $db->setQuery($query);
+
+        return (int) $db->loadResult() > 0;
+    }
+
+    /**
+     * Build a synthetic subscription stub from the FIRST subscription product in
+     * an order. Reads period/period_units/subscription_length from the product's
+     * params JSON (subscriptionproduct namespace).
+     *
+     * Returned object satisfies the shape PayPalSubscriptions::createBillingPlan
+     * expects: id, product_id, period, period_units, subscription_length, renewal_amount.
+     */
+    private function buildSubscriptionStubFromOrder(string $orderIdString): ?\stdClass
+    {
+        $db    = $this->getDatabase();
+        $type1 = 'subscriptionproduct';
+        $type2 = 'variablesubscriptionproduct';
+
+        $query = $db->getQuery(true)
+            ->select(['oi.product_id', 'oi.orderitem_finalprice', 'oi.orderitem_name', 'p.params'])
+            ->from($db->quoteName('#__j2commerce_orderitems', 'oi'))
+            ->innerJoin(
+                $db->quoteName('#__j2commerce_products', 'p')
+                . ' ON ' . $db->quoteName('p.j2commerce_product_id') . ' = ' . $db->quoteName('oi.product_id')
+            )
+            ->where($db->quoteName('oi.order_id') . ' = :oid')
+            ->where($db->quoteName('oi.product_type') . ' IN (:t1, :t2)')
+            ->bind(':oid', $orderIdString)
+            ->bind(':t1', $type1)
+            ->bind(':t2', $type2)
+            ->setLimit(1);
+
+        $db->setQuery($query);
+
+        $row = $db->loadObject();
+
+        if (!$row) {
+            return null;
+        }
+
+        $productParams = json_decode((string) ($row->params ?? '{}'), true);
+        $subParams     = $productParams['subscriptionproduct'] ?? [];
+
+        $period      = strtoupper((string) ($subParams['subscription_period'] ?? 'M'));
+        $periodMap   = ['D' => 'DAY', 'W' => 'WEEK', 'M' => 'MONTH', 'Y' => 'YEAR'];
+        $periodNorm  = $periodMap[$period] ?? 'MONTH';
+        $periodUnits = max(1, (int) ($subParams['subscription_period_units'] ?? 1));
+        $length      = max(0, (int) ($subParams['subscription_length'] ?? 0));
+
+        return (object) [
+            'id'                  => (int) ($row->product_id ?? 0),
+            'product_id'          => (int) ($row->product_id ?? 0),
+            'period'              => $periodNorm,
+            'period_units'        => $periodUnits,
+            'subscription_length' => $length,
+            'renewal_amount'      => (float) ($row->orderitem_finalprice ?? 0),
+            'product_name'        => (string) ($row->orderitem_name ?? 'Subscription'),
+        ];
+    }
+
+    /**
+     * createOrder branch for subscription carts. Builds a PayPal Subscription
+     * (Catalog Product → Billing Plan → Subscription resource) instead of a
+     * one-off Orders v2 order. Returns the PayPal subscription id which the
+     * Smart Buttons SDK hands to its createSubscription callback.
+     *
+     * Stashes paypal_subscription_id, paypal_plan_id, paypal_product_id in the
+     * order's transaction_details JSON so onPaymentCaptureOrder + onAfterPayment
+     * can pick them up.
+     */
+    public function createPayPalSubscriptionForOrder(array $data): array
+    {
+        try {
+            $orderId = (string) ($data['order_id'] ?? '');
+
+            if ($orderId === '') {
+                return ['success' => false, 'error' => 'Missing order_id'];
+            }
+
+            $orderTable = Factory::getApplication()
+                ->bootComponent('com_j2commerce')
+                ->getMVCFactory()
+                ->createTable('Order', 'Administrator');
+
+            if (!$orderTable->load(['order_id' => $orderId])) {
+                return ['success' => false, 'error' => Text::_('PLG_J2COMMERCE_PAYMENT_PAYPAL_ORDER_NOT_FOUND')];
+            }
+
+            $stub = $this->buildSubscriptionStubFromOrder($orderId);
+
+            if ($stub === null) {
+                return ['success' => false, 'error' => 'No subscription product found in order'];
+            }
+
+            $currency = $this->getCurrency($orderTable);
+
+            if (!PayPalCurrencyHelper::isValid($currency)) {
+                return [
+                    'success' => false,
+                    'error'   => Text::sprintf('PLG_J2COMMERCE_PAYMENT_PAYPAL_CURRENCY_NOT_SUPPORTED', $currency),
+                ];
+            }
+
+            $brand   = (string) Factory::getApplication()->get('sitename', 'J2Commerce');
+            $context = [
+                'brand_name'     => $brand,
+                'product_name'   => $stub->product_name,
+                'currency_code'  => $currency,
+                'catalog_prefix' => 'j2c',
+            ];
+
+            $subs = $this->getPayPalSubscriptions();
+
+            $productId = $subs->getOrCreateCatalogProduct($stub, $context);
+            $planId    = $subs->createBillingPlan($stub, $orderTable, $context);
+
+            $userId = (int) ($orderTable->user_id ?? 0);
+            $user   = $userId > 0
+                ? Factory::getApplication()->getIdentity()
+                : null;
+
+            // Best-effort name + email from the buyer. Falls back to order's user_email
+            // and order info billing address if available.
+            $given   = $user && !empty($user->name) ? trim(explode(' ', $user->name, 2)[0] ?? 'Customer') : 'Customer';
+            $surname = $user && !empty($user->name) && str_contains($user->name, ' ')
+                ? trim(substr($user->name, strpos($user->name, ' ') + 1))
+                : 'PayPal';
+            $email   = (string) ($orderTable->user_email ?? '');
+
+            if ($email === '' && $user) {
+                $email = (string) ($user->email ?? '');
+            }
+
+            $returnUrl = Route::_(
+                'index.php?option=com_j2commerce&view=checkout&task=checkout.confirmPayment'
+                . '&orderpayment_type=' . $this->_name . '&paction=display',
+                false,
+                Route::TLS_IGNORE,
+                true
+            );
+            $cancelUrl = Route::_(
+                'index.php?option=com_j2commerce&view=checkout',
+                false,
+                Route::TLS_IGNORE,
+                true
+            );
+
+            $context += [
+                'subscriber_given_name' => $given,
+                'subscriber_surname'    => $surname,
+                'subscriber_email'      => $email,
+                'return_url'            => $returnUrl,
+                'cancel_url'            => $cancelUrl,
+            ];
+
+            $created = $subs->createSubscription($planId, $stub, $context);
+
+            if (empty($created['success'])) {
+                return [
+                    'success' => false,
+                    'error'   => $created['error'] ?? 'PayPal subscription create failed',
+                ];
+            }
+
+            $details = json_decode((string) ($orderTable->transaction_details ?? '{}'), true);
+
+            if (!\is_array($details)) {
+                $details = [];
+            }
+
+            $details['paypal_subscription_id'] = $created['id'];
+            $details['paypal_plan_id']         = $planId;
+            $details['paypal_product_id']      = $productId;
+            $details['subscription_status']    = $created['status'];
+            $details['created_at']             = date('Y-m-d H:i:s');
+
+            $orderTable->transaction_details = json_encode($details);
+            $orderTable->store();
+
+            $this->log(sprintf(
+                'createPayPalSubscriptionForOrder: order=%s paypal_sub=%s plan=%s product=%s',
+                $orderId,
+                $created['id'],
+                $planId,
+                $productId
+            ));
+
+            return [
+                'success'                => true,
+                'is_subscription'        => true,
+                'paypal_subscription_id' => $created['id'],
+                'plan_id'                => $planId,
+                'approve_url'            => $created['approve_url'],
+            ];
+        } catch (\Throwable $e) {
+            $this->log('createPayPalSubscriptionForOrder exception: ' . $e->getMessage(), Log::ERROR);
+
+            return ['success' => false, 'error' => $e->getMessage()];
+        }
+    }
+
+    /**
+     * onApprove branch for subscription carts. PayPal already auto-charged the
+     * first cycle as part of subscription activation — we just verify it went
+     * ACTIVE / APPROVED and mark the local order paid. No Orders v2 capture
+     * call needed.
+     *
+     * The subsequent onJ2CommerceAfterPayment listener (priority -100) writes
+     * the paypal_subscription_id metakey to link the local subscription row.
+     */
+    public function finalizePayPalSubscriptionApproval(string $orderIdString, string $paypalSubscriptionId): array
+    {
+        try {
+            if ($orderIdString === '') {
+                return ['success' => false, 'error' => 'Missing order_id'];
+            }
+
+            $orderTable = Factory::getApplication()
+                ->bootComponent('com_j2commerce')
+                ->getMVCFactory()
+                ->createTable('Order', 'Administrator');
+
+            if (!$orderTable->load(['order_id' => $orderIdString])) {
+                return ['success' => false, 'error' => Text::_('PLG_J2COMMERCE_PAYMENT_PAYPAL_ORDER_NOT_FOUND')];
+            }
+
+            $details = json_decode((string) ($orderTable->transaction_details ?? '{}'), true) ?: [];
+
+            if ($paypalSubscriptionId === '') {
+                $paypalSubscriptionId = (string) ($details['paypal_subscription_id'] ?? '');
+            }
+
+            if ($paypalSubscriptionId === '') {
+                return ['success' => false, 'error' => 'No PayPal subscription id stored on order'];
+            }
+
+            $info   = $this->getPayPalSubscriptions()->getSubscriptionDetails($paypalSubscriptionId);
+            $status = strtoupper((string) ($info['body']['status'] ?? ''));
+
+            if (!\in_array($status, ['ACTIVE', 'APPROVED', 'APPROVAL_PENDING'], true)) {
+                $this->log(
+                    'finalizePayPalSubscriptionApproval: unexpected PayPal sub status=' . $status . ' for ' . $paypalSubscriptionId,
+                    Log::WARNING
+                );
+
+                return [
+                    'success' => false,
+                    'error'   => 'PayPal subscription is not active (status: ' . $status . ')',
+                ];
+            }
+
+            $confirmedStateId = (int) $this->params->get('order_state_id', 1);
+
+            $orderTable->orderpayment_type   = $this->_name;
+            $orderTable->order_state_id      = $confirmedStateId;
+            $orderTable->transaction_id      = $paypalSubscriptionId;
+            $orderTable->transaction_status  = 'Completed';
+
+            $details['paypal_subscription_id'] = $paypalSubscriptionId;
+            $details['subscription_status']    = $status;
+            $details['approved_at']            = date('Y-m-d H:i:s');
+
+            $orderTable->transaction_details = json_encode($details);
+            $orderTable->store();
+
+            OrderHistoryHelper::add(
+                orderId: (string) $orderTable->order_id,
+                comment: Text::sprintf(
+                    'COM_J2COMMERCE_ORDER_HISTORY_PAYMENT_RECEIVED',
+                    Text::_('PLG_J2COMMERCE_PAYMENT_PAYPAL')
+                ) . ' (subscription ' . $paypalSubscriptionId . ', status ' . $status . ')',
+                orderStateId: $confirmedStateId,
+            );
+
+            $this->log(sprintf(
+                'finalizePayPalSubscriptionApproval: order=%s paypal_sub=%s status=%s',
+                $orderIdString,
+                $paypalSubscriptionId,
+                $status
+            ));
+
+            return [
+                'success'                => true,
+                'is_subscription'        => true,
+                'paypal_subscription_id' => $paypalSubscriptionId,
+                'remote_status'          => $status,
+                'redirect'               => Route::_(
+                    'index.php?option=com_j2commerce&view=checkout&task=checkout.confirmPayment'
+                    . '&orderpayment_type=' . $this->_name . '&paction=display',
+                    false
+                ),
+            ];
+        } catch (\Throwable $e) {
+            $this->log('finalizePayPalSubscriptionApproval exception: ' . $e->getMessage(), Log::ERROR);
+
+            return ['success' => false, 'error' => $e->getMessage()];
+        }
     }
 
     public function _prePayment(array $data): string
@@ -487,7 +1648,10 @@ final class PaymentPaypal extends CMSPlugin implements SubscriberInterface
         $vars->csrf_token = Session::getFormToken();
         $vars->debug      = (int) $this->params->get('debug', 0);
 
-        $this->log('_prePayment: Prepared vars - order_id: ' . $vars->order_id . ', currency: ' . $vars->currency_code . ', amount: ' . $vars->orderpayment_amount);
+        $vars->is_subscription   = $this->isSubscriptionOrder((string) $vars->order_id);
+        $vars->subscription_mode = $vars->is_subscription ? $this->getSubscriptionMode() : 'rest';
+
+        $this->log('_prePayment: Prepared vars - order_id: ' . $vars->order_id . ', currency: ' . $vars->currency_code . ', amount: ' . $vars->orderpayment_amount . ', is_subscription: ' . ($vars->is_subscription ? '1' : '0') . ', subscription_mode: ' . $vars->subscription_mode);
 
         return $this->_getLayout('prepayment', $vars);
     }
@@ -500,6 +1664,36 @@ final class PaymentPaypal extends CMSPlugin implements SubscriberInterface
         $html    = '';
 
         $this->log('_postPayment: Processing payment response with paction: ' . $paction);
+
+        // NVP Express Checkout return handling — customer just bounced back from
+        // PayPal with TOKEN + PayerID query params. Run DoExpressCheckoutPayment
+        // BEFORE the standard postpayment flow so the BAID gets stored and
+        // onJ2CommerceAfterPayment fires with the right transaction_details.
+        $nvpFlag    = $app->input->getInt('nvp', 0);
+        $nvpToken   = (string) $app->input->getString('token', '');
+        $nvpPayerId = (string) $app->input->getString('PayerID', '');
+
+        if ($nvpFlag === 1 && $nvpToken !== '' && $nvpPayerId !== '') {
+            $orderIdFromUrl = (string) $app->input->getString('order_id', '');
+
+            if ($orderIdFromUrl === '') {
+                $orderIdFromUrl = (string) ($data->order_id ?? '');
+            }
+
+            $this->log('_postPayment NVP return: order=' . $orderIdFromUrl . ' token=' . $nvpToken . ' payerid=' . $nvpPayerId);
+
+            $completion = $this->completeNvpExpressCheckoutForOrder($orderIdFromUrl, $nvpToken, $nvpPayerId);
+
+            if (empty($completion['success'])) {
+                $vars->message = (string) ($completion['error'] ?? Text::_($this->params->get('onerrorpayment', 'PLG_J2COMMERCE_PAYMENT_PAYPAL_PAYMENT_FAILED')));
+                return $this->_getLayout('message', $vars);
+            }
+
+            // Re-load the order now that completeNvpExpressCheckoutForOrder
+            // has stamped billing_agreement_id into transaction_details. The
+            // CheckoutController will dispatch onJ2CommerceAfterPayment after
+            // _postPayment returns, which is when the metakey gets written.
+        }
 
         switch ($paction) {
             case 'display':
@@ -779,6 +1973,94 @@ final class PaymentPaypal extends CMSPlugin implements SubscriberInterface
         return $this->paypalRefunds;
     }
 
+    private function getPayPalSubscriptions(): PayPalSubscriptions
+    {
+        if (!$this->paypalSubscriptions) {
+            $this->paypalSubscriptions = new PayPalSubscriptions($this->getPayPalClient());
+        }
+
+        return $this->paypalSubscriptions;
+    }
+
+    /**
+     * NVP client for legacy J2Store BAID renewals (Path C hybrid).
+     *
+     * Credential selection follows availability, NOT the site's REST sandbox
+     * toggle:
+     *   - When site is sandbox=1: prefer sandbox NVP creds; fall back to live
+     *     NVP creds if sandbox creds are blank (PayPal stopped issuing sandbox
+     *     NVP to new merchants — live-only is common for J2Store migrants).
+     *   - When site is sandbox=0: live NVP creds only.
+     *
+     * The fallback logs a warning each time it's used so admins know they're
+     * hitting live PayPal endpoints during sandbox testing. Migrated BAIDs are
+     * live-account-issued anyway, so a live-NVP fallback is the only way to
+     * actually exercise renewals against real BAIDs.
+     *
+     * Returns a configured client even when ALL credentials are blank — caller
+     * checks ->isConfigured() before invoking renewal methods.
+     */
+    private function getPayPalNvp(): PayPalNvpClient
+    {
+        if (!$this->paypalNvp) {
+            $siteSandbox = (bool) (int) $this->params->get('sandbox', 0);
+
+            $sandboxUser = (string) $this->params->get('sandbox_api_username', '');
+            $sandboxPwd  = (string) $this->params->get('sandbox_api_password', '');
+            $sandboxSig  = (string) $this->params->get('sandbox_api_signature', '');
+            $liveUser    = (string) $this->params->get('api_username', '');
+            $livePwd     = (string) $this->params->get('api_password', '');
+            $liveSig     = (string) $this->params->get('api_signature', '');
+
+            $sandboxConfigured = $sandboxUser !== '' && $sandboxPwd !== '' && $sandboxSig !== '';
+            $liveConfigured    = $liveUser !== '' && $livePwd !== '' && $liveSig !== '';
+
+            // Pick which credential set + endpoint to use:
+            //   - Sandbox creds available → use sandbox endpoint
+            //   - No sandbox creds but live creds available → use live endpoint
+            //     (warn when this happens during sandbox-mode testing)
+            //   - Neither → empty client; isConfigured() returns false
+            if ($siteSandbox && $sandboxConfigured) {
+                $useSandbox = true;
+                $useUser    = $sandboxUser;
+                $usePwd     = $sandboxPwd;
+                $useSig     = $sandboxSig;
+            } elseif ($liveConfigured) {
+                $useSandbox = false;
+                $useUser    = $liveUser;
+                $usePwd     = $livePwd;
+                $useSig     = $liveSig;
+
+                if ($siteSandbox) {
+                    $this->log(
+                        'NVP fallback: site is sandbox=1 but only LIVE NVP credentials are configured — NVP renewals will hit api-3t.paypal.com against your LIVE PayPal account. This is intentional for testing migrated J2Store BAIDs (which are live-account-issued).',
+                        Log::WARNING
+                    );
+                }
+            } else {
+                $useSandbox = $siteSandbox;
+                $useUser    = '';
+                $usePwd     = '';
+                $useSig     = '';
+            }
+
+            $logger = function (string $message, int $priority): void {
+                $this->log($message, $priority);
+            };
+
+            $this->paypalNvp = new PayPalNvpClient(
+                apiUsername:  $useUser,
+                apiPassword:  $usePwd,
+                apiSignature: $useSig,
+                sandbox:      $useSandbox,
+                debug:        (bool) (int) $this->params->get('debug', 0),
+                logger:       \Closure::fromCallable($logger)
+            );
+        }
+
+        return $this->paypalNvp;
+    }
+
     private function checkGeozone(int $geozoneId, array $address): bool
     {
         $db    = $this->getDatabase();
@@ -820,6 +2102,291 @@ final class PaymentPaypal extends CMSPlugin implements SubscriberInterface
         }
 
         return true;
+    }
+
+    /**
+     * AJAX entry point for the PayPal sandbox subscription test harness.
+     *
+     * Routed via:
+     *   index.php?option=com_ajax&group=j2commerce&plugin=payment_paypal&format=json&task=<task>
+     *
+     * Tasks:
+     *   testCredentials       — exercise OAuth (validates client_id + secret)
+     *   testCreateSubscription — full flow: catalog product → billing plan → subscription, returns approve_url
+     *   testCheckStatus       — given paypal_subscription_id query param, returns PayPal subscription details
+     *   testCancel            — given paypal_subscription_id query param, cancels at PayPal
+     *
+     * All tasks gate on core.admin ACL + form token. Sandbox-only by design — refuses to run when sandbox=0.
+     */
+    public function onAjaxHandler(Event $event): void
+    {
+        $app  = Factory::getApplication();
+        $task = $app->getInput()->getCmd('task', '');
+        $user = $app->getIdentity();
+
+        if (!$user || $user->guest || !$user->authorise('core.admin')) {
+            $event->setArgument('result', ['ok' => false, 'error' => 'Forbidden', 'status' => 403]);
+            return;
+        }
+
+        if (!Session::checkToken('request')) {
+            $event->setArgument('result', ['ok' => false, 'error' => 'Invalid token', 'status' => 403]);
+            return;
+        }
+
+        if ((int) $this->params->get('sandbox', 0) !== 1) {
+            $event->setArgument('result', [
+                'ok'    => false,
+                'error' => 'Test harness only runs in sandbox mode. Enable "Use sandbox" in plugin params first.',
+            ]);
+            return;
+        }
+
+        try {
+            $result = match ($task) {
+                'testCredentials'        => $this->testSandboxCredentials(),
+                'testCreateSubscription' => $this->testSandboxCreateSubscription(),
+                'testCheckStatus'        => $this->testSandboxCheckStatus(),
+                'testCancel'             => $this->testSandboxCancel(),
+                'testNvpCredentials'     => $this->testSandboxNvpCredentials(),
+                default                  => ['ok' => false, 'error' => 'Unknown task: ' . $task],
+            };
+        } catch (\Throwable $e) {
+            $this->log('Sandbox test ' . $task . ' exception: ' . $e->getMessage(), Log::ERROR);
+            $result = ['ok' => false, 'error' => $e->getMessage()];
+        }
+
+        $event->setArgument('result', $result);
+    }
+
+    /**
+     * Step 1 — exercise OAuth via a single GET against an endpoint that requires a token.
+     * Bad credentials → 401; good → 200 with the bearer working.
+     */
+    private function testSandboxCredentials(): array
+    {
+        $client = $this->getPayPalClient();
+
+        // GET /v1/billing/plans?page_size=1 is cheap and only succeeds with a valid token.
+        $response = $client->request('GET', '/v1/billing/plans?page_size=1');
+        $status   = (int) ($response['status'] ?? 0);
+
+        if ($status >= 200 && $status < 300) {
+            return ['ok' => true, 'message' => 'Sandbox credentials valid (bearer token authenticated against /v1/billing/plans)'];
+        }
+
+        return [
+            'ok'      => false,
+            'status'  => $status,
+            'error'   => 'Credentials test failed — HTTP ' . $status,
+            'detail'  => $response['body'] ?? null,
+            'hint'    => 'Verify sandbox_client_id and sandbox_secret in plugin params; sandbox account must have Subscriptions enabled.',
+        ];
+    }
+
+    /**
+     * Step 2 — full create flow. Creates a real catalog product + plan + subscription
+     * in the connected PayPal sandbox account. Plan is $1.00/day (Subscriptions API
+     * minimum interval is DAY), set to 5 cycles total so it auto-expires if forgotten.
+     *
+     * Returns the approve URL — the admin clicks it, logs into a sandbox PERSONAL
+     * account, approves, and PayPal redirects back. After approval, click "Check
+     * Status" to verify ACTIVE + read the next billing date.
+     */
+    private function testSandboxCreateSubscription(): array
+    {
+        $subs = $this->getPayPalSubscriptions();
+
+        $fakeSubscription = (object) [
+            'id'                  => 9999000 + random_int(1, 9999),
+            'product_id'          => 99,
+            'period'              => 'DAY',
+            'period_units'        => 1,
+            'subscription_length' => 5,
+            'renewal_amount'      => 1.00,
+        ];
+
+        $fakeOrder = (object) [
+            'order_id'    => 'TEST-' . date('YmdHis'),
+            'order_total' => 1.00,
+        ];
+
+        $brand = Factory::getApplication()->get('sitename', 'J2Commerce');
+
+        $context = [
+            'brand_name'     => $brand,
+            'product_name'   => 'J2Commerce Sandbox Test Subscription',
+            'currency_code'  => 'USD',
+            'catalog_prefix' => 'j2c-sandboxtest',
+        ];
+
+        $productId = $subs->getOrCreateCatalogProduct($fakeSubscription, $context);
+        $planId    = $subs->createBillingPlan($fakeSubscription, $fakeOrder, $context);
+
+        $returnUrl = Factory::getApplication()->get('live_site') ?: rtrim(\Joomla\CMS\Uri\Uri::root(), '/');
+        $context  += [
+            'subscriber_given_name' => 'Sandbox',
+            'subscriber_surname'    => 'Tester',
+            'subscriber_email'      => 'sandbox-tester@example.com',
+            'return_url'            => $returnUrl . '/index.php?paypal_test=approved',
+            'cancel_url'            => $returnUrl . '/index.php?paypal_test=cancelled',
+        ];
+
+        $created = $subs->createSubscription($planId, $fakeSubscription, $context);
+
+        if (empty($created['success'])) {
+            return [
+                'ok'         => false,
+                'error'      => $created['error'] ?? 'Unknown error during createSubscription',
+                'product_id' => $productId,
+                'plan_id'    => $planId,
+            ];
+        }
+
+        return [
+            'ok'                     => true,
+            'message'                => 'Subscription created in PayPal sandbox. Open the approve_url in a new tab, log in with a sandbox PERSONAL account, approve, then run "testCheckStatus".',
+            'paypal_subscription_id' => $created['id'],
+            'status'                 => $created['status'],
+            'approve_url'            => $created['approve_url'],
+            'product_id'             => $productId,
+            'plan_id'                => $planId,
+        ];
+    }
+
+    private function testSandboxCheckStatus(): array
+    {
+        $paypalSubId = trim((string) Factory::getApplication()->getInput()->getString('paypal_subscription_id', ''));
+
+        if ($paypalSubId === '') {
+            return ['ok' => false, 'error' => 'paypal_subscription_id query param required'];
+        }
+
+        $details = $this->getPayPalSubscriptions()->getSubscriptionDetails($paypalSubId);
+        $body    = $details['body'] ?? [];
+        $status  = (string) ($body['status'] ?? 'UNKNOWN');
+
+        return [
+            'ok'                     => ($details['status'] >= 200 && $details['status'] < 300),
+            'http_status'            => $details['status'],
+            'paypal_subscription_id' => $paypalSubId,
+            'remote_status'          => $status,
+            'next_billing_time'      => $body['billing_info']['next_billing_time'] ?? null,
+            'plan_id'                => $body['plan_id'] ?? null,
+            'subscriber_email'       => $body['subscriber']['email_address'] ?? null,
+            'last_payment'           => $body['billing_info']['last_payment'] ?? null,
+            'failed_payments_count'  => $body['billing_info']['failed_payments_count'] ?? null,
+            'raw'                    => $body,
+        ];
+    }
+
+    private function testSandboxCancel(): array
+    {
+        $paypalSubId = trim((string) Factory::getApplication()->getInput()->getString('paypal_subscription_id', ''));
+
+        if ($paypalSubId === '') {
+            return ['ok' => false, 'error' => 'paypal_subscription_id query param required'];
+        }
+
+        $ok = $this->getPayPalSubscriptions()->cancelSubscription($paypalSubId, 'Sandbox test cleanup');
+
+        return [
+            'ok'                     => $ok,
+            'paypal_subscription_id' => $paypalSubId,
+            'message'                => $ok ? 'Cancelled at PayPal' : 'Cancel failed — see plugin log',
+        ];
+    }
+
+    /**
+     * Test the NVP transport + credentials. Calls BillAgreementUpdate against a
+     * deliberately bogus REFERENCEID — PayPal will return ACK=Failure with a
+     * specific error code (10201 / 10004) when credentials are GOOD but the BAID
+     * doesn't exist. That's the success indicator: the request was authenticated
+     * and parsed by PayPal, just rejected because the BAID is bogus.
+     *
+     * If credentials are bad, PayPal returns a different error: 10002 "Security
+     * header is not valid" — which the test surfaces as configuration error.
+     *
+     * Credential fallback: tries sandbox creds first; if any blank, falls back
+     * to live creds against the LIVE PayPal NVP endpoint (clearly labelled in
+     * the response so the admin knows). PayPal stopped issuing sandbox NVP
+     * credentials to new merchants — many existing J2Store merchants only have
+     * live NVP creds, and the BillAgreementUpdate-with-bogus-BAID test is
+     * harmless against live (no charge, no state change).
+     */
+    private function testSandboxNvpCredentials(): array
+    {
+        $sandboxUser = (string) $this->params->get('sandbox_api_username', '');
+        $sandboxPwd  = (string) $this->params->get('sandbox_api_password', '');
+        $sandboxSig  = (string) $this->params->get('sandbox_api_signature', '');
+
+        $liveUser = (string) $this->params->get('api_username', '');
+        $livePwd  = (string) $this->params->get('api_password', '');
+        $liveSig  = (string) $this->params->get('api_signature', '');
+
+        $sandboxConfigured = $sandboxUser !== '' && $sandboxPwd !== '' && $sandboxSig !== '';
+        $liveConfigured    = $liveUser !== '' && $livePwd !== '' && $liveSig !== '';
+
+        if (!$sandboxConfigured && !$liveConfigured) {
+            return [
+                'ok'    => false,
+                'error' => 'No NVP credentials configured. Fill EITHER the live (api_*) OR sandbox (sandbox_api_*) NVP credential fields.',
+                'hint'  => 'NVP credentials are needed only if you have migrated J2Store subscriptions with billing_agreement_id metakey. PayPal stopped issuing NVP credentials to new merchants in 2023 — existing J2Store merchants typically have LIVE creds (sandbox NVP is rarer to obtain).',
+            ];
+        }
+
+        $useLive = !$sandboxConfigured && $liveConfigured;
+        $logger  = function (string $message, int $priority): void {
+            $this->log($message, $priority);
+        };
+
+        $client = new PayPalNvpClient(
+            apiUsername:  $useLive ? $liveUser : $sandboxUser,
+            apiPassword:  $useLive ? $livePwd  : $sandboxPwd,
+            apiSignature: $useLive ? $liveSig  : $sandboxSig,
+            sandbox:      !$useLive,
+            debug:        (bool) (int) $this->params->get('debug', 0),
+            logger:       \Closure::fromCallable($logger)
+        );
+
+        $bogusReferenceId = 'B-NVPTEST' . str_pad((string) random_int(0, 99999999), 8, '0', STR_PAD_LEFT);
+        $response         = $client->getBillAgreementDetails($bogusReferenceId);
+
+        $code     = (string) ($response['L_ERRORCODE0'] ?? '');
+        $short    = (string) ($response['L_SHORTMESSAGE0'] ?? '');
+        $endpoint = $useLive ? 'api-3t.paypal.com (LIVE)' : 'api-3t.sandbox.paypal.com (sandbox)';
+
+        // Auth failure codes — credentials are wrong / signature mismatch
+        $authFailureCodes = ['10002', '10001'];
+
+        if (\in_array($code, $authFailureCodes, true)) {
+            return [
+                'ok'                => false,
+                'used_credentials'  => $useLive ? 'live' : 'sandbox',
+                'tested_endpoint'   => $endpoint,
+                'error'             => 'NVP authentication failed: [' . $code . '] ' . $short,
+                'gateway_response'  => $response,
+                'hint'              => 'Verify ' . ($useLive ? 'live' : 'sandbox') . ' api_username, api_password, and api_signature match your PayPal account exactly. They are case-sensitive and have no surrounding whitespace.',
+            ];
+        }
+
+        $message = 'NVP credentials authenticated against ' . $endpoint
+            . ' (PayPal accepted the request — error ' . $code . ' / "' . $short
+            . '" is expected for the bogus test BAID, which means transport + auth work correctly).';
+
+        if ($useLive) {
+            $message = '⚠️ Tested with LIVE NVP credentials (sandbox creds were blank). The bogus BAID test does NOT charge or change anything at PayPal — it is safe against live. ' . $message;
+        }
+
+        return [
+            'ok'                => true,
+            'used_credentials'  => $useLive ? 'live' : 'sandbox',
+            'tested_endpoint'   => $endpoint,
+            'message'           => $message,
+            'gateway_response'  => $response,
+            'note'              => 'Now ready to renew migrated J2Store subscriptions with billing_agreement_id metakey via the renewal cron.'
+                . ($useLive ? ' Note: live NVP creds will be used for ALL renewals (sandbox toggle in plugin params controls REST sandbox/live, NOT NVP — NVP routes by which credential set is configured).' : ''),
+        ];
     }
 
     private function getCurrency(object $order): string

--- a/plugins/j2commerce/payment_paypal/src/Field/PaypaltestbuttonsField.php
+++ b/plugins/j2commerce/payment_paypal/src/Field/PaypaltestbuttonsField.php
@@ -1,0 +1,141 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  plg_j2commerce_payment_paypal
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Plugin\J2Commerce\PaymentPaypal\Field;
+
+\defined('_JEXEC') or die;
+
+use Joomla\CMS\Form\FormField;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Session\Session;
+use Joomla\CMS\Uri\Uri;
+
+/**
+ * Renders the sandbox subscription test panel — four buttons that call the
+ * plugin's onAjaxHandler tasks and stream results into a preformatted block
+ * underneath. Visible only when sandbox:1.
+ *
+ * @since  6.1.7
+ */
+final class PaypaltestbuttonsField extends FormField
+{
+    protected $type = 'Paypaltestbuttons';
+
+    protected function getInput(): string
+    {
+        $token = Session::getFormToken();
+
+        // Field renders inside admin plugin-edit form — must hit /administrator/index.php
+        // so the admin session + ACL apply. Uri::root() gives the site root which routes
+        // to a different com_ajax handler (frontend session, no admin permissions).
+        $baseUrl = Uri::base() . 'index.php?option=com_ajax&group=j2commerce&plugin=payment_paypal&format=json';
+
+        $labels = [
+            'creds'   => Text::_('PLG_J2COMMERCE_PAYMENT_PAYPAL_SANDBOX_TEST_CREDS'),
+            'create'  => Text::_('PLG_J2COMMERCE_PAYMENT_PAYPAL_SANDBOX_TEST_CREATE'),
+            'check'   => Text::_('PLG_J2COMMERCE_PAYMENT_PAYPAL_SANDBOX_TEST_CHECK'),
+            'cancel'  => Text::_('PLG_J2COMMERCE_PAYMENT_PAYPAL_SANDBOX_TEST_CANCEL'),
+            'nvp'     => Text::_('PLG_J2COMMERCE_PAYMENT_PAYPAL_SANDBOX_TEST_NVP'),
+            'subId'   => Text::_('PLG_J2COMMERCE_PAYMENT_PAYPAL_SANDBOX_TEST_SUBID_LABEL'),
+            'subHelp' => Text::_('PLG_J2COMMERCE_PAYMENT_PAYPAL_SANDBOX_TEST_SUBID_HELP'),
+        ];
+
+        $html  = '<div class="paypal-sandbox-test-panel">';
+        $html .= '<div class="d-flex flex-wrap gap-2 mb-3">';
+        $html .= '<button type="button" class="btn btn-outline-primary" data-paypal-test="testCredentials">'
+            . htmlspecialchars($labels['creds'], ENT_QUOTES, 'UTF-8') . '</button>';
+        $html .= '<button type="button" class="btn btn-outline-success" data-paypal-test="testCreateSubscription">'
+            . htmlspecialchars($labels['create'], ENT_QUOTES, 'UTF-8') . '</button>';
+        $html .= '<button type="button" class="btn btn-outline-info" data-paypal-test="testCheckStatus">'
+            . htmlspecialchars($labels['check'], ENT_QUOTES, 'UTF-8') . '</button>';
+        $html .= '<button type="button" class="btn btn-outline-danger" data-paypal-test="testCancel">'
+            . htmlspecialchars($labels['cancel'], ENT_QUOTES, 'UTF-8') . '</button>';
+        $html .= '<button type="button" class="btn btn-outline-warning" data-paypal-test="testNvpCredentials">'
+            . htmlspecialchars($labels['nvp'], ENT_QUOTES, 'UTF-8') . '</button>';
+        $html .= '</div>';
+        $html .= '<div class="mb-2">';
+        $html .= '<label for="paypal-test-sub-id" class="form-label">'
+            . htmlspecialchars($labels['subId'], ENT_QUOTES, 'UTF-8') . '</label>';
+        $html .= '<input type="text" id="paypal-test-sub-id" class="form-control"'
+            . ' placeholder="I-XXXXXXXXXXXX">';
+        $html .= '<div class="form-text">'
+            . htmlspecialchars($labels['subHelp'], ENT_QUOTES, 'UTF-8') . '</div>';
+        $html .= '</div>';
+        $html .= '<pre id="paypal-test-output" class="bg-body-tertiary p-3 rounded mt-2" style="max-height:400px; overflow:auto; min-height:60px;"></pre>';
+        $html .= '</div>';
+
+        $baseUrlJs = json_encode($baseUrl);
+        $tokenJs   = json_encode($token);
+
+        $script = <<<JS
+(function(){
+    var panel = document.querySelector('.paypal-sandbox-test-panel');
+    if (!panel) { return; }
+    var output = panel.querySelector('#paypal-test-output');
+    var subInput = panel.querySelector('#paypal-test-sub-id');
+    var baseUrl = {$baseUrlJs};
+    var token   = {$tokenJs};
+
+    function show(label, payload) {
+        var ts = new Date().toISOString().replace('T',' ').slice(0,19);
+        var pre = '[' + ts + '] ' + label + '\\n' + JSON.stringify(payload, null, 2) + '\\n\\n';
+        output.textContent = pre + (output.textContent || '');
+        if (payload && payload.paypal_subscription_id && !subInput.value) {
+            subInput.value = payload.paypal_subscription_id;
+        }
+        if (payload && payload.approve_url) {
+            var link = document.createElement('a');
+            link.href = payload.approve_url;
+            link.target = '_blank';
+            link.rel = 'noopener';
+            link.className = 'btn btn-warning btn-sm mt-2';
+            link.textContent = 'Open PayPal approval URL ↗';
+            output.parentNode.insertBefore(link, output);
+        }
+    }
+
+    panel.addEventListener('click', function(e){
+        var btn = e.target.closest('[data-paypal-test]');
+        if (!btn) return;
+        e.preventDefault();
+        var task = btn.getAttribute('data-paypal-test');
+        var url = baseUrl + '&task=' + encodeURIComponent(task) + '&' + encodeURIComponent(token) + '=1';
+        if (task === 'testCheckStatus' || task === 'testCancel') {
+            var v = (subInput.value || '').trim();
+            if (!v) { show(task, {ok:false, error:'Fill PayPal Subscription ID first'}); return; }
+            url += '&paypal_subscription_id=' + encodeURIComponent(v);
+        }
+        btn.disabled = true;
+        fetch(url, {credentials:'same-origin', headers:{'Accept':'application/json'}})
+            .then(function(r){ return r.json(); })
+            .then(function(json){
+                // com_ajax wraps plugin output in {success, message, data}.
+                // For our handler, data is a single object; for some Joomla versions it's [object].
+                var payload;
+                if (json && Object.prototype.hasOwnProperty.call(json, 'data')) {
+                    payload = Array.isArray(json.data) ? (json.data[0] || json.data) : json.data;
+                } else {
+                    payload = json;
+                }
+                show(task, payload);
+            })
+            .catch(function(err){ show(task, {ok:false, error:String(err)}); })
+            .finally(function(){ btn.disabled = false; });
+    });
+})();
+JS;
+
+        $html .= '<script>' . $script . '</script>';
+
+        return $html;
+    }
+}

--- a/plugins/j2commerce/payment_paypal/src/Service/PayPalNvpClient.php
+++ b/plugins/j2commerce/payment_paypal/src/Service/PayPalNvpClient.php
@@ -1,0 +1,385 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  plg_j2commerce_payment_paypal
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Plugin\J2Commerce\PaymentPaypal\Service;
+
+\defined('_JEXEC') or die;
+
+/**
+ * PayPal Classic NVP API client.
+ *
+ * Used for charging legacy J2Store-issued Billing Agreement IDs (BAID) via
+ * DoReferenceTransaction, and for cancelling them via BillAgreementUpdate.
+ * NVP API endpoint is `api-3t.{sandbox.}paypal.com/nvp`.
+ *
+ * **NVP is deprecated by PayPal for new merchants** — only PayPal Business
+ * accounts that obtained NVP API credentials before mid-2023 can still use
+ * this surface. New merchants must use the modern REST flow (PayPalClient).
+ *
+ * This class is only required for hybrid Path C: legacy J2Store data with
+ * `billing_agreement_id` metakey continues to renew via NVP, while new
+ * subscriptions go through the modern REST/Vault path.
+ *
+ * @since  6.1.7
+ */
+final class PayPalNvpClient
+{
+    private const SIGNATURE_VERSION = '204.0';
+
+    public function __construct(
+        private readonly string $apiUsername,
+        private readonly string $apiPassword,
+        private readonly string $apiSignature,
+        private readonly bool $sandbox = false,
+        private readonly bool $debug = false,
+        private readonly ?\Closure $logger = null
+    ) {
+    }
+
+    public function isConfigured(): bool
+    {
+        return $this->apiUsername !== ''
+            && $this->apiPassword !== ''
+            && $this->apiSignature !== '';
+    }
+
+    public function isSandbox(): bool
+    {
+        return $this->sandbox;
+    }
+
+    private function endpoint(): string
+    {
+        return $this->sandbox
+            ? 'https://api-3t.sandbox.paypal.com/nvp'
+            : 'https://api-3t.paypal.com/nvp';
+    }
+
+    public function log(string $message, int $priority = \Joomla\CMS\Log\Log::INFO): void
+    {
+        if ($this->logger !== null) {
+            ($this->logger)($message, $priority);
+        }
+    }
+
+    /**
+     * Charge a saved BAID off-session. PayPal returns ACK=Success on approval,
+     * ACK=Failure with L_ERRORCODE0=10412 on duplicate INVNUM, or ACK=Failure
+     * with various 10xxx codes on decline / expired card.
+     *
+     * @param  array<string, scalar>  $extra  Extra NVP fields (e.g. invoice line items)
+     * @return array<string, mixed>
+     */
+    public function doReferenceTransaction(
+        string $referenceId,
+        float $amount,
+        string $currencyCode,
+        string $invoiceNumber = '',
+        string $description = '',
+        string $paymentAction = 'Sale',
+        array $extra = []
+    ): array {
+        $fields = array_merge([
+            'METHOD'        => 'DoReferenceTransaction',
+            'REFERENCEID'   => $referenceId,
+            'PAYMENTACTION' => $paymentAction,
+            'AMT'           => number_format($amount, 2, '.', ''),
+            'CURRENCYCODE'  => $currencyCode,
+        ], $extra);
+
+        if ($invoiceNumber !== '') {
+            $fields['INVNUM'] = $invoiceNumber;
+        }
+
+        if ($description !== '') {
+            $fields['DESC'] = substr($description, 0, 127);
+        }
+
+        return $this->request($fields);
+    }
+
+    /**
+     * Cancel a BAID at PayPal. After this, no further DoReferenceTransaction
+     * against the BAID will succeed — PayPal returns ACK=Failure with
+     * L_ERRORCODE0=11451 (BillingAgreement is canceled).
+     *
+     * @return array<string, mixed>
+     */
+    public function billAgreementUpdate(string $referenceId, string $action = 'Cancel', string $note = ''): array
+    {
+        $fields = [
+            'METHOD'                  => 'BillAgreementUpdate',
+            'REFERENCEID'             => $referenceId,
+            'BILLINGAGREEMENTSTATUS'  => $action === 'Cancel' ? 'Canceled' : 'Active',
+        ];
+
+        if ($note !== '') {
+            $fields['DESC'] = substr($note, 0, 127);
+        }
+
+        return $this->request($fields);
+    }
+
+    /**
+     * Get details of a saved BAID. Returns ACK=Success and BILLINGAGREEMENTSTATUS
+     * (Active|Canceled) when the BAID exists.
+     *
+     * @return array<string, mixed>
+     */
+    public function getBillAgreementDetails(string $referenceId): array
+    {
+        return $this->request([
+            'METHOD'      => 'BillAgreementUpdate',
+            'REFERENCEID' => $referenceId,
+        ]);
+    }
+
+    /**
+     * SetExpressCheckout — start the legacy NVP Express Checkout flow. Used to
+     * create a Billing Agreement (BAID) for subscription products.
+     *
+     * Returns ACK=Success + TOKEN. The caller redirects the customer to:
+     *   https://www.{sandbox.}paypal.com/cgi-bin/webscr?cmd=_express-checkout&token={TOKEN}
+     * After approval, PayPal redirects to ReturnURL with TOKEN + PayerID query params.
+     *
+     * @param  array<int, array{name: string, amt: float, qty: int}>  $items
+     * @return array<string, mixed>
+     */
+    public function setExpressCheckout(
+        float $amount,
+        string $currencyCode,
+        string $returnUrl,
+        string $cancelUrl,
+        string $invoiceNumber = '',
+        string $billingDescription = 'Automatic payments for subscription product',
+        string $custom = '',
+        array $items = []
+    ): array {
+        $fields = [
+            'METHOD'                                       => 'SetExpressCheckout',
+            'PAYMENTREQUEST_0_PAYMENTACTION'               => 'Sale',
+            'PAYMENTREQUEST_0_AMT'                         => number_format($amount, 2, '.', ''),
+            'PAYMENTREQUEST_0_CURRENCYCODE'                => $currencyCode,
+            'RETURNURL'                                    => $returnUrl,
+            'CANCELURL'                                    => $cancelUrl,
+            'L_BILLINGTYPE0'                               => 'MerchantInitiatedBillingSingleAgreement',
+            'L_BILLINGAGREEMENTDESCRIPTION0'               => substr(strip_tags($billingDescription), 0, 127),
+            'NOSHIPPING'                                   => '1',
+            'ALLOWNOTE'                                    => '0',
+        ];
+
+        if ($invoiceNumber !== '') {
+            $fields['PAYMENTREQUEST_0_INVNUM'] = substr($invoiceNumber, 0, 127);
+        }
+
+        if ($custom !== '') {
+            $fields['PAYMENTREQUEST_0_CUSTOM'] = substr($custom, 0, 255);
+        }
+
+        $i = 0;
+        $itemTotal = 0.0;
+
+        foreach ($items as $item) {
+            $name = (string) ($item['name'] ?? '');
+            $amt  = (float) ($item['amt'] ?? 0);
+            $qty  = (int) ($item['qty'] ?? 1);
+
+            if ($name === '' || $amt <= 0 || $qty <= 0) {
+                continue;
+            }
+
+            $fields['L_PAYMENTREQUEST_0_NAME' . $i] = substr($name, 0, 126);
+            $fields['L_PAYMENTREQUEST_0_AMT' . $i]  = number_format($amt, 2, '.', '');
+            $fields['L_PAYMENTREQUEST_0_QTY' . $i]  = (string) $qty;
+            $itemTotal += $amt * $qty;
+            $i++;
+        }
+
+        if ($itemTotal > 0) {
+            $fields['PAYMENTREQUEST_0_ITEMAMT'] = number_format($itemTotal, 2, '.', '');
+        }
+
+        return $this->request($fields);
+    }
+
+    /**
+     * GetExpressCheckoutDetails — verify a TOKEN after customer approval and
+     * read the PayerID + email + buyer details. Called between Return URL hit
+     * and DoExpressCheckoutPayment.
+     *
+     * @return array<string, mixed>
+     */
+    public function getExpressCheckoutDetails(string $token): array
+    {
+        return $this->request([
+            'METHOD' => 'GetExpressCheckoutDetails',
+            'TOKEN'  => $token,
+        ]);
+    }
+
+    /**
+     * DoExpressCheckoutPayment — finalize the Express Checkout payment AND
+     * create the Billing Agreement. ACK=Success returns BILLINGAGREEMENTID
+     * (the BAID) and PAYMENTINFO_0_TRANSACTIONID for the first-cycle charge.
+     *
+     * @return array<string, mixed>
+     */
+    public function doExpressCheckoutPayment(
+        string $token,
+        string $payerId,
+        float $amount,
+        string $currencyCode,
+        string $invoiceNumber = '',
+        string $custom = ''
+    ): array {
+        $fields = [
+            'METHOD'                          => 'DoExpressCheckoutPayment',
+            'TOKEN'                           => $token,
+            'PAYERID'                         => $payerId,
+            'PAYMENTREQUEST_0_PAYMENTACTION'  => 'Sale',
+            'PAYMENTREQUEST_0_AMT'            => number_format($amount, 2, '.', ''),
+            'PAYMENTREQUEST_0_CURRENCYCODE'   => $currencyCode,
+            'PAYMENTREQUEST_0_ITEMAMT'        => number_format($amount, 2, '.', ''),
+        ];
+
+        if ($invoiceNumber !== '') {
+            $fields['PAYMENTREQUEST_0_INVNUM'] = substr($invoiceNumber, 0, 127);
+        }
+
+        if ($custom !== '') {
+            $fields['PAYMENTREQUEST_0_CUSTOM'] = substr($custom, 0, 255);
+        }
+
+        return $this->request($fields);
+    }
+
+    /**
+     * Build the customer-facing approval URL for a TOKEN returned by
+     * SetExpressCheckout. Customer is redirected here to authorize the BAID.
+     */
+    public function getApprovalUrl(string $token): string
+    {
+        $base = $this->sandbox
+            ? 'https://www.sandbox.paypal.com'
+            : 'https://www.paypal.com';
+
+        return $base . '/cgi-bin/webscr?cmd=_express-checkout&token=' . urlencode($token);
+    }
+
+    /**
+     * @param  array<string, scalar>  $fields
+     * @return array<string, mixed>
+     */
+    private function request(array $fields): array
+    {
+        if (!$this->isConfigured()) {
+            return [
+                'ACK'             => 'Failure',
+                'L_ERRORCODE0'    => '_PLUGIN_NO_CREDS',
+                'L_SHORTMESSAGE0' => 'NVP credentials not configured',
+                'L_LONGMESSAGE0'  => 'api_username, api_password, and api_signature are required for the NVP renewal path. Configure them in payment_paypal plugin params.',
+            ];
+        }
+
+        $payload = array_merge([
+            'USER'      => $this->apiUsername,
+            'PWD'       => $this->apiPassword,
+            'SIGNATURE' => $this->apiSignature,
+            'VERSION'   => self::SIGNATURE_VERSION,
+        ], $fields);
+
+        $body = http_build_query($payload, '', '&');
+
+        if ($this->debug) {
+            $this->log('NVP request: ' . ($fields['METHOD'] ?? 'unknown') . ' to ' . $this->endpoint());
+        }
+
+        $ch = curl_init($this->endpoint());
+
+        curl_setopt_array($ch, [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_POST           => true,
+            CURLOPT_POSTFIELDS     => $body,
+            CURLOPT_TIMEOUT        => 30,
+            CURLOPT_CONNECTTIMEOUT => 10,
+            CURLOPT_SSL_VERIFYPEER => true,
+            CURLOPT_SSL_VERIFYHOST => 2,
+            CURLOPT_HTTPHEADER     => [
+                'Content-Type: application/x-www-form-urlencoded',
+                'Accept: */*',
+            ],
+        ]);
+
+        $rawResponse = curl_exec($ch);
+        $curlError   = curl_error($ch);
+        $httpStatus  = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
+
+        curl_close($ch);
+
+        if ($rawResponse === false || $rawResponse === '') {
+            $this->log('NVP transport error: ' . $curlError, \Joomla\CMS\Log\Log::ERROR);
+
+            return [
+                'ACK'             => 'Failure',
+                'L_ERRORCODE0'    => '_TRANSPORT',
+                'L_SHORTMESSAGE0' => 'PayPal NVP unreachable',
+                'L_LONGMESSAGE0'  => $curlError ?: 'No response from PayPal NVP API',
+                '_http_status'    => $httpStatus,
+            ];
+        }
+
+        parse_str((string) $rawResponse, $parsed);
+
+        if ($this->debug) {
+            $this->log(sprintf(
+                'NVP response: ACK=%s ERR=%s SHORT=%s',
+                $parsed['ACK'] ?? '?',
+                $parsed['L_ERRORCODE0'] ?? '',
+                $parsed['L_SHORTMESSAGE0'] ?? ''
+            ));
+        }
+
+        $parsed['_http_status'] = $httpStatus;
+
+        return $parsed;
+    }
+
+    public static function isSuccess(array $response): bool
+    {
+        $ack = strtoupper((string) ($response['ACK'] ?? ''));
+
+        return $ack === 'SUCCESS' || $ack === 'SUCCESSWITHWARNING';
+    }
+
+    public static function getErrorMessage(array $response): string
+    {
+        $short = (string) ($response['L_SHORTMESSAGE0'] ?? '');
+        $long  = (string) ($response['L_LONGMESSAGE0'] ?? '');
+        $code  = (string) ($response['L_ERRORCODE0'] ?? '');
+
+        $parts = [];
+
+        if ($code !== '') {
+            $parts[] = '[' . $code . ']';
+        }
+
+        if ($short !== '') {
+            $parts[] = $short;
+        }
+
+        if ($long !== '' && $long !== $short) {
+            $parts[] = $long;
+        }
+
+        return $parts !== [] ? implode(' ', $parts) : 'Unknown NVP error';
+    }
+}

--- a/plugins/j2commerce/payment_paypal/src/Service/PayPalWebhooks.php
+++ b/plugins/j2commerce/payment_paypal/src/Service/PayPalWebhooks.php
@@ -16,6 +16,8 @@ use J2Commerce\Component\J2commerce\Administrator\Helper\OrderHistoryHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\Database\DatabaseInterface;
+use Joomla\Database\ParameterType;
+use Joomla\Event\Event;
 use Joomla\Registry\Registry;
 
 final class PayPalWebhooks
@@ -69,20 +71,182 @@ final class PayPalWebhooks
 
         try {
             $result = match ($event['event_type']) {
-                'PAYMENT.CAPTURE.COMPLETED' => $this->handleCaptureCompleted($event, $params),
-                'PAYMENT.CAPTURE.PENDING'   => $this->handleCapturePending($event, $params),
-                'PAYMENT.CAPTURE.DENIED'    => $this->handleCaptureDenied($event, $params),
-                'PAYMENT.CAPTURE.REFUNDED'  => $this->handleCaptureRefunded($event, $params),
-                'PAYMENT.CAPTURE.REVERSED'  => $this->handleCaptureReversed($event, $params),
-                'CUSTOMER.DISPUTE.CREATED'  => $this->handleDisputeCreated($event, $params),
-                'CUSTOMER.DISPUTE.RESOLVED' => $this->handleDisputeResolved($event, $params),
-                default                     => ['status' => 200, 'message' => 'Event type not handled'],
+                'PAYMENT.CAPTURE.COMPLETED'           => $this->handleCaptureCompleted($event, $params),
+                'PAYMENT.CAPTURE.PENDING'             => $this->handleCapturePending($event, $params),
+                'PAYMENT.CAPTURE.DENIED'              => $this->handleCaptureDenied($event, $params),
+                'PAYMENT.CAPTURE.REFUNDED'            => $this->handleCaptureRefunded($event, $params),
+                'PAYMENT.CAPTURE.REVERSED'            => $this->handleCaptureReversed($event, $params),
+                'CUSTOMER.DISPUTE.CREATED'            => $this->handleDisputeCreated($event, $params),
+                'CUSTOMER.DISPUTE.RESOLVED'           => $this->handleDisputeResolved($event, $params),
+                'BILLING.SUBSCRIPTION.ACTIVATED'      => $this->handleSubscriptionActivated($event),
+                'BILLING.SUBSCRIPTION.CANCELLED'      => $this->handleSubscriptionStatusChange($event, 'cancelled'),
+                'BILLING.SUBSCRIPTION.SUSPENDED'      => $this->handleSubscriptionStatusChange($event, 'pending'),
+                'BILLING.SUBSCRIPTION.EXPIRED'        => $this->handleSubscriptionStatusChange($event, 'expired'),
+                'PAYMENT.SALE.COMPLETED'              => $this->handleSubscriptionRenewalSuccess($event),
+                'BILLING.SUBSCRIPTION.PAYMENT.FAILED' => $this->handleSubscriptionRenewalFailed($event),
+                default                               => ['status' => 200, 'message' => 'Event type not handled: ' . $event['event_type']],
             };
 
             return $result;
         } catch (\Exception $e) {
             return ['status' => 500, 'message' => 'Internal error: ' . $e->getMessage()];
         }
+    }
+
+    /**
+     * Map a PayPal subscription id (I-XXX...) to a local J2Commerce subscription id
+     * by reading the paypal_subscription_id metafield set at onJ2CommerceAfterPayment.
+     */
+    private function loadLocalSubscriptionByPayPalId(string $paypalSubscriptionId): ?\stdClass
+    {
+        if ($paypalSubscriptionId === '') {
+            return null;
+        }
+
+        $metakey       = 'paypal_subscription_id';
+        $namespace     = 'subscription';
+        $ownerResource = 'subscriptions';
+
+        $query = $this->db->getQuery(true)
+            ->select('s.*')
+            ->from($this->db->quoteName('#__j2commerce_metafields', 'm'))
+            ->innerJoin(
+                $this->db->quoteName('#__j2commerce_subscriptions', 's')
+                . ' ON ' . $this->db->quoteName('s.id') . ' = ' . $this->db->quoteName('m.owner_id')
+            )
+            ->where($this->db->quoteName('m.metakey') . ' = :metakey')
+            ->where($this->db->quoteName('m.namespace') . ' = :ns')
+            ->where($this->db->quoteName('m.owner_resource') . ' = :res')
+            ->where($this->db->quoteName('m.metavalue') . ' = :pps')
+            ->bind(':metakey', $metakey)
+            ->bind(':ns', $namespace)
+            ->bind(':res', $ownerResource)
+            ->bind(':pps', $paypalSubscriptionId)
+            ->setLimit(1);
+
+        $this->db->setQuery($query);
+
+        return $this->db->loadObject() ?: null;
+    }
+
+    /**
+     * @param array<string, mixed> $event
+     * @return array{status: int, message: string}
+     */
+    private function handleSubscriptionActivated(array $event): array
+    {
+        $paypalSubId  = (string) ($event['resource']['id'] ?? '');
+        $subscription = $this->loadLocalSubscriptionByPayPalId($paypalSubId);
+
+        if ($subscription === null) {
+            return ['status' => 404, 'message' => 'Local subscription not found for ' . $paypalSubId];
+        }
+
+        Factory::getApplication()->getDispatcher()->dispatch(
+            'onJ2CommerceChangeSubscriptionStatus',
+            new Event('onJ2CommerceChangeSubscriptionStatus', [(int) $subscription->id, 'active', 1])
+        );
+
+        return ['status' => 200, 'message' => 'Subscription #' . $subscription->id . ' activated'];
+    }
+
+    /**
+     * Handle CANCELLED, SUSPENDED, EXPIRED — direct status changes on the local sub.
+     *
+     * @param array<string, mixed> $event
+     * @return array{status: int, message: string}
+     */
+    private function handleSubscriptionStatusChange(array $event, string $newStatus): array
+    {
+        $paypalSubId  = (string) ($event['resource']['id'] ?? '');
+        $subscription = $this->loadLocalSubscriptionByPayPalId($paypalSubId);
+
+        if ($subscription === null) {
+            return ['status' => 404, 'message' => 'Local subscription not found for ' . $paypalSubId];
+        }
+
+        Factory::getApplication()->getDispatcher()->dispatch(
+            'onJ2CommerceChangeSubscriptionStatus',
+            new Event('onJ2CommerceChangeSubscriptionStatus', [(int) $subscription->id, $newStatus, 1])
+        );
+
+        return ['status' => 200, 'message' => 'Subscription #' . $subscription->id . ' → ' . $newStatus];
+    }
+
+    /**
+     * Recurring sale completed — dispatch SuccessRenewalPayment so the local sub
+     * advances its billing cycle and (optionally) creates a renewal order shell.
+     *
+     * @param array<string, mixed> $event
+     * @return array{status: int, message: string}
+     */
+    private function handleSubscriptionRenewalSuccess(array $event): array
+    {
+        $resource    = $event['resource'] ?? [];
+        $paypalSubId = (string) ($resource['billing_agreement_id'] ?? '');
+
+        if ($paypalSubId === '') {
+            // Not a recurring sale event (could be a regular Orders v2 capture echo) — ignore.
+            return ['status' => 200, 'message' => 'Sale event not subscription-related'];
+        }
+
+        $subscription = $this->loadLocalSubscriptionByPayPalId($paypalSubId);
+
+        if ($subscription === null) {
+            return ['status' => 404, 'message' => 'Local subscription not found for ' . $paypalSubId];
+        }
+
+        // Build a minimal order-like object the renewal helper can consume.
+        $renewalOrder = (object) [
+            'order_id'        => (string) ($subscription->order_id ?? ''),
+            'order_total'     => (float) ($subscription->renewal_amount ?? 0),
+            'currency_code'   => (string) ($resource['amount']['currency'] ?? 'USD'),
+            'transaction_id'  => (string) ($resource['id'] ?? ''),
+            'paypal_sale_id'  => (string) ($resource['id'] ?? ''),
+        ];
+
+        Factory::getApplication()->getDispatcher()->dispatch(
+            'onJ2CommerceSuccessRenewalPayment',
+            new Event('onJ2CommerceSuccessRenewalPayment', [
+                'subscription'      => $subscription,
+                'order'             => $renewalOrder,
+                'updateRenewalDate' => true,
+            ])
+        );
+
+        return ['status' => 200, 'message' => 'Subscription #' . $subscription->id . ' renewal recorded'];
+    }
+
+    /**
+     * @param array<string, mixed> $event
+     * @return array{status: int, message: string}
+     */
+    private function handleSubscriptionRenewalFailed(array $event): array
+    {
+        $resource    = $event['resource'] ?? [];
+        $paypalSubId = (string) ($resource['id'] ?? '');
+
+        $subscription = $this->loadLocalSubscriptionByPayPalId($paypalSubId);
+
+        if ($subscription === null) {
+            return ['status' => 404, 'message' => 'Local subscription not found for ' . $paypalSubId];
+        }
+
+        $renewalOrder = (object) [
+            'order_id'      => (string) ($subscription->order_id ?? ''),
+            'order_total'   => (float) ($subscription->renewal_amount ?? 0),
+            'currency_code' => 'USD',
+        ];
+
+        Factory::getApplication()->getDispatcher()->dispatch(
+            'onJ2CommerceFailedRenewalPayment',
+            new Event('onJ2CommerceFailedRenewalPayment', [
+                'subscription' => $subscription,
+                'order'        => $renewalOrder,
+            ])
+        );
+
+        return ['status' => 200, 'message' => 'Subscription #' . $subscription->id . ' renewal failure recorded'];
     }
 
     public function isAlreadyProcessed(string $eventId): bool

--- a/plugins/j2commerce/payment_paypal/tmpl/prepayment.php
+++ b/plugins/j2commerce/payment_paypal/tmpl/prepayment.php
@@ -49,6 +49,8 @@ $clientId = $vars->client_id ?? '';
      data-amount="<?php echo number_format($vars->orderpayment_amount, 2, '.', ''); ?>"
      data-sandbox="<?php echo $sandbox ? 'true' : 'false'; ?>"
      data-client-id="<?php echo htmlspecialchars($clientId, ENT_QUOTES, 'UTF-8'); ?>"
+     data-is-subscription="<?php echo !empty($vars->is_subscription) ? 'true' : 'false'; ?>"
+     data-subscription-mode="<?php echo htmlspecialchars($vars->subscription_mode ?? 'rest', ENT_QUOTES, 'UTF-8'); ?>"
      data-debug="<?php echo ($vars->debug ?? 0) ? 'true' : 'false'; ?>"
 ></div>
 


### PR DESCRIPTION
## Core Update — payment_paypal

### Changes
- **New service:** `PayPalNvpClient` — legacy PayPal NVP API client for operations not exposed via REST (recurring billing profile management, legacy refund flows)
- **New form field:** `PaypaltestbuttonsField` — admin sandbox/live credential test buttons (round-trip API call, displays merchant info on success)
- **Webhook updates:** `PayPalWebhooks` event handler refinements for subscription renewal lifecycle
- **Frontend:** `prepayment.php` + `paypal-checkout.js` updated for new flow
- **Language:** new en-GB strings for test-buttons UI

### Files Modified (8)
| Type | Count |
|------|-------|
| PHP files | 5 (Extension, PayPalWebhooks, PayPalNvpClient new, PaypaltestbuttonsField new, prepayment tmpl) |
| JS | 1 (paypal-checkout.js) |
| Language | 1 (en-GB ini) |
| XML manifest | 1 (payment_paypal.xml) |

### Pre-Flight
- [x] PHP syntax check passed (5 .php files)
- [x] No secrets detected
- [x] No FOF remnants (`F0FModel`/`F0FController`/`F0FTable`/`JFactory::`)
- [x] Core file scope only (only payment_paypal touched)