### PR TITLE
fix(orders): repair admin order history pagination (fixes #840)

### DIFF
--- a/media/com_j2commerce/js/administrator/admin-order.js
+++ b/media/com_j2commerce/js/administrator/admin-order.js
@@ -356,7 +356,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
                     if (result.success) {
                         itemsEl.innerHTML = renderHistoryItems(result.items);
-                        injectPluginIcons(itemsEl, result.items);
                         historyContainer.dataset.currentPage = targetPage;
                         historyContainer.dataset.totalPages = result.totalPages;
                         updatePagination(historyNav, targetPage, result.totalPages);


### PR DESCRIPTION
## Summary
Fixes #840

The admin order view's history-timeline pagination forwarded to page 2 but
could never come back, and the active page indicator never moved. Root
cause: an orphan `injectPluginIcons(itemsEl, result.items)` call inside
the click handler. The function is never defined, so it threw
`ReferenceError` after items rendered but before `dataset.currentPage` and
`updatePagination()` ran. Result:

- Items DID swap to page 2 (call already ran)
- Active class stuck on "1" (`updatePagination` never reached)
- `dataset.currentPage` stayed `1`, so clicking "1"/"prev" hit the
  active-guard at the top of the handler and returned early

`renderHistoryItems()` already inlines `item.pluginIcon` (see lines
404–406 of the same file), so the separate `injectPluginIcons` call was a
leftover from commit 4992f11e8 (`feat(orders): add RenderOrderHistoryIcon
plugin event for history timeline`) and the fix is to delete it.

## Changes
- Remove the orphan `injectPluginIcons(itemsEl, result.items)` line in
  the order-history pagination click handler.

## Testing
1. Open an order in admin with more than 20 history rows (or temporarily
   lower the global `list_limit` to force pagination).
2. Click **next** — items swap, page 2 highlights, prev enables, next
   disables on the last page.
3. Click **1** or **prev** — page 1 returns and "1" highlights again.
4. DevTools console — no `injectPluginIcons is not defined` ReferenceError.

## Files Changed
- `media/com_j2commerce/js/administrator/admin-order.js` — drop one line