### PR TITLE
fix(admin): load keepalive on interactive non-edit views (fixes #873)

### DIFF
--- a/administrator/components/com_j2commerce/tmpl/advancedpricing/default.php
+++ b/administrator/components/com_j2commerce/tmpl/advancedpricing/default.php
@@ -24,6 +24,7 @@ $stepValue        = $currencyDecimals > 0 ? '0.' . str_repeat('0', $currencyDeci
 $wa = $this->getDocument()->getWebAssetManager();
 $wa->useScript('table.columns');
 $wa->useScript('multiselect');
+$wa->useScript('keepalive');
 ?>
 
 <?php echo $this->navbar ?? ''; ?>

--- a/administrator/components/com_j2commerce/tmpl/analytics/default.php
+++ b/administrator/components/com_j2commerce/tmpl/analytics/default.php
@@ -19,12 +19,14 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Session\Session;
 
-Factory::getApplication()->getDocument()->getWebAssetManager()->registerAndUseScript(
-    'com_j2commerce.add-module-modal',
-    'media/com_j2commerce/js/administrator/add-module-modal.js',
-    [],
-    ['defer' => true]
-);
+Factory::getApplication()->getDocument()->getWebAssetManager()
+    ->registerAndUseScript(
+        'com_j2commerce.add-module-modal',
+        'media/com_j2commerce/js/administrator/add-module-modal.js',
+        [],
+        ['defer' => true]
+    )
+    ->useScript('keepalive');
 
 /** @var \J2Commerce\Component\J2commerce\Administrator\View\Analytics\HtmlView $this */
 

--- a/administrator/components/com_j2commerce/tmpl/dashboard/default.php
+++ b/administrator/components/com_j2commerce/tmpl/dashboard/default.php
@@ -52,13 +52,15 @@ $changeHtml = function (array $change): string {
 // discovery hint) so they split the row 50/50 regardless of module count.
 $colClass = 'col-lg-6';
 
-// Register the "Add Module" modal + its JS helper
-$doc->getWebAssetManager()->registerAndUseScript(
-    'com_j2commerce.add-module-modal',
-    'media/com_j2commerce/js/administrator/add-module-modal.js',
-    [],
-    ['defer' => true]
-);
+// Register the "Add Module" modal + its JS helper, plus keepalive so long-idle dashboards don't lose their session
+$doc->getWebAssetManager()
+    ->registerAndUseScript(
+        'com_j2commerce.add-module-modal',
+        'media/com_j2commerce/js/administrator/add-module-modal.js',
+        [],
+        ['defer' => true]
+    )
+    ->useScript('keepalive');
 ?>
 
 <?php echo $this->navbar; ?>

--- a/administrator/components/com_j2commerce/tmpl/inventory/default.php
+++ b/administrator/components/com_j2commerce/tmpl/inventory/default.php
@@ -28,7 +28,8 @@ $user = $app->getIdentity();
 // Load necessary assets
 $wa->useScript('core')
     ->useScript('multiselect')
-    ->useScript('table.columns');
+    ->useScript('table.columns')
+    ->useScript('keepalive');
 
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));

--- a/administrator/components/com_j2commerce/tmpl/orders/default.php
+++ b/administrator/components/com_j2commerce/tmpl/orders/default.php
@@ -23,7 +23,8 @@ use Joomla\CMS\Router\Route;
 
 $wa = $this->getDocument()->getWebAssetManager();
 $wa->useScript('table.columns')
-    ->useScript('multiselect');
+    ->useScript('multiselect')
+    ->useScript('keepalive');
 
 $user      = $this->getCurrentUser();
 $userId    = $user->id;


### PR DESCRIPTION
## Summary
Fixes #873 — follow-up to #839 / #874.

Joomla auto-registers the `keepalive` script on edit-form layouts only. Five non-edit admin layouts ship persistent on-page JS that AJAXes against the open session and silently fails when the session expires (same class of bug as #839).

## Changes
- `tmpl/orders/default.php` — chain `keepalive` into existing `$wa` setup (admin-order-list.js: bulk status, batch popup)
- `tmpl/dashboard/default.php` — chain `keepalive` after add-module-modal register (dashboard.js, liveusers.js, setup-guide.js, onboarding.js, category-wizard.js, inline sample-data fetch)
- `tmpl/analytics/default.php` — same pattern as dashboard (analytics date-filter, liveusers)
- `tmpl/advancedpricing/default.php` — `$wa->useScript('keepalive');` (admin-advancedpricing bulk batch)
- `tmpl/inventory/default.php` — chain `keepalive` after `table.columns` (inline `saveItem` fetch per row)

Plain CRUD list views (countries, weights, lengths, etc.) still rely on full-page form submits, so they don't need keepalive and are left untouched.

## Audit results
**Already loads keepalive (no change):**
- `tmpl/order/view.php` (#874)
- `tmpl/overrides/default.php` (page builder)
- `tmpl/productprice/productpricing.php` (special-pricing editor)
- All 24 `tmpl/<entity>/edit.php` form layouts

**Skipped (no on-page AJAX):** shippingtroubles, queues, queuelogs, reports, apps, plain CRUD list views.

## Testing
1. Open each of the 5 admin pages (`view=orders`, `view=dashboard`, `view=analytics`, `view=advancedpricing`, `view=inventory`).
2. View page source → confirm `media/system/js/keepalive.min.js` loads.
3. (Optional) Set Joomla session lifetime to 1 min, leave the page idle ≥90s, then trigger an AJAX action (orders bulk status, inventory row save, advancedpricing batch). Should still authenticate; no "network error".

## Follow-up (out of scope)
Convention should be documented in docs.j2commerce.com / `E:\WIKI\j2commerce\` so contributors know to register keepalive on any new interactive admin view. Cannot land in this repo because `docs/` and `CLAUDE.md` are gitignored here.

## Files Changed
- `administrator/components/com_j2commerce/tmpl/orders/default.php`
- `administrator/components/com_j2commerce/tmpl/dashboard/default.php`
- `administrator/components/com_j2commerce/tmpl/analytics/default.php`
- `administrator/components/com_j2commerce/tmpl/advancedpricing/default.php`
- `administrator/components/com_j2commerce/tmpl/inventory/default.php`