### PR TITLE
chore(gitignore): exclude j2commercemigrator package build files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -480,3 +480,10 @@ plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_variablesubscriptionproduct.php
 plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_variablesubscriptionproductoptions.php
 # Added by code-review-graph
 .code-review-graph/
+
+# ===========================================================================
+# Migrator package files belong in the j2commerce6extensions repo, not core
+# ===========================================================================
+build/build_pkg_j2commercemigrator.php
+build/script.pkg_j2commercemigrator.php
+build/language/*/pkg_j2commercemigrator.sys.ini


### PR DESCRIPTION
## Summary

`com_j2commercemigrator` lives in the `j2commerce/j2commerce6extensions` repo, not core. But its three build/install support files get deployed alongside core into local dev installs (so the package builder can find them), which makes them show up as untracked in `git status` against core — and would silently get committed if anyone ran `git add -A`.

This adds explicit `.gitignore` rules so they stop appearing as untracked in the core repo:

- `build/build_pkg_j2commercemigrator.php`
- `build/script.pkg_j2commercemigrator.php`
- `build/language/*/pkg_j2commercemigrator.sys.ini`

The files themselves are unchanged on disk — they continue to work for local builds. They're committed in `j2commerce6extensions` (see commit `9dcd47f` on its `main` branch), which is the correct home for them.

## Test plan
- [ ] `git status` in a fresh checkout no longer lists the three migrator files as untracked
- [ ] Migrator package can still be built from the extensions repo
