### PR TITLE
fix(order-view): use semantic table for admin order items

### DIFF
--- a/administrator/components/com_j2commerce/src/View/Order/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Order/HtmlView.php
@@ -108,7 +108,7 @@ class HtmlView extends BaseHtmlView
             'com_j2commerce.admin-order',
             'media/com_j2commerce/css/administrator/admin-order.css',
             [],
-            ['version' => '6.0.7']
+            ['version' => '6.0.8']
         );
 
         $layout = Factory::getApplication()->getInput()->getString('layout', 'view');

--- a/administrator/components/com_j2commerce/src/View/Orders/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Orders/HtmlView.php
@@ -95,7 +95,7 @@ class HtmlView extends BaseHtmlView
             'com_j2commerce.admin-order',
             'media/com_j2commerce/css/administrator/admin-order.css',
             [],
-            ['version' => '6.0.7']
+            ['version' => '6.0.8']
         );
 
         parent::display($tpl);

--- a/administrator/components/com_j2commerce/tmpl/order/view_items.php
+++ b/administrator/components/com_j2commerce/tmpl/order/view_items.php
@@ -29,55 +29,52 @@ $currencyCode = $item->currency_code ?? '';
     </div>
     <div class="card-body">
         <?php if (!empty($orderItems)) : ?>
-            <?php foreach ($orderItems as $orderItem) :
-                $orderItemImage = '';
-                if(!empty($orderItem->orderitem_params)){
-                    $orderItemParams = json_decode($orderItem->orderitem_params);
-                    $orderItemImage = $orderItemParams->thumb_image ?? '';
-                }
-                ?>
-                <div class="border mb-4 rounded-3 px-4 py-3 text-subdued">
-                    <div class="row align-items-lg-start">
-                        <div class="col-lg-9">
-                            <div class="row justify-content-lg-between align-items-lg-start">
-                                <div class="col-lg-8">
-                                    <div class="order-item-left">
-                                        <div class="d-flex align-items-start">
-                                            <?php if (!empty($orderItemImage)) : ?>
-                                                <div class="cart-product-image me-2">
-                                                    <img src="<?php echo Uri::root().$orderItemImage; ?>" alt="<?php echo $this->escape($orderItem->orderitem_name); ?>" class="img-fluid" style="height: 64px;">
-                                                </div>
-                                            <?php endif; ?>
-                                            <div class="cart-product-info">
-                                                <h3 class="cart-product-name mb-1 fs-5"><?php echo $this->escape($orderItem->orderitem_name); ?></h3>
-                                                <?php echo J2CommerceHelper::plugin()->eventWithHtml('AfterDisplayLineItemTitle', array($orderItem, $item, $this->params))->getArgument('html', ''); ?>
-                                                <div class="small d-flex align-items-center">
-                                                    <div class="item-option item-option-name"><?php echo Text::_('COM_J2COMMERCE_PRODUCT_SKU');?>:</div>
-                                                    <div class="item-option item-option-value fw-bold ms-1"><?php echo $this->escape($orderItem->orderitem_sku); ?></div>
-                                                </div>
-                                                <?php if (!empty($orderItem->orderitemattributes)) : ?>
-                                                    <?php echo LayoutHelper::render('orderitem.attributes', [
-                                                        'attributes' => $orderItem->orderitemattributes,
-                                                        'item'       => $orderItem,
-                                                        'context'    => 'admin_order',
-                                                        'variant'    => 'full',
-                                                    ], JPATH_ROOT . '/components/com_j2commerce/layouts'); ?>
-                                                <?php endif; ?>
-                                            </div>
-                                        </div>
+            <table class="order-items-table">
+                <caption class="visually-hidden"><?php echo Text::_('COM_J2COMMERCE_ORDER_ITEMS'); ?></caption>
+                <tbody>
+                    <?php foreach ($orderItems as $orderItem) :
+                        $orderItemImage = '';
+                        if (!empty($orderItem->orderitem_params)) {
+                            $orderItemParams = json_decode($orderItem->orderitem_params);
+                            $orderItemImage = $orderItemParams->thumb_image ?? '';
+                        }
+                        ?>
+                        <tr class="order-items-row text-subdued">
+                            <td class="order-items-cell order-items-cell-image">
+                                <?php if (!empty($orderItemImage)) : ?>
+                                    <div class="cart-product-image">
+                                        <img src="<?php echo Uri::root() . $orderItemImage; ?>" alt="<?php echo $this->escape($orderItem->orderitem_name); ?>" class="img-fluid" style="height: 64px;">
                                     </div>
