### PR TITLE
fix(modules): use ModuleHelper::getLayoutPath for slider include

### DIFF
--- a/modules/mod_j2commerce_products/tmpl/default.php
+++ b/modules/mod_j2commerce_products/tmpl/default.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Helper\ModuleHelper;
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 use J2Commerce\Component\J2commerce\Site\Service\ProductLayoutService;
 
@@ -26,7 +27,7 @@ if (empty($products)) {
 
 // Route to slider template if configured
 if ($layoutType === 'slider') {
-    require __DIR__ . '/slider.php';
+    require ModuleHelper::getLayoutPath('mod_j2commerce_products', 'slider');
     return;
 }
 

--- a/modules/mod_j2commerce_relatedproducts/tmpl/default.php
+++ b/modules/mod_j2commerce_relatedproducts/tmpl/default.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
+use Joomla\CMS\Helper\ModuleHelper;
 use Joomla\CMS\Language\Text;
 use J2Commerce\Component\J2commerce\Site\Service\ProductLayoutService;
 
@@ -30,7 +31,7 @@ if (empty($products)) {
 }
 
 if ($layoutType === 'slider') {
-    require __DIR__ . '/slider.php';
+    require ModuleHelper::getLayoutPath('mod_j2commerce_relatedproducts', 'slider');
     return;
 }
 


### PR DESCRIPTION
## Summary
Fixes #946

Mirrors [joomla/joomla-cms#47599](https://github.com/joomla/joomla-cms/pull/47599) for J2Commerce product modules.

## Problem
`modules/mod_j2commerce_products/tmpl/default.php` and `modules/mod_j2commerce_relatedproducts/tmpl/default.php` route to the slider layout via:

```php
require __DIR__ . '/slider.php';
```

When a template overrides `default.php`, `__DIR__` resolves to the override directory instead of the module's `tmpl/`, so the slider layout cannot be overridden in tandem and the include path can break entirely depending on where the override lives.

## Fix
Use `ModuleHelper::getLayoutPath()` so override resolution works the same way it does for the top-level layout:

```php
require ModuleHelper::getLayoutPath('mod_j2commerce_products', 'slider');
require ModuleHelper::getLayoutPath('mod_j2commerce_relatedproducts', 'slider');
```

## Files Changed
- `modules/mod_j2commerce_products/tmpl/default.php` — add `use Joomla\CMS\Helper\ModuleHelper;`, swap require
- `modules/mod_j2commerce_relatedproducts/tmpl/default.php` — same

## Testing
1. Copy `modules/mod_j2commerce_products/tmpl/slider.php` to `templates/<your-template>/html/mod_j2commerce_products/slider.php` and add a marker comment.
2. Frontend: render a Products module with layout = Slider — the override is used.
3. Repeat for `mod_j2commerce_relatedproducts/slider.php`.
4. Without an override the default `tmpl/slider.php` still loads.

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants / `JFactory::`
- [x] Core files only