### PR TITLE
fix(orders): label admin notes as "Order Note" in history timeline (fixes #889)

### DIFF
--- a/administrator/components/com_j2commerce/src/View/Order/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Order/HtmlView.php
@@ -133,6 +133,7 @@ class HtmlView extends BaseHtmlView
             );
             Text::script('JACTION_DELETE');
             Text::script('COM_J2COMMERCE_ORDER_HISTORY_ROW_ICONS_LABEL');
+            Text::script('COM_J2COMMERCE_ORDER_NOTE');
         }
 
         $this->addToolbar($layout);

--- a/administrator/components/com_j2commerce/tmpl/order/view_history.php
+++ b/administrator/components/com_j2commerce/tmpl/order/view_history.php
@@ -141,6 +141,9 @@ $currentUserId = (int) (Factory::getApplication()->getIdentity()?->id ?? 0);
                                         </span>
                                     </h3>
                                 <?php endif; ?>
+                                <?php if ($isAdminNote) : ?>
+                                    <strong><?php echo Text::_('COM_J2COMMERCE_ORDER_NOTE'); ?></strong>
+                                <?php endif; ?>
                                 <?php if (!empty($comment)) : ?>
                                     <p class="card-text text-body-secondary small mb-0"><?php echo $this->escape($comment); ?></p>
                                 <?php endif; ?>

--- a/media/com_j2commerce/js/administrator/admin-order.js
+++ b/media/com_j2commerce/js/administrator/admin-order.js
@@ -409,6 +409,10 @@ document.addEventListener('DOMContentLoaded', () => {
                 ? `<h4 class="card-title small mb-1"><span class="badge rounded-2 px-2 text-bg-${color}">${escHtml(item.orderstatus_name)}</span></h4>`
                 : '';
 
+            const noteLabelHtml = item.isAdminNote
+                ? `<strong>${escHtml(Joomla.Text._('COM_J2COMMERCE_ORDER_NOTE'))}</strong>`
+                : '';
+
             const commentHtml = item.comment
                 ? `<p class="card-text text-body-secondary small mb-0">${escHtml(item.comment)}</p>`
                 : '';
@@ -441,6 +445,7 @@ document.addEventListener('DOMContentLoaded', () => {
                                 ${deleteBtn}
                             </div>
                             ${statusHtml}
+                            ${noteLabelHtml}
                             ${commentHtml}
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- Add an `<strong>Order Note</strong>` label above the comment for `admin_note` history rows so they can be visually distinguished from status changes and system events.
- Renders identically in the PHP timeline (`tmpl/order/view_history.php`) and the JS-rendered AJAX reload path (`media/com_j2commerce/js/administrator/admin-order.js`).
- Registers the existing `COM_J2COMMERCE_ORDER_NOTE` language key for JS via `Text::script()` in `View/Order/HtmlView.php`.

No new language strings, no schema/SQL changes, no auth/CSRF surface touched. Output is escaped via `$this->escape()` in PHP and `escHtml()` in JS.

## Test plan
- [ ] Open an order in admin and add an admin note — the new row in the history timeline shows "Order Note" above the comment text.
- [ ] After adding/deleting a note, confirm the AJAX-reloaded timeline shows the same "Order Note" label (parity with the initial PHP render).
- [ ] Status-change rows continue to show the status badge and no "Order Note" label.
- [ ] Verify on en-GB and en-US — both already contain `COM_J2COMMERCE_ORDER_NOTE="Order Note"`.

Fixes #889