### PR TITLE
fix(orders): apply invoice prefix and number on order create

### DIFF
--- a/administrator/components/com_j2commerce/src/Helper/CartOrder.php
+++ b/administrator/components/com_j2commerce/src/Helper/CartOrder.php
@@ -1363,7 +1363,7 @@ class CartOrder
 
         // Config
         $params         = J2CommerceHelper::config();
-        $invoicePrefix  = $params->get('invoice_prefix', 'INV-');
+        $invoicePrefix  = (string) $params->get('invoice_prefix', '');
         $isIncludingTax = (int) $params->get('config_including_tax', 0);
 
         // Determine if order is shippable
@@ -1419,6 +1419,10 @@ class CartOrder
         // order_id = time() . PK and token, then store() again.
         $orderTable->order_id = $orderTable->generateOrderId();
         $orderTable->token    = $orderTable->generateToken();
+
+        if ($invoicePrefix !== '') {
+            $orderTable->invoice_number = (int) $orderTable->j2commerce_order_id;
+        }
 
         if (!$orderTable->store()) {
             throw new \RuntimeException(


### PR DESCRIPTION
## Summary
Fixes #833

The configured invoice prefix was being stored on each new order, but `invoice_number` was never assigned. `OrderModel::getInvoiceNumber()` then short-circuited on the empty number and returned the bare `j2commerce_order_id`, so the prefix never appeared.

## Changes
- `CartOrder::createOrder()` now assigns `invoice_number = j2commerce_order_id` between the two-pass save when an invoice prefix is configured. Displayed invoice becomes `{prefix}{PK}` and matches the order ID.
- Removed the hardcoded `'INV-'` fallback when reading `invoice_prefix` from config. An unset config now means no prefix — no magic string baked into order rows.

## Testing
1. Admin → Components → J2Commerce → Configuration → Orders tab → set Invoice Prefix to `BT26-` → save
2. Frontend: place a new order
3. Admin → J2Commerce → Orders → verify Invoice column shows `BT26-{j2commerce_order_id}` (e.g. `BT26-42`)
4. Place another order → verify next sequential invoice
5. Clear the prefix in config → next order falls back to PK alone (no `INV-`)

## Files Changed
- `administrator/components/com_j2commerce/src/Helper/CartOrder.php` — drop `INV-` default, assign invoice_number from PK on order create