### PR TITLE
fix(orders): remove stale order history count badge (fixes #898)

### DIFF
--- a/administrator/components/com_j2commerce/tmpl/order/view_history.php
+++ b/administrator/components/com_j2commerce/tmpl/order/view_history.php
@@ -32,11 +32,8 @@ $lastKey = array_key_last($currentPage);
 $currentUserId = (int) (Factory::getApplication()->getIdentity()?->id ?? 0);
 ?>
 <div class="card order-history-card mb-4 border-0 shadow-none bg-transparent" id="j2c-order-history-card">
-    <div class="card-header d-flex justify-content-between align-items-center px-0">
+    <div class="card-header px-0">
         <h2 class="card-title mb-0 fs-4"><?php echo Text::_('COM_J2COMMERCE_ORDER_HISTORY'); ?></h2>
-        <?php if ($totalItems > 0) : ?>
-            <span class="<?php echo J2htmlHelper::badgeClass('badge text-bg-secondary'); ?>"><?php echo $totalItems; ?></span>
-        <?php endif; ?>
     </div>
 
     <div class="admin-note-card card mb-3 mx-0 mt-3">

--- a/media/com_j2commerce/js/administrator/admin-order.js
+++ b/media/com_j2commerce/js/administrator/admin-order.js
@@ -318,9 +318,6 @@ document.addEventListener('DOMContentLoaded', () => {
         historyContainer.dataset.currentPage = '1';
         historyContainer.dataset.totalPages = histResult.totalPages;
 
-        const badge = document.querySelector('#j2c-order-history-card .badge.text-bg-secondary');
-        if (badge) badge.textContent = histResult.total;
-
         const historyNav = historyContainer.querySelector('.j2c-history-pagination');
         if (historyNav) updatePagination(historyNav, 1, histResult.totalPages);
     }


### PR DESCRIPTION
## Summary

Fixes #898.

The admin order history card header showed a count badge (`<span class="badge text-bg-secondary">N</span>`) that was only refreshed on full page reload — and incidentally after add/delete admin note via `reloadHistory()`. Other history changes (status updates, item removals, notification emails) all left the count stale. Per the reporter's preference, removed the badge entirely; the timeline itself already conveys the order of events and adding accurate AJAX sync to every code path that touches history was not worth the cost for a number that adds no value.

## Changes

- `administrator/components/com_j2commerce/tmpl/order/view_history.php` — removed the `$totalItems` badge from the card header and the now-unneeded `d-flex justify-content-between align-items-center` flex classes on the header.
- `media/com_j2commerce/js/administrator/admin-order.js` — removed the dead `#j2c-order-history-card .badge.text-bg-secondary` query inside `reloadHistory()`.

`$totalItems` itself is kept (still used to compute `$totalPages` for the pagination nav).

## Testing

1. Open Components → J2Commerce → Orders → edit any order with history.
2. Confirm the **Order History** card header shows only the title with no count badge to its right.
3. Add an admin note, then delete it — confirm the timeline reloads cleanly with no JS console errors.
4. With >20 history rows, click prev/next — confirm pagination still works.
5. Change order status — confirm the timeline refresh path still works.

## Files Changed

- `administrator/components/com_j2commerce/tmpl/order/view_history.php` — removed count badge from card header
- `media/com_j2commerce/js/administrator/admin-order.js` — removed dead badge sync inside `reloadHistory()`