### PR TITLE
fix(core): correct bootstrap.collapse vendor path in bootstrap5 accordion view

### DIFF
--- a/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/view_accordions.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/view_accordions.php
@@ -28,7 +28,7 @@ if ($wa->assetExists('script', 'bootstrap.esm')) {
     $deps[] = 'bootstrap.bundle';
 }
 
-$wa->registerAndUseScript('bootstrap.collapse',Uri::base().'media/com_j2commerce/js/site/vendor/bootstrap/collapse.min.js',[],['type' => 'module'],$deps);
+$wa->registerAndUseScript('bootstrap.collapse',Uri::base().'media/com_j2commerce/vendor/bootstrap/collapse.min.js',[],['type' => 'module'],$deps);
 HTMLHelper::_('bootstrap.collapse', '.accordion-button', []);
 $hasShortDesc = $this->params->get('item_show_sdesc', 1) && !empty(trim(strip_tags($this->product->product_short_desc ?? '')));
 $hasLongDesc  = $this->params->get('item_show_ldesc', 1) && !empty(trim(strip_tags($this->product->product_long_desc ?? '')));


### PR DESCRIPTION
## Core Update

### Changes
- `plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/view_accordions.php`: vendor path corrected from `media/com_j2commerce/js/site/vendor/bootstrap/collapse.min.js` to `media/com_j2commerce/vendor/bootstrap/collapse.min.js` to match actual asset location.

### Files Modified
| Type | Count |
|------|-------|
| PHP files | 1 |

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only (non-core excluded)