### PR TITLE
fix(orders): normalize status badge cssclass in AJAX response (fixes #899)

### DIFF
--- a/administrator/components/com_j2commerce/src/Controller/OrderController.php
+++ b/administrator/components/com_j2commerce/src/Controller/OrderController.php
@@ -16,6 +16,7 @@ namespace J2Commerce\Component\J2commerce\Administrator\Controller;
 
 use J2Commerce\Component\J2commerce\Administrator\Helper\EmailHelper;
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2htmlHelper;
 use J2Commerce\Component\J2commerce\Administrator\Helper\PackingSlipHelper;
 use J2Commerce\Component\J2commerce\Administrator\Helper\QueueHelper;
 use Joomla\CMS\Factory;
@@ -246,7 +247,7 @@ class OrderController extends FormController
                 'messageType' => $messageType,
                 'data'        => [
                     'statusName' => Text::_($status->orderstatus_name ?? ''),
-                    'cssclass'   => $status->orderstatus_cssclass ?? 'secondary',
+                    'cssclass'   => J2htmlHelper::badgeClass($status->orderstatus_cssclass ?? 'badge text-bg-secondary'),
                 ],
             ]);
         } catch (\Exception $e) {


### PR DESCRIPTION
## Summary

Fixes #899.

`OrderController::ajaxUpdateStatus` (single-order detail view) returned the orderstatus_cssclass **raw** — e.g. `badge text-bg-info` — so the JS-rendered badge kept the `text-bg-*` classes while the page-load template ran the same value through `J2htmlHelper::badgeClass()`, which strips `text-` under the default `atum` badge style. Result: change the order status from the header dropdown and the badge styling no longer matched what you see after a full reload (and any layout artefacts riding on the broken classes — including the "cancelled button is just a number" the reporter described — disappear once the class is shaped correctly).

The companion `OrdersController::ajaxUpdateStatus` (orders list view) already does this correctly, so only the order detail view was affected.

## Changes

- `administrator/components/com_j2commerce/src/Controller/OrderController.php`
  - Imported `J2htmlHelper`.
  - Wrapped the AJAX response's `cssclass` field with `J2htmlHelper::badgeClass()` and replaced the broken `'secondary'` fallback with the proper `'badge text-bg-secondary'` so the response shape matches `OrdersController::ajaxUpdateStatus`.

## Testing

1. Settings → J2Commerce options → confirm **Badge Style** is `atum` (default).
2. Open any order → change status from the header dropdown (try Cancelled, Confirmed, Pending) → click **Apply**.
3. The badge should render identically to a full-page refresh — `bg-warning` / `bg-success` / etc., not `text-bg-*`.
4. Switch **Badge Style** to `j2commerce` and repeat — classes should stay `text-bg-*` consistently in both states.

## Files Changed

- `administrator/components/com_j2commerce/src/Controller/OrderController.php` — added `J2htmlHelper` import, normalized AJAX `cssclass` response.