### PR TITLE
fix(stats): correct last 7 days off-by-one

### DIFF
--- a/administrator/modules/mod_j2commerce_stats/src/Helper/StatsHelper.php
+++ b/administrator/modules/mod_j2commerce_stats/src/Helper/StatsHelper.php
@@ -127,7 +127,7 @@ class StatsHelper
         // Date strings for recent periods
         $today     = $now->format('Y-m-d');
         $yesterday = Factory::getDate('now -1 days', $tz)->format('Y-m-d');
-        $weekAgo   = Factory::getDate('now -7 days', $tz)->format('Y-m-d');
+        $weekAgo   = Factory::getDate('now -6 days', $tz)->format('Y-m-d');
 
         return [
             'total'    => $this->getOrderStats($orderStatuses),


### PR DESCRIPTION
## Summary
Fixes #837

The "Last 7 Days" row in `mod_j2commerce_stats` was counting 8 calendar days because the start of the range used `now -7 days` while the end used today `23:59:59`.

## Changes
- `administrator/modules/mod_j2commerce_stats/src/Helper/StatsHelper.php` — change `$weekAgo` from `now -7 days` to `now -6 days` so the rolling window spans exactly 7 days inclusive of today.

## Testing
1. Open `/administrator/` and view the Home Dashboard.
2. The "Last 7 Days" row should cover exactly 7 calendar days ending today.
3. "Today", "Yesterday", "This Month", "Last Month", "This Year", "Last Year", and "Daily Average" rows are unchanged.

## Files Changed
- `administrator/modules/mod_j2commerce_stats/src/Helper/StatsHelper.php` — single string literal change.