### PR TITLE
OnBoarding/Category wizards and Setup Guide focus and keyboard navigation

### DIFF
--- a/administrator/components/com_j2commerce/src/View/Dashboard/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Dashboard/HtmlView.php
@@ -313,8 +313,9 @@ JS);
 
         // Category Wizard — always register so the modal is available from setup guide and dashboard
         HTMLHelper::_('bootstrap.modal', '#j2commerceCategoryWizardModal');
+        $wa->registerAndUseScript('com_j2commerce.modal-coordinator', 'media/com_j2commerce/js/administrator/modal-coordinator.js', [], ['defer' => true]);
         $wa->usePreset('choicesjs');
-        $wa->registerAndUseScript('com_j2commerce.category-wizard', 'media/com_j2commerce/js/administrator/category-wizard.js', [], ['defer' => true]);
+        $wa->registerAndUseScript('com_j2commerce.category-wizard', 'media/com_j2commerce/js/administrator/category-wizard.js', [], ['defer' => true], ['com_j2commerce.modal-coordinator']);
         $wa->registerAndUseStyle('com_j2commerce.category-wizard.css', 'media/com_j2commerce/css/administrator/category-wizard.css');
 
         Text::script('COM_J2COMMERCE_WIZARD_ERR_PRODUCT_NAME_REQUIRED');
@@ -365,7 +366,7 @@ JS);
 
         if (!SetupGuideHelper::isComplete()) {
             HTMLHelper::_('bootstrap.offcanvas', '#j2commerce-setup-guide');
-            $wa->registerAndUseScript('com_j2commerce.setup-guide', 'media/com_j2commerce/js/administrator/setup-guide.js', [], ['defer' => true]);
+            $wa->registerAndUseScript('com_j2commerce.setup-guide', 'media/com_j2commerce/js/administrator/setup-guide.js', [], ['defer' => true], ['com_j2commerce.modal-coordinator']);
             $wa->registerAndUseStyle('com_j2commerce.setup-guide.css', 'media/com_j2commerce/css/administrator/setup-guide.css');
             $this->getDocument()->addScriptOptions('com_j2commerce.setupGuide', [
                 'isRtl' => Factory::getApplication()->getLanguage()->isRtl(),
@@ -403,7 +404,7 @@ JS);
                 'keyboard' => false,
             ]);
 
-            $wa->registerAndUseScript('com_j2commerce.onboarding', 'media/com_j2commerce/js/administrator/onboarding.js', [], ['defer' => true]);
+            $wa->registerAndUseScript('com_j2commerce.onboarding', 'media/com_j2commerce/js/administrator/onboarding.js', [], ['defer' => true], ['com_j2commerce.modal-coordinator']);
             $wa->registerAndUseStyle('com_j2commerce.onboarding.css', 'media/com_j2commerce/css/administrator/onboarding.css');
 
             // Build JS options for onboarding (replaces inline <script> in template)

--- a/administrator/components/com_j2commerce/tmpl/dashboard/default_categorywizard.php
+++ b/administrator/components/com_j2commerce/tmpl/dashboard/default_categorywizard.php
@@ -159,7 +159,7 @@ $sefRewrite = (bool) $app->get('sef_rewrite', false);
                                    aria-label="<?php echo htmlspecialchars(Text::sprintf('COM_J2COMMERCE_WIZARD_OPTION_TITLE_LABEL', 1), ENT_QUOTES, 'UTF-8'); ?>">
                         </div>
                     </div>
-                    <button type="button" class="btn btn-outline-secondary btn-sm" id="j2c-add-option-title">
+                    <button type="button" class="btn btn-secondary btn-sm" id="j2c-add-option-title">
                         <span class="fa-solid fa-plus me-1" aria-hidden="true"></span>
                         <?php echo Text::_('COM_J2COMMERCE_WIZARD_ADD_OPTION'); ?>
                     </button>
@@ -288,7 +288,7 @@ $sefRewrite = (bool) $app->get('sef_rewrite', false);
                     <div id="j2c-category-names-container">
                         <!-- Populated by JS based on category count selection -->
                     </div>
-                    <button type="button" class="btn btn-outline-secondary btn-sm d-none" id="j2c-add-category">
+                    <button type="button" class="btn btn-secondary btn-sm d-none" id="j2c-add-category">
                         <span class="fa-solid fa-plus me-1" aria-hidden="true"></span>
                         <?php echo Text::_('COM_J2COMMERCE_WIZARD_ADD_CATEGORY'); ?>
                     </button>

--- a/administrator/components/com_j2commerce/tmpl/dashboard/default_onboarding.php
+++ b/administrator/components/com_j2commerce/tmpl/dashboard/default_onboarding.php
@@ -701,7 +701,7 @@ $e = fn(string $s): string => htmlspecialchars($s, ENT_QUOTES, 'UTF-8');
           </div>
 
           <div id="ob-sampledata-prompt" class="d-none">
-            <div class="alert alert-info text-center mb-0">
+            <div class="alert alert-info text-center">
               <p class="mb-2"><?php echo Text::_('COM_J2COMMERCE_ONBOARDING_SAMPLEDATA_PROMPT'); ?></p>
               <button type="button" class="btn btn-primary btn-sm me-2" data-action="load-sampledata">
                 <span class="fa-solid fa-database me-1" aria-hidden="true"></span>

--- a/media/com_j2commerce/css/administrator/category-wizard.css
+++ b/media/com_j2commerce/css/administrator/category-wizard.css
@@ -114,7 +114,17 @@
     box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25) !important;
 }
 
