### PR TITLE
fix(payment_paypal): drop &paction=display redirects so AfterPayment fires

### DIFF
--- a/plugins/j2commerce/payment_paypal/payment_paypal.xml
+++ b/plugins/j2commerce/payment_paypal/payment_paypal.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="j2commerce" method="upgrade">
     <name>PLG_J2COMMERCE_PAYMENT_PAYPAL</name>
-    <version>6.2.2</version>
+    <version>6.2.3</version>
     <author>J2Commerce, LLC</author>
-    <creationDate>2026-02</creationDate>
+    <creationDate>2026-04-27</creationDate>
     <copyright>Copyright (C) 2024–2026 J2Commerce, LLC. All rights reserved.</copyright>
     <license>GNU General Public License version 2 or later</license>
     <authorEmail>support@j2commerce.com</authorEmail>

--- a/plugins/j2commerce/payment_paypal/src/Extension/PaymentPaypal.php
+++ b/plugins/j2commerce/payment_paypal/src/Extension/PaymentPaypal.php
@@ -701,7 +701,7 @@ final class PaymentPaypal extends CMSPlugin implements SubscriberInterface
 
             $returnUrl = Route::_(
                 'index.php?option=com_j2commerce&task=checkout.confirmPayment'
-                . '&orderpayment_type=' . $this->_name . '&paction=display'
+                . '&orderpayment_type=' . $this->_name
                 . '&order_id=' . urlencode($orderId)
                 . '&nvp=1',
                 false,
@@ -875,7 +875,8 @@ final class PaymentPaypal extends CMSPlugin implements SubscriberInterface
                 'transaction_id'       => $transId,
                 'redirect'             => Route::_(
                     'index.php?option=com_j2commerce&view=checkout&task=checkout.confirmPayment'
-                    . '&orderpayment_type=' . $this->_name . '&paction=display',
+                    . '&orderpayment_type=' . $this->_name
+                    . '&order_id=' . urlencode($orderIdString),
                     false
                 ),
             ];
@@ -1444,7 +1445,8 @@ final class PaymentPaypal extends CMSPlugin implements SubscriberInterface
 
             $returnUrl = Route::_(
                 'index.php?option=com_j2commerce&view=checkout&task=checkout.confirmPayment'
-                . '&orderpayment_type=' . $this->_name . '&paction=display',
+                . '&orderpayment_type=' . $this->_name
+                . '&order_id=' . urlencode($orderId),
                 false,
                 Route::TLS_IGNORE,
                 true
@@ -1597,7 +1599,8 @@ final class PaymentPaypal extends CMSPlugin implements SubscriberInterface
                 'remote_status'          => $status,
                 'redirect'               => Route::_(
                     'index.php?option=com_j2commerce&view=checkout&task=checkout.confirmPayment'
-                    . '&orderpayment_type=' . $this->_name . '&paction=display',
+                    . '&orderpayment_type=' . $this->_name
+                    . '&order_id=' . urlencode($orderIdString),
                     false
                 ),
             ];
@@ -1665,6 +1668,27 @@ final class PaymentPaypal extends CMSPlugin implements SubscriberInterface
 
         $this->log('_postPayment: Processing payment response with paction: ' . $paction);
 
+        // isAlreadyFinalized short-circuit — re-entry from a side-finalised flow
+        // (Smart Buttons capture, vault subscription approval, replayed NVP
+        // return). Order has transaction_status=Completed; skip the gateway
+        // call and render the postpayment template. CheckoutController then
+        // dispatches onJ2CommerceAfterPayment via the no-paction branch, which
+        // creates the subscription row, sends the order email, and clears the
+        // cart. Without this guard, a refresh on the return URL would re-call
+        // DoExpressCheckoutPayment and fail.
+        $orderIdFromUrl = (string) $app->input->getString('order_id', '');
+
+        if ($orderIdFromUrl === '') {
+            $orderIdFromUrl = (string) ($data->order_id ?? '');
+        }
+
+        if ($paction === '' && $orderIdFromUrl !== '' && $this->isAlreadyFinalized($orderIdFromUrl)) {
+            $this->log('_postPayment: Order ' . $orderIdFromUrl . ' already finalized — rendering postpayment template');
+            $vars->onafterpayment_text = Text::_($this->params->get('onafterpayment', ''));
+
+            return $this->_getLayout('postpayment', $vars) . $this->base->_displayArticle();
+        }
+
         // NVP Express Checkout return handling — customer just bounced back from
         // PayPal with TOKEN + PayerID query params. Run DoExpressCheckoutPayment
         // BEFORE the standard postpayment flow so the BAID gets stored and
@@ -1674,12 +1698,6 @@ final class PaymentPaypal extends CMSPlugin implements SubscriberInterface
         $nvpPayerId = (string) $app->input->getString('PayerID', '');
 
         if ($nvpFlag === 1 && $nvpToken !== '' && $nvpPayerId !== '') {
-            $orderIdFromUrl = (string) $app->input->getString('order_id', '');
-
-            if ($orderIdFromUrl === '') {
-                $orderIdFromUrl = (string) ($data->order_id ?? '');
-            }
-
             $this->log('_postPayment NVP return: order=' . $orderIdFromUrl . ' token=' . $nvpToken . ' payerid=' . $nvpPayerId);
 
             $completion = $this->completeNvpExpressCheckoutForOrder($orderIdFromUrl, $nvpToken, $nvpPayerId);
@@ -1689,10 +1707,14 @@ final class PaymentPaypal extends CMSPlugin implements SubscriberInterface
                 return $this->_getLayout('message', $vars);
             }
 
