### PR TITLE
fix(cart): default empty cart redirect to cart page (fixes #944)

### DIFF
--- a/administrator/components/com_j2commerce/config.xml
+++ b/administrator/components/com_j2commerce/config.xml
@@ -837,7 +837,7 @@
             type="list"
             label="COM_J2COMMERCE_CONFIG_CART_EMPTY_REDIRECT"
             description="COM_J2COMMERCE_CONFIG_CART_EMPTY_REDIRECT_DESC"
-            default="homepage"
+            default="cart"
             validate="options"
         >
             <option value="homepage">COM_J2COMMERCE_TO_HOMEPAGE</option>


### PR DESCRIPTION
## Summary
Fixes #944

The `config_cart_empty_redirect` config field shipped with `default="homepage"`. With an empty basket, clicking the Shopping Basket or Checkout menu link bounced the user to the site home page. Default is now `cart` — stays on the cart page and shows the empty-cart message.

## Changes
- `administrator/components/com_j2commerce/config.xml` — flip default from `homepage` to `cart`

## Behaviour
- Existing installs with a saved value are unaffected (saved value preserved).
- Fresh installs and "Reset to default" pickups now stay on the cart page when empty.

## Testing
1. Fresh install or reset config: empty the cart, click the Shopping Basket menu link → stays on cart page with empty-cart message (no homepage bounce).
2. Empty cart, click the Checkout menu link → redirects to cart page, stays there.
3. Admin → J2Commerce config → Cart tab: "Empty Cart Redirect" default selection shows "To Cart".