### PR TITLE
fix(core): ModulesHelper loadPosition silent failure + missing chrome

### DIFF
--- a/administrator/components/com_j2commerce/src/Helper/ModulesHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/ModulesHelper.php
@@ -14,7 +14,7 @@ namespace J2Commerce\Component\J2commerce\Administrator\Helper;
 
 \defined('_JEXEC') or die;
 
-use Joomla\CMS\Document\DocumentInterface;
+use Joomla\CMS\Document\HtmlDocument;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\ModuleHelper;
 
@@ -61,31 +61,30 @@ class ModulesHelper
      * and renders them using the specified style.
      *
      * @param   string  $position  The module position name (e.g., 'j2commerce-product-top').
-     * @param   string  $style     The module chrome style (default: 'xhtml').
-     *                             Common styles: 'none', 'xhtml', 'html5', 'card', 'outline'.
+     * @param   string  $style     The module chrome style (default: 'html5').
+     *                             Joomla 6 chromes: 'none', 'html5', 'outline', 'table'.
+     *                             Cassiopeia adds: 'card', 'noCard'.
      *
      * @return  string  The rendered HTML output of all modules in the position.
      *
      * @since   6.0.0
      *
      * @example
-     * // Load modules from 'j2commerce-cart-below' position with default xhtml style
+     * // Load modules from 'j2commerce-cart-below' position with default html5 style
      * $cartModules = ModulesHelper::loadPosition('j2commerce-cart-below');
      *
      * // Load modules with card chrome style
      * $sidebarModules = ModulesHelper::loadPosition('j2commerce-sidebar', 'card');
      */
