### PR TITLE
fix(admin): clear data-alt-value on calendar filters when Clear clicked

### DIFF
--- a/media/com_j2commerce/js/administrator/j2commerce.js
+++ b/media/com_j2commerce/js/administrator/j2commerce.js
@@ -1,0 +1,36 @@
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+(() => {
+    'use strict';
+
+    // Workaround for joomla/joomla-cms#47671 — Joomla 6 searchtools Clear button
+    // blanks input.value but ignores data-alt-value on calendar fields, so list
+    // views remain filtered by the stale ISO date. Mirrors upstream PR #47686.
+    // Capture phase fires before Joomla's own clear handler; once #47686 lands
+    // this becomes a no-op (data-alt-value already empty).
+    document.addEventListener('click', (event) => {
+        const button = event.target.closest('.js-stools-btn-clear');
+        if (!button) {
+            return;
+        }
+
+        const form = button.closest('form');
+        if (!form) {
+            return;
+        }
+
+        form.querySelectorAll('input[data-alt-value]').forEach((input) => {
+            if (input.getAttribute('data-alt-value') === '') {
+                return;
+            }
+            input.setAttribute('data-alt-value', '');
+            input.dispatchEvent(new Event('change', { bubbles: true }));
+        });
+    }, true);
+})();


### PR DESCRIPTION
## Summary
Fixes #844

Joomla 6 core `searchtools.es6.js` Clear handler blanks `input.value` but ignores `data-alt-value` on calendar fields, so admin list views remain filtered by the stale ISO date. Affects Orders, Products, and Carts list views (the three `forms/filter_*.xml` that use `type="calendar"`).

Mirrors the upstream fix in joomla/joomla-cms#47686 with a capture-phase delegate so the workaround becomes a no-op once the upstream PR lands.

## Changes
- New `media/com_j2commerce/js/administrator/j2commerce.js` — capture-phase click delegate on `.js-stools-btn-clear` clears `data-alt-value` on every calendar input in the form before Joomla's own clear iteration runs.
- File was already registered by `StrapperHelper::loadAdminScripts()` (line 552) but missing on disk; this also resolves the silent 404.

## Testing
1. Hard-refresh admin to load the new asset.
2. Components → J2Commerce → Orders.
3. Open the filter bar, set a "Created From" date, click Search — list filters as expected.
4. Click Clear.
5. Verify the date input is empty AND the list shows ALL orders.
6. Repeat on Products and Carts list views.

## Files Changed
- `media/com_j2commerce/js/administrator/j2commerce.js` — new file (37 lines)