### PR TITLE
fix(assets): conditionally load j2commerce-j2store.css on frontend

### DIFF
--- a/administrator/components/com_j2commerce/src/Helper/StrapperHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/StrapperHelper.php
@@ -768,6 +768,13 @@ class StrapperHelper
         } else {
             $wa->registerAndUseStyle('com_j2commerce.site', 'media/com_j2commerce/css/site/j2commerce.css');
         }
+
+        if (file_exists(JPATH_SITE . '/media/com_j2commerce/css/site/j2commerce-j2store.css')) {
+            $wa->registerAndUseStyle(
+                'com_j2commerce.site.j2store',
+                'media/com_j2commerce/css/site/j2commerce-j2store.css'
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
Fixes #845

Adds an optional compatibility CSS hook so a `j2commerce-j2store.css` file dropped into `media/com_j2commerce/css/site/` is automatically loaded on every frontend view that loads the core J2Commerce CSS. When the file is absent, behaviour is unchanged.

## Changes
- `StrapperHelper::loadCoreCSS()` now performs a `file_exists()` check for `JPATH_SITE/media/com_j2commerce/css/site/j2commerce-j2store.css` after registering the core `j2commerce.css`. If present, it is registered via `registerAndUseStyle()` with the handle `com_j2commerce.site.j2store`.
- Because both `loadFrontendCSS()` and `loadCoreAssets()` route through `loadCoreCSS()`, the optional file loads on all frontend pages that already load the core CSS — products, category, product detail, cart, checkout, my profile, etc.

## Testing
1. Visit any frontend J2Commerce view (e.g. `/index.php?option=com_j2commerce&view=products`). Inspect `<head>` — only `j2commerce.css` should be linked.
2. Create an empty `media/com_j2commerce/css/site/j2commerce-j2store.css`. Reload — both `j2commerce.css` and `j2commerce-j2store.css` should now appear in `<head>` on every frontend J2Commerce view.
3. Delete the file — only `j2commerce.css` should load.

## Files Changed
- `administrator/components/com_j2commerce/src/Helper/StrapperHelper.php` — added the conditional `registerAndUseStyle()` block in `loadCoreCSS()`.

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only
- [x] Rebased on latest `upstream/main`