### PR TITLE
fix(orders): clarify Order vs Invoice labels and sync invoice number to order PK

### DIFF
--- a/administrator/components/com_j2commerce/src/Helper/EmailHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/EmailHelper.php
@@ -1956,14 +1956,13 @@ class EmailHelper
      */
     protected function getInvoiceNumber(object $order): string
     {
-        $prefix = $order->invoice_prefix ?? '';
-        $number = $order->invoice_number ?? 0;
+        $orderId = (string) ($order->j2commerce_order_id ?? '');
 
-        if (empty($number)) {
+        if ($orderId === '') {
             return '';
         }
 
-        return $prefix . $number;
+        return ($order->invoice_prefix ?? '') . $orderId;
     }
 
     /**

--- a/administrator/components/com_j2commerce/src/Helper/InvoiceHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/InvoiceHelper.php
@@ -462,14 +462,13 @@ class InvoiceHelper
      */
     public static function getInvoiceNumber(object $order): string
     {
-        $prefix = $order->invoice_prefix ?? '';
-        $number = $order->invoice_number ?? 0;
+        $orderId = (string) ($order->j2commerce_order_id ?? '');
 
-        if (empty($number)) {
+        if ($orderId === '') {
             return '';
         }
 
-        return $prefix . $number;
+        return ($order->invoice_prefix ?? '') . $orderId;
     }
 
     /**
@@ -483,8 +482,6 @@ class InvoiceHelper
      */
     public static function hasInvoiceNumber(object $order): bool
     {
-        $number = $order->invoice_number ?? 0;
-
-        return !empty($number) && (int) $number > 0;
+        return !empty($order->j2commerce_order_id ?? 0);
     }
 }

--- a/administrator/components/com_j2commerce/src/Model/OrderModel.php
+++ b/administrator/components/com_j2commerce/src/Model/OrderModel.php
@@ -510,11 +510,13 @@ class OrderModel extends AdminModel
      */
     public function getInvoiceNumber(object $order): string
     {
-        if (empty($order->invoice_prefix) || empty($order->invoice_number) || $order->invoice_number == 0) {
-            return (string) ($order->j2commerce_order_id ?? '');
+        $orderId = (string) ($order->j2commerce_order_id ?? '');
+
+        if ($orderId === '') {
+            return '';
         }
 
-        return $order->invoice_prefix . $order->invoice_number;
+        return ($order->invoice_prefix ?? '') . $orderId;
     }
 
     /**
@@ -867,10 +869,10 @@ class OrderModel extends AdminModel
             ->select([
                 $db->quoteName('a') . '.*',
                 'CASE WHEN ' . $db->quoteName('a.invoice_prefix') . ' IS NULL OR ' .
-                $db->quoteName('a.invoice_number') . ' = 0 THEN ' .
+                $db->quoteName('a.invoice_prefix') . ' = ' . $db->quote('') . ' THEN ' .
                 $db->quoteName('a.j2commerce_order_id') .
                 ' ELSE CONCAT(' . $db->quoteName('a.invoice_prefix') . ', ' .
-                $db->quoteName('a.invoice_number') . ') END AS ' . $db->quoteName('invoice'),
+                $db->quoteName('a.j2commerce_order_id') . ') END AS ' . $db->quoteName('invoice'),
                 $db->quoteName('os.orderstatus_name'),
                 $db->quoteName('os.orderstatus_cssclass'),
             ])

--- a/administrator/components/com_j2commerce/src/Model/OrdersModel.php
+++ b/administrator/components/com_j2commerce/src/Model/OrdersModel.php
@@ -140,10 +140,10 @@ class OrdersModel extends ListModel
         // Computed invoice field
         $query->select(
             'CASE WHEN ' . $db->quoteName('a.invoice_prefix') . ' IS NULL OR ' .
-            $db->quoteName('a.invoice_number') . ' = 0 THEN ' .
+            $db->quoteName('a.invoice_prefix') . ' = ' . $db->quote('') . ' THEN ' .
             $db->quoteName('a.j2commerce_order_id') .
             ' ELSE CONCAT(' . $db->quoteName('a.invoice_prefix') . ', ' .
-            $db->quoteName('a.invoice_number') . ') END AS ' . $db->quoteName('invoice')
+            $db->quoteName('a.j2commerce_order_id') . ') END AS ' . $db->quoteName('invoice')
         );
 
         $query->from($db->quoteName('#__j2commerce_orders', 'a'));
@@ -312,28 +312,18 @@ class OrdersModel extends ListModel
             $query->where($db->quoteName('a.order_total') . ' > 0');
         }
 
-        // Invoice number range: from
+        // Invoice number range: from (invoice = prefix + j2commerce_order_id, so range over PK)
         $fromInvoice = (int) $this->getState('filter.from_invoice', 0);
         if ($fromInvoice > 0) {
-            $query->where(
-                'CASE WHEN ' . $db->quoteName('a.invoice_number') . ' = 0 THEN ' .
-                $db->quoteName('a.j2commerce_order_id') . ' >= :fromInvoice1 ELSE ' .
-                $db->quoteName('a.invoice_number') . ' >= :fromInvoice2 END'
-            )
-                ->bind(':fromInvoice1', $fromInvoice, ParameterType::INTEGER)
-                ->bind(':fromInvoice2', $fromInvoice, ParameterType::INTEGER);
+            $query->where($db->quoteName('a.j2commerce_order_id') . ' >= :fromInvoice')
+                ->bind(':fromInvoice', $fromInvoice, ParameterType::INTEGER);
         }
 
         // Invoice number range: to
         $toInvoice = (int) $this->getState('filter.to_invoice', 0);
         if ($toInvoice > 0) {
-            $query->where(
-                'CASE WHEN ' . $db->quoteName('a.invoice_number') . ' = 0 THEN ' .
-                $db->quoteName('a.j2commerce_order_id') . ' <= :toInvoice1 ELSE ' .
-                $db->quoteName('a.invoice_number') . ' <= :toInvoice2 END'
-            )
-                ->bind(':toInvoice1', $toInvoice, ParameterType::INTEGER)
-                ->bind(':toInvoice2', $toInvoice, ParameterType::INTEGER);
+            $query->where($db->quoteName('a.j2commerce_order_id') . ' <= :toInvoice')
+                ->bind(':toInvoice', $toInvoice, ParameterType::INTEGER);
         }
 
         // Coupon code filter
@@ -396,6 +386,8 @@ class OrdersModel extends ListModel
                     $db->quoteName('oi.billing_last_name') . ') LIKE :search6 OR ' .
                     $db->quoteName('oi.billing_first_name') . ' LIKE :search7 OR ' .
                     $db->quoteName('oi.billing_last_name') . ' LIKE :search8 OR ' .
+                    'CONCAT(IFNULL(' . $db->quoteName('a.invoice_prefix') . ', ' . $db->quote('') . '), ' .
+                    $db->quoteName('a.j2commerce_order_id') . ') LIKE :search9 OR ' .
                     'EXISTS (SELECT 1 FROM ' . $db->quoteName('#__j2commerce_orderitems', 'oitem') .
                     ' LEFT JOIN ' . $db->quoteName('#__j2commerce_variants', 'v') .
                     ' ON ' . $db->quoteName('oitem.variant_id') . ' = ' . $db->quoteName('v.j2commerce_variant_id') .
@@ -414,7 +406,8 @@ class OrdersModel extends ListModel
                     ->bind(':search5', $searchLike)
                     ->bind(':search6', $searchLike)
                     ->bind(':search7', $searchLike)
-                    ->bind(':search8', $searchLike);
+                    ->bind(':search8', $searchLike)
+                    ->bind(':search9', $searchLike);
             }
         }
     }

--- a/administrator/components/com_j2commerce/src/View/Order/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Order/HtmlView.php
@@ -150,7 +150,7 @@ class HtmlView extends BaseHtmlView
         $checkedOut    = !(($this->item->checked_out ?? null) === null || ($this->item->checked_out ?? 0) == $user->id);
         $toolbar       = $this->getDocument()->getToolbar();
 
-        $orderDisplay = $this->item->invoice ?? $this->item->order_id ?? Text::_('COM_J2COMMERCE_ORDER');
+        $orderDisplay = $this->item->order_id ?? $this->item->invoice ?? Text::_('COM_J2COMMERCE_ORDER');
 
         if ($layout === 'edit') {
             ToolbarHelper::title(

--- a/administrator/components/com_j2commerce/tmpl/coupon/history.php
+++ b/administrator/components/com_j2commerce/tmpl/coupon/history.php
@@ -54,10 +54,10 @@ J2CommerceHelper::strapper()->addCSS();
                                     <td>
                                         <a href="<?php echo $orderLink; ?>" target="_blank" class="text-decoration-none">
                                             <span class="icon-external-link" aria-hidden="true"></span>
-                                            <?php if (!empty($item->invoice_number)) : ?>
-                                                <?php echo htmlspecialchars($item->invoice_prefix . $item->invoice_number, ENT_QUOTES, 'UTF-8'); ?>
+                                            <?php if (!empty($item->invoice_prefix)) : ?>
+                                                <?php echo htmlspecialchars($item->invoice_prefix . $item->j2commerce_order_id, ENT_QUOTES, 'UTF-8'); ?>
                                             <?php else : ?>
-                                                <?php echo $item->j2commerce_order_id; ?>
+                                                <?php echo (int) $item->j2commerce_order_id; ?>
                                             <?php endif; ?>
                                         </a>
                                     </td>

--- a/administrator/components/com_j2commerce/tmpl/order/view.php
+++ b/administrator/components/com_j2commerce/tmpl/order/view.php
@@ -49,12 +49,20 @@ if (empty($customerName)) {
                     <span class="icon-arrow-left-4" aria-hidden="true"></span>
                 </a>
                 <div>
-                    <div class="j2-title-top d-flex align-items-center mb-1">
-                        <h2 class="h3 mb-0 order-id">#<?php echo $this->escape($item->invoice); ?></h2>
-                        <div class="ms-2 fw-normal fs-5">(<b><?php echo $this->escape($item->order_id); ?></b>)</div>
+                    <div class="j2-title-top d-flex align-items-center flex-wrap mb-1">
+                        <h2 class="h3 mb-0 order-id">
+                            <span class="fw-normal fs-6 me-1"><?php echo Text::_('COM_J2COMMERCE_HEADING_ORDER'); ?></span>
+                            #<?php echo $this->escape($item->order_id); ?>
+                        </h2>
                         <div class="<?php echo $this->escape(J2htmlHelper::badgeClass($item->orderstatus_cssclass ?? 'badge text-bg-secondary')); ?> ms-2" id="orderStatusBadge">
                             <?php echo Text::_($item->orderstatus_name ?? 'Unknown'); ?>
                         </div>
+                    </div>
+                    <div class="j2-title-invoice mb-1">
+                        <small class="text-body-secondary">
+                            <?php echo Text::_('COM_J2COMMERCE_HEADING_INVOICE'); ?>:
+                            <strong class="text-body">#<?php echo $this->escape($item->invoice); ?></strong>
+                        </small>
                     </div>
                     <div class="j2-title-bottom d-flex align-items-center">
                         <small><?php echo HTMLHelper::_('date', $item->created_on, $dateFormat); ?></small>

--- a/administrator/components/com_j2commerce/tmpl/orders/default.php
+++ b/administrator/components/com_j2commerce/tmpl/orders/default.php
@@ -64,6 +64,9 @@ $dateFormat = ComponentHelper::getParams('com_j2commerce')->get('date_format', '
                                 <th scope="col">
                                     <?php echo HTMLHelper::_('searchtools.sort', 'COM_J2COMMERCE_HEADING_ORDER', 'a.order_id', $listDirn, $listOrder); ?>
                                 </th>
+                                <th scope="col" class="d-none d-md-table-cell">
+                                    <?php echo HTMLHelper::_('searchtools.sort', 'COM_J2COMMERCE_HEADING_INVOICE', 'a.j2commerce_order_id', $listDirn, $listOrder); ?>
+                                </th>
                                 <th scope="col" class="d-none d-lg-table-cell">
                                     <?php echo HTMLHelper::_('searchtools.sort', 'COM_J2COMMERCE_HEADING_DATE', 'a.created_on', $listDirn, $listOrder); ?>
                                 </th>
@@ -114,6 +117,9 @@ $dateFormat = ComponentHelper::getParams('com_j2commerce')->get('date_format', '
                                         <small><?php echo $this->escape($item->order_id); ?></small>
                                     <?php endif; ?>
                                 </th>
+                                <td class="d-none d-md-table-cell">
+                                    <small><?php echo $this->escape($item->invoice ?? ''); ?></small>
+                                </td>
                                 <td class="d-none d-lg-table-cell">
                                     <small><?php echo HTMLHelper::_('date', $item->created_on, $dateFormat); ?></small>
                                 </td>

--- a/administrator/components/com_j2commerce/tmpl/voucher/history.php
+++ b/administrator/components/com_j2commerce/tmpl/voucher/history.php
@@ -54,10 +54,10 @@ J2CommerceHelper::strapper()->addCSS();
                                     <td>
                                         <a href="<?php echo $orderLink; ?>" target="_blank" class="text-decoration-none">
                                             <span class="icon-external-link" aria-hidden="true"></span>
-                                            <?php if (!empty($item->invoice_number) && count($item->invoice_number) > 0) : ?>
-                                                <?php echo htmlspecialchars($item->invoice_prefix . $item->invoice_number, ENT_QUOTES, 'UTF-8'); ?>
+                                            <?php if (!empty($item->invoice_prefix)) : ?>
+                                                <?php echo htmlspecialchars($item->invoice_prefix . $item->j2commerce_order_id, ENT_QUOTES, 'UTF-8'); ?>
                                             <?php else : ?>
-                                                <?php echo $item->j2commerce_order_id; ?>
+                                                <?php echo (int) $item->j2commerce_order_id; ?>
                                             <?php endif; ?>
                                         </a>
                                     </td>


### PR DESCRIPTION
## Summary

Fixes #834

Resolves the Order/Invoice terminology confusion in the admin and aligns the invoice number with the order primary key so the trailing digits always match.

## Changes

- **Toolbar title** — uses `order_id` (matches the "Order:" label).
- **Detail header** — h2 reads `Order #<order_id>` with status badge; new labeled secondary line `Invoice: #<invoice>`.
- **Orders list** — added sortable Invoice column (hidden < md).
- **Search** — invoice form `<prefix><PK>` and bare PK both match.
- **Invoice display = `prefix + j2commerce_order_id`** everywhere (`OrderModel`, `OrdersModel`, `EmailHelper`, `InvoiceHelper`, voucher/coupon history templates). The trailing number in the invoice now always matches the trailing PK in the order_id token, eliminating drift caused by legacy `MAX(invoice_number)+1` generation paths.
- **from/to_invoice range filter** simplified to direct PK comparison.

## Testing

1. /administrator → Orders. New "Invoice" column appears between Order and Date; sortable.
2. Order #N now displays `<prefix>N` everywhere — list, detail header secondary line, invoice template, packing slip, email, voucher/coupon history.
3. Search by `AM-262` or `262` → matches.
4. Detail page header reads `Order #<order_id>` (h2) + `Invoice: #<invoice>` underneath.
5. Toolbar title at top reads `Order: #<order_id>`.
6. Invoice range filter (from=250, to=270) returns PKs 250-270.

## Files Changed

- `administrator/components/com_j2commerce/src/View/Order/HtmlView.php` — toolbar `$orderDisplay` order swap.
- `administrator/components/com_j2commerce/tmpl/order/view.php` — h2 label + secondary invoice line.
- `administrator/components/com_j2commerce/tmpl/orders/default.php` — Invoice column + sort key.
- `administrator/components/com_j2commerce/src/Model/OrdersModel.php` — invoice CASE → PK, search clause, range filter simplified.
- `administrator/components/com_j2commerce/src/Model/OrderModel.php` — `getInvoiceNumber()` + getOrdersByUser CASE → PK.
- `administrator/components/com_j2commerce/src/Helper/EmailHelper.php` — `getInvoiceNumber()` → PK.
- `administrator/components/com_j2commerce/src/Helper/InvoiceHelper.php` — `getInvoiceNumber()` + `hasInvoiceNumber()` → PK.
- `administrator/components/com_j2commerce/tmpl/voucher/history.php` — display prefix + PK.
- `administrator/components/com_j2commerce/tmpl/coupon/history.php` — display prefix + PK.

## Notes

The `invoice_number` column is no longer used for display. It remains in the schema as historical/legacy data. Behavioral change: invoice numbers now follow the order PK sequence (gap-free per insert, with gaps from deletes), instead of a separate `MAX(invoice_number)+1` counter — businesses requiring a *separate* sequential invoice counter for legal/VAT purposes should be aware.