### PR TITLE
fix(dashboard): correct date-range label off-by-one

### DIFF
--- a/media/com_j2commerce/js/administrator/dashboard.js
+++ b/media/com_j2commerce/js/administrator/dashboard.js
@@ -351,7 +351,7 @@
         const from = document.getElementById('dashboard-from')?.value;
         const to = document.getElementById('dashboard-to')?.value;
         if (!from || !to) return;
-        const days = Math.round((new Date(to) - new Date(from)) / 86400000);
+        const days = Math.round((new Date(to) - new Date(from)) / 86400000) + 1;
         const unit = Joomla.Text._(days === 1 ? 'COM_J2COMMERCE_DASHBOARD_DAY' : 'COM_J2COMMERCE_DASHBOARD_DAYS');
         el.innerHTML = Joomla.Text._('COM_J2COMMERCE_DASHBOARD_DATA_BASED_ON')
             .replace('%s', days)


### PR DESCRIPTION
## Summary
Fixes #837

The "Data is based on the past N days" label on the analytics dashboard counted the exclusive interval between `from` and `to` instead of the inclusive calendar-day range. Clicking the **Last 7 Days** preset showed "past 6 days", 30 showed "past 29 days", 90 showed "past 89 days", even though the underlying queries returned the correct N-day data set.

## Changes
- `media/com_j2commerce/js/administrator/dashboard.js` — add `+1` in `updateDateRangeLabel()` so the displayed day count equals the inclusive calendar-day span between the two date inputs.

## Testing
1. Open `/administrator/?option=com_j2commerce&view=dashboard` and hard-reload (Ctrl+F5) to bust the JS cache.
2. Click **Last 7 Days** → label reads "Data is based on the past **7 days**".
3. Click **Last 30 Days** → "past **30 days**".
4. Click **Last 90 Days** → "past **90 days**".
5. Custom range Apr 21 → Apr 27 + Refresh → "past **7 days**".

The 1-day preset still expands its range to `today-1 → today` (chart needs two points), so it reports "past 2 days" — that matches the data the chart actually plots.

## Files Changed
- `media/com_j2commerce/js/administrator/dashboard.js` — single-line `+1`.