### PR TITLE
fix(language): remove duplicate admin language keys (fixes #913)

### DIFF
--- a/administrator/components/com_j2commerce/language/en-GB/com_j2commerce.ini
+++ b/administrator/components/com_j2commerce/language/en-GB/com_j2commerce.ini
@@ -387,8 +387,6 @@ COM_J2COMMERCE_VIEW_COUNTRIES="View Countries"
 COM_J2COMMERCE_GEOZONES="Geo Zones"
 COM_J2COMMERCE_GEOZONES_DESC="Manage geographic zones for shipping and tax rules"
 COM_J2COMMERCE_HEADING_GEOZONE_NAME="Geo Zone Name"
-COM_J2COMMERCE_HEADING_GEOZONE_NAME_ASC="Geo Zone Name - Ascending"
-COM_J2COMMERCE_HEADING_GEOZONE_NAME_DESC="Geo Zone Name - Descending"
 
 ; Geo Zones View - Edit
 COM_J2COMMERCE_GEOZONE="Geo Zone"
@@ -688,9 +686,7 @@ COM_J2COMMERCE_FIELD_UPLOAD_MAX_FILES_DESC="Maximum number of files a customer c
 COM_J2COMMERCE_FIELD_UPLOAD_MAX_FILE_SIZE="Max File Size (MB)"
 COM_J2COMMERCE_FIELD_UPLOAD_MAX_FILE_SIZE_DESC="Maximum size per file in megabytes."
 COM_J2COMMERCE_FIELD_UPLOAD_ALLOWED_TYPES="Allowed File Types"
-COM_J2COMMERCE_FIELD_UPLOAD_ALLOWED_TYPES_DESC="Comma-separated list of allowed file extensions (e.g. pdf,jpg,png). Leave empty to allow all types."
 COM_J2COMMERCE_FIELD_UPLOAD_DIRECTORY="Upload Directory"
-COM_J2COMMERCE_FIELD_UPLOAD_DIRECTORY_DESC="Server path relative to the site root where uploaded files will be stored."
 ; Checkout Upload Field - UI Strings
 COM_J2COMMERCE_CHECKOUT_UPLOAD_ACCEPTED_TYPES="Accepted files"
 COM_J2COMMERCE_CHECKOUT_UPLOAD_BROWSE="browse your device"
@@ -751,7 +747,6 @@ COM_J2COMMERCE_FIELDTYPE_TIME="Time"
 COM_J2COMMERCE_FIELDTYPE_DATETIME="Date & Time"
 COM_J2COMMERCE_FIELDTYPE_CUSTOMTEXT="Custom Text"
 COM_J2COMMERCE_FIELDTYPE_TELEPHONE="Telephone"
-COM_J2COMMERCE_FIELDTYPE_MULTIUPLOADER="File Upload (Multi)"
 
 ; Telephone Field
 COM_J2COMMERCE_PHONE_SELECT_COUNTRY="Select country code"
@@ -2792,7 +2787,6 @@ COM_J2COMMERCE_FILTER_SHIPPING_STATUS_DESC="Filter by shipping status"
 ; Filter Groups
 ; ============================================
 COM_J2COMMERCE_FILTERGROUP_FILTERS="Filters"
-COM_J2COMMERCE_FILTERGROUP_FILTERS_DESC="Select the filters for this group"
 COM_J2COMMERCE_FILTERGROUP_GROUP_NAME="Group Name"
 COM_J2COMMERCE_FILTERGROUP_GROUP_NAME_DESC="Enter the name of the filter group"
 COM_J2COMMERCE_FILTERGROUP_NAME_ASC="Group Name - Ascending"
@@ -3487,7 +3481,6 @@ COM_J2COMMERCE_CONTENT_PLUGIN_LINK_TEXT="Content - J2Commerce plugin"
 COM_J2COMMERCE_FEATURE_AVAILABLE_IN_PRODUCT_LAYOUTS_AND_ARTICLES="This feature is available in J2Commerce product layouts and articles"
 
 ; Product Dimensions
-COM_J2COMMERCE_PRODUCT_DIMENSIONS="Dimension (L x W x H)"
 
 ; Product Options
 COM_J2COMMERCE_PRODUCT_OPTION_SAVED_SUCCESSFULLY="Option saved"
@@ -3584,7 +3577,6 @@ COM_J2COMMERCE_PRODUCT_OPTION_CHOOSE_FILE="Choose File"
 ; Frontend Filter Strings
 COM_J2COMMERCE_FILTER_PRODUCTS="Filter Products"
 COM_J2COMMERCE_FILTER_CATEGORY="Category"
-COM_J2COMMERCE_FILTER_PRICE="Price Range"
 COM_J2COMMERCE_FILTER_PRICE_MIN="Min"
 COM_J2COMMERCE_FILTER_PRICE_MAX="Max"
 COM_J2COMMERCE_FILTER_APPLY="Apply Filters"
@@ -3729,7 +3721,6 @@ COM_J2COMMERCE_PRODUCT_USE_ACCORDIONS="Use Accordions"
 COM_J2COMMERCE_PRODUCT_SHOW_PAGE_HEADING="Show Page Heading"
 COM_J2COMMERCE_PRODUCT_SHOW_PAGE_HEADING_DESC="Show the page heading at the top of the product list"
 COM_J2COMMERCE_PRODUCT_SHOW_BACK_BUTTON="Show Back Button"
-COM_J2COMMERCE_PRODUCT_RELATED_COLUMNS_DESC="Number of columns to display related products"
 
 ; Categories Display Settings
 COM_J2COMMERCE_CATEGORIES_DISPLAY="Categories"
@@ -4626,13 +4617,9 @@ COM_J2COMMERCE_ERR_INVALID_FILE_PATH="Invalid file path."
 COM_J2COMMERCE_ERR_FILE_NOT_FOUND="File not found."
 
 ; Multiuploader Custom Field
-COM_J2COMMERCE_FIELDSET_MULTIUPLOADER_OPTIONS="Upload Settings"
 COM_J2COMMERCE_FIELDTYPE_MULTIUPLOADER="File Upload"
 COM_J2COMMERCE_FIELD_UPLOAD_ALLOWED_TYPES_DESC="Comma-separated file extensions (e.g., pdf,jpg,png,doc). Leave empty to allow all types permitted by Joomla Media settings."
 COM_J2COMMERCE_FIELD_UPLOAD_DIRECTORY_DESC="Server directory for uploaded files. Must start with 'images/'. Default: images/checkout-uploads."
-COM_J2COMMERCE_FIELD_UPLOAD_MAX_FILES_DESC="Maximum number of files the customer can upload. Default: 5."
-COM_J2COMMERCE_FIELD_UPLOAD_MAX_FILE_SIZE="Maximum File Size (MB)"
-COM_J2COMMERCE_FIELD_UPLOAD_MAX_FILE_SIZE_DESC="Maximum size per file in megabytes. Default: 10 MB."
 
 ; ==========================================
 ; Onboarding Wizard

--- a/administrator/components/com_j2commerce/language/en-US/com_j2commerce.ini
+++ b/administrator/components/com_j2commerce/language/en-US/com_j2commerce.ini
@@ -387,8 +387,6 @@ COM_J2COMMERCE_VIEW_COUNTRIES="View Countries"
 COM_J2COMMERCE_GEOZONES="Geo Zones"
 COM_J2COMMERCE_GEOZONES_DESC="Manage geographic zones for shipping and tax rules"
 COM_J2COMMERCE_HEADING_GEOZONE_NAME="Geo Zone Name"
-COM_J2COMMERCE_HEADING_GEOZONE_NAME_ASC="Geo Zone Name - Ascending"
-COM_J2COMMERCE_HEADING_GEOZONE_NAME_DESC="Geo Zone Name - Descending"
 
 ; Geo Zones View - Edit
 COM_J2COMMERCE_GEOZONE="Geo Zone"
@@ -688,9 +686,7 @@ COM_J2COMMERCE_FIELD_UPLOAD_MAX_FILES_DESC="Maximum number of files a customer c
 COM_J2COMMERCE_FIELD_UPLOAD_MAX_FILE_SIZE="Max File Size (MB)"
 COM_J2COMMERCE_FIELD_UPLOAD_MAX_FILE_SIZE_DESC="Maximum size per file in megabytes."
 COM_J2COMMERCE_FIELD_UPLOAD_ALLOWED_TYPES="Allowed File Types"
-COM_J2COMMERCE_FIELD_UPLOAD_ALLOWED_TYPES_DESC="Comma-separated list of allowed file extensions (e.g. pdf,jpg,png). Leave empty to allow all types."
 COM_J2COMMERCE_FIELD_UPLOAD_DIRECTORY="Upload Directory"
-COM_J2COMMERCE_FIELD_UPLOAD_DIRECTORY_DESC="Server path relative to the site root where uploaded files will be stored."
 ; Checkout Upload Field - UI Strings
 COM_J2COMMERCE_CHECKOUT_UPLOAD_ACCEPTED_TYPES="Accepted files"
 COM_J2COMMERCE_CHECKOUT_UPLOAD_BROWSE="browse your device"
@@ -751,7 +747,6 @@ COM_J2COMMERCE_FIELDTYPE_TIME="Time"
 COM_J2COMMERCE_FIELDTYPE_DATETIME="Date & Time"
 COM_J2COMMERCE_FIELDTYPE_CUSTOMTEXT="Custom Text"
 COM_J2COMMERCE_FIELDTYPE_TELEPHONE="Telephone"
-COM_J2COMMERCE_FIELDTYPE_MULTIUPLOADER="File Upload (Multi)"
 
 ; Telephone Field
 COM_J2COMMERCE_PHONE_SELECT_COUNTRY="Select country code"
@@ -2797,7 +2792,6 @@ COM_J2COMMERCE_FILTER_SHIPPING_STATUS_DESC="Filter by shipping status"
 ; Filter Groups
 ; ============================================
 COM_J2COMMERCE_FILTERGROUP_FILTERS="Filters"
-COM_J2COMMERCE_FILTERGROUP_FILTERS_DESC="Select the filters for this group"
 COM_J2COMMERCE_FILTERGROUP_GROUP_NAME="Group Name"
 COM_J2COMMERCE_FILTERGROUP_GROUP_NAME_DESC="Enter the name of the filter group"
 COM_J2COMMERCE_FILTERGROUP_NAME_ASC="Group Name - Ascending"
@@ -3519,7 +3513,6 @@ COM_J2COMMERCE_CONTENT_PLUGIN_LINK_TEXT="Content - J2Commerce plugin"
 COM_J2COMMERCE_FEATURE_AVAILABLE_IN_PRODUCT_LAYOUTS_AND_ARTICLES="This feature is available in J2Commerce product layouts and articles"
 
 ; Product Dimensions
-COM_J2COMMERCE_PRODUCT_DIMENSIONS="Dimension (L x W x H)"
 
 ; Product Options
 COM_J2COMMERCE_PRODUCT_OPTION_SAVED_SUCCESSFULLY="Option saved"
@@ -3618,7 +3611,6 @@ COM_J2COMMERCE_PRODUCT_OPTION_CHOOSE_FILE="Choose File"
 ; Frontend Filter Strings
 COM_J2COMMERCE_FILTER_PRODUCTS="Filter Products"
 COM_J2COMMERCE_FILTER_CATEGORY="Category"
-COM_J2COMMERCE_FILTER_PRICE="Price Range"
 COM_J2COMMERCE_FILTER_PRICE_MIN="Min"
 COM_J2COMMERCE_FILTER_PRICE_MAX="Max"
 COM_J2COMMERCE_FILTER_APPLY="Apply Filters"
@@ -3763,7 +3755,6 @@ COM_J2COMMERCE_PRODUCT_USE_ACCORDIONS="Use Accordions"
 COM_J2COMMERCE_PRODUCT_SHOW_PAGE_HEADING="Show Page Heading"
 COM_J2COMMERCE_PRODUCT_SHOW_PAGE_HEADING_DESC="Show the page heading at the top of the product list"
 COM_J2COMMERCE_PRODUCT_SHOW_BACK_BUTTON="Show Back Button"
-COM_J2COMMERCE_PRODUCT_RELATED_COLUMNS_DESC="Number of columns to display related products"
 
 ; Categories Display Settings
 COM_J2COMMERCE_CATEGORIES_DISPLAY="Categories"
@@ -4683,16 +4674,12 @@ COM_J2COMMERCE_CHECKOUT_UPLOAD_REMOVE="Remove"
 COM_J2COMMERCE_CHECKOUT_UPLOAD_REQUIRED="Please upload at least one file"
 COM_J2COMMERCE_CHECKOUT_UPLOAD_TYPE_NOT_ALLOWED="File type not allowed"
 COM_J2COMMERCE_CHECKOUT_UPLOAD_UPLOADING="Uploading..."
-COM_J2COMMERCE_FIELDSET_MULTIUPLOADER_OPTIONS="Upload Settings"
 COM_J2COMMERCE_FIELDTYPE_MULTIUPLOADER="File Upload"
 COM_J2COMMERCE_FIELD_UPLOAD_ALLOWED_TYPES="Allowed File Types"
 COM_J2COMMERCE_FIELD_UPLOAD_ALLOWED_TYPES_DESC="Comma-separated file extensions (e.g., pdf,jpg,png,doc). Leave empty to allow all types permitted by Joomla Media settings."
 COM_J2COMMERCE_FIELD_UPLOAD_DIRECTORY="Upload Directory"
 COM_J2COMMERCE_FIELD_UPLOAD_DIRECTORY_DESC="Server directory for uploaded files. Must start with 'images/'. Default: images/checkout-uploads."
 COM_J2COMMERCE_FIELD_UPLOAD_MAX_FILES="Maximum Files"
-COM_J2COMMERCE_FIELD_UPLOAD_MAX_FILES_DESC="Maximum number of files the customer can upload. Default: 5."
-COM_J2COMMERCE_FIELD_UPLOAD_MAX_FILE_SIZE="Maximum File Size (MB)"
-COM_J2COMMERCE_FIELD_UPLOAD_MAX_FILE_SIZE_DESC="Maximum size per file in megabytes. Default: 10 MB."
 COM_J2COMMERCE_ORDER_DOWNLOAD_FILE="Download"
 COM_J2COMMERCE_ORDER_UPLOADED_FILES="Uploaded Files"
 

--- a/administrator/language/en-GB/com_j2commerce.ini
+++ b/administrator/language/en-GB/com_j2commerce.ini
@@ -387,8 +387,6 @@ COM_J2COMMERCE_VIEW_COUNTRIES="View Countries"
 COM_J2COMMERCE_GEOZONES="Geo Zones"
 COM_J2COMMERCE_GEOZONES_DESC="Manage geographic zones for shipping and tax rules"
 COM_J2COMMERCE_HEADING_GEOZONE_NAME="Geo Zone Name"
-COM_J2COMMERCE_HEADING_GEOZONE_NAME_ASC="Geo Zone Name - Ascending"
-COM_J2COMMERCE_HEADING_GEOZONE_NAME_DESC="Geo Zone Name - Descending"
 
 ; Geo Zones View - Edit
 COM_J2COMMERCE_GEOZONE="Geo Zone"
@@ -688,9 +686,7 @@ COM_J2COMMERCE_FIELD_UPLOAD_MAX_FILES_DESC="Maximum number of files a customer c
 COM_J2COMMERCE_FIELD_UPLOAD_MAX_FILE_SIZE="Max File Size (MB)"
 COM_J2COMMERCE_FIELD_UPLOAD_MAX_FILE_SIZE_DESC="Maximum size per file in megabytes."
 COM_J2COMMERCE_FIELD_UPLOAD_ALLOWED_TYPES="Allowed File Types"
-COM_J2COMMERCE_FIELD_UPLOAD_ALLOWED_TYPES_DESC="Comma-separated list of allowed file extensions (e.g. pdf,jpg,png). Leave empty to allow all types."
 COM_J2COMMERCE_FIELD_UPLOAD_DIRECTORY="Upload Directory"
-COM_J2COMMERCE_FIELD_UPLOAD_DIRECTORY_DESC="Server path relative to the site root where uploaded files will be stored."
 ; Checkout Upload Field - UI Strings
 COM_J2COMMERCE_CHECKOUT_UPLOAD_ACCEPTED_TYPES="Accepted files"
 COM_J2COMMERCE_CHECKOUT_UPLOAD_BROWSE="browse your device"
@@ -751,7 +747,6 @@ COM_J2COMMERCE_FIELDTYPE_TIME="Time"
 COM_J2COMMERCE_FIELDTYPE_DATETIME="Date & Time"
 COM_J2COMMERCE_FIELDTYPE_CUSTOMTEXT="Custom Text"
 COM_J2COMMERCE_FIELDTYPE_TELEPHONE="Telephone"
-COM_J2COMMERCE_FIELDTYPE_MULTIUPLOADER="File Upload (Multi)"
 
 ; Telephone Field
 COM_J2COMMERCE_PHONE_SELECT_COUNTRY="Select country code"
@@ -2792,7 +2787,6 @@ COM_J2COMMERCE_FILTER_SHIPPING_STATUS_DESC="Filter by shipping status"
 ; Filter Groups
 ; ============================================
 COM_J2COMMERCE_FILTERGROUP_FILTERS="Filters"
-COM_J2COMMERCE_FILTERGROUP_FILTERS_DESC="Select the filters for this group"
 COM_J2COMMERCE_FILTERGROUP_GROUP_NAME="Group Name"
 COM_J2COMMERCE_FILTERGROUP_GROUP_NAME_DESC="Enter the name of the filter group"
 COM_J2COMMERCE_FILTERGROUP_NAME_ASC="Group Name - Ascending"
@@ -3487,7 +3481,6 @@ COM_J2COMMERCE_CONTENT_PLUGIN_LINK_TEXT="Content - J2Commerce plugin"
 COM_J2COMMERCE_FEATURE_AVAILABLE_IN_PRODUCT_LAYOUTS_AND_ARTICLES="This feature is available in J2Commerce product layouts and articles"
 
 ; Product Dimensions
-COM_J2COMMERCE_PRODUCT_DIMENSIONS="Dimension (L x W x H)"
 
 ; Product Options
 COM_J2COMMERCE_PRODUCT_OPTION_SAVED_SUCCESSFULLY="Option saved"
@@ -3584,7 +3577,6 @@ COM_J2COMMERCE_PRODUCT_OPTION_CHOOSE_FILE="Choose File"
 ; Frontend Filter Strings
 COM_J2COMMERCE_FILTER_PRODUCTS="Filter Products"
 COM_J2COMMERCE_FILTER_CATEGORY="Category"
-COM_J2COMMERCE_FILTER_PRICE="Price Range"
 COM_J2COMMERCE_FILTER_PRICE_MIN="Min"
 COM_J2COMMERCE_FILTER_PRICE_MAX="Max"
 COM_J2COMMERCE_FILTER_APPLY="Apply Filters"
@@ -3729,7 +3721,6 @@ COM_J2COMMERCE_PRODUCT_USE_ACCORDIONS="Use Accordions"
 COM_J2COMMERCE_PRODUCT_SHOW_PAGE_HEADING="Show Page Heading"
 COM_J2COMMERCE_PRODUCT_SHOW_PAGE_HEADING_DESC="Show the page heading at the top of the product list"
 COM_J2COMMERCE_PRODUCT_SHOW_BACK_BUTTON="Show Back Button"
-COM_J2COMMERCE_PRODUCT_RELATED_COLUMNS_DESC="Number of columns to display related products"
 
 ; Categories Display Settings
 COM_J2COMMERCE_CATEGORIES_DISPLAY="Categories"
@@ -4626,13 +4617,9 @@ COM_J2COMMERCE_ERR_INVALID_FILE_PATH="Invalid file path."
 COM_J2COMMERCE_ERR_FILE_NOT_FOUND="File not found."
 
 ; Multiuploader Custom Field
-COM_J2COMMERCE_FIELDSET_MULTIUPLOADER_OPTIONS="Upload Settings"
 COM_J2COMMERCE_FIELDTYPE_MULTIUPLOADER="File Upload"
 COM_J2COMMERCE_FIELD_UPLOAD_ALLOWED_TYPES_DESC="Comma-separated file extensions (e.g., pdf,jpg,png,doc). Leave empty to allow all types permitted by Joomla Media settings."
 COM_J2COMMERCE_FIELD_UPLOAD_DIRECTORY_DESC="Server directory for uploaded files. Must start with 'images/'. Default: images/checkout-uploads."
-COM_J2COMMERCE_FIELD_UPLOAD_MAX_FILES_DESC="Maximum number of files the customer can upload. Default: 5."
-COM_J2COMMERCE_FIELD_UPLOAD_MAX_FILE_SIZE="Maximum File Size (MB)"
-COM_J2COMMERCE_FIELD_UPLOAD_MAX_FILE_SIZE_DESC="Maximum size per file in megabytes. Default: 10 MB."
 
 ; ==========================================
 ; Onboarding Wizard

--- a/administrator/language/en-US/com_j2commerce.ini
+++ b/administrator/language/en-US/com_j2commerce.ini
@@ -387,8 +387,6 @@ COM_J2COMMERCE_VIEW_COUNTRIES="View Countries"
 COM_J2COMMERCE_GEOZONES="Geo Zones"
 COM_J2COMMERCE_GEOZONES_DESC="Manage geographic zones for shipping and tax rules"
 COM_J2COMMERCE_HEADING_GEOZONE_NAME="Geo Zone Name"
-COM_J2COMMERCE_HEADING_GEOZONE_NAME_ASC="Geo Zone Name - Ascending"
-COM_J2COMMERCE_HEADING_GEOZONE_NAME_DESC="Geo Zone Name - Descending"
 
 ; Geo Zones View - Edit
 COM_J2COMMERCE_GEOZONE="Geo Zone"
@@ -688,9 +686,7 @@ COM_J2COMMERCE_FIELD_UPLOAD_MAX_FILES_DESC="Maximum number of files a customer c
 COM_J2COMMERCE_FIELD_UPLOAD_MAX_FILE_SIZE="Max File Size (MB)"
 COM_J2COMMERCE_FIELD_UPLOAD_MAX_FILE_SIZE_DESC="Maximum size per file in megabytes."
 COM_J2COMMERCE_FIELD_UPLOAD_ALLOWED_TYPES="Allowed File Types"
-COM_J2COMMERCE_FIELD_UPLOAD_ALLOWED_TYPES_DESC="Comma-separated list of allowed file extensions (e.g. pdf,jpg,png). Leave empty to allow all types."
 COM_J2COMMERCE_FIELD_UPLOAD_DIRECTORY="Upload Directory"
-COM_J2COMMERCE_FIELD_UPLOAD_DIRECTORY_DESC="Server path relative to the site root where uploaded files will be stored."
 ; Checkout Upload Field - UI Strings
 COM_J2COMMERCE_CHECKOUT_UPLOAD_ACCEPTED_TYPES="Accepted files"
 COM_J2COMMERCE_CHECKOUT_UPLOAD_BROWSE="browse your device"
@@ -751,7 +747,6 @@ COM_J2COMMERCE_FIELDTYPE_TIME="Time"
 COM_J2COMMERCE_FIELDTYPE_DATETIME="Date & Time"
 COM_J2COMMERCE_FIELDTYPE_CUSTOMTEXT="Custom Text"
 COM_J2COMMERCE_FIELDTYPE_TELEPHONE="Telephone"
-COM_J2COMMERCE_FIELDTYPE_MULTIUPLOADER="File Upload (Multi)"
 
 ; Telephone Field
 COM_J2COMMERCE_PHONE_SELECT_COUNTRY="Select country code"
@@ -2797,7 +2792,6 @@ COM_J2COMMERCE_FILTER_SHIPPING_STATUS_DESC="Filter by shipping status"
 ; Filter Groups
 ; ============================================
 COM_J2COMMERCE_FILTERGROUP_FILTERS="Filters"
-COM_J2COMMERCE_FILTERGROUP_FILTERS_DESC="Select the filters for this group"
 COM_J2COMMERCE_FILTERGROUP_GROUP_NAME="Group Name"
 COM_J2COMMERCE_FILTERGROUP_GROUP_NAME_DESC="Enter the name of the filter group"
 COM_J2COMMERCE_FILTERGROUP_NAME_ASC="Group Name - Ascending"
@@ -3519,7 +3513,6 @@ COM_J2COMMERCE_CONTENT_PLUGIN_LINK_TEXT="Content - J2Commerce plugin"
 COM_J2COMMERCE_FEATURE_AVAILABLE_IN_PRODUCT_LAYOUTS_AND_ARTICLES="This feature is available in J2Commerce product layouts and articles"
 
 ; Product Dimensions
-COM_J2COMMERCE_PRODUCT_DIMENSIONS="Dimension (L x W x H)"
 
 ; Product Options
 COM_J2COMMERCE_PRODUCT_OPTION_SAVED_SUCCESSFULLY="Option saved"
@@ -3618,7 +3611,6 @@ COM_J2COMMERCE_PRODUCT_OPTION_CHOOSE_FILE="Choose File"
 ; Frontend Filter Strings
 COM_J2COMMERCE_FILTER_PRODUCTS="Filter Products"
 COM_J2COMMERCE_FILTER_CATEGORY="Category"
-COM_J2COMMERCE_FILTER_PRICE="Price Range"
 COM_J2COMMERCE_FILTER_PRICE_MIN="Min"
 COM_J2COMMERCE_FILTER_PRICE_MAX="Max"
 COM_J2COMMERCE_FILTER_APPLY="Apply Filters"
@@ -3763,7 +3755,6 @@ COM_J2COMMERCE_PRODUCT_USE_ACCORDIONS="Use Accordions"
 COM_J2COMMERCE_PRODUCT_SHOW_PAGE_HEADING="Show Page Heading"
 COM_J2COMMERCE_PRODUCT_SHOW_PAGE_HEADING_DESC="Show the page heading at the top of the product list"
 COM_J2COMMERCE_PRODUCT_SHOW_BACK_BUTTON="Show Back Button"
-COM_J2COMMERCE_PRODUCT_RELATED_COLUMNS_DESC="Number of columns to display related products"
 
 ; Categories Display Settings
 COM_J2COMMERCE_CATEGORIES_DISPLAY="Categories"
@@ -4683,16 +4674,12 @@ COM_J2COMMERCE_CHECKOUT_UPLOAD_REMOVE="Remove"
 COM_J2COMMERCE_CHECKOUT_UPLOAD_REQUIRED="Please upload at least one file"
 COM_J2COMMERCE_CHECKOUT_UPLOAD_TYPE_NOT_ALLOWED="File type not allowed"
 COM_J2COMMERCE_CHECKOUT_UPLOAD_UPLOADING="Uploading..."
-COM_J2COMMERCE_FIELDSET_MULTIUPLOADER_OPTIONS="Upload Settings"
 COM_J2COMMERCE_FIELDTYPE_MULTIUPLOADER="File Upload"
 COM_J2COMMERCE_FIELD_UPLOAD_ALLOWED_TYPES="Allowed File Types"
 COM_J2COMMERCE_FIELD_UPLOAD_ALLOWED_TYPES_DESC="Comma-separated file extensions (e.g., pdf,jpg,png,doc). Leave empty to allow all types permitted by Joomla Media settings."
 COM_J2COMMERCE_FIELD_UPLOAD_DIRECTORY="Upload Directory"
 COM_J2COMMERCE_FIELD_UPLOAD_DIRECTORY_DESC="Server directory for uploaded files. Must start with 'images/'. Default: images/checkout-uploads."
 COM_J2COMMERCE_FIELD_UPLOAD_MAX_FILES="Maximum Files"
-COM_J2COMMERCE_FIELD_UPLOAD_MAX_FILES_DESC="Maximum number of files the customer can upload. Default: 5."
-COM_J2COMMERCE_FIELD_UPLOAD_MAX_FILE_SIZE="Maximum File Size (MB)"
-COM_J2COMMERCE_FIELD_UPLOAD_MAX_FILE_SIZE_DESC="Maximum size per file in megabytes. Default: 10 MB."
 COM_J2COMMERCE_ORDER_DOWNLOAD_FILE="Download"
 COM_J2COMMERCE_ORDER_UPLOADED_FILES="Uploaded Files"
 


### PR DESCRIPTION
Removed 13 duplicate string definitions from the admin com_j2commerce.ini files (canonical and mirror, en-US and en-GB) so each key is defined exactly once with the canonical value:

- COM_J2COMMERCE_HEADING_GEOZONE_NAME_ASC / _DESC
- COM_J2COMMERCE_FIELDSET_MULTIUPLOADER_OPTIONS
- COM_J2COMMERCE_FIELD_UPLOAD_MAX_FILES_DESC
- COM_J2COMMERCE_FIELD_UPLOAD_MAX_FILE_SIZE / _DESC
- COM_J2COMMERCE_FIELD_UPLOAD_ALLOWED_TYPES_DESC
- COM_J2COMMERCE_FIELD_UPLOAD_DIRECTORY_DESC
- COM_J2COMMERCE_FIELDTYPE_MULTIUPLOADER
- COM_J2COMMERCE_PRODUCT_DIMENSIONS
- COM_J2COMMERCE_PRODUCT_RELATED_COLUMNS_DESC
- COM_J2COMMERCE_FILTERGROUP_FILTERS_DESC
- COM_J2COMMERCE_FILTER_PRICE

Same 13 keys removed from en-US and en-GB so locale parity is preserved (no new entries in the language sync report).