+                                <?php endif; ?>
+                            </td>
+                            <td class="order-items-cell order-items-cell-info">
+                                <div class="cart-product-info">
+                                    <h3 class="cart-product-name mb-1 fs-5"><?php echo $this->escape($orderItem->orderitem_name); ?></h3>
+                                    <?php echo J2CommerceHelper::plugin()->eventWithHtml('AfterDisplayLineItemTitle', array($orderItem, $item, $this->params))->getArgument('html', ''); ?>
+                                    <div class="small d-flex align-items-center">
+                                        <div class="item-option item-option-name"><?php echo Text::_('COM_J2COMMERCE_PRODUCT_SKU'); ?>:</div>
+                                        <div class="item-option item-option-value fw-bold ms-1"><?php echo $this->escape($orderItem->orderitem_sku); ?></div>
+                                    </div>
+                                    <?php if (!empty($orderItem->orderitemattributes)) : ?>
+                                        <?php echo LayoutHelper::render('orderitem.attributes', [
+                                            'attributes' => $orderItem->orderitemattributes,
+                                            'item'       => $orderItem,
+                                            'context'    => 'admin_order',
+                                            'variant'    => 'full',
+                                        ], JPATH_ROOT . '/components/com_j2commerce/layouts'); ?>
+                                    <?php endif; ?>
                                 </div>
-                                <div class="col-lg-4">
-                                    <div class="fw-medium fs-6 text-end"><?php echo (int) $orderItem->orderitem_quantity; ?><span class="fa-solid fa-times small text-muted mx-1" aria-hidden="true"></span><?php echo CurrencyHelper::format((float) $orderItem->orderitem_price, $currencyCode); ?></div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-lg-2">
-                            <div class="fw-medium fs-5 text-end"><strong><?php echo CurrencyHelper::format((float) $orderItem->orderitem_finalprice, $currencyCode); ?></strong></div>
-                        </div>
-                    </div>
-                </div>
-            <?php endforeach; ?>
+                            </td>
+                            <td class="order-items-cell order-items-cell-qty">
+                                <div class="fw-medium fs-6 text-end"><?php echo (int) $orderItem->orderitem_quantity; ?><span class="fa-solid fa-times small text-body-secondary mx-1" aria-hidden="true"></span><?php echo CurrencyHelper::format((float) $orderItem->orderitem_price, $currencyCode); ?></div>
+                            </td>
+                            <td class="order-items-cell order-items-cell-total">
+                                <div class="fw-medium fs-5 text-end"><strong><?php echo CurrencyHelper::format((float) $orderItem->orderitem_finalprice, $currencyCode); ?></strong></div>
+                            </td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
         <?php else : ?>
             <div class="p-3">
                 <div class="alert alert-info mb-0"><?php echo Text::_('COM_J2COMMERCE_NO_ORDER_ITEMS'); ?></div>

--- a/media/com_j2commerce/css/administrator/admin-order.css
+++ b/media/com_j2commerce/css/administrator/admin-order.css
@@ -115,6 +115,63 @@ a.j2c-history-row-icon:hover { opacity: 0.75; }
 /* ============================
    ORDER ITEMS
    ============================ */
