### PR TITLE
fix(strapper): native Joomla 6 calendar field for product-option date/datetime

### DIFF
--- a/administrator/components/com_j2commerce/src/Helper/J2CommerceHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/J2CommerceHelper.php
@@ -756,8 +756,8 @@ class J2CommerceHelper extends ContentHelper
      * $strapper->addJS();
      * $strapper->addCSS();
      *
-     * // Add date picker to an element
-     * $strapper->addDatePicker('my-date-field', ['date_format' => 'yy-mm-dd']);
+     * // Render a native Joomla 6 calendar (date) field
+     * echo $strapper->addDatePicker('my_date', 'my_date_id', '2026-01-15');
      *
      * // Format file size
      * $formatted = $strapper->sizeFormat(1024000);

--- a/administrator/components/com_j2commerce/src/Helper/StrapperHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/StrapperHelper.php
@@ -17,6 +17,7 @@ namespace J2Commerce\Component\J2commerce\Administrator\Helper;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Event\GenericEvent;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Database\ParameterType;
@@ -397,6 +398,138 @@ class StrapperHelper
         }
         return $filesize . " bytes";
 
+    }
+
+    /**
+     * Render a native Joomla 6 calendar (date) field.
+     *
+     * Delegates to the core `joomla.form.field.calendar` layout, which handles
+     * Web Asset Manager registration, Text::script keys, and the input/button
+     * markup that `media/system/js/fields/calendar.js` auto-initializes.
+     *
+     * @param string                     $name     Form input name
+     * @param string                     $id       DOM id (used by calendar.js to bind the trigger)
+     * @param string                     $value    Initial value (Y-m-d or empty)
+     * @param array|string|Registry|null $params   Option parameters (JSON, array, or Registry)
+     * @param bool                       $required Whether the field is required
+     * @since 6.0.0
+     */
+    public function addDatePicker(
+        string $name,
+        string $id,
+        string $value = '',
+        $params = null,
+        bool $required = false
+    ): string {
+        return $this->renderCalendarField($name, $id, $value, false, $params, $required);
+    }
+
+    /**
+     * Render a native Joomla 6 calendar field with time selector.
+     *
+     * @param string                     $name     Form input name
+     * @param string                     $id       DOM id
+     * @param string                     $value    Initial value (Y-m-d H:i or empty)
+     * @param array|string|Registry|null $params   Option parameters
+     * @param bool                       $required Whether the field is required
+     * @since 6.0.0
+     */
+    public function addDateTimePicker(
+        string $name,
+        string $id,
+        string $value = '',
+        $params = null,
+        bool $required = false
+    ): string {
+        return $this->renderCalendarField($name, $id, $value, true, $params, $required);
+    }
+
+    /**
+     * Shared renderer that builds the displayData array for `joomla.form.field.calendar`.
+     *
+     * @since 6.0.0
+     */
+    protected function renderCalendarField(
+        string $name,
+        string $id,
+        string $value,
+        bool $showTime,
+        $params,
+        bool $required
+    ): string {
+        if ($this->app === null) {
+            return '';
+        }
+
+        $registry = $params instanceof Registry ? $params : new Registry($params);
+
+        $format = (string) $registry->get(
+            'date_format_strftime',
+            $showTime ? '%Y-%m-%d %H:%M' : '%Y-%m-%d'
+        );
+
+        // Joomla calendar treats min/max year as OFFSETS from current year.
+        $minYear = (int) $registry->get('hide_pastdates', 0) === 1 ? 0 : -1900;
+        $maxYear = 200;
+
+        $lang      = $this->app->getLanguage();
+        $calendar  = $lang->getCalendar();
+        $direction = strtolower($this->app->getDocument()->getDirection());
+
+        $helperPath = 'system/fields/calendar-locales/date/gregorian/date-helper.min.js';
+        if ($calendar && is_dir(JPATH_ROOT . '/media/system/js/fields/calendar-locales/date/' . strtolower($calendar))) {
+            $helperPath = 'system/fields/calendar-locales/date/' . strtolower($calendar) . '/date-helper.min.js';
+        }
+
+        $weekend = preg_replace('/[^0-9,]/', '', (string) $lang->getWeekEnd()) ?: '0,6';
+
+        return LayoutHelper::render('joomla.form.field.calendar', [
+            'autocomplete'   => 'off',
+            'autofocus'      => false,
+            'class'          => '',
+            'description'    => '',
+            'disabled'       => false,
+            'group'          => null,
+            'hidden'         => false,
+            'hint'           => '',
+            'id'             => $id,
+            'label'          => '',
+            'labelclass'     => '',
+            'multiple'       => false,
+            'name'           => $name,
+            'onchange'       => '',
+            'onclick'        => '',
+            'pattern'        => '',
+            'readonly'       => false,
+            'repeat'         => false,
+            'required'       => $required,
+            'size'           => 0,
+            'spellcheck'     => false,
+            'validate'       => '',
+            'value'          => $value,
+            'checkedOptions' => [],
+            'hasValue'       => $value !== '',
+            'options'        => [],
+            'dataAttribute'  => '',
+            'dataAttributes' => [],
+            'maxlength'      => 0,
+            'maxLength'      => 45,
+            'format'         => $format,
+            'filter'         => '',
+            'todaybutton'    => 1,
+            'weeknumbers'    => 0,
+            'showtime'       => $showTime ? 1 : 0,
+            'filltable'      => 1,
+            'timeformat'     => 24,
+            'singleheader'   => 0,
+            'helperPath'     => $helperPath,
+            'minYear'        => $minYear,
+            'maxYear'        => $maxYear,
+            'direction'      => $direction,
+            'calendar'       => $calendar,
+            'firstday'       => (int) $lang->getFirstDay(),
+            'weekend'        => explode(',', $weekend),
+        ]);
     }
 
     /**

--- a/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/view_configurableoptions.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/view_configurableoptions.php
@@ -213,14 +213,16 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
                 <?php if ($option['required']) : ?>
                 <span class="required">*</span>
                 <?php endif; ?>
-                <b><?php echo $esc(Text::_($option['option_name'])); ?>:</b><br>
-                <input type="text"
-                    name="product_option[<?php echo $optionId; ?>]"
-                    value="<?php echo $esc($option['optionvalue'] ?? ''); ?>"
-                    class="<?php echo $element_date; ?>" />
+                <b><label for="<?php echo $element_date; ?>"><?php echo $esc(Text::_($option['option_name'])); ?>:</label></b><br>
+                <?php echo J2CommerceHelper::strapper()->addDatePicker(
+                    'product_option[' . $optionId . ']',
+                    $element_date,
+                    (string) ($option['optionvalue'] ?? ''),
+                    $option['option_params'],
+                    (bool) $option['required']
+                ); ?>
             </div>
             <br>
-            <?php J2CommerceHelper::strapper()->addDatePicker($element_date, $option['option_params']); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] == 'datetime') : ?>
@@ -230,14 +232,16 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
                 <?php if ($option['required']) : ?>
                 <span class="required">*</span>
                 <?php endif; ?>
-                <b><?php echo $esc(Text::_($option['option_name'])); ?>:</b><br>
-                <input type="text"
-                    name="product_option[<?php echo $optionId; ?>]"
-                    value="<?php echo $esc($option['optionvalue'] ?? ''); ?>"
-                    class="<?php echo $element_datetime; ?>" />
+                <b><label for="<?php echo $element_datetime; ?>"><?php echo $esc(Text::_($option['option_name'])); ?>:</label></b><br>
+                <?php echo J2CommerceHelper::strapper()->addDateTimePicker(
+                    'product_option[' . $optionId . ']',
+                    $element_datetime,
+                    (string) ($option['optionvalue'] ?? ''),
+                    $option['option_params'],
+                    (bool) $option['required']
+                ); ?>
             </div>
             <br>
-            <?php J2CommerceHelper::strapper()->addDateTimePicker($element_datetime, $option['option_params']); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] == 'time') : ?>

--- a/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/view_options.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/view_options.php
@@ -195,13 +195,15 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
                 <?php if ($option['required']) : ?>
                 <span class="required text-danger">*</span>
                 <?php endif; ?>
-                <label class="form-label fw-bold"><?php echo Text::_($option['option_name']); ?>:</label>
-                <input type="text"
-                    name="product_option[<?php echo (int) $option['productoption_id']; ?>]"
-                    value="<?php echo $esc($option['optionvalue'] ?? ''); ?>"
-                    class="form-control <?php echo $element_date; ?>" />
+                <label class="form-label fw-bold" for="<?php echo $element_date; ?>"><?php echo Text::_($option['option_name']); ?>:</label>
+                <?php echo J2CommerceHelper::strapper()->addDatePicker(
+                    'product_option[' . (int) $option['productoption_id'] . ']',
+                    $element_date,
+                    (string) ($option['optionvalue'] ?? ''),
+                    $option['option_params'],
+                    (bool) $option['required']
+                ); ?>
             </div>
-            <?php J2CommerceHelper::strapper()->addDatePicker($element_date, $option['option_params']); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] == 'datetime') : ?>
@@ -211,13 +213,15 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
                 <?php if ($option['required']) : ?>
                 <span class="required text-danger">*</span>
                 <?php endif; ?>
-                <label class="form-label fw-bold"><?php echo Text::_($option['option_name']); ?>:</label>
-                <input type="text"
-                    name="product_option[<?php echo (int) $option['productoption_id']; ?>]"
-                    value="<?php echo $esc($option['optionvalue'] ?? ''); ?>"
-                    class="form-control <?php echo $element_datetime; ?>" />
+                <label class="form-label fw-bold" for="<?php echo $element_datetime; ?>"><?php echo Text::_($option['option_name']); ?>:</label>
+                <?php echo J2CommerceHelper::strapper()->addDateTimePicker(
+                    'product_option[' . (int) $option['productoption_id'] . ']',
+                    $element_datetime,
+                    (string) ($option['optionvalue'] ?? ''),
+                    $option['option_params'],
+                    (bool) $option['required']
+                ); ?>
             </div>
-            <?php J2CommerceHelper::strapper()->addDateTimePicker($element_datetime, $option['option_params']); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] == 'time') : ?>

--- a/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/view_variableoptions.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/view_variableoptions.php
@@ -253,13 +253,14 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
                         <span class="text-danger">*</span>
                     <?php endif; ?>
                 </label>
-                <input type="text"
-                       id="<?php echo $element_date; ?>"
-                       class="form-control <?php echo $element_date; ?>"
-                       name="product_option[<?php echo (int) $option['productoption_id']; ?>]"
-                       value="<?php echo $esc($option['optionvalue'] ?? ''); ?>" />
+                <?php echo J2CommerceHelper::strapper()->addDatePicker(
+                    'product_option[' . (int) $option['productoption_id'] . ']',
+                    $element_date,
+                    (string) ($option['optionvalue'] ?? ''),
+                    $option['option_params'],
+                    (bool) $option['required']
+                ); ?>
             </div>
-            <?php J2CommerceHelper::strapper()->addDatePicker($element_date, $option['option_params']); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] === 'datetime') : ?>
@@ -271,13 +272,14 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
                         <span class="text-danger">*</span>
                     <?php endif; ?>
                 </label>
-                <input type="text"
-                       id="<?php echo $element_datetime; ?>"
-                       class="form-control <?php echo $element_datetime; ?>"
-                       name="product_option[<?php echo (int) $option['productoption_id']; ?>]"
-                       value="<?php echo $esc($option['optionvalue'] ?? ''); ?>" />
+                <?php echo J2CommerceHelper::strapper()->addDateTimePicker(
+                    'product_option[' . (int) $option['productoption_id'] . ']',
+                    $element_datetime,
+                    (string) ($option['optionvalue'] ?? ''),
+                    $option['option_params'],
+                    (bool) $option['required']
+                ); ?>
             </div>
-            <?php J2CommerceHelper::strapper()->addDateTimePicker($element_datetime, $option['option_params']); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] === 'time') : ?>

--- a/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/view_configurableoptions.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/view_configurableoptions.php
@@ -213,14 +213,16 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
                 <?php if ($option['required']) : ?>
                 <span class="required">*</span>
                 <?php endif; ?>
-                <b><?php echo $esc(Text::_($option['option_name'])); ?>:</b><br>
-                <input type="text"
-                    name="product_option[<?php echo $optionId; ?>]"
-                    value="<?php echo $esc($option['optionvalue'] ?? ''); ?>"
-                    class="<?php echo $element_date; ?>" />
+                <b><label for="<?php echo $element_date; ?>"><?php echo $esc(Text::_($option['option_name'])); ?>:</label></b><br>
+                <?php echo J2CommerceHelper::strapper()->addDatePicker(
+                    'product_option[' . $optionId . ']',
+                    $element_date,
+                    (string) ($option['optionvalue'] ?? ''),
+                    $option['option_params'],
+                    (bool) $option['required']
+                ); ?>
             </div>
             <br>
-            <?php J2CommerceHelper::strapper()->addDatePicker($element_date, $option['option_params']); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] == 'datetime') : ?>
@@ -230,14 +232,16 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
                 <?php if ($option['required']) : ?>
                 <span class="required">*</span>
                 <?php endif; ?>
-                <b><?php echo $esc(Text::_($option['option_name'])); ?>:</b><br>
-                <input type="text"
-                    name="product_option[<?php echo $optionId; ?>]"
-                    value="<?php echo $esc($option['optionvalue'] ?? ''); ?>"
-                    class="<?php echo $element_datetime; ?>" />
+                <b><label for="<?php echo $element_datetime; ?>"><?php echo $esc(Text::_($option['option_name'])); ?>:</label></b><br>
+                <?php echo J2CommerceHelper::strapper()->addDateTimePicker(
+                    'product_option[' . $optionId . ']',
+                    $element_datetime,
+                    (string) ($option['optionvalue'] ?? ''),
+                    $option['option_params'],
+                    (bool) $option['required']
+                ); ?>
             </div>
             <br>
-            <?php J2CommerceHelper::strapper()->addDateTimePicker($element_datetime, $option['option_params']); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] == 'time') : ?>

--- a/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/view_options.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/view_options.php
@@ -194,13 +194,15 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
                 <?php if ($option['required']) : ?>
                 <span class="required text-danger">*</span>
                 <?php endif; ?>
-                <label class="form-label fw-bold"><?php echo Text::_($option['option_name']); ?>:</label>
-                <input type="text"
-                    name="product_option[<?php echo (int) $option['productoption_id']; ?>]"
-                    value="<?php echo $esc($option['optionvalue'] ?? ''); ?>"
-                    class="form-control <?php echo $element_date; ?>" />
+                <label class="form-label fw-bold" for="<?php echo $element_date; ?>"><?php echo Text::_($option['option_name']); ?>:</label>
+                <?php echo J2CommerceHelper::strapper()->addDatePicker(
+                    'product_option[' . (int) $option['productoption_id'] . ']',
+                    $element_date,
+                    (string) ($option['optionvalue'] ?? ''),
+                    $option['option_params'],
+                    (bool) $option['required']
+                ); ?>
             </div>
-            <?php J2CommerceHelper::strapper()->addDatePicker($element_date, $option['option_params']); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] == 'datetime') : ?>
@@ -210,13 +212,15 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
                 <?php if ($option['required']) : ?>
                 <span class="required text-danger">*</span>
                 <?php endif; ?>
-                <label class="form-label fw-bold"><?php echo Text::_($option['option_name']); ?>:</label>
-                <input type="text"
-                    name="product_option[<?php echo (int) $option['productoption_id']; ?>]"
-                    value="<?php echo $esc($option['optionvalue'] ?? ''); ?>"
-                    class="form-control <?php echo $element_datetime; ?>" />
+                <label class="form-label fw-bold" for="<?php echo $element_datetime; ?>"><?php echo Text::_($option['option_name']); ?>:</label>
+                <?php echo J2CommerceHelper::strapper()->addDateTimePicker(
+                    'product_option[' . (int) $option['productoption_id'] . ']',
+                    $element_datetime,
+                    (string) ($option['optionvalue'] ?? ''),
+                    $option['option_params'],
+                    (bool) $option['required']
+                ); ?>
             </div>
-            <?php J2CommerceHelper::strapper()->addDateTimePicker($element_datetime, $option['option_params']); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] == 'time') : ?>

--- a/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/view_variableoptions.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/view_variableoptions.php
@@ -253,13 +253,14 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
                         <span class="text-danger">*</span>
                     <?php endif; ?>
                 </label>
-                <input type="text"
-                       id="<?php echo $element_date; ?>"
-                       class="form-control <?php echo $element_date; ?>"
-                       name="product_option[<?php echo $option['productoption_id']; ?>]"
-                       value="<?php echo $esc($option['optionvalue'] ?? ''); ?>" />
+                <?php echo J2CommerceHelper::strapper()->addDatePicker(
+                    'product_option[' . $option['productoption_id'] . ']',
+                    $element_date,
+                    (string) ($option['optionvalue'] ?? ''),
+                    $option['option_params'],
+                    (bool) $option['required']
+                ); ?>
             </div>
-            <?php J2CommerceHelper::strapper()->addDatePicker($element_date, $option['option_params']); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] === 'datetime') : ?>
@@ -271,13 +272,14 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
                         <span class="text-danger">*</span>
                     <?php endif; ?>
                 </label>
-                <input type="text"
-                       id="<?php echo $element_datetime; ?>"
-                       class="form-control <?php echo $element_datetime; ?>"
-                       name="product_option[<?php echo $option['productoption_id']; ?>]"
-                       value="<?php echo $esc($option['optionvalue'] ?? ''); ?>" />
+                <?php echo J2CommerceHelper::strapper()->addDateTimePicker(
+                    'product_option[' . $option['productoption_id'] . ']',
+                    $element_datetime,
+                    (string) ($option['optionvalue'] ?? ''),
+                    $option['option_params'],
+                    (bool) $option['required']
+                ); ?>
             </div>
-            <?php J2CommerceHelper::strapper()->addDateTimePicker($element_datetime, $option['option_params']); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] === 'time') : ?>

--- a/plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_configurableoptions.php
+++ b/plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_configurableoptions.php
@@ -212,13 +212,15 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
                 <?php if ($option['required']) : ?>
                 <span class="uk-text-danger">*</span>
                 <?php endif; ?>
-                <b><?php echo $this->escape(Text::_($option['option_name'])); ?>:</b><br>
-                <input type="text"
-                    class="uk-input <?php echo $element_date; ?>"
-                    name="product_option[<?php echo $option['productoption_id']; ?>]"
-                    value="<?php echo $option['optionvalue']; ?>" />
+                <b><label for="<?php echo $element_date; ?>"><?php echo $this->escape(Text::_($option['option_name'])); ?>:</label></b><br>
+                <?php echo J2CommerceHelper::strapper()->addDatePicker(
+                    'product_option[' . $option['productoption_id'] . ']',
+                    $element_date,
+                    (string) ($option['optionvalue'] ?? ''),
+                    $option['option_params'],
+                    (bool) $option['required']
+                ); ?>
             </div>
-            <?php J2CommerceHelper::strapper()->addDatePicker($element_date, $option['option_params']); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] == 'datetime') : ?>
@@ -227,13 +229,15 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
                 <?php if ($option['required']) : ?>
                 <span class="uk-text-danger">*</span>
                 <?php endif; ?>
-                <b><?php echo $this->escape(Text::_($option['option_name'])); ?>:</b><br>
-                <input type="text"
-                    class="uk-input <?php echo $element_datetime; ?>"
-                    name="product_option[<?php echo $option['productoption_id']; ?>]"
-                    value="<?php echo $option['optionvalue']; ?>" />
+                <b><label for="<?php echo $element_datetime; ?>"><?php echo $this->escape(Text::_($option['option_name'])); ?>:</label></b><br>
+                <?php echo J2CommerceHelper::strapper()->addDateTimePicker(
+                    'product_option[' . $option['productoption_id'] . ']',
+                    $element_datetime,
+                    (string) ($option['optionvalue'] ?? ''),
+                    $option['option_params'],
+                    (bool) $option['required']
+                ); ?>
             </div>
-            <?php J2CommerceHelper::strapper()->addDateTimePicker($element_datetime, $option['option_params']); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] == 'time') : ?>

--- a/plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_options.php
+++ b/plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_options.php
@@ -183,13 +183,15 @@ $ajax_url = Route::_('index.php', false);
                 <?php if ($option['required']) : ?>
                 <span class="uk-text-danger">*</span>
                 <?php endif; ?>
-                <label class="uk-form-label uk-text-bold"><?php echo Text::_($option['option_name']); ?>:</label>
-                <input type="text"
-                    class="uk-input <?php echo $element_date; ?>"
-                    name="product_option[<?php echo $option['productoption_id']; ?>]"
-                    value="<?php echo $option['optionvalue']; ?>" />
+                <label class="uk-form-label uk-text-bold" for="<?php echo $element_date; ?>"><?php echo Text::_($option['option_name']); ?>:</label>
+                <?php echo J2CommerceHelper::strapper()->addDatePicker(
+                    'product_option[' . $option['productoption_id'] . ']',
+                    $element_date,
+                    (string) ($option['optionvalue'] ?? ''),
+                    $option['option_params'],
+                    (bool) $option['required']
+                ); ?>
             </div>
-            <?php J2CommerceHelper::strapper()->addDatePicker($element_date, $option['option_params']); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] == 'datetime') : ?>
@@ -198,13 +200,15 @@ $ajax_url = Route::_('index.php', false);
                 <?php if ($option['required']) : ?>
                 <span class="uk-text-danger">*</span>
                 <?php endif; ?>
-                <label class="uk-form-label uk-text-bold"><?php echo Text::_($option['option_name']); ?>:</label>
-                <input type="text"
-                    class="uk-input <?php echo $element_datetime; ?>"
-                    name="product_option[<?php echo $option['productoption_id']; ?>]"
-                    value="<?php echo $option['optionvalue']; ?>" />
+                <label class="uk-form-label uk-text-bold" for="<?php echo $element_datetime; ?>"><?php echo Text::_($option['option_name']); ?>:</label>
+                <?php echo J2CommerceHelper::strapper()->addDateTimePicker(
+                    'product_option[' . $option['productoption_id'] . ']',
+                    $element_datetime,
+                    (string) ($option['optionvalue'] ?? ''),
+                    $option['option_params'],
+                    (bool) $option['required']
+                ); ?>
             </div>
-            <?php J2CommerceHelper::strapper()->addDateTimePicker($element_datetime, $option['option_params']); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] == 'time') : ?>

--- a/plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_variableoptions.php
+++ b/plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_variableoptions.php
@@ -248,13 +248,14 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
                         <span class="uk-text-danger">*</span>
                     <?php endif; ?>
                 </label>
-                <input type="text"
-                       id="<?php echo $element_date; ?>"
-                       class="uk-input <?php echo $element_date; ?>"
-                       name="product_option[<?php echo $option['productoption_id']; ?>]"
-                       value="<?php echo $esc($option['optionvalue'] ?? ''); ?>" />
+                <?php echo J2CommerceHelper::strapper()->addDatePicker(
+                    'product_option[' . $option['productoption_id'] . ']',
+                    $element_date,
+                    (string) ($option['optionvalue'] ?? ''),
+                    $option['option_params'],
+                    (bool) $option['required']
+                ); ?>
             </div>
-            <?php J2CommerceHelper::strapper()->addDatePicker($element_date, $option['option_params']); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] === 'datetime') : ?>
@@ -266,13 +267,14 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
                         <span class="uk-text-danger">*</span>
                     <?php endif; ?>
                 </label>
-                <input type="text"
-                       id="<?php echo $element_datetime; ?>"
-                       class="uk-input <?php echo $element_datetime; ?>"
-                       name="product_option[<?php echo $option['productoption_id']; ?>]"
-                       value="<?php echo $esc($option['optionvalue'] ?? ''); ?>" />
+                <?php echo J2CommerceHelper::strapper()->addDateTimePicker(
+                    'product_option[' . $option['productoption_id'] . ']',
+                    $element_datetime,
+                    (string) ($option['optionvalue'] ?? ''),
+                    $option['option_params'],
+                    (bool) $option['required']
+                ); ?>
             </div>
-            <?php J2CommerceHelper::strapper()->addDateTimePicker($element_datetime, $option['option_params']); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] === 'time') : ?>

--- a/plugins/j2commerce/app_uikit/tmpl/uikit/view_configurableoptions.php
+++ b/plugins/j2commerce/app_uikit/tmpl/uikit/view_configurableoptions.php
@@ -212,13 +212,15 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
                 <?php if ($option['required']) : ?>
                 <span class="uk-text-danger">*</span>
                 <?php endif; ?>
-                <b><?php echo $this->escape(Text::_($option['option_name'])); ?>:</b><br>
-                <input type="text"
-                    class="uk-input <?php echo $element_date; ?>"
-                    name="product_option[<?php echo $option['productoption_id']; ?>]"
-                    value="<?php echo $option['optionvalue']; ?>" />
+                <b><label for="<?php echo $element_date; ?>"><?php echo $this->escape(Text::_($option['option_name'])); ?>:</label></b><br>
+                <?php echo J2CommerceHelper::strapper()->addDatePicker(
+                    'product_option[' . $option['productoption_id'] . ']',
+                    $element_date,
+                    (string) ($option['optionvalue'] ?? ''),
+                    $option['option_params'],
+                    (bool) $option['required']
+                ); ?>
             </div>
-            <?php J2CommerceHelper::strapper()->addDatePicker($element_date, $option['option_params']); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] == 'datetime') : ?>
@@ -227,13 +229,15 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
                 <?php if ($option['required']) : ?>
                 <span class="uk-text-danger">*</span>
                 <?php endif; ?>
-                <b><?php echo $this->escape(Text::_($option['option_name'])); ?>:</b><br>
-                <input type="text"
-                    class="uk-input <?php echo $element_datetime; ?>"
-                    name="product_option[<?php echo $option['productoption_id']; ?>]"
-                    value="<?php echo $option['optionvalue']; ?>" />
+                <b><label for="<?php echo $element_datetime; ?>"><?php echo $this->escape(Text::_($option['option_name'])); ?>:</label></b><br>
+                <?php echo J2CommerceHelper::strapper()->addDateTimePicker(
+                    'product_option[' . $option['productoption_id'] . ']',
+                    $element_datetime,
+                    (string) ($option['optionvalue'] ?? ''),
+                    $option['option_params'],
+                    (bool) $option['required']
+                ); ?>
             </div>
-            <?php J2CommerceHelper::strapper()->addDateTimePicker($element_datetime, $option['option_params']); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] == 'time') : ?>

--- a/plugins/j2commerce/app_uikit/tmpl/uikit/view_options.php
+++ b/plugins/j2commerce/app_uikit/tmpl/uikit/view_options.php
@@ -183,13 +183,15 @@ $ajax_url = Route::_('index.php', false);
                 <?php if ($option['required']) : ?>
                 <span class="uk-text-danger">*</span>
                 <?php endif; ?>
-                <label class="uk-form-label uk-text-bold"><?php echo Text::_($option['option_name']); ?>:</label>
-                <input type="text"
-                    class="uk-input <?php echo $element_date; ?>"
-                    name="product_option[<?php echo $option['productoption_id']; ?>]"
-                    value="<?php echo $option['optionvalue']; ?>" />
+                <label class="uk-form-label uk-text-bold" for="<?php echo $element_date; ?>"><?php echo Text::_($option['option_name']); ?>:</label>
+                <?php echo J2CommerceHelper::strapper()->addDatePicker(
+                    'product_option[' . $option['productoption_id'] . ']',
+                    $element_date,
+                    (string) ($option['optionvalue'] ?? ''),
+                    $option['option_params'],
+                    (bool) $option['required']
+                ); ?>
             </div>
-            <?php J2CommerceHelper::strapper()->addDatePicker($element_date, $option['option_params']); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] == 'datetime') : ?>
@@ -198,13 +200,15 @@ $ajax_url = Route::_('index.php', false);
                 <?php if ($option['required']) : ?>
                 <span class="uk-text-danger">*</span>
                 <?php endif; ?>
-                <label class="uk-form-label uk-text-bold"><?php echo Text::_($option['option_name']); ?>:</label>
-                <input type="text"
-                    class="uk-input <?php echo $element_datetime; ?>"
-                    name="product_option[<?php echo $option['productoption_id']; ?>]"
-                    value="<?php echo $option['optionvalue']; ?>" />
+                <label class="uk-form-label uk-text-bold" for="<?php echo $element_datetime; ?>"><?php echo Text::_($option['option_name']); ?>:</label>
+                <?php echo J2CommerceHelper::strapper()->addDateTimePicker(
+                    'product_option[' . $option['productoption_id'] . ']',
+                    $element_datetime,
+                    (string) ($option['optionvalue'] ?? ''),
+                    $option['option_params'],
+                    (bool) $option['required']
+                ); ?>
             </div>
-            <?php J2CommerceHelper::strapper()->addDateTimePicker($element_datetime, $option['option_params']); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] == 'time') : ?>

--- a/plugins/j2commerce/app_uikit/tmpl/uikit/view_variableoptions.php
+++ b/plugins/j2commerce/app_uikit/tmpl/uikit/view_variableoptions.php
@@ -249,13 +249,14 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
                         <span class="uk-text-danger">*</span>
                     <?php endif; ?>
                 </label>
-                <input type="text"
-                       id="<?php echo $element_date; ?>"
-                       class="uk-input <?php echo $element_date; ?>"
-                       name="product_option[<?php echo $option['productoption_id']; ?>]"
-                       value="<?php echo $esc($option['optionvalue'] ?? ''); ?>" />
+                <?php echo J2CommerceHelper::strapper()->addDatePicker(
+                    'product_option[' . $option['productoption_id'] . ']',
+                    $element_date,
+                    (string) ($option['optionvalue'] ?? ''),
+                    $option['option_params'],
+                    (bool) $option['required']
+                ); ?>
             </div>
-            <?php J2CommerceHelper::strapper()->addDatePicker($element_date, $option['option_params']); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] === 'datetime') : ?>
@@ -267,13 +268,14 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
                         <span class="uk-text-danger">*</span>
                     <?php endif; ?>
                 </label>
-                <input type="text"
-                       id="<?php echo $element_datetime; ?>"
-                       class="uk-input <?php echo $element_datetime; ?>"
-                       name="product_option[<?php echo $option['productoption_id']; ?>]"
-                       value="<?php echo $esc($option['optionvalue'] ?? ''); ?>" />
+                <?php echo J2CommerceHelper::strapper()->addDateTimePicker(
+                    'product_option[' . $option['productoption_id'] . ']',
+                    $element_datetime,
+                    (string) ($option['optionvalue'] ?? ''),
+                    $option['option_params'],
+                    (bool) $option['required']
+                ); ?>
             </div>
-            <?php J2CommerceHelper::strapper()->addDateTimePicker($element_datetime, $option['option_params']); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] === 'time') : ?>


### PR DESCRIPTION
## Summary

Fixes "Call to undefined method addDatePicker / addDateTimePicker" on every product page that exposes a `date` or `datetime` option. Renders the actual Joomla 6 `CalendarField` server-side via the core `joomla.form.field.calendar` layout — no inline-JS wrapping of a text input, no DOM construction race, no jQuery UI.

Supersedes #858 (closed). The previous PR wrapped a `<input type="text">` via a head-injected IIFE — fragile because it raced the deferred core `calendar.js` auto-init handler. 

## What changed

```php
// Old (broken — method did not exist)
J2CommerceHelper::strapper()->addDatePicker($element, $params);

// New
echo J2CommerceHelper::strapper()->addDatePicker(
    $name, $id, $value, $params, $required
);
```

`addDatePicker` / `addDateTimePicker` delegate to a shared `renderCalendarField()` that builds the displayData array `CalendarField::getInput()` passes to `LayoutHelper::render('joomla.form.field.calendar', $data)`. The core layout owns:

- WAM registration: `field.calendar.helper`, `field.calendar` (script + style)
- `Text::script()` language strings the widget consumes at runtime
- Full DOM (`field-calendar` wrapper → `input-group` → `<input>` → trigger `<button>`) with every `data-*` attribute
- Auto-init via `media/system/js/fields/calendar.js` on `DOMContentLoaded`

## Defensive details

- `minYear` / `maxYear` are **relative offsets** from the current year (`calendar.js`: `params.minYear = currentYear + dataset.minYear`). `hide_pastdates=1` → `0`; otherwise `-1900` / `200` to mirror `CalendarField` defaults. Passing absolute years rendered year 4052 in the picker.
- Locale-aware date helper: probes `/media/system/js/fields/calendar-locales/date/{calendar}/` and falls back to gregorian when the language calendar has no helper script.
- `weekend` is regex-stripped to `[0-9,]` with `0,6` fallback so non-numeric locale data cannot break the data-weekend attribute.

## Template shape

Templates lost the hand-rolled `<input type="text">` + class hook + post-call `addDatePicker()`. They now `echo` the helper, which emits the entire field. Labels gained `for="$id"` for accessibility. The plain-HTML `j2commerce_time` field is unchanged.

## Files Modified

| Type | Count |
|------|-------|
| Helper PHP | 2 (StrapperHelper.php, J2CommerceHelper.php docblock) |
| Plugin templates | 12 (bs5/tag_bs5/uikit/tag_uikit × view_options/configurableoptions/variableoptions) |
| **Total** | **14** |

## Pre-Flight

- [x] PHP syntax check passed (14/14)
- [x] No secrets detected
- [x] No FOF remnants (no `JFactory::`, no `F0F*`)
- [x] No jQuery introduced
- [x] No `innerHTML` / `insertAdjacentHTML`
- [x] No `text-muted` introduced
- [x] Core files only (non-core excluded)