### PR TITLE
fix(category-wizard): visible keyboard focus outlines

### DIFF
--- a/media/com_j2commerce/css/administrator/category-wizard.css
+++ b/media/com_j2commerce/css/administrator/category-wizard.css
@@ -40,14 +40,23 @@
     box-shadow: 0 0 0 0.15rem rgba(13, 110, 253, 0.2);
 }
 
-/* Keyboard focus ring on card when hidden radio receives focus */
+/* Keyboard focus ring on the card when its hidden radio receives focus.
+   The radio itself is .visually-hidden, so the focus ring must move to
+   the parent label. :has(input:focus-visible) limits the ring to true
+   keyboard focus (Tab); :focus-within is the fallback for any browser
+   without :has() support. (issue #897) */
+.j2c-wizard-card:has(input[type="radio"]:focus-visible),
 .j2c-wizard-card:focus-within {
     border-color: var(--bs-primary, #0d6efd);
+    outline: 2px solid var(--bs-primary, #0d6efd);
+    outline-offset: 2px;
     box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25);
 }
 
-/* Remove focus ring when radio loses focus (mouse click selects differently) */
-.j2c-wizard-card input[type="radio"]:focus:not(:focus-visible) + .j2c-wizard-card-body {
+/* In :has()-capable browsers, suppress the :focus-within ring when the
+   focus came from a mouse click (input is :focus but not :focus-visible). */
+.j2c-wizard-card:has(input[type="radio"]:focus:not(:focus-visible)):not(:has(input[type="radio"]:focus-visible)) {
+    outline: none;
     box-shadow: none;
 }
 
@@ -94,12 +103,22 @@
     justify-content: flex-start;
 }
 
-/* ---- Focus styling (a11y) ---- */
-.j2c-onboarding-footer .btn:focus-visible,
-.j2c-step .btn:focus-visible,
-.j2c-step a.btn:focus-visible,
-.j2c-step button:focus-visible {
+/* ---- Focus styling (a11y) ----
+   Visible 2px outline on every interactive control inside the wizard
+   modal so keyboard users can always see where focus is. (issue #897) */
+#j2commerceCategoryWizardModal .modal-footer .btn:focus-visible,
+#j2commerceCategoryWizardModal .modal-body .btn:focus-visible,
+#j2commerceCategoryWizardModal .btn-close:focus-visible {
     outline: 2px solid var(--bs-primary, var(--primary, #0d6efd)) !important;
     outline-offset: 2px !important;
     box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25) !important;
+}
+
+[data-bs-theme="dark"] #j2commerceCategoryWizardModal .modal-footer .btn:focus-visible,
+[data-bs-theme="dark"] #j2commerceCategoryWizardModal .modal-body .btn:focus-visible,
+[data-bs-theme="dark"] #j2commerceCategoryWizardModal .btn-close:focus-visible,
+[data-bs-theme="dark"] .j2c-wizard-card:has(input[type="radio"]:focus-visible),
+[data-bs-theme="dark"] .j2c-wizard-card:focus-within {
+    outline-color: var(--template-link-color, var(--bs-primary, #0d6efd)) !important;
+    box-shadow: 0 0 0 0.25rem rgba(111, 191, 219, 0.35) !important;
 }


### PR DESCRIPTION
## Summary

Fixes #897

The Category Setup Wizard modal had two accessibility gaps for keyboard users — focus indicators were either missing or far too faint to satisfy WCAG 2.4.7 (Focus Visible). This PR replaces the dead focus-visible selectors with ones that actually match the wizard modal and strengthens the card focus ring.

## Changes

`media/com_j2commerce/css/administrator/category-wizard.css`

1. **Card focus** — `.j2c-wizard-card` (the label that wraps a `.visually-hidden` `<input type="radio">`) now shows a 2px solid outline + box-shadow when its hidden radio receives keyboard focus.
   - Uses `:has(input[type="radio"]:focus-visible)` for true keyboard-only indication
   - Falls back to `:focus-within` for any browser without `:has()`
   - Defensive rule suppresses the ring after a mouse click in `:has()`-capable browsers

2. **Button focus** — replaced the dead `.j2c-onboarding-footer .btn:focus-visible` / `.j2c-step .btn:focus-visible` selectors (those classes belong to the onboarding/setup-guide views, not the wizard modal — copy-paste leftover) with selectors scoped to `#j2commerceCategoryWizardModal`:
   - `.modal-footer .btn:focus-visible` — Back / Next / Create / Done
   - `.modal-body .btn:focus-visible` — Add option / Add category
   - `.btn-close:focus-visible` — modal X button

3. **Dark theme** — added matching dark-theme rules using `--template-link-color` for the outline and the cooler shadow tint, mirroring the existing pattern in `onboarding.css`.

CSS-only change. No PHP, JS, language strings, or DB touch-points. Joomla auto cache-busts the asset via filemtime.

## Testing

1. Admin → **Components → J2Commerce → Dashboard** → click **Category Setup Wizard** (or open it from the Setup Guide widget)
2. Press **Tab** repeatedly through every interactive control:
   - Close (X) button → 2px outline visible
   - Each card option on Step 1 (1 / 2-10 / 11-50 / 50+) → outline + box-shadow on the focused card
   - Back / Next / Create / Done buttons in the footer → outline visible
   - Add option / Add category buttons in later steps → outline visible
3. Verify the focused card outline color matches the primary accent
4. Click a card with the mouse → no focus outline left behind (only the `.selected` highlight)
5. Toggle Joomla admin to dark mode → repeat the tab pass → outline color and shadow match the dark-theme palette

## Files Changed

| File | What changed |
|------|--------------|
| `media/com_j2commerce/css/administrator/category-wizard.css` | Strengthened card focus ring with `:has(...)` + outline; replaced dead focus-visible selectors with wizard-modal-scoped ones; added dark-theme variants |

## Pre-flight

- [x] CSS-only — no PHP / JS / language sync
- [x] No selectors removed that affect any other view (`.j2c-onboarding-footer` / `.j2c-step` are duplicated in `onboarding.css` for those views)
- [x] `:has()` supported in all current browsers (Chrome 105+, Safari 15.4+, Firefox 121+); `:focus-within` fallback covers older
- [x] Rebased on latest `upstream/main`
