### PR TITLE
fix(order): load keepalive on order view layout

### DIFF
--- a/administrator/components/com_j2commerce/tmpl/order/view.php
+++ b/administrator/components/com_j2commerce/tmpl/order/view.php
@@ -21,6 +21,8 @@ use Joomla\CMS\Session\Session;
 
 /** @var \J2Commerce\Component\J2commerce\Administrator\View\Order\HtmlView $this */
 
+$this->getDocument()->getWebAssetManager()->useScript('keepalive');
+
 $item = $this->item;
 $orderInfo = $item->orderinfo ?? null;
 $orderItems = $item->orderitems ?? [];


### PR DESCRIPTION
## Summary
Fixes #839

Adds the Joomla `keepalive` script to the admin order detail layout (`view=order&layout=view`). Without it, sessions time out and interactive AJAX (status change, customer notify, history actions) fails with "network error".

## Changes
- `administrator/components/com_j2commerce/tmpl/order/view.php` — register `keepalive` on the WebAssetManager (mirrors the pattern already used in `edit.php`)

## Testing
1. Open admin → Sales → Orders → click any order (loads `view=order&layout=view`)
2. Confirm `media/system/js/keepalive.min.js` loads in the page
3. Leave the page idle past the configured session lifetime
4. Change order status / send customer notification
5. Verify the request succeeds (no "network error")

## Follow-up
Tracked in #873 — broader audit of every admin view with on-page interaction to confirm `keepalive` is registered.