### PR TITLE
fix(inventory): remove undefined saveOrder block from list view

### DIFF
--- a/administrator/components/com_j2commerce/tmpl/inventory/default.php
+++ b/administrator/components/com_j2commerce/tmpl/inventory/default.php
@@ -258,7 +258,7 @@ document.addEventListener("DOMContentLoaded", function() {
                                 </th>
                             </tr>
                         </thead>
-                        <tbody <?php if ($saveOrder) : ?> class="js-draggable" data-url="<?php echo $saveOrderingUrl; ?>" data-direction="<?php echo strtolower($listDirn); ?>" <?php endif; ?>>
+                        <tbody>
                             <?php
                             $returnUrl = base64_encode('index.php?option=com_j2commerce&view=inventory');
                             foreach ($this->items as $i => $item) :


### PR DESCRIPTION
## Summary
Fixes #910

The inventory admin list view's `<tbody>` opening tag referenced `$saveOrder` and `$saveOrderingUrl`, but neither variable is ever assigned in this template (unlike `apps/`, `coupons/`, `customfields/`, `emailtemplates/`, etc., which define `$saveOrder = $listOrder == 'a.ordering';` near the top). This produced a PHP `Undefined variable` warning on every inventory page load.

As @brianteeman points out in the issue, inventory has no ordering — there is no `a.ordering` column on the model, no `saveOrderAjax` task on `InventoryController` / `InventoriesController`, and the model's default ordering is `p.j2commerce_product_id`. The drag-reorder block is dead code, so the fix is to delete it.

## Changes
- Replaced the conditional `<tbody <?php if ($saveOrder) : ?> class="js-draggable" data-url="<?php echo $saveOrderingUrl; ?>" data-direction="..." <?php endif; ?>>` opening with a plain `<tbody>` — the conditional was always falsy (PHP coerces undefined to null) so no observable behaviour changes beyond silencing the warning.

## Testing
1. Open `administrator/index.php?option=com_j2commerce&view=inventory`.
2. With PHP error display on (or by tailing the error log), reload the page — verify no `Undefined variable $saveOrder` / `Undefined variable $saveOrderingUrl` warning is emitted.
3. Confirm the inventory list still renders products and variants.
4. Confirm column-header sorting (Product ID, Product Name, SKU, Quantity) still works.
5. Confirm the AJAX Save button on a row still saves quantity / manage-stock / availability changes.

## Files Changed
- `administrator/components/com_j2commerce/tmpl/inventory/default.php` — removed undefined-variable block on the `<tbody>` opening tag (line 261, single-line change)
