### PR TITLE
fix(orders): warn admin when status change skips customer email (fixes #838)

### DIFF
--- a/administrator/components/com_j2commerce/language/en-GB/com_j2commerce.ini
+++ b/administrator/components/com_j2commerce/language/en-GB/com_j2commerce.ini
@@ -2488,7 +2488,9 @@ COM_J2COMMERCE_ORDER_HISTORY_ADMIN_NOTE="Admin note added"
 
 ; Order View - Messages
 COM_J2COMMERCE_ORDER_STATUS_UPDATED="Order status updated"
+COM_J2COMMERCE_ORDER_STATUS_UPDATED_NO_CUSTOMER_EMAIL="Order status updated, but no customer email was sent: %s"
 COM_J2COMMERCE_ORDER_STATUS_UPDATED_TO="Order status updated to %s"
+COM_J2COMMERCE_ORDERS_STATUS_UPDATED_NO_CUSTOMER_EMAIL="No customer email was sent for the following order(s): %s. No matching email template was found for the new status."
 COM_J2COMMERCE_ORDER_NOTE="Order Note"
 COM_J2COMMERCE_ORDER_NOTE_PLACEHOLDER="Add an internal note to this order..."
 COM_J2COMMERCE_ORDER_NOTE_INTERNAL_ONLY="This note is internal only and will never be shown to customers."

--- a/administrator/components/com_j2commerce/language/en-US/com_j2commerce.ini
+++ b/administrator/components/com_j2commerce/language/en-US/com_j2commerce.ini
@@ -2490,7 +2490,9 @@ COM_J2COMMERCE_ORDER_HISTORY_ADMIN_NOTE="Admin note added"
 
 ; Order View - Messages
 COM_J2COMMERCE_ORDER_STATUS_UPDATED="Order status updated"
+COM_J2COMMERCE_ORDER_STATUS_UPDATED_NO_CUSTOMER_EMAIL="Order status updated, but no customer email was sent: %s"
 COM_J2COMMERCE_ORDER_STATUS_UPDATED_TO="Order status updated to %s"
+COM_J2COMMERCE_ORDERS_STATUS_UPDATED_NO_CUSTOMER_EMAIL="No customer email was sent for the following order(s): %s. No matching email template was found for the new status."
 COM_J2COMMERCE_ORDER_NOTE="Order Note"
 COM_J2COMMERCE_ORDER_NOTE_PLACEHOLDER="Add an internal note to this order..."
 COM_J2COMMERCE_ORDER_NOTE_INTERNAL_ONLY="This note is internal only and will never be shown to customers."

--- a/administrator/components/com_j2commerce/src/Controller/OrderController.php
+++ b/administrator/components/com_j2commerce/src/Controller/OrderController.php
@@ -86,8 +86,28 @@ class OrderController extends FormController
 
             $model = $this->getModel();
 
-            if ($model->updateOrderStatus($orderId, $statusId, $notify, $comment)) {
-                $this->setMessage(Text::_('COM_J2COMMERCE_ORDER_STATUS_UPDATED'));
+            if ($model->updateOrderStatus($orderId, $statusId, false, $comment)) {
+                if ($notify) {
+                    $order        = $model->getItem($orderId);
+                    $notifyResult = $order && !empty($order->order_id)
+                        ? $model->sendOrderNotification($order->order_id, true, true)
+                        : ['customer_sent' => 0, 'errors' => []];
+
+                    if (($notifyResult['customer_sent'] ?? 0) === 0) {
+                        $reason = !empty($notifyResult['errors'])
+                            ? implode('; ', $notifyResult['errors'])
+                            : Text::_('COM_J2COMMERCE_NO_EMAIL_TEMPLATES_FOUND');
+
+                        $this->app->enqueueMessage(
+                            Text::sprintf('COM_J2COMMERCE_ORDER_STATUS_UPDATED_NO_CUSTOMER_EMAIL', $reason),
+                            'warning'
+                        );
+                    } else {
+                        $this->setMessage(Text::_('COM_J2COMMERCE_ORDER_STATUS_UPDATED'));
+                    }
+                } else {
+                    $this->setMessage(Text::_('COM_J2COMMERCE_ORDER_STATUS_UPDATED'));
+                }
             } else {
                 $errors = $model->getErrors();
                 throw new \Exception(implode("\n", $errors));
@@ -195,17 +215,36 @@ class OrderController extends FormController
 
             $model = $this->getModel();
 
-            if (!$model->updateOrderStatus($orderId, $statusId, $notify)) {
+            if (!$model->updateOrderStatus($orderId, $statusId, false)) {
                 $errors = $model->getErrors();
                 throw new \Exception(implode("\n", $errors));
+            }
+
+            $message     = Text::_('COM_J2COMMERCE_ORDER_STATUS_UPDATED');
+            $messageType = 'success';
+
+            if ($notify) {
+                $order        = $model->getItem($orderId);
+                $notifyResult = $order && !empty($order->order_id)
+                    ? $model->sendOrderNotification($order->order_id, true, true)
+                    : ['customer_sent' => 0, 'errors' => []];
+
+                if (($notifyResult['customer_sent'] ?? 0) === 0) {
+                    $reason      = !empty($notifyResult['errors'])
+                        ? implode('; ', $notifyResult['errors'])
+                        : Text::_('COM_J2COMMERCE_NO_EMAIL_TEMPLATES_FOUND');
+                    $message     = Text::sprintf('COM_J2COMMERCE_ORDER_STATUS_UPDATED_NO_CUSTOMER_EMAIL', $reason);
+                    $messageType = 'warning';
+                }
             }
 
             $status = $this->getStatusInfo($statusId);
 
             echo json_encode([
-                'success' => true,
-                'message' => Text::_('COM_J2COMMERCE_ORDER_STATUS_UPDATED'),
-                'data'    => [
+                'success'     => true,
+                'message'     => $message,
+                'messageType' => $messageType,
+                'data'        => [
                     'statusName' => Text::_($status->orderstatus_name ?? ''),
                     'cssclass'   => $status->orderstatus_cssclass ?? 'secondary',
                 ],

--- a/administrator/components/com_j2commerce/src/Controller/OrdersController.php
+++ b/administrator/components/com_j2commerce/src/Controller/OrdersController.php
@@ -84,17 +84,46 @@ class OrdersController extends AdminController
                 throw new \Exception(Text::_('COM_J2COMMERCE_ERROR_NO_STATUS_SELECTED'));
             }
 
-            $model        = $this->getModel();
-            $updatedCount = 0;
+            $model              = $this->getModel();
+            $updatedCount       = 0;
+            $missingTemplateIds = [];
 
             foreach ($pks as $pk) {
-                if ($model->updateOrderStatus($pk, $statusId, $notify, $comment)) {
-                    $updatedCount++;
+                if (!$model->updateOrderStatus($pk, $statusId, false, $comment)) {
+                    continue;
+                }
+
+                $updatedCount++;
+
+                if (!$notify) {
+                    continue;
+                }
+
+                $order = $model->getItem($pk);
+
+                if (!$order || empty($order->order_id)) {
+                    continue;
+                }
+
+                $notifyResult = $model->sendOrderNotification($order->order_id, true, true);
+
+                if (($notifyResult['customer_sent'] ?? 0) === 0) {
+                    $missingTemplateIds[] = $order->order_id;
                 }
             }
 
             if ($updatedCount > 0) {
                 $this->setMessage(Text::plural('COM_J2COMMERCE_N_ORDERS_STATUS_UPDATED', $updatedCount));
+            }
+
+            if (!empty($missingTemplateIds)) {
+                $this->app->enqueueMessage(
+                    Text::sprintf(
+                        'COM_J2COMMERCE_ORDERS_STATUS_UPDATED_NO_CUSTOMER_EMAIL',
+                        implode(', ', $missingTemplateIds)
+                    ),
+                    'warning'
+                );
             }
         } catch (\Exception $e) {
             $this->app->enqueueMessage($e->getMessage(), 'warning');
@@ -174,16 +203,35 @@ class OrdersController extends AdminController
 
             $model = $this->getModel();
 
-            if (!$model->updateOrderStatus($orderId, $newStatus, $notify)) {
+            if (!$model->updateOrderStatus($orderId, $newStatus, false)) {
                 $errors = $model->getErrors();
                 throw new \Exception(implode("\n", $errors));
             }
 
             $statusInfo = $this->getStatusInfo($newStatus);
-            $response   = [
-                'success' => true,
-                'message' => Text::sprintf('COM_J2COMMERCE_ORDER_STATUS_UPDATED_TO', Text::_($statusInfo->orderstatus_name ?? '')),
-                'data'    => [
+            $message    = Text::sprintf('COM_J2COMMERCE_ORDER_STATUS_UPDATED_TO', Text::_($statusInfo->orderstatus_name ?? ''));
+            $messageType = 'success';
+
+            if ($notify) {
+                $order        = $model->getItem($orderId);
+                $notifyResult = $order && !empty($order->order_id)
+                    ? $model->sendOrderNotification($order->order_id, true, true)
+                    : ['customer_sent' => 0, 'errors' => []];
+
+                if (($notifyResult['customer_sent'] ?? 0) === 0) {
+                    $reason      = !empty($notifyResult['errors'])
+                        ? implode('; ', $notifyResult['errors'])
+                        : Text::_('COM_J2COMMERCE_NO_EMAIL_TEMPLATES_FOUND');
+                    $message     = Text::sprintf('COM_J2COMMERCE_ORDER_STATUS_UPDATED_NO_CUSTOMER_EMAIL', $reason);
+                    $messageType = 'warning';
+                }
+            }
+
+            $response = [
+                'success'     => true,
+                'message'     => $message,
+                'messageType' => $messageType,
+                'data'        => [
                     'statusName' => Text::_($statusInfo->orderstatus_name ?? ''),
                     'cssclass'   => J2htmlHelper::badgeClass($statusInfo->orderstatus_cssclass ?? 'badge text-bg-secondary'),
                 ],

--- a/administrator/components/com_j2commerce/src/Model/OrderModel.php
+++ b/administrator/components/com_j2commerce/src/Model/OrderModel.php
@@ -996,11 +996,11 @@ class OrderModel extends AdminModel
      * @param   bool    $notifyCustomer  Send to customer.
      * @param   bool    $notifyAdmin     Send to admin.
      *
-     * @return  array{sent: int, errors: string[]}
+     * @return  array{sent: int, customer_sent: int, admin_sent: int, errors: string[]}
      */
     public function sendOrderNotification(string $orderId, bool $notifyCustomer = true, bool $notifyAdmin = true): array
     {
-        $result = ['sent' => 0, 'errors' => []];
+        $result = ['sent' => 0, 'customer_sent' => 0, 'admin_sent' => 0, 'errors' => []];
 
         if (empty($orderId)) {
             $result['errors'][] = 'No order ID provided';
@@ -1058,6 +1058,7 @@ class OrderModel extends AdminModel
                         );
                         $emailHelper->logEmailSend($orderId, 'customer', $template->mailer->Subject, array_keys($recipients), true);
                         $result['sent']++;
+                        $result['customer_sent']++;
                     }
                 } catch (\Throwable $e) {
                     $errorMsg           = Text::sprintf('COM_J2COMMERCE_EMAIL_SEND_FAILED', $e->getMessage());
@@ -1098,6 +1099,7 @@ class OrderModel extends AdminModel
                         );
                         $emailHelper->logEmailSend($orderId, 'admin', $template->mailer->Subject, array_keys($recipients), true);
                         $result['sent']++;
+                        $result['admin_sent']++;
                     }
                 } catch (\Throwable $e) {
                     $errorMsg           = Text::sprintf('COM_J2COMMERCE_EMAIL_SEND_FAILED', $e->getMessage());

--- a/administrator/language/en-GB/com_j2commerce.ini
+++ b/administrator/language/en-GB/com_j2commerce.ini
@@ -2488,7 +2488,9 @@ COM_J2COMMERCE_ORDER_HISTORY_ADMIN_NOTE="Admin note added"
 
 ; Order View - Messages
 COM_J2COMMERCE_ORDER_STATUS_UPDATED="Order status updated"
+COM_J2COMMERCE_ORDER_STATUS_UPDATED_NO_CUSTOMER_EMAIL="Order status updated, but no customer email was sent: %s"
 COM_J2COMMERCE_ORDER_STATUS_UPDATED_TO="Order status updated to %s"
+COM_J2COMMERCE_ORDERS_STATUS_UPDATED_NO_CUSTOMER_EMAIL="No customer email was sent for the following order(s): %s. No matching email template was found for the new status."
 COM_J2COMMERCE_ORDER_NOTE="Order Note"
 COM_J2COMMERCE_ORDER_NOTE_PLACEHOLDER="Add an internal note to this order..."
 COM_J2COMMERCE_ORDER_NOTE_INTERNAL_ONLY="This note is internal only and will never be shown to customers."

--- a/administrator/language/en-US/com_j2commerce.ini
+++ b/administrator/language/en-US/com_j2commerce.ini
@@ -2490,7 +2490,9 @@ COM_J2COMMERCE_ORDER_HISTORY_ADMIN_NOTE="Admin note added"
 
 ; Order View - Messages
 COM_J2COMMERCE_ORDER_STATUS_UPDATED="Order status updated"
+COM_J2COMMERCE_ORDER_STATUS_UPDATED_NO_CUSTOMER_EMAIL="Order status updated, but no customer email was sent: %s"
 COM_J2COMMERCE_ORDER_STATUS_UPDATED_TO="Order status updated to %s"
+COM_J2COMMERCE_ORDERS_STATUS_UPDATED_NO_CUSTOMER_EMAIL="No customer email was sent for the following order(s): %s. No matching email template was found for the new status."
 COM_J2COMMERCE_ORDER_NOTE="Order Note"
 COM_J2COMMERCE_ORDER_NOTE_PLACEHOLDER="Add an internal note to this order..."
 COM_J2COMMERCE_ORDER_NOTE_INTERNAL_ONLY="This note is internal only and will never be shown to customers."


### PR DESCRIPTION
## Summary
Fixes #838

When an admin updated an order status with **Notify Customer** ticked but no email template matched the new status, the UI showed the generic "Order status updated" success message and the admin had no way to know the email had not been sent.

The "Resend Email" button already surfaces this case correctly. This PR brings the inline status-change flows in line with that behavior.

## Changes
- `OrderModel::sendOrderNotification()` now also returns `customer_sent` and `admin_sent` counts (additive — backwards compatible). Existing callers that read `sent` continue to work.
- Admin controllers (`OrderController::updatestatus`, `OrderController::ajaxUpdateStatus`, `OrdersController::updatestatus` bulk, `OrdersController::ajaxUpdateStatus`) now call `updateOrderStatus(notify=false)` and handle notification themselves so the per-receiver result can be inspected.
- When `notify_customer` is on but `customer_sent === 0`, a **warning** toast is shown that names the reason ("No matching email templates found for this order" or the actual email error).
- Plugin callers (`payment_amazonpay`, `shipping_atoship`, etc.) keep the existing internal-notify path unchanged — only admin UI flows are decoupled.
- Two new language strings (mirrored across all four en-US / en-GB ini files):
  - `COM_J2COMMERCE_ORDER_STATUS_UPDATED_NO_CUSTOMER_EMAIL`
  - `COM_J2COMMERCE_ORDERS_STATUS_UPDATED_NO_CUSTOMER_EMAIL`

## Testing
1. Backend → Orders → open an order.
2. Change status to one with **no** email template (e.g. a custom status). Tick **Notify Customer**. Save.
3. Verify a yellow warning toast appears: *"Order status updated, but no customer email was sent: No matching email templates found for this order"*.
4. Re-test with a status that **does** have an email template → green "Order status updated" toast as before.
5. Inline AJAX status change (orders list dropdown) — same warning behavior on JSON path.
6. Bulk: select 2 orders → change to a no-template status with notify ticked → single warning lists the affected order_ids.
7. Resend Email button continues to behave as it always has.

## Files Changed
- `administrator/components/com_j2commerce/src/Model/OrderModel.php` — per-receiver counters in `sendOrderNotification`
- `administrator/components/com_j2commerce/src/Controller/OrderController.php` — `updatestatus` + `ajaxUpdateStatus` branch on notify result
- `administrator/components/com_j2commerce/src/Controller/OrdersController.php` — `updatestatus` (bulk) + `ajaxUpdateStatus` branch on notify result
- `administrator/components/com_j2commerce/language/{en-US,en-GB}/com_j2commerce.ini` — new keys
- `administrator/language/{en-US,en-GB}/com_j2commerce.ini` — admin mirror

## Pre-Flight
- [x] PHP syntax check passed (3 files)
- [x] No secrets detected
- [x] No FOF remnants / `JFactory::` usage
- [x] Core files only
- [x] Language keys synced across all four ini mirrors