### PR TITLE
fix(email): correct View Your Order link in confirmation email

### DIFF
--- a/administrator/components/com_j2commerce/src/Helper/EmailHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/EmailHelper.php
@@ -411,7 +411,7 @@ class EmailHelper
 
         // Invoice URL — links to myprofile order view (no token; unauthenticated users get login redirect)
         $orderId           = $order->order_id ?? '';
-        $defaultInvoiceUrl = Route::_('index.php?option=com_j2commerce&view=myprofile&task=orderView&order_id=' . urlencode((string) $orderId), false);
+        $defaultInvoiceUrl = Route::_('index.php?option=com_j2commerce&view=myprofile&layout=order&order_id=' . urlencode((string) $orderId), false);
         $url               = str_replace('&amp;', '&', $defaultInvoiceUrl);
         $url               = str_replace('/administrator', '', $url);
         $url               = ltrim($url, '/');


### PR DESCRIPTION
## Summary
Fixes #842

The "View Your Order" link in the order confirmation email used `task=orderView`, but no `orderView` controller method exists in the myprofile view. The actual myprofile UI uses `layout=order` (which maps to `tmpl/myprofile/order.php`). Email recipients clicking the link landed on the my-account index instead of the order detail page.

## Changes
- `administrator/components/com_j2commerce/src/Helper/EmailHelper.php` — switch the email order-view URL from `&task=orderView&order_id=…` to `&layout=order&order_id=…`, mirroring the working pattern already used in `components/com_j2commerce/tmpl/myprofile/default_orders.php`.

## Testing
1. Place a test order on the frontend and complete checkout.
2. Open the order confirmation email.
3. Click the "View Your Order" link.
4. Verify the order detail page renders (not the my-account index or a 404).

## Files Changed
- `administrator/components/com_j2commerce/src/Helper/EmailHelper.php` — one-line URL fix.