+/* Fallback for browsers where JS-driven focus in the Tab trap does not
+   always match :focus-visible; keep footer actions visibly focused. */
+#j2commerceCategoryWizardModal .modal-footer .btn:focus,
+#j2commerceCategoryWizardModal #j2c-wizard-create:focus {
+    outline: 2px solid var(--bs-primary, var(--primary, #0d6efd)) !important;
+    outline-offset: 2px !important;
+    box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25) !important;
+}
+
 [data-bs-theme="dark"] #j2commerceCategoryWizardModal .modal-footer .btn:focus-visible,
+[data-bs-theme="dark"] #j2commerceCategoryWizardModal .modal-footer .btn:focus,
 [data-bs-theme="dark"] #j2commerceCategoryWizardModal .modal-body .btn:focus-visible,
 [data-bs-theme="dark"] #j2commerceCategoryWizardModal .btn-close:focus-visible,
 [data-bs-theme="dark"] .j2c-wizard-card:has(input[type="radio"]:focus-visible),

--- a/media/com_j2commerce/css/administrator/category-wizard.css
+++ b/media/com_j2commerce/css/administrator/category-wizard.css
@@ -48,9 +48,9 @@
 .j2c-wizard-card:has(input[type="radio"]:focus-visible),
 .j2c-wizard-card:focus-within {
     border-color: var(--bs-primary, #0d6efd);
-    outline: 2px solid var(--bs-primary, #0d6efd);
+    outline: 3px solid var(--bs-primary, #0d6efd);
     outline-offset: 2px;
-    box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25);
+    box-shadow: 0 0 0 0.3rem rgba(13, 110, 253, 0.3);
 }
 
 /* In :has()-capable browsers, suppress the :focus-within ring when the
@@ -130,5 +130,5 @@
 [data-bs-theme="dark"] .j2c-wizard-card:has(input[type="radio"]:focus-visible),
 [data-bs-theme="dark"] .j2c-wizard-card:focus-within {
     outline-color: var(--template-link-color, var(--bs-primary, #0d6efd)) !important;
-    box-shadow: 0 0 0 0.25rem rgba(111, 191, 219, 0.35) !important;
+    box-shadow: 0 0 0 0.18rem rgba(0, 0, 0, 0.55), 0 0 0 0.4rem rgba(111, 191, 219, 0.55) !important;
 }

--- a/media/com_j2commerce/css/administrator/onboarding.css
+++ b/media/com_j2commerce/css/administrator/onboarding.css
@@ -155,6 +155,14 @@
     background-color: var(--template-bg-dark-3);
 }
 
+/* Keep product type card focus highly visible for keyboard users. */
+.card.j2c-product-type-card:focus-visible {
+    outline: 3px solid var(--template-link-color, var(--bs-primary, #0d6efd));
+    outline-offset: 2px;
+    border-color: var(--template-link-color, var(--bs-primary, #0d6efd));
+    box-shadow: 0 0 0 0.3rem rgba(13, 110, 253, 0.3);
+}
+
 .j2c-product-type-card .fa-solid {
     font-size: 32px;
     color: var(--template-link-color);
@@ -269,6 +277,14 @@
 [data-bs-theme="dark"] .card.j2c-product-type-card:focus-visible {
     outline-color: var(--template-link-color, var(--bs-primary));
     box-shadow: 0 0 0 0.25rem rgba(111, 191, 219, 0.35);
+}
+
+[data-bs-theme="dark"] .card.j2c-product-type-card:focus-visible,
+[data-bs-theme="dark"] .card.j2c-product-type-card:focus {
+    outline: 3px solid var(--template-link-color, #6fbfdb);
+    outline-offset: 2px;
+    border-color: var(--template-link-color, #6fbfdb);
+    box-shadow: 0 0 0 0.18rem rgba(0, 0, 0, 0.55), 0 0 0 0.4rem rgba(111, 191, 219, 0.55);
 }
 
 /* ---- Responsive ---- */

--- a/media/com_j2commerce/css/administrator/setup-guide.css
+++ b/media/com_j2commerce/css/administrator/setup-guide.css
@@ -129,6 +129,12 @@
     background: var(--main-nav-mm-active-bg);
 }
 
+.setup-group-header:focus-visible {
+    outline: 2px solid var(--info, #0d6efd);
+    outline-offset: -2px;
+    background: var(--main-nav-mm-active-bg);
+}
+
 .setup-group-label {
     margin-inline-start: 10px;
     font-size: 0.9rem;
@@ -184,7 +190,14 @@
     background: var(--main-nav-mm-active-bg);
 }
 
-.setup-check-item-label {
+.setup-check-item:focus-visible {
+    outline: 2px solid var(--info, #0d6efd);
+    outline-offset: -2px;
+    background: var(--main-nav-mm-active-bg);
+}
+
+.setup-check-item-label,
+.setup-check-label {
     flex: 1;
     font-size: 0.875rem;
     line-height: 1.4;

--- a/media/com_j2commerce/js/administrator/category-wizard.js
+++ b/media/com_j2commerce/js/administrator/category-wizard.js
@@ -70,7 +70,19 @@ class CategoryWizard {
 
         // Detect template on modal open (once)
         let templateDetected = false;
-        this.el.addEventListener('show.bs.modal', () => {
+        this.el.addEventListener('show.bs.modal', (event) => {
+            const onboardingModal = document.getElementById('j2commerceOnboardingModal');
+
+            if (onboardingModal && onboardingModal.classList.contains('show')) {
+                event.preventDefault();
+
+                if (window.J2CommerceModalCoordinator) {
+                    window.J2CommerceModalCoordinator.showExclusive('j2commerceCategoryWizardModal', 'j2commerceOnboardingModal');
+                }
+
+                return;
+            }
+
             if (!templateDetected) {
                 templateDetected = true;
                 this.detectTemplate();
@@ -78,11 +90,47 @@ class CategoryWizard {
             this.reset();
         });
 
+        this.el.addEventListener('shown.bs.modal', () => {
+            this.enforceBodyScrollLock();
+            this.focusActiveStepStart();
+        });
+
         // Refresh setup guide when wizard closes after successful creation
         this.el.addEventListener('hidden.bs.modal', () => {
+            if (!document.querySelector('.modal.show')) {
+                document.body.classList.remove('modal-open');
+                document.body.style.removeProperty('overflow');
+            }
+
             if (this.createdData) {
                 document.dispatchEvent(new CustomEvent('j2commerce:wizard:complete'));
             }
+        });
+
+        // Fallback focus trap to prevent tab focus escaping to the page behind the modal.
+        this.el.addEventListener('keydown', (event) => {
+            if (event.key !== 'Tab' || !this.el.classList.contains('show')) {
+                return;
+            }
+
+            event.preventDefault();
+            this.enforceBodyScrollLock();
+            this.moveFocusByTab(event.shiftKey);
+        });
+
+        document.addEventListener('focusin', (event) => {
+            if (!this.el.classList.contains('show')) {
+                return;
+            }
+
+            const target = event.target;
+
+            if (target instanceof Node && this.el.contains(target)) {
+                return;
+            }
+
+            this.enforceBodyScrollLock();
+            this.keepFocusInsideModal();
         });
 
         // Back / Next / Create / Done buttons
@@ -130,6 +178,27 @@ class CategoryWizard {
             }
         });
 
+        // Keyboard support for wizard cards (Enter/Space to select)
+        this.el.addEventListener('keydown', (e) => {
+            if (e.key !== 'Enter' && e.key !== ' ') {
+                return;
+            }
+
+            const radio = e.target.closest('input[type="radio"]');
+            if (!radio) {
+                return;
+            }
+
+            // Prevent default space behavior (page scroll)
+            if (e.key === ' ') {
+                e.preventDefault();
+            }
+
+            // Focus the radio and trigger change
+            radio.checked = true;
+            radio.dispatchEvent(new Event('change', { bubbles: true }));
+        });
+
         // Card radio selection — apply/remove 'selected' class
         this.el.addEventListener('change', (e) => {
             const radio = e.target;
@@ -156,6 +225,15 @@ class CategoryWizard {
                 this.updateNextButton();
             });
         }
+
+        // Enable/disable Next based on option title inputs (delegated)
+        this.el.addEventListener('input', (e) => {
+            if (e.target.classList.contains('j2c-option-title-input') ||
+                e.target.classList.contains('j2c-option-value-input') ||
+                e.target.classList.contains('j2c-category-name-input')) {
+                this.updateNextButton();
+            }
+        });
     }
 
     // =========================================================================
@@ -204,6 +282,135 @@ class CategoryWizard {
         this.updateNavButtons();
         this.updateStepIndicator();
         this.hideError();
+
+        requestAnimationFrame(() => {
+            this.focusActiveStepStart();
+        });
+    }
+
+    collectFocusable(root) {
+        if (!(root instanceof Element)) {
+            return [];
+        }
+
+        const selector = [
+            'a[href]',
+            'button:not([disabled])',
+            'input:not([disabled]):not([type="hidden"])',
+            'select:not([disabled])',
+            'textarea:not([disabled])',
+            '[tabindex]:not([tabindex="-1"])',
+        ].join(',');
+
+        return Array.from(root.querySelectorAll(selector)).filter((el) => {
+            if (!(el instanceof HTMLElement)) {
+                return false;
+            }
+
+            if (el.hidden || el.getAttribute('aria-hidden') === 'true') {
+                return false;
+            }
+
+            if (el.closest('[hidden], [aria-hidden="true"], [inert]')) {
+                return false;
+            }
+
+            return el.offsetParent !== null || el === document.activeElement;
+        });
+    }
+
+    getFocusableElements() {
+        const focusable = [];
+        const seen = new Set();
+
+        const pushUnique = (elements) => {
+            elements.forEach((el) => {
+                if (!seen.has(el)) {
+                    seen.add(el);
+                    focusable.push(el);
+                }
+            });
+        };
+
+        const modalHeader = this.el.querySelector('.modal-header');
+        if (modalHeader) {
+            pushUnique(this.collectFocusable(modalHeader));
+        }
+
+        const activeStep = this.el.querySelector(`.j2c-wizard-step[data-step="${this.currentStepKey}"]:not(.d-none):not([hidden])`);
+        if (activeStep) {
+            pushUnique(this.collectFocusable(activeStep));
+        }
+
+        const modalFooter = this.el.querySelector('.modal-footer');
+        if (modalFooter) {
+            pushUnique(this.collectFocusable(modalFooter));
+        }
+
+        return focusable;
+    }
+
+    keepFocusInsideModal() {
+        if (!this.el.classList.contains('show')) {
+            return;
+        }
+
+        const focusable = this.getFocusableElements();
+
+        if (focusable.length > 0) {
+            focusable[0].focus({ preventScroll: true });
+        } else {
+            this.el.focus({ preventScroll: true });
+        }
+    }
+
+    focusActiveStepStart() {
+        if (!this.el.classList.contains('show')) {
+            return;
+        }
+
+        const activeStep = this.el.querySelector(`.j2c-wizard-step[data-step="${this.currentStepKey}"]:not(.d-none):not([hidden])`);
+
+        if (activeStep) {
+            const stepFocusable = this.collectFocusable(activeStep);
+            if (stepFocusable.length > 0) {
+                stepFocusable[0].focus({ preventScroll: true });
+                return;
+            }
+        }
+
+        this.keepFocusInsideModal();
+    }
+
+    enforceBodyScrollLock() {
+        if (!this.el.classList.contains('show')) {
+            return;
+        }
+
+        document.body.classList.add('modal-open');
+        document.body.style.overflow = 'hidden';
+    }
+
+    moveFocusByTab(backward) {
+        const focusable = this.getFocusableElements();
+
+        if (focusable.length === 0) {
+            this.el.focus({ preventScroll: true });
+            return;
+        }
+
+        const active = document.activeElement;
+        const currentIndex = focusable.indexOf(active);
+
+        let targetIndex;
+
+        if (backward) {
+            targetIndex = currentIndex <= 0 ? focusable.length - 1 : currentIndex - 1;
+        } else {
+            targetIndex = currentIndex < 0 || currentIndex === focusable.length - 1 ? 0 : currentIndex + 1;
+        }
+
+        focusable[targetIndex].focus({ preventScroll: true });
     }
 
     goNext() {
@@ -500,6 +707,39 @@ class CategoryWizard {
             enabled = !!this.el.querySelector('input[name="product_count"]:checked');
         } else if (this.currentStepKey === '2a') {
             enabled = (this.el.querySelector('#j2c-product-name')?.value.trim() || '') !== '';
+        } else if (this.currentStepKey === '2b') {
+            enabled = !!this.el.querySelector('input[name="category_count"]:checked');
+        } else if (this.currentStepKey === '3a') {
+            // Step 3a: product type selection (at least one card/radio selected)
+            enabled = !!this.el.querySelector('input[name="product_type"]:checked');
+        } else if (this.currentStepKey === '3b') {
+            // Step 3b: option titles (at least one non-empty title)
+            const titles = this.collectOptionTitles();
+            enabled = titles.some((t) => t !== '');
+        } else if (this.currentStepKey === '3c') {
+            // Step 3c: option values (all options must have at least one value)
+            const values = this.collectOptionValues();
+            enabled = this.data.optionTitles.every((title) => values[title] && values[title].length > 0);
+        } else if (this.currentStepKey === '3b-multi') {
+            // Step 3b-multi: menu type selection
+            enabled = !!this.el.querySelector('input[name="menu_type"]:checked');
+        } else if (this.currentStepKey === 'category-source') {
+            // Category source selection
+            enabled = !!this.el.querySelector('input[name="category_source"]:checked');
+        } else if (this.currentStepKey === 'category-select') {
+            // At least one category selected
+            let selectedCount = 0;
+            if (this._categoryChoices) {
+                selectedCount = this._categoryChoices.getValue(true).length;
+            } else {
+                const select = this.el.querySelector('#j2c-existing-categories-select');
+                selectedCount = select ? Array.from(select.selectedOptions).length : 0;
+            }
+            enabled = selectedCount > 0;
+        } else if (this.currentStepKey === 'category-naming') {
+            // At least one non-empty category name
+            const names = this.collectCategoryNames();
+            enabled = names.length > 0;
         }
 
         this.btnNext.disabled = !enabled;
@@ -537,13 +777,13 @@ class CategoryWizard {
 
         const removeBtn = document.createElement('button');
         removeBtn.type      = 'button';
-        removeBtn.className = 'btn btn-outline-danger btn-sm flex-shrink-0';
+        removeBtn.className = 'btn btn-danger btn-sm flex-shrink-0 m-0 p-0';
         removeBtn.setAttribute('data-remove-option-title', '');
         removeBtn.setAttribute('aria-label', Joomla.Text._('COM_J2COMMERCE_WIZARD_REMOVE_OPTION'));
         removeBtn.title = Joomla.Text._('COM_J2COMMERCE_WIZARD_REMOVE_OPTION');
 
         const icon = document.createElement('span');
-        icon.className = 'fa-solid fa-times';
+        icon.className = 'fa-solid fa-times m-0';
         removeBtn.appendChild(icon);
 
         row.appendChild(input);
@@ -607,7 +847,7 @@ class CategoryWizard {
 
             const addBtn = document.createElement('button');
             addBtn.type      = 'button';
-            addBtn.className = 'btn btn-outline-secondary btn-sm mt-2';
+            addBtn.className = 'btn btn-secondary btn-sm mt-2';
             addBtn.setAttribute('data-add-option-value', title);
 
             const plusIcon = document.createElement('span');
@@ -631,13 +871,13 @@ class CategoryWizard {
 
         const removeBtn = document.createElement('button');
         removeBtn.type      = 'button';
-        removeBtn.className = 'btn btn-outline-danger btn-sm flex-shrink-0';
+        removeBtn.className = 'btn btn-danger btn-sm flex-shrink-0 p-0 m-0';
         removeBtn.setAttribute('data-remove-option-value', '');
         removeBtn.setAttribute('aria-label', Joomla.Text._('COM_J2COMMERCE_WIZARD_REMOVE_VALUE'));
         removeBtn.title = Joomla.Text._('COM_J2COMMERCE_WIZARD_REMOVE_VALUE');
 
         const icon = document.createElement('span');
-        icon.className = 'fa-solid fa-times';
+        icon.className = 'fa-solid fa-times m-0';
         removeBtn.appendChild(icon);
 
         row.appendChild(input);
@@ -769,6 +1009,11 @@ class CategoryWizard {
                 noChoicesText: Joomla.Text._('JGLOBAL_SELECT_NO_RESULTS_MATCH'),
                 itemSelectText: '',
             });
+
+            // Update Next button when Choices.js selections change
+            select.addEventListener('change', () => {
+                this.updateNextButton();
+            });
         }
     }
 
@@ -835,13 +1080,13 @@ class CategoryWizard {
         if (removable) {
             const removeBtn = document.createElement('button');
             removeBtn.type      = 'button';
-            removeBtn.className = 'btn btn-outline-danger btn-sm flex-shrink-0';
+            removeBtn.className = 'btn btn-danger btn-sm flex-shrink-0 p-0 m-0';
             removeBtn.setAttribute('data-remove-category', '');
             removeBtn.setAttribute('aria-label', Joomla.Text._('COM_J2COMMERCE_WIZARD_REMOVE_OPTION'));
             removeBtn.title = Joomla.Text._('COM_J2COMMERCE_WIZARD_REMOVE_OPTION');
 
             const icon = document.createElement('span');
-            icon.className = 'fa-solid fa-times';
+            icon.className = 'fa-solid fa-times m-0';
             removeBtn.appendChild(icon);
             row.appendChild(removeBtn);
         }

--- a/media/com_j2commerce/js/administrator/modal-coordinator.js
+++ b/media/com_j2commerce/js/administrator/modal-coordinator.js
@@ -1,0 +1,58 @@
+/**
+ * Coordinates Bootstrap modal handoffs so only one modal is active at a time.
+ */
+(function (window) {
+    'use strict';
+
+    const pendingHandoffs = new Set();
+
+    function getModalElement(id) {
+        return document.getElementById(id);
+    }
+
+    function isShown(modalEl) {
+        return Boolean(modalEl && modalEl.classList.contains('show'));
+    }
+
+    function showExclusive(targetId, blockerId) {
+        const targetModal = getModalElement(targetId);
+
+        if (!targetModal) {
+            return;
+        }
+
+        const showTarget = () => bootstrap.Modal.getOrCreateInstance(targetModal).show();
+
+        if (!blockerId) {
+            showTarget();
+            return;
+        }
+
+        const blockerModal = getModalElement(blockerId);
+
+        if (!isShown(blockerModal)) {
+            showTarget();
+            return;
+        }
+
+        const handoffKey = `${targetId}<-${blockerId}`;
+
+        if (pendingHandoffs.has(handoffKey)) {
+            return;
+        }
+
+        pendingHandoffs.add(handoffKey);
+
+        blockerModal.addEventListener('hidden.bs.modal', () => {
+            pendingHandoffs.delete(handoffKey);
+            showTarget();
+        }, { once: true });
+
+        bootstrap.Modal.getOrCreateInstance(blockerModal).hide();
+    }
+
+    window.J2CommerceModalCoordinator = {
+        showExclusive,
+    };
+})(window);
+

--- a/media/com_j2commerce/js/administrator/onboarding.js
+++ b/media/com_j2commerce/js/administrator/onboarding.js
@@ -21,6 +21,187 @@ document.addEventListener('DOMContentLoaded', () => {
     let currentStep = parseInt(document.getElementById('ob-resume-step')?.value || '1', 10) || 1;
 
     const modalInstance = bootstrap.Modal.getOrCreateInstance(modal);
+
+    const collectFocusable = (root) => {
+        if (!(root instanceof Element)) {
+            return [];
+        }
+
+        const selector = [
+            'a[href]',
+            'button:not([disabled])',
+            'input:not([disabled]):not([type="hidden"])',
+            'select:not([disabled])',
+            'textarea:not([disabled])',
+            '[tabindex]:not([tabindex="-1"])',
+        ].join(',');
+
+        return Array.from(root.querySelectorAll(selector)).filter((el) => {
+            if (!(el instanceof HTMLElement)) {
+                return false;
+            }
+
+            if (el.hidden || el.getAttribute('aria-hidden') === 'true') {
+                return false;
+            }
+
+            // Skip elements inside hidden containers (hidden steps, collapsed sections, etc.)
+            if (el.closest('[hidden], [aria-hidden="true"]')) {
+                return false;
+            }
+
+            return el.offsetParent !== null || el === document.activeElement;
+        });
+    };
+
+    const getFocusableElements = () => {
+        const focusable = [];
+        const seen = new Set();
+
+        const pushUnique = (elements) => {
+            elements.forEach((el) => {
+                if (!seen.has(el)) {
+                    seen.add(el);
+                    focusable.push(el);
+                }
+            });
+        };
+
+        const activeStep = modal.querySelector(`.j2c-step[data-step="${currentStep}"]:not([hidden])`);
+
+        // Keep close action reachable for keyboard users.
+        const modalHeader = modal.querySelector('.modal-header');
+        if (modalHeader) {
+            pushUnique(collectFocusable(modalHeader));
+        }
+
+        if (activeStep) {
+            pushUnique(collectFocusable(activeStep));
+        }
+
+        // Keep wizard nav controls reachable across steps (when visible).
+        const modalFooter = modal.querySelector('#ob-footer');
+        if (modalFooter) {
+            pushUnique(collectFocusable(modalFooter));
+        }
+
+        return focusable;
+    };
+
+    const keepFocusInsideModal = () => {
+        if (!modal.classList.contains('show')) {
+            return;
+        }
+
+        const focusable = getFocusableElements();
+
+        if (focusable.length > 0) {
+            focusable[0].focus({ preventScroll: true });
+        } else {
+            modal.focus({ preventScroll: true });
+        }
+    };
+
+    const focusActiveStepStart = () => {
+        if (!modal.classList.contains('show')) {
+            return;
+        }
+
+        const activeStep = modal.querySelector(`.j2c-step[data-step="${currentStep}"]:not([hidden])`);
+
+        if (activeStep) {
+            const stepFocusable = collectFocusable(activeStep);
+            if (stepFocusable.length > 0) {
+                stepFocusable[0].focus({ preventScroll: true });
+                return;
+            }
+        }
+
+        keepFocusInsideModal();
+    };
+
+    const enforceBodyScrollLock = () => {
+        if (!modal.classList.contains('show')) {
+            return;
+        }
+
+        document.body.classList.add('modal-open');
+        document.body.style.overflow = 'hidden';
+    };
+
+    const moveFocusByTab = (backward) => {
+        const focusable = getFocusableElements();
+
+        if (focusable.length === 0) {
+            modal.focus({ preventScroll: true });
+            return;
+        }
+
+        const active = document.activeElement;
+        const currentIndex = focusable.indexOf(active);
+
+        let targetIndex;
+
+        if (backward) {
+            targetIndex = currentIndex <= 0 ? focusable.length - 1 : currentIndex - 1;
+        } else {
+            targetIndex = currentIndex < 0 || currentIndex === focusable.length - 1 ? 0 : currentIndex + 1;
+        }
+
+        focusable[targetIndex].focus({ preventScroll: true });
+    };
+
+    modal.addEventListener('show.bs.modal', (event) => {
+        const wizardModal = document.getElementById('j2commerceCategoryWizardModal');
+
+        if (wizardModal && wizardModal.classList.contains('show')) {
+            event.preventDefault();
+
+            if (window.J2CommerceModalCoordinator) {
+                window.J2CommerceModalCoordinator.showExclusive('j2commerceOnboardingModal', 'j2commerceCategoryWizardModal');
+            }
+        }
+    });
+
+    // Fallback focus trap to prevent focus leakage/scrolling of the page behind the modal.
+    modal.addEventListener('keydown', (event) => {
+        if (event.key !== 'Tab' || !modal.classList.contains('show')) {
+            return;
+        }
+
+        // Always handle Tab ourselves to avoid browser moving focus outside the modal.
+        event.preventDefault();
+        enforceBodyScrollLock();
+        moveFocusByTab(event.shiftKey);
+    });
+
+    document.addEventListener('focusin', (event) => {
+        if (!modal.classList.contains('show')) {
+            return;
+        }
+
+        const target = event.target;
+
+        if (target instanceof Node && modal.contains(target)) {
+            return;
+        }
+
+        enforceBodyScrollLock();
+        keepFocusInsideModal();
+    });
+
+    modal.addEventListener('shown.bs.modal', () => {
+        enforceBodyScrollLock();
+        focusActiveStepStart();
+    });
+
+    modal.addEventListener('hidden.bs.modal', () => {
+        if (!document.querySelector('.modal.show')) {
+            document.body.classList.remove('modal-open');
+            document.body.style.removeProperty('overflow');
+        }
+    });
+
     modalInstance.show();
 
     // -------------------------------------------------------------------------
@@ -167,6 +348,9 @@ document.addEventListener('DOMContentLoaded', () => {
             updateStepper(targetStep);
             updateButtons(targetStep);
             initStep(targetStep);
+            requestAnimationFrame(() => {
+                focusActiveStepStart();
+            });
         }, 250);
     }
 
@@ -565,8 +749,6 @@ document.addEventListener('DOMContentLoaded', () => {
                 break;
             }
             case 'dismiss-onboarding': {
-                const confirmed = window.confirm(Joomla.Text._('COM_J2COMMERCE_ONBOARDING_DISMISS_CONFIRM'));
-                if (!confirmed) return;
 
                 const fd = new FormData();
                 fd.append(token, '1');

--- a/media/com_j2commerce/js/administrator/setup-guide.js
+++ b/media/com_j2commerce/js/administrator/setup-guide.js
@@ -26,10 +26,17 @@ class SetupGuide {
         this.progressFill = el.querySelector('.setup-progress-fill');
 
         this.inDetail = false;
+        this.lastFocusedCheckId = null;
     }
 
     init() {
         this.offcanvas = bootstrap.Offcanvas.getOrCreateInstance(this.el);
+
+        // Announce async status/detail updates to assistive tech.
+        this.groupsList?.setAttribute('aria-live', 'polite');
+        this.groupsList?.setAttribute('aria-atomic', 'false');
+        this.detailView?.setAttribute('aria-live', 'polite');
+        this.detailView?.setAttribute('aria-atomic', 'false');
 
         document.addEventListener('click', (e) => {
             const slide = e.target.closest('[data-message-id="j2commerce_setup_guide"]');
@@ -39,8 +46,31 @@ class SetupGuide {
             }
         });
 
+        // Lock page scroll while the setup guide is open
+        this.el.addEventListener('show.bs.offcanvas', () => {
+            document.body.style.overflow = 'hidden';
+        });
+
+        this.el.addEventListener('hidden.bs.offcanvas', () => {
+            document.body.style.removeProperty('overflow');
+        });
+
         this.el.addEventListener('shown.bs.offcanvas', () => {
             if (!this.inDetail) this.loadStatus();
+        });
+
+        // Tab focus trap — prevent background page scroll when tabbing through the offcanvas
+        this.el.addEventListener('keydown', (event) => {
+            if (event.key !== 'Tab' || !this.el.classList.contains('show')) return;
+            event.preventDefault();
+            this.moveFocusByTab(event.shiftKey);
+        });
+
+        // Recovery guard — if focus somehow escapes, pull it back
+        document.addEventListener('focusin', (event) => {
+            if (!this.el.classList.contains('show')) return;
+            if (event.target instanceof Node && this.el.contains(event.target)) return;
+            this.keepFocusInside();
         });
 
         // Refresh when category wizard completes successfully
@@ -74,7 +104,7 @@ class SetupGuide {
             }
 
             const checkItem = e.target.closest('[data-setup-check]');
-            if (checkItem && !e.target.closest('button')) {
+            if (checkItem && !e.target.closest('button, a, input, select, textarea')) {
                 return this.loadDetail(checkItem.dataset.setupCheck);
             }
 
@@ -125,9 +155,38 @@ class SetupGuide {
                 return this.toggleGroup(groupHeader);
             }
         });
+
+        this.el.addEventListener('keydown', (e) => {
+            if ((e.key !== 'Enter' && e.key !== ' ') || !this.el.classList.contains('show')) {
+                return;
+            }
+
+            const groupHeader = e.target.closest('.setup-group-header');
+
+            if (groupHeader && !e.target.closest('button, a, input, select, textarea')) {
+                e.preventDefault();
+                this.toggleGroup(groupHeader);
+                return;
+            }
+
+            const checkItem = e.target.closest('[data-setup-check]');
+
+            if (!checkItem) {
+                return;
+            }
+
+            // Let native controls inside the row keep their own keyboard behavior.
+            if (e.target.closest('button, a, input, select, textarea')) {
+                return;
+            }
+
+            e.preventDefault();
+            this.loadDetail(checkItem.dataset.setupCheck);
+        });
     }
 
     async loadStatus() {
+        this.groupsList?.setAttribute('aria-busy', 'true');
         this.showLoading(true);
 
         try {
@@ -144,23 +203,27 @@ class SetupGuide {
             this.showLoading(false);
             this.groupsList.innerHTML = `<div class="alert alert-danger m-3">${err.message}</div>`;
             this.groupsList.classList.remove('d-none');
+        } finally {
+            this.groupsList?.setAttribute('aria-busy', 'false');
         }
     }
 
     async loadDetail(checkId) {
+        this.lastFocusedCheckId = checkId;
+        this.detailView?.setAttribute('aria-busy', 'true');
         this.detailView.replaceChildren();
         const spinner = document.createElement('div');
         spinner.className = 'text-center py-4';
-      
+
         const icon = document.createElement('div');
         icon.className = 'spinner-border spinner-border-sm';
         icon.setAttribute('role', 'status');
-      
+
         const hidden = document.createElement('span');
         hidden.className = 'visually-hidden';
         hidden.textContent = Joomla.Text._("COM_J2COMMERCE_LOADING");
-      
-        icon.appendChild(hidden);      
+
+        icon.appendChild(hidden);
         spinner.appendChild(icon);
         this.detailView.appendChild(spinner);
         this.showDetail();
@@ -175,12 +238,25 @@ class SetupGuide {
             tpl.innerHTML = json.data.html;
             this.detailView.replaceChildren(tpl.content);
             this.initTimezoneClocks();
+
+            requestAnimationFrame(() => {
+                const target = this.detailView.querySelector('h1, h2, h3, h4, h5, h6, button:not([disabled]), a[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])');
+
+                if (target instanceof HTMLElement) {
+                    if (/^H[1-6]$/.test(target.tagName) && !target.hasAttribute('tabindex')) {
+                        target.setAttribute('tabindex', '-1');
+                    }
+                    target.focus({ preventScroll: true });
+                }
+            });
         } catch (err) {
             this.detailView.replaceChildren();
             const alert = document.createElement('div');
             alert.className = 'alert alert-danger';
             alert.textContent = err.message;
             this.detailView.appendChild(alert);
+        } finally {
+            this.detailView?.setAttribute('aria-busy', 'false');
         }
     }
 
@@ -236,10 +312,27 @@ class SetupGuide {
 
         // Client-side actions — no AJAX needed
         if (action === 'open_category_wizard') {
-            const wizardModal = document.getElementById('j2commerceCategoryWizardModal');
-            if (wizardModal) {
-                bootstrap.Modal.getOrCreateInstance(wizardModal).show();
+            const openWizard = () => {
+                if (window.J2CommerceModalCoordinator) {
+                    window.J2CommerceModalCoordinator.showExclusive('j2commerceCategoryWizardModal', 'j2commerceOnboardingModal');
+                    return;
+                }
+
+                const wizardModal = document.getElementById('j2commerceCategoryWizardModal');
+                if (wizardModal) {
+                    bootstrap.Modal.getOrCreateInstance(wizardModal).show();
+                }
+            };
+
+            if (this.el.classList.contains('show') && this.offcanvas) {
+                this.el.addEventListener('hidden.bs.offcanvas', () => {
+                    openWizard();
+                }, { once: true });
+                this.offcanvas.hide();
+            } else {
+                openWizard();
             }
+
             return;
         }
 
@@ -411,14 +504,15 @@ class SetupGuide {
             const allPassed = group.passed === group.total;
             const collapsed = allPassed ? ' is-collapsed' : '';
             const hidden = allPassed ? ' d-none' : '';
+            const checksId = `setup-group-checks-${this.escHtml(group.id)}`;
 
             html += `<div class="setup-group" data-group="${group.id}">`;
-            html += `<div class="setup-group-header${collapsed}">
+            html += `<div class="setup-group-header${collapsed}" role="button" tabindex="0" aria-controls="${checksId}" aria-expanded="${allPassed ? 'false' : 'true'}">
                 <span class="setup-group-chevron icon-chevron-down" aria-hidden="true"></span>
                 <span class="setup-group-label flex-grow-1">${this.escHtml(group.label)}</span>
                 <span class="badge ${allPassed ? 'bg-success' : 'bg-warning'}">${group.passed}/${group.total}</span>
             </div>`;
-            html += `<div class="setup-group-checks${hidden}">`;
+            html += `<div id="${checksId}" class="setup-group-checks${hidden}">`;
 
             for (const check of group.checks) {
                 const statusClass = check.dismissed ? 'dismissed' : check.status;
@@ -431,7 +525,7 @@ class SetupGuide {
                 };
                 const iconClass = iconMap[statusClass] || iconMap.fail;
 
-                html += `<div class="setup-check-item" data-setup-check="${this.escHtml(check.id)}">
+                html += `<div class="setup-check-item" data-setup-check="${this.escHtml(check.id)}" role="button" tabindex="0" aria-label="${this.escHtml(check.label)}">
                     <span class="${iconClass} setup-check-icon" aria-hidden="true"></span>
                     <span class="setup-check-label flex-grow-1">${this.escHtml(check.label)}</span>`;
 
@@ -449,12 +543,14 @@ class SetupGuide {
                 if (check.dismissible && check.status !== 'pass' && !check.dismissed) {
                     html += `<button type="button" class="btn btn-sm btn-link text-danger setup-dismiss-btn"
                         data-setup-dismiss="${this.escHtml(check.id)}"
+                        aria-label="${this.escHtml(Joomla.Text._('COM_J2COMMERCE_SETUP_GUIDE_DISMISS'))}"
                         title="${Joomla.Text._('COM_J2COMMERCE_SETUP_GUIDE_DISMISS')}">
                         <span class="icon-times" aria-hidden="true"></span></button>`;
                 }
 
                 if (check.guidedTourUid) {
                     html += `<button type="button" class="btn btn-sm btn-outline-info button-start-guidedtour ms-1"
+                        aria-label="${this.escHtml(Joomla.Text._('COM_J2COMMERCE_SETUP_GUIDE_START_GUIDED_TOUR'))}"
                         data-gt-uid="${this.escHtml(check.guidedTourUid)}">
                         <span class="icon-map-signs" aria-hidden="true"></span></button>`;
                 }
@@ -480,17 +576,81 @@ class SetupGuide {
         this.detailView.classList.add('d-none');
         this.groupsList.classList.remove('d-none');
         this.backBtn.classList.add('d-none');
+
+        if (this.lastFocusedCheckId) {
+            requestAnimationFrame(() => {
+                const selector = `[data-setup-check="${CSS.escape(this.lastFocusedCheckId)}"]`;
+                const row = this.el.querySelector(selector);
+
+                if (row instanceof HTMLElement) {
+                    row.focus({ preventScroll: true });
+                }
+            });
+        }
     }
 
     toggleGroup(header) {
         header.classList.toggle('is-collapsed');
         const checks = header.nextElementSibling;
-        if (checks) checks.classList.toggle('d-none');
+        if (checks) {
+            checks.classList.toggle('d-none');
+            header.setAttribute('aria-expanded', checks.classList.contains('d-none') ? 'false' : 'true');
+        }
     }
 
     showLoading(show) {
         this.loading.classList.toggle('d-none', !show);
         if (show) this.groupsList.classList.add('d-none');
+    }
+
+    // =========================================================================
+    // Focus trap helpers
+    // =========================================================================
+
+    getFocusableElements() {
+        const selector = [
+            'a[href]',
+            'button:not([disabled])',
+            'input:not([disabled]):not([type="hidden"])',
+            'select:not([disabled])',
+            'textarea:not([disabled])',
+            '[tabindex]:not([tabindex="-1"])',
+        ].join(',');
+
+        return Array.from(this.el.querySelectorAll(selector)).filter((el) => {
+            if (!(el instanceof HTMLElement)) return false;
+            if (el.hidden || el.getAttribute('aria-hidden') === 'true') return false;
+            if (el.closest('[hidden], [aria-hidden="true"], [inert]')) return false;
+            return el.offsetParent !== null || el === document.activeElement;
+        });
+    }
+
+    keepFocusInside() {
+        const focusable = this.getFocusableElements();
+        if (focusable.length > 0) {
+            focusable[0].focus({ preventScroll: true });
+        } else {
+            this.el.focus({ preventScroll: true });
+        }
+    }
+
+    moveFocusByTab(backward) {
+        const focusable = this.getFocusableElements();
+        if (focusable.length === 0) {
+            this.el.focus({ preventScroll: true });
+            return;
+        }
+
+        const currentIndex = focusable.indexOf(document.activeElement);
+        let targetIndex;
+
+        if (backward) {
+            targetIndex = currentIndex <= 0 ? focusable.length - 1 : currentIndex - 1;
+        } else {
+            targetIndex = currentIndex < 0 || currentIndex === focusable.length - 1 ? 0 : currentIndex + 1;
+        }
+
+        focusable[targetIndex].focus({ preventScroll: true });
     }
 
     escHtml(str) {


### PR DESCRIPTION
This PR addresses many issues related to the wizards and guide.

- removed focus loss during tabbing through the wizards (page under modals 'shift')
- improved outline of elements when tabbed through so it is more visible, even in dark mode
- added focus to category wizard elements and selection with 'Enter'. No selection keeps 'Next' disabled'
- added possibility to tab through all items of the setup guide, and collapse/uncollapse sections
- removed double scrollbars when setup guide is open (underlying page is locked)
- added a helper (coordinator) to ensure only one modal is shown at a time (Bootstrap modals function properly that way)
- tweaked CSS 