### PR TITLE
fix(layout): tag list AJAX broken by subtemplate alias mismap (fixes #932)

### DIFF
--- a/components/com_j2commerce/src/Service/ProductLayoutService.php
+++ b/components/com_j2commerce/src/Service/ProductLayoutService.php
@@ -198,10 +198,7 @@ final class ProductLayoutService
 
     public static function setSubtemplateOverride(string $subtemplate): void
     {
-        // Accept both element names (app_bootstrap5) and short names (bootstrap5)
-        self::$subtemplateOverride = str_starts_with($subtemplate, 'app_')
-            ? $subtemplate
-            : 'app_' . $subtemplate;
+        self::$subtemplateOverride = self::mapSubtemplateToPluginFolder($subtemplate);
     }
 
     public static function clearSubtemplateOverride(): void
@@ -227,13 +224,27 @@ final class ProductLayoutService
             $subtemplate = 'bootstrap5';
         }
 
-        $folder = match ($subtemplate) {
-            'tag_bootstrap5', 'bootstrap5' => 'app_bootstrap5',
-            'uikit'                        => 'app_uikit',
-            default                        => 'app_' . $subtemplate,
-        };
+        $folder = self::mapSubtemplateToPluginFolder($subtemplate);
 
         return $folder;
+    }
+
+    /**
+     * Resolve a subtemplate name to its owning plugin element folder.
+     * Accepts plugin element names (app_bootstrap5), short names (bootstrap5),
+     * and view-scoped aliases (tag_bootstrap5, tag_uikit) the matching plugin handles.
+     */
+    private static function mapSubtemplateToPluginFolder(string $subtemplate): string
+    {
+        if (str_starts_with($subtemplate, 'app_')) {
+            $subtemplate = substr($subtemplate, 4);
+        }
+
+        return match ($subtemplate) {
+            'bootstrap5', 'tag_bootstrap5' => 'app_bootstrap5',
+            'uikit', 'tag_uikit'           => 'app_uikit',
+            default                        => 'app_' . $subtemplate,
+        };
     }
 
     private static function getImageWidth(Registry $params, string $context): int


### PR DESCRIPTION
## Summary
Fixes #932 — Ajax broken on Tags list view.

## Root cause
`ProductLayoutService::setSubtemplateOverride()` prepended `app_` to whatever it received. Tag menus store `subtemplate=tag_bootstrap5`, so the override resolved to the non-existent `app_tag_bootstrap5` plugin folder. `FileLayout` found no include paths and returned an empty string per item — AJAX filter / search / pagination on producttags views returned empty `<div class="col-md-4"></div>` wrappers and products vanished.

`resolvePluginFolder()` already had the alias mapping (`tag_bootstrap5 → app_bootstrap5`) but only on its global-config branch; the override branch returned the override verbatim and bypassed it.

Initial PHP render works because the bootstrap5 plugin renders the producttags page directly without ever calling `setSubtemplateOverride()` — the override branch is only hit via the AJAX `products.filter` controller and the two product modules' dispatchers.

## Changes
- Centralised the subtemplate→plugin-folder mapping in a new private `mapSubtemplateToPluginFolder()` helper.
- `setSubtemplateOverride()` and `resolvePluginFolder()` both route through the helper (DRY).
- Helper handles `app_*` prefixed names, short names (`bootstrap5`, `uikit`), and view-scoped aliases (`tag_bootstrap5`, `tag_uikit`).

## Files Changed
- `components/com_j2commerce/src/Service/ProductLayoutService.php` — new mapping helper + reuse on both branches.

## Testing
1. Open a producttags menu with `subtemplate=tag_bootstrap5` and multiple paginated pages of products.
2. Click a pagination link → product list updates via AJAX.
3. Type in the search box / tick a sidebar filter checkbox → filtered products appear without page reload.
4. Regression: same flow on a category list view (`subtemplate=bootstrap5`) still works.
5. (Optional) Same flow on a `tag_uikit` platform site if available.

Verified locally on `/dark-chocolate-tag-view`: AJAX endpoint now returns ~5 KB of populated product HTML containing `j2commerce-product-item`. Before the fix the same endpoint returned an empty `col-md-4` wrapper.