### PR TITLE
fix(helpers): allow null $unit in Length/Weight format methods

### DIFF
--- a/administrator/components/com_j2commerce/src/Helper/LengthHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/LengthHelper.php
@@ -440,7 +440,7 @@ class LengthHelper
      *
      * @since   6.0.0
      */
-    public static function formatValue(mixed $value, string $unit = '', ?int $lengthClassId = null): string
+    public static function formatValue(mixed $value, ?string $unit = '', ?int $lengthClassId = null): string
     {
         $floatValue = (float) $value;
         $decimals   = self::getDecimalPlaces($lengthClassId);
@@ -467,7 +467,7 @@ class LengthHelper
      *
      * @since   6.0.0
      */
-    public static function formatDimensions(mixed $length, mixed $width, mixed $height, string $unit = '', ?int $lengthClassId = null): string
+    public static function formatDimensions(mixed $length, mixed $width, mixed $height, ?string $unit = '', ?int $lengthClassId = null): string
     {
         $formatted = self::formatValue($length, '', $lengthClassId) . ' x ' . self::formatValue($width, '', $lengthClassId) . ' x ' . self::formatValue($height, '', $lengthClassId);
 

--- a/administrator/components/com_j2commerce/src/Helper/WeightHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/WeightHelper.php
@@ -419,7 +419,7 @@ class WeightHelper
      *
      * @since   6.0.0
      */
-    public static function formatValue(mixed $value, string $unit = '', ?int $weightClassId = null): string
+    public static function formatValue(mixed $value, ?string $unit = '', ?int $weightClassId = null): string
     {
         $floatValue = (float) $value;
         $decimals   = self::getDecimalPlaces($weightClassId);


### PR DESCRIPTION
## Core Update

### Changes
Widens `$unit` param to `?string` in three helper methods so products without an assigned `length_class` or `weight_class` (null `length_title`/`weight_title`) no longer fatal under PHP 8 strict typing.

- `LengthHelper::formatValue()`
- `LengthHelper::formatDimensions()`
- `WeightHelper::formatValue()`

The internal `!empty($unit)` check is already null-safe, so behavior is unchanged for non-null callers.

### Repro

Add a product with dimensions filled but no `length_class_id` set, then view the product page. Before this fix:

```
TypeError: LengthHelper::formatDimensions(): Argument #4 ($unit) must be of type string, null given,
called in plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/view_specs.php on line 75
```

Bug introduced in commit `e562b92fb` (per-unit decimal places, 2026-02-01).

### Files Modified
| Type | Count |
|------|-------|
| PHP files | 2 |

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only (non-core excluded)