### PR TITLE
fix(orders): sort invoice column numerically

### DIFF
--- a/administrator/components/com_j2commerce/src/Model/OrdersModel.php
+++ b/administrator/components/com_j2commerce/src/Model/OrdersModel.php
@@ -224,7 +224,12 @@ class OrdersModel extends ListModel
             $orderDir = 'DESC';
         }
 
-        $query->order($db->escape($orderCol) . ' ' . $db->escape($orderDir));
+        if ($orderCol === 'invoice') {
+            $query->order($db->quoteName('a.invoice_prefix') . ' ' . $db->escape($orderDir))
+                ->order($db->quoteName('a.j2commerce_order_id') . ' ' . $db->escape($orderDir));
+        } else {
+            $query->order($db->escape($orderCol) . ' ' . $db->escape($orderDir));
+        }
 
         return $query;
     }


### PR DESCRIPTION
## Summary
Fixes #940

The Orders admin list sorts the `invoice` column alphabetically because it is a computed `CONCAT(invoice_prefix, j2commerce_order_id)` VARCHAR. That produces `INV-1, INV-10, INV-11, INV-2, INV-21` instead of numeric order.

## Changes
- `administrator/components/com_j2commerce/src/Model/OrdersModel.php` — when the active sort column is `invoice`, emit two ORDER BY clauses (`a.invoice_prefix DIR`, then `a.j2commerce_order_id DIR`) so the numeric PK drives the sort. All other sort columns are unchanged.

## Testing
1. Admin → J2Commerce → Orders.
2. Click the **Invoice** column header (ASC).
3. Verify order is `INV-1, INV-2, INV-10, INV-11, INV-21` — numeric, not lexicographic.
4. Click again to flip to DESC and confirm reverse order.
5. Click Date / Total / other columns — unchanged behaviour.

## Files Changed
- `administrator/components/com_j2commerce/src/Model/OrdersModel.php` — invoice-column sort path