### PR TITLE
fix(orders): translate order history timeline comments

### DIFF
--- a/administrator/components/com_j2commerce/src/Table/OrderTable.php
+++ b/administrator/components/com_j2commerce/src/Table/OrderTable.php
@@ -202,15 +202,46 @@ class OrderTable extends Table
         }
 
         // Add order history entry for status change
+        if ($isNew) {
+            $statusComment = Text::_('COM_J2COMMERCE_ORDER_CREATED');
+        } else {
+            $statusComment = Text::sprintf(
+                'COM_J2COMMERCE_STATUS_CHANGED',
+                $this->resolveStatusName($oldStatusId),
+                $this->resolveStatusName($newStatusId)
+            );
+        }
+
         OrderHistoryHelper::add(
             orderId: $this->order_id,
             orderStateId: $newStatusId,
-            comment: $isNew
-                ? Text::_('COM_J2COMMERCE_ORDER_CREATED')
-                : Text::sprintf('COM_J2COMMERCE_STATUS_CHANGED', (string) $oldStatusId, (string) $newStatusId),
+            comment: $statusComment,
         );
 
         return true;
+    }
+
+    /**
+     * Resolve an order status ID to its translated status name.
+     *
+     * Falls back to the numeric ID when no matching status row is found.
+     */
+    private function resolveStatusName(?int $statusId): string
+    {
+        if (!$statusId) {
+            return (string) ($statusId ?? '');
+        }
+
+        $db    = $this->getDatabase();
+        $query = $db->getQuery(true)
+            ->select($db->quoteName('orderstatus_name'))
+            ->from($db->quoteName('#__j2commerce_orderstatuses'))
+            ->where($db->quoteName('j2commerce_orderstatus_id') . ' = :id')
+            ->bind(':id', $statusId, \Joomla\Database\ParameterType::INTEGER);
+        $db->setQuery($query);
+        $name = (string) ($db->loadResult() ?? '');
+
+        return $name !== '' ? Text::_($name) : (string) $statusId;
     }
 
     /**

--- a/components/com_j2commerce/language/en-GB/com_j2commerce.ini
+++ b/components/com_j2commerce/language/en-GB/com_j2commerce.ini
@@ -476,6 +476,11 @@ COM_J2COMMERCE_ORDER_CREATED="Order Created"
 COM_J2COMMERCE_ORDER_DOWNLOAD_PERMISSION_GRANTED="Download permission granted."
 COM_J2COMMERCE_ORDER_DOWNLOAD_LIMIT_RESET="Download limits have been reset."
 COM_J2COMMERCE_ORDER_DOWNLOAD_ACCESS_RESET="Download access has been reset."
+COM_J2COMMERCE_ORDERITEM_STOCK_REDUCED="Stock for %s reduced from %s to %s"
+COM_J2COMMERCE_ORDERITEM_STOCK_INCREASED="Stock for %s increased from %s to %s"
+COM_J2COMMERCE_CUSTOMER_NOTIFIED="Customer notified with the subject: %s"
+COM_J2COMMERCE_ADMIN_NOTIFIED="Administrator(s) notified with subject: %s"
+COM_J2COMMERCE_EMAIL_SEND_FAILED="Email send failed: %s"
 
 ; Flexivariable Plugin Settings
 COM_J2COMMERCE_SHOW_PRICE_RANGE="Show Price Range"

--- a/components/com_j2commerce/language/en-US/com_j2commerce.ini
+++ b/components/com_j2commerce/language/en-US/com_j2commerce.ini
@@ -476,6 +476,11 @@ COM_J2COMMERCE_ORDER_CREATED="Order Created"
 COM_J2COMMERCE_ORDER_DOWNLOAD_PERMISSION_GRANTED="Download permission granted."
 COM_J2COMMERCE_ORDER_DOWNLOAD_LIMIT_RESET="Download limits have been reset."
 COM_J2COMMERCE_ORDER_DOWNLOAD_ACCESS_RESET="Download access has been reset."
+COM_J2COMMERCE_ORDERITEM_STOCK_REDUCED="Stock for %s reduced from %s to %s"
+COM_J2COMMERCE_ORDERITEM_STOCK_INCREASED="Stock for %s increased from %s to %s"
+COM_J2COMMERCE_CUSTOMER_NOTIFIED="Customer notified with the subject: %s"
+COM_J2COMMERCE_ADMIN_NOTIFIED="Administrator(s) notified with subject: %s"
+COM_J2COMMERCE_EMAIL_SEND_FAILED="Email send failed: %s"
 
 ; Flexivariable Plugin Settings
 COM_J2COMMERCE_SHOW_PRICE_RANGE="Show Price Range"


### PR DESCRIPTION
## Summary
Fixes #841

The order timeline rendered raw language keys for history rows written from the frontend checkout/payment flow, and showed numeric status IDs for the status-changed entry.

## Changes
- Added the missing keys (`COM_J2COMMERCE_ORDERITEM_STOCK_REDUCED`, `COM_J2COMMERCE_ORDERITEM_STOCK_INCREASED`, `COM_J2COMMERCE_CUSTOMER_NOTIFIED`, `COM_J2COMMERCE_ADMIN_NOTIFIED`, `COM_J2COMMERCE_EMAIL_SEND_FAILED`) to the frontend `com_j2commerce.ini` (en-US + en-GB) so `Text::sprintf` resolves them when `InventoryHelper::reduceOrderStock` and `OrderModel::sendOrderNotification` execute on the site application.
- Resolved order state IDs to translated status names in `OrderTable::store()` via a new private `resolveStatusName()` helper. The `COM_J2COMMERCE_STATUS_CHANGED` comment now reads `Order status changed from Incomplete to Confirmed` instead of `Order status changed from 5 to 1`.

## Testing
1. Place a new frontend order with a managed-stock product, pay via Cash on Delivery.
2. Open the order in admin → Timeline panel.
3. Verify:
   - Stock-reduced rows render `Stock for {name} reduced from {old} to {new}`.
   - Customer-notified row renders `Customer notified with the subject: {subject}`.
   - Admin-notified row renders `Administrator(s) notified with subject: {subject}`.
   - Status-change row renders `Order status changed from Incomplete to Confirmed`.
4. Existing pre-fix history rows keep their original (literal-key) text — only new history rows write resolved comments.

## Files Changed
- `administrator/components/com_j2commerce/src/Table/OrderTable.php` — added `resolveStatusName()` and used it in the status-changed comment.
- `components/com_j2commerce/language/en-US/com_j2commerce.ini` — added 5 missing keys.
- `components/com_j2commerce/language/en-GB/com_j2commerce.ini` — added 5 missing keys.

## Out of Scope
While verifying this fix, found a separate pre-existing data-corruption bug: the seeded email subjects/bodies in `administrator/components/com_j2commerce/sql/install/mysql/emailtemplates.sql` contain UTF-8 em-dashes that get stored in the DB as literal `???`. This surfaces in the timeline now that the Customer/Admin Notified comments translate correctly. Filing a separate issue for that.