### PR TITLE
fix(orders): add Invoice to sort dropdown, align with column order

### DIFF
--- a/administrator/components/com_j2commerce/forms/filter_orders.xml
+++ b/administrator/components/com_j2commerce/forms/filter_orders.xml
@@ -117,6 +117,8 @@
             <option value="">JGLOBAL_SORT_BY</option>
             <option value="a.order_id ASC">COM_J2COMMERCE_HEADING_ORDER_ID_ASC</option>
             <option value="a.order_id DESC">COM_J2COMMERCE_HEADING_ORDER_ID_DESC</option>
+            <option value="invoice ASC">COM_J2COMMERCE_HEADING_INVOICE_ASC</option>
+            <option value="invoice DESC">COM_J2COMMERCE_HEADING_INVOICE_DESC</option>
             <option value="a.created_on ASC">COM_J2COMMERCE_HEADING_DATE_ASC</option>
             <option value="a.created_on DESC">COM_J2COMMERCE_HEADING_DATE_DESC</option>
             <option value="oi.billing_last_name ASC">COM_J2COMMERCE_HEADING_CUSTOMER_ASC</option>

--- a/administrator/components/com_j2commerce/tmpl/orders/default.php
+++ b/administrator/components/com_j2commerce/tmpl/orders/default.php
@@ -65,7 +65,7 @@ $dateFormat = ComponentHelper::getParams('com_j2commerce')->get('date_format', '
                                     <?php echo HTMLHelper::_('searchtools.sort', 'COM_J2COMMERCE_HEADING_ORDER', 'a.order_id', $listDirn, $listOrder); ?>
                                 </th>
                                 <th scope="col" class="d-none d-md-table-cell">
-                                    <?php echo HTMLHelper::_('searchtools.sort', 'COM_J2COMMERCE_HEADING_INVOICE', 'a.j2commerce_order_id', $listDirn, $listOrder); ?>
+                                    <?php echo HTMLHelper::_('searchtools.sort', 'COM_J2COMMERCE_HEADING_INVOICE', 'invoice', $listDirn, $listOrder); ?>
                                 </th>
                                 <th scope="col" class="d-none d-lg-table-cell">
                                     <?php echo HTMLHelper::_('searchtools.sort', 'COM_J2COMMERCE_HEADING_DATE', 'a.created_on', $listDirn, $listOrder); ?>


### PR DESCRIPTION
## Summary
Fixes #887

Adds Invoice entries to the orders list "Sort By" dropdown and aligns the dropdown order with the on-screen column order. Also changes the Invoice column-header sort key so column-click and dropdown agree.

## Changes
- `administrator/components/com_j2commerce/forms/filter_orders.xml` — added `invoice ASC` and `invoice DESC` options to the `fullordering` field, positioned between Order ID and Date to match column display order.
- `administrator/components/com_j2commerce/tmpl/orders/default.php` — switched the Invoice column header sort key from `a.j2commerce_order_id` to the existing `invoice` SELECT alias, so it sorts on the displayed value rather than the raw PK (which made it indistinguishable from the ID column).

## Why this works
- The `invoice` alias is already built in `OrdersModel::getListQuery()` as `CASE WHEN invoice_prefix IS NULL OR invoice_prefix = '' THEN j2commerce_order_id ELSE CONCAT(invoice_prefix, j2commerce_order_id) END AS invoice`, and `invoice` is already whitelisted in `filter_fields`.
- MySQL allows `ORDER BY` on a SELECT alias.
- Search behaviour is unchanged — `OrdersModel::buildWhereClause()` already matches the computed invoice (search9: `CONCAT(IFNULL(invoice_prefix, ''), j2commerce_order_id) LIKE :search9`).
- Existing language strings `COM_J2COMMERCE_HEADING_INVOICE_ASC` / `_DESC` are reused — no new strings needed.

## Testing
1. Open admin → J2Commerce → Orders.
2. Open the **Sort By** dropdown — verify **Invoice - Ascending** and **Invoice - Descending** appear directly after the Order ID entries and before Date.
3. Pick **Invoice - Ascending** — rows re-sort by the displayed invoice (alphabetical, so distinct prefixes group together).
4. Click the Invoice column header — produces the same sort as the dropdown entry.
5. Click the ID column header / pick **ID - Ascending** — still numeric on `a.j2commerce_order_id`, distinct from Invoice.
6. Search a partial invoice (e.g. `AM-2`) — matching rows still appear.
7. Confirm Order, Date, Customer, Total, Status sort entries still work after the dropdown reorder.

## Files Changed
- `administrator/components/com_j2commerce/forms/filter_orders.xml` — +2 lines (Invoice ASC/DESC options)
- `administrator/components/com_j2commerce/tmpl/orders/default.php` — sort key change on the Invoice header