+
+/* Order Items table — semantic <table> styled to look like the
+   previous bordered rounded "card per item" layout (issue #901). */
+.order-items-table {
+    width: 100%;
+    border-collapse: separate;
+    border-spacing: 0 1rem;
+    margin: 0;
+}
+
+.order-items-table > tbody > tr.order-items-row > td {
+    background-color: transparent;
+    border-top: 1px solid var(--bs-border-color, #dee2e6);
+    border-bottom: 1px solid var(--bs-border-color, #dee2e6);
+    padding: 0.75rem 0;
+    vertical-align: top;
+}
+
+.order-items-table > tbody > tr.order-items-row > td:first-child {
+    border-left: 1px solid var(--bs-border-color, #dee2e6);
+    border-top-left-radius: 0.5rem;
+    border-bottom-left-radius: 0.5rem;
+    padding-left: 1.5rem;
+}
+
+.order-items-table > tbody > tr.order-items-row > td:last-child {
+    border-right: 1px solid var(--bs-border-color, #dee2e6);
+    border-top-right-radius: 0.5rem;
+    border-bottom-right-radius: 0.5rem;
+    padding-right: 1.5rem;
+}
+
+.order-items-table .order-items-cell-image {
+    width: 80px;
+    padding-right: 0.5rem;
+}
+
+.order-items-table .order-items-cell-qty {
+    width: 25%;
+    white-space: nowrap;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+}
+
+.order-items-table .order-items-cell-total {
+    width: 16.66667%;
+    white-space: nowrap;
+}
+
+@media (max-width: 991.98px) {
+    .order-items-table .order-items-cell-image,
+    .order-items-table .order-items-cell-qty,
+    .order-items-table .order-items-cell-total {
+        width: auto;
+    }
+}
+
 .j2c-order-item {
     padding: 0.75rem 0;
     border-bottom: 1px solid var(--template-bg-dark-5, #f0f0f0);


### PR DESCRIPTION
## Summary

Fixes #901

The admin **Order Items** panel (`administrator/.../tmpl/order/view_items.php`) rendered tabular data — image, product name, qty × unit price, line total — using nested Bootstrap grid divs ("div soup"). This PR replaces that with a semantic `<table class="order-items-table">` while keeping the visual output **pixel-identical** to the previous bordered/rounded "card per item" appearance.

## Changes

- `tmpl/order/view_items.php`
  - Replaced nested `.row > .col-lg-9 > .col-lg-8 > .d-flex` div soup with a real `<table>`
  - Each line item is one `<tr>` with four `<td>`s: image · product info · qty × price · line total
  - Visually-hidden `<caption>` for screen-reader context
  - All existing event hooks preserved (`BeforeAdminOrderItems`, `AfterDisplayLineItemTitle`, `AfterAdminOrderItems`)
  - `LayoutHelper::render('orderitem.attributes', ...)` for attribute rendering preserved
  - Stray `text-muted` swapped for `text-body-secondary` (Bootstrap 5.3 canonical replacement, per project policy)

- `media/com_j2commerce/css/administrator/admin-order.css`
  - Added `.order-items-table` rules using `border-collapse: separate` + `border-spacing: 0 1rem`
  - Per-row borders + `border-radius` on first/last cell so each `<tr>` renders as a rounded, bordered card row matching the previous layout
  - Fixed cell widths for image (80px), qty (25%), total (16.67%); auto on `<992px` for responsive collapse

- `src/View/Order/HtmlView.php` and `src/View/Orders/HtmlView.php`
  - Bumped `admin-order.css` asset version `6.0.7` → `6.0.8` to bust browser cache

## Testing

1. Admin → **Components → J2Commerce → Orders** → open any order with multiple line items
2. Verify the **Order Items** section appears identical to before — each item still shown as a rounded, bordered card with image, name, SKU, attributes, qty × unit price, and line total
3. View source / DevTools → confirm a `<table class="order-items-table">` with `<tbody>` and one `<tr>` per item now renders the section
4. Open an order with attributes/options → confirm they still display under the product name
5. Open an order with no items → "No order items" alert still displays
6. Resize the viewport narrower than 992px → layout remains readable

## Files Changed

| File | What changed |
|------|--------------|
| `administrator/components/com_j2commerce/tmpl/order/view_items.php` | Div soup → semantic `<table>`; `text-muted` → `text-body-secondary` |
| `media/com_j2commerce/css/administrator/admin-order.css` | New `.order-items-table` rules to render `<tr>` rows as bordered cards |
| `administrator/components/com_j2commerce/src/View/Order/HtmlView.php` | CSS asset version bump |
| `administrator/components/com_j2commerce/src/View/Orders/HtmlView.php` | CSS asset version bump |

## Pre-flight

- [x] `php -l` — no syntax errors on all 3 modified PHP files
- [x] No language file changes (no en-US ↔ en-GB sync needed)
- [x] No core controller / model / helper modifications
- [x] All event hooks preserved
- [x] Rebased on latest `upstream/main`