-            // Re-load the order now that completeNvpExpressCheckoutForOrder
-            // has stamped billing_agreement_id into transaction_details. The
-            // CheckoutController will dispatch onJ2CommerceAfterPayment after
-            // _postPayment returns, which is when the metakey gets written.
+            // NVP completion stamped billing_agreement_id and
+            // transaction_status=Completed onto the order. Render the
+            // postpayment template now and let CheckoutController dispatch
+            // onJ2CommerceAfterPayment via the no-paction branch (which writes
+            // the metakey, creates the subscription row, and sends emails).
+            $vars->onafterpayment_text = Text::_($this->params->get('onafterpayment', ''));
+
+            return $this->_getLayout('postpayment', $vars) . $this->base->_displayArticle();
         }
 
         switch ($paction) {
@@ -1717,6 +1739,36 @@ final class PaymentPaypal extends CMSPlugin implements SubscriberInterface
         }
 
         return $html;
+    }
+
+    /**
+     * True when the given order has already been finalised at PayPal
+     * (transaction_status === 'Completed'). Used as a short-circuit in
+     * _postPayment so a refresh / replay of the return URL doesn't re-call
+     * the gateway.
+     */
+    private function isAlreadyFinalized(string $orderIdString): bool
+    {
+        if ($orderIdString === '') {
+            return false;
+        }
+
+        try {
+            $orderTable = Factory::getApplication()
+                ->bootComponent('com_j2commerce')
+                ->getMVCFactory()
+                ->createTable('Order', 'Administrator');
+
+            if (!$orderTable->load(['order_id' => $orderIdString])) {
+                return false;
+            }
+
+            return strtolower((string) ($orderTable->transaction_status ?? '')) === 'completed';
+        } catch (\Throwable $e) {
+            $this->log('isAlreadyFinalized exception: ' . $e->getMessage(), Log::ERROR);
+
+            return false;
+        }
     }
 
     public function createPayPalOrder(array $data): array


### PR DESCRIPTION
## Summary
Fixes #877

`payment_paypal` had four redirect URLs that hardcoded `&paction=display`. `CheckoutController::confirmPayment` explicitly skips its `onJ2CommerceAfterPayment` dispatch when `paction === 'display'`, so:
- `app_subscriptionproduct.onAfterPayment` never fired → **no subscription row created** for PayPal subscriptions
- Plugin priority -100 listeners (vault metadata) never ran
- Order confirmation email was silently skipped

Same root-cause pattern as [`payment_square` v6.0.1](https://github.com/j2commerce/j2commerce6extensions/pull/114) and [`payment_kustom` v6.0.2](https://github.com/j2commerce/j2commerce6extensions/pull/124).

## Changes
- Drop `&paction=display` from all four redirect URLs:
  - NVP Express `returnUrl` (line 702)
  - `completeNvpExpressCheckoutForOrder` JSON redirect (line 876)
  - Vault subscription `returnUrl` (line 1445)
  - `finalizePayPalSubscriptionApproval` JSON redirect (line 1598)
- Append `&order_id=` on the three URLs that lacked it.
- Add `isAlreadyFinalized()` helper and short-circuit at the top of `_postPayment` so a refresh / replay of the return URL doesn't re-call PayPal (`transaction_status === 'Completed'` ⇒ render postpayment template, let CheckoutController dispatch `AfterPayment` via the no-paction branch).
- After a successful NVP `DoExpressCheckoutPayment` completion, render the postpayment template directly instead of relying on `paction=display`.
- Bump `payment_paypal` to `6.2.3` / `creationDate 2026-04-27`.

## Testing
1. **NVP Express subscription** (set `subscription_mode=nvp`, fill NVP creds): complete a PayPal subscription checkout → verify row in `#__j2commerce_subscriptions`, order email arrives.
2. **Vault subscription** (default `subscription_mode=rest`): complete a Smart Buttons subscription checkout → same checks.
3. **Smart Buttons one-time** (non-subscription cart): regression check — confirmation page renders, email arrives.
4. **Refresh the confirmation URL** → no double charge, postpayment template still renders, log shows `Order N already finalized — rendering postpayment template`.
5. **Replayed POST** → idempotent (existing `hasCompletedTransaction` guards in `_prePayment` paths).

## Files Changed
- `plugins/j2commerce/payment_paypal/src/Extension/PaymentPaypal.php` — 4 URL fixes + `isAlreadyFinalized()` helper + `_postPayment` short-circuit + return postpayment HTML after NVP completion.
- `plugins/j2commerce/payment_paypal/payment_paypal.xml` — version 6.2.2 → 6.2.3, creationDate 2026-04-27.

## Related
- Audit issue: j2commerce/j2commerce6extensions#115
- Reference fix (Square): j2commerce/j2commerce6extensions#114
- Reference fix (Kustom): j2commerce/j2commerce6extensions#124
- Architecture: `components/com_j2commerce/src/Controller/CheckoutController.php` lines 1376–1428