-    public static function loadPosition(string $position, string $style = 'xhtml'): string
+    public static function loadPosition(string $position, string $style = 'html5'): string
     {
         if (empty($position)) {
             return '';
         }
 
-        $app      = Factory::getApplication();
-        $document = $app->getDocument();
+        $document = Factory::getApplication()->getDocument();
 
-        // Only process for HTML documents
-        if (!$document instanceof DocumentInterface || $document->getType() !== 'html') {
+        if (!$document instanceof HtmlDocument) {
             return '';
         }
 
@@ -93,9 +92,7 @@ class ModulesHelper
         $params   = ['style' => $style];
         $contents = '';
 
-        $modules = ModuleHelper::getModules($position);
-
-        foreach ($modules as $module) {
+        foreach (ModuleHelper::getModules($position) as $module) {
             $contents .= $renderer->render($module, $params);
         }
 
@@ -174,7 +171,7 @@ class ModulesHelper
      * regardless of its position assignment.
      *
      * @param   string  $name   The module name/title to load.
-     * @param   string  $style  The module chrome style (default: 'xhtml').
+     * @param   string  $style  The module chrome style (default: 'html5').
      *
      * @return  string  The rendered HTML output of the module, or empty string if not found.
      *
@@ -184,17 +181,15 @@ class ModulesHelper
      * // Load a specific module by name
      * $miniCart = ModulesHelper::loadModule('J2Commerce Mini Cart', 'none');
      */
-    public static function loadModule(string $name, string $style = 'xhtml'): string
+    public static function loadModule(string $name, string $style = 'html5'): string
     {
         if (empty($name)) {
             return '';
         }
 
-        $app      = Factory::getApplication();
-        $document = $app->getDocument();
+        $document = Factory::getApplication()->getDocument();
 
-        // Only process for HTML documents
-        if (!$document instanceof DocumentInterface || $document->getType() !== 'html') {
+        if (!$document instanceof HtmlDocument) {
             return '';
         }
 
@@ -291,17 +286,17 @@ class ModulesHelper
     public static function getJ2CommercePositions(): array
     {
         return [
-            'j2commerce-product-top'     => 'Above product details',
-            'j2commerce-product-bottom'  => 'Below product details',
-            'j2commerce-product-sidebar' => 'Product page sidebar',
-            'j2commerce-cart-top'        => 'Above cart contents',
-            'j2commerce-cart-bottom'     => 'Below cart contents',
-            'j2commerce-checkout-top'    => 'Above checkout form',
-            'j2commerce-checkout-bottom' => 'Below checkout form',
-            'j2commerce-category-top'    => 'Above category listing',
-            'j2commerce-category-bottom' => 'Below category listing',
-            'j2commerce-order-top'       => 'Above order details',
-            'j2commerce-order-bottom'    => 'Below order details',
+            'j2commerce-categories-top'      => 'Above categories listing',
+            'j2commerce-categories-middle'   => 'Between categories sections',
+            'j2commerce-categories-bottom'   => 'Below categories listing',
+            'j2commerce-product-list-top'    => 'Above product list (products view)',
+            'j2commerce-product-list-bottom' => 'Below product list (products view)',
+            'j2commerce-filter-left-top'     => 'Above left-hand filter sidebar',
+            'j2commerce-filter-left-bottom'  => 'Below left-hand filter sidebar',
+            'j2commerce-filter-right-top'    => 'Above right-hand filter sidebar',
+            'j2commerce-filter-right-bottom' => 'Below right-hand filter sidebar',
+            'j2commerce-single-product-top'    => 'Above single product detail',
+            'j2commerce-single-product-bottom' => 'Below single product detail',
         ];
     }
 }


### PR DESCRIPTION
## Core Update

Two bugs in `administrator/components/com_j2commerce/src/Helper/ModulesHelper.php` that caused **every** J2Commerce module position to render empty: `j2commerce-categories-top`, `-middle`, `-bottom`, `product-list-*`, `filter-*`, `single-product-*`.

### Changes

#### 1. `instanceof DocumentInterface` check was always false

`Joomla\CMS\Document\DocumentInterface` **does not exist** in Joomla 6 — only `DocumentAwareInterface` and `FactoryInterface` live in that namespace. PHP's `instanceof` against a non-existent class silently returns false (no fatal, no warning, no notice), so the guard

```php
if (!$document instanceof DocumentInterface || $document->getType() !== 'html') {
    return '';
}
```

was always true and the helper bailed before ever calling `ModuleHelper::getModules()`. Replaced with `HtmlDocument` instanceof check.

#### 2. Default chrome style `'xhtml'` was removed in Joomla 4+

`ModuleHelper::renderModule` resolves chromes via:

```php
LayoutHelper::render('chromes.' . $style, $displayData, $basePath);
```

`chromes/xhtml.php` was removed in J4. With `$style = 'xhtml'` the lookup returned `false` and `$module->content` stayed raw — no `<div class="moduletable">` wrapper, no `<h3>` title, no `moduleclass_sfx`. Default changed to `'html5'` (the J6 analog from `libraries/layouts/chromes/html5.php`):
- `<div class="moduletable {moduleclass_sfx}">` wrapper
- Configurable `module_tag` (`div`/`section`/etc.)
- `bootstrap_size` → `col-md-N`
- `header_tag` / `header_class` for title
- `showtitle` honored
- A11y: `aria-labelledby` / `aria-label` on non-div tags

Module's own **Advanced → Module Style** param still overrides via line 182 of `ModuleHelper::renderModule`, so site builders can pin a specific chrome per module.

Both fixes also applied to `loadModule()`.

### Files Modified

| Type | Count |
|------|-------|
| PHP files | 1 |

### Pre-Flight

- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] No JFactory references
- [x] Core files only

### Verification

Tested live on `https://localhost/joomla6/shop-categories` with a published mod_custom assigned to `j2commerce-categories-top`:

- **Before fix:** module silently absent (early return)
- **After fix #1:** module body renders, but no chrome wrapper / no title (`xhtml` chrome missing)
- **After fix #2:** module renders with full `<div class="moduletable"><h3>Title</h3>content</div>` wrapper and honors all module params