### PR TITLE
fix(admin): link order customer to J2Commerce customers list (fixes #832)

### DIFF
--- a/administrator/components/com_j2commerce/tmpl/order/view_sidebar.php
+++ b/administrator/components/com_j2commerce/tmpl/order/view_sidebar.php
@@ -57,8 +57,8 @@ if ($orderInfo) {
                 <div class="col-9">
                     <div class="customer-information-item mb-2">
                         <span class="icon-user me-1 fa-fw" aria-hidden="true"></span>
-                        <?php if ((int) $item->user_id > 0) : ?>
-                            <a href="<?php echo Route::_('index.php?option=com_users&task=user.edit&id=' . (int) $item->user_id); ?>">
+                        <?php if (!empty($item->user_email)) : ?>
+                            <a href="<?php echo Route::_('index.php?option=com_j2commerce&view=customers&filter[search]=' . urlencode($item->user_email)); ?>">
                                 <?php echo $this->escape($customerName ?: $item->user_email); ?>
                             </a>
                         <?php else : ?>


### PR DESCRIPTION
## Summary
Fixes #832

Order view sidebar Customer Information block linked the customer name to `com_users&task=user.edit` (Joomla user edit). Swap target to `com_j2commerce&view=customers&filter[search]=<email>` so the admin lands on the J2Commerce customer record instead of the bare Joomla user.

## Changes
- `administrator/components/com_j2commerce/tmpl/order/view_sidebar.php` — change href, widen guard from `user_id > 0` to `user_email` so guest orders also link

## Testing
1. Open any order in admin
2. Click customer name in the Customer Information sidebar block
3. Lands on Components → J2Commerce → Customers, list filtered to that customer's email
4. Works for both registered (user_id>0) and guest (user_id=0) orders