### PR TITLE
fix(sql): drop ADD COLUMN IF NOT EXISTS in 6.2.2-2026-04-30-2.sql (fixes #916)

### DIFF
--- a/administrator/components/com_j2commerce/sql/updates/mysql/6.2.2-2026-04-30-2.sql
+++ b/administrator/components/com_j2commerce/sql/updates/mysql/6.2.2-2026-04-30-2.sql
@@ -13,7 +13,7 @@
 --
 
 ALTER TABLE `#__j2commerce_emailtemplates`
-    ADD COLUMN IF NOT EXISTS `is_default` tinyint NOT NULL DEFAULT 0;
+    ADD COLUMN `is_default` tinyint NOT NULL DEFAULT 0 /** CAN FAIL **/;
 
 UPDATE `#__j2commerce_emailtemplates`
    SET `is_default` = 1


### PR DESCRIPTION
## Summary
Fixes #916

## Changes
- Replaced `ADD COLUMN IF NOT EXISTS` with `ADD COLUMN ... /** CAN FAIL **/` in `6.2.2-2026-04-30-2.sql`.

## Why
Joomla's schema-check parser does not understand MySQL's `ADD COLUMN IF NOT EXISTS` syntax. It tokenises `IF` as the column name, producing the reported DB Fix error:

> Table 'j6_j2commerce_emailtemplates' does not have column 'IF'. (From file 6.2.2-2026-04-30-2.sql.)

The actual ALTER ran successfully on databases that needed it — the column `is_default` exists — but the parser keeps reporting the file as broken.

`/** CAN FAIL **/` is the J2Commerce/Joomla-recognised marker that tells the schema-check engine to tolerate a duplicate-column failure (needed because `install.mysql.utf8.sql:325` already creates `is_default` on fresh installs). Same convention is already used in `6.2.2-2026-04-20.sql` lines 8/11 for the `valid_from` / `valid_to` columns.

## Testing
1. Open admin → System → Maintenance → Database
2. Click "Fix"
3. Verify the `column 'IF'` error on `j6_j2commerce_emailtemplates` is gone and DB status is OK.
4. `SHOW COLUMNS FROM j6_j2commerce_emailtemplates LIKE 'is_default';` still returns one row.

## Files Changed
- `administrator/components/com_j2commerce/sql/updates/mysql/6.2.2-2026-04-30-2.sql` — drop `IF NOT EXISTS`, add `/** CAN FAIL **/` marker