### PR TITLE
fix(products): add status filter to admin products list

### DIFF
--- a/administrator/components/com_j2commerce/forms/filter_products.xml
+++ b/administrator/components/com_j2commerce/forms/filter_products.xml
@@ -10,7 +10,17 @@
             inputmode="search"
         />
 
-        <!-- Column-matched filters (in column order: Product ID, Product Type, Price, Visibility) -->
+        <!-- Column-matched filters (in column order: Status, Product ID, Product Type, Price, Visibility) -->
+
+        <field
+            name="state"
+            type="status"
+            label="JOPTION_SELECT_PUBLISHED"
+            optionsFilter="*,-2,0,1,2"
+            class="js-select-submit-on-change"
+        >
+            <option value="">JOPTION_SELECT_PUBLISHED</option>
+        </field>
 
         <field
             name="product_id_from"

--- a/administrator/components/com_j2commerce/src/Model/ProductsModel.php
+++ b/administrator/components/com_j2commerce/src/Model/ProductsModel.php
@@ -286,11 +286,11 @@ class ProductsModel extends ListModel
     {
         $db = $this->getDatabase();
 
-        // Filter by published state
+        // Filter by published state (matches the Joomla content state shown in the Status column)
         $state = $this->getState('filter.state');
         if (is_numeric($state)) {
             $stateInt = (int) $state;
-            $query->where($db->quoteName('a.enabled') . ' = :state')
+            $query->where($db->quoteName('c.state') . ' = :state')
                 ->bind(':state', $stateInt, ParameterType::INTEGER);
         }
 


### PR DESCRIPTION
## Summary
Fixes #912

The products admin list view has a sortable Status column but no matching filter. This adds a column-matched `state` filter using Joomla's standard `type="status"` pattern (the same pattern already used by `filter_countries.xml`) and aligns the existing `ProductsModel::addQueryFilters()` `filter.state` branch to query `c.state` (the Joomla content state shown in the Status column) instead of the legacy `a.enabled` column.

## Changes
- `administrator/components/com_j2commerce/forms/filter_products.xml` — Added `<field name="state" type="status" optionsFilter="*,-2,0,1,2">` in the column-matched filters section. No new language strings (uses core `JOPTION_SELECT_PUBLISHED`).
- `administrator/components/com_j2commerce/src/Model/ProductsModel.php` — Changed the WHERE column from `a.enabled` to `c.state` so the filter matches the displayed and sorted column.

## Audit
Audited all 26 admin list views with a status column. Only `products` was missing a filter; the other 25 (apps, countries, coupons, currencies, customfields, emailtemplates, filtergroups, geozones, invoicetemplates, lengths, manufacturers, options, orders, orderstatuses, paymentmethods, queues, queuelogs, reports, shippingmethods, taxprofiles, taxrates, vendors, vouchers, weights, zones) already have one.

## Testing
1. Open admin → J2Commerce → Products
2. Click **Search Tools** → confirm a new **Select Status** dropdown appears with All / Trashed / Unpublished / Published / Archived options
3. Toggle one product to Unpublished via the status button
4. Pick **Unpublished** in the new filter → only that product remains
5. Pick **Published** → unpublished product disappears
6. Pick **\* (All)** → full list returns

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only

## Files Changed
- `administrator/components/com_j2commerce/forms/filter_products.xml` — added `state` status filter
- `administrator/components/com_j2commerce/src/Model/ProductsModel.php` — aligned filter.state WHERE clause from `a.enabled` to `c.state`