### PR TITLE
fix(orders): rename order ID filter fields to j2commerce_order_id

### DIFF
--- a/administrator/components/com_j2commerce/forms/filter_orders.xml
+++ b/administrator/components/com_j2commerce/forms/filter_orders.xml
@@ -13,7 +13,7 @@
         <!-- Column-matched filters (in column order: Order, Date, Customer, Total, Payment, Status) -->
 
         <field
-            name="from_order_id"
+            name="from_j2commerce_order_id"
             type="number"
             label="COM_J2COMMERCE_FILTER_ORDER_ID_FROM"
             hint="COM_J2COMMERCE_FILTER_ORDER_ID_FROM_HINT"
@@ -22,7 +22,7 @@
         />
 
         <field
-            name="to_order_id"
+            name="to_j2commerce_order_id"
             type="number"
             label="COM_J2COMMERCE_FILTER_ORDER_ID_TO"
             hint="COM_J2COMMERCE_FILTER_ORDER_ID_TO_HINT"

--- a/administrator/components/com_j2commerce/src/Model/OrdersModel.php
+++ b/administrator/components/com_j2commerce/src/Model/OrdersModel.php
@@ -49,7 +49,7 @@ class OrdersModel extends ListModel
                 'orderstatus_name', 'os.orderstatus_name',
                 'coupon_code',
                 'amount_from', 'amount_to',
-                'from_order_id', 'to_order_id',
+                'from_j2commerce_order_id', 'to_j2commerce_order_id',
             ];
         }
 
@@ -92,8 +92,8 @@ class OrdersModel extends ListModel
         $id .= ':' . $this->getState('filter.coupon_code');
         $id .= ':' . $this->getState('filter.amount_from');
         $id .= ':' . $this->getState('filter.amount_to');
-        $id .= ':' . $this->getState('filter.from_order_id');
-        $id .= ':' . $this->getState('filter.to_order_id');
+        $id .= ':' . $this->getState('filter.from_j2commerce_order_id');
+        $id .= ':' . $this->getState('filter.to_j2commerce_order_id');
         $id .= ':' . $this->getState('filter.token');
         $id .= ':' . $this->getState('filter.user_email');
         $id .= ':' . $this->getState('filter.parent_id');
@@ -350,14 +350,14 @@ class OrdersModel extends ListModel
         }
 
         // Order ID range: from
-        $fromOrderId = (int) $this->getState('filter.from_order_id', 0);
+        $fromOrderId = (int) $this->getState('filter.from_j2commerce_order_id', 0);
         if ($fromOrderId > 0) {
             $query->where($db->quoteName('a.j2commerce_order_id') . ' >= :fromOrderId')
                 ->bind(':fromOrderId', $fromOrderId, ParameterType::INTEGER);
         }
 
         // Order ID range: to
-        $toOrderId = (int) $this->getState('filter.to_order_id', 0);
+        $toOrderId = (int) $this->getState('filter.to_j2commerce_order_id', 0);
         if ($toOrderId > 0) {
             $query->where($db->quoteName('a.j2commerce_order_id') . ' <= :toOrderId')
                 ->bind(':toOrderId', $toOrderId, ParameterType::INTEGER);


### PR DESCRIPTION
## Summary
Fixes #900

The order list filter form had fields named `from_order_id` / `to_order_id`, which read as if they filtered by the long string `a.order_id` (e.g. `J2-AB12CD34`) — Brian flagged that filtering ranges of those wouldn't make sense. The SQL was already filtering by the integer PK `a.j2commerce_order_id`; only the field names were misleading.

This PR renames the filter fields so the form schema, URL params, and SQL column all line up. Visible label text ("Order ID From" / "Order ID To") is unchanged.

## Changes
- `from_order_id` → `from_j2commerce_order_id` (form field name)
- `to_order_id` → `to_j2commerce_order_id` (form field name)
- `OrdersModel::__construct()` — updated `filter_fields` whitelist
- `OrdersModel::getStoreId()` — updated cache-key state reads
- `OrdersModel::getListQuery()` — updated filter state reads (SQL already targeted `a.j2commerce_order_id`, no query-shape change)

No language strings touched — label/hint text is preserved exactly.

## Testing
1. J2Commerce → Orders in admin
2. Open the filters panel — labels still read **"Order ID From"** / **"Order ID To"**
3. Enter `1` in From and `10` in To
4. URL contains `filter_from_j2commerce_order_id=1` and `filter_to_j2commerce_order_id=10`
5. List narrows to orders with integer PKs 1–10
6. Sort headers ("Order" by `a.order_id`, "ID" by `a.j2commerce_order_id`) still work
7. Clear filters → full list returns

## Files Changed
- `administrator/components/com_j2commerce/forms/filter_orders.xml` — rename two field `name` attributes
- `administrator/components/com_j2commerce/src/Model/OrdersModel.php` — update three corresponding state-key reads + filter_fields entry

## Pre-Flight
- [x] PHP syntax check passed (`php -l`)
- [x] No secrets detected
- [x] No FOF remnants / `JFactory::` usage
- [x] Core files only (only `com_j2commerce` admin component touched)
- [x] Rebased on latest `upstream/main`