### PR TITLE
fix(orders): refresh history timeline after status update (fixes #831)

### DIFF
--- a/media/com_j2commerce/js/administrator/admin-order.js
+++ b/media/com_j2commerce/js/administrator/admin-order.js
@@ -83,6 +83,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         badge.textContent = result.data.statusName || '';
                     }
 
+                    await reloadHistory();
                     flashSuccess(headerSaveBtn);
                 } else {
                     showMessage('error', result.message || 'Error updating status');


### PR DESCRIPTION
## Summary
Fixes #831

The order status save handler updated the status badge but never refreshed the order history timeline. Adding a note or deleting a note already reloaded the timeline correctly — status save was the outlier.

## Changes
- `media/com_j2commerce/js/administrator/admin-order.js` — added `await reloadHistory()` inside the `headerSaveStatus` success branch so the new history row appears immediately

Server-side (`OrderModel::updateOrderStatus()`) already writes the history row; only the client refresh was missing.

## Testing
1. Open admin → Components → J2Commerce → Orders → click any order
2. Change the status dropdown in the header bar, click **Apply**
3. Verify timeline below immediately gets a new entry ("Order status changed from X to Y") with the correct badge color and timestamp — no manual page refresh
4. Confirm the count badge in the "Order History" header increments
5. Add a note (regression check) — still works
6. Delete a note (regression check) — still works