### PR TITLE
fix(layouts): dispatch list.tag.item_* on tag listings (was hardcoded to category)

### DIFF
--- a/components/com_j2commerce/layouts/app_bootstrap5/list/category/item.php
+++ b/components/com_j2commerce/layouts/app_bootstrap5/list/category/item.php
@@ -18,7 +18,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 
 $productType = strtolower($displayData['product']->product_type ?? 'simple');
-$layoutContext = 'category';
+$layoutContext = ($displayData['contextSub'] ?? '') === 'tag' ? 'tag' : 'category';
 
 // Core product type layout mappings
 $layoutMap = [

--- a/components/com_j2commerce/layouts/app_uikit/list/category/item.php
+++ b/components/com_j2commerce/layouts/app_uikit/list/category/item.php
@@ -18,7 +18,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 
 $productType = strtolower($displayData['product']->product_type ?? 'simple');
-$layoutContext = 'category';
+$layoutContext = ($displayData['contextSub'] ?? '') === 'tag' ? 'tag' : 'category';
 
 // Core product type layout mappings
 $layoutMap = [

--- a/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/default.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/default.php
@@ -83,7 +83,7 @@ if ($this->params->get('list_show_filter', 1) && $filterPosition === 'left'){
                             }
                             ?>
                             <div class="<?php echo $colClass; ?>">
-                                <?php echo ProductLayoutService::renderProductItem($product, $this->params, ProductLayoutService::CONTEXT_LIST, $itemId); ?>
+                                <?php echo ProductLayoutService::renderProductItem($product, $this->params, ProductLayoutService::CONTEXT_LIST . '.tag', $itemId); ?>
                             </div>
                         <?php endforeach; ?>
                     </div>

--- a/plugins/j2commerce/app_uikit/tmpl/tag_uikit/default.php
+++ b/plugins/j2commerce/app_uikit/tmpl/tag_uikit/default.php
@@ -82,7 +82,7 @@ if ($this->params->get('list_show_filter', 1) && $filterPosition === 'left'){
                             }
                             ?>
                             <div>
-                                <?php echo ProductLayoutService::renderProductItem($product, $this->params, ProductLayoutService::CONTEXT_LIST, $itemId); ?>
+                                <?php echo ProductLayoutService::renderProductItem($product, $this->params, ProductLayoutService::CONTEXT_LIST . '.tag', $itemId); ?>
                             </div>
                         <?php endforeach; ?>
                     </div>


### PR DESCRIPTION
## Summary

Producttags views were rendering every product item via the `list.category.item_*` layout chain regardless of context, making the parallel `list/tag/*` trees in the core component, `app_uikit`, `app_bootstrap5`, and any template overrides completely **unreachable** until now.

Two missing links wired:

### 1. Tag wrapper templates pass `'list.tag'` context

```php
// before
ProductLayoutService::renderProductItem($product, $this->params, ProductLayoutService::CONTEXT_LIST, $itemId);

// after
ProductLayoutService::renderProductItem($product, $this->params, ProductLayoutService::CONTEXT_LIST . '.tag', $itemId);
```

So `parseContext('list.tag')` produces `contextBase='list'`, `contextSub='tag'` on `$displayData`.

Files:
- `plugins/j2commerce/app_uikit/tmpl/tag_uikit/default.php`
- `plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/default.php`

### 2. Entry item layouts derive `$layoutContext` from `contextSub`

```php
// before
$layoutContext = 'category';

// after
$layoutContext = ($displayData['contextSub'] ?? '') === 'tag' ? 'tag' : 'category';
```

So `$layoutMap` resolves `list.tag.item_<type>` on tag pages and `list.category.item_<type>` everywhere else.

Files:
- `components/com_j2commerce/layouts/app_uikit/list/category/item.php`
- `components/com_j2commerce/layouts/app_bootstrap5/list/category/item.php`

## Effect

Tag pages now correctly load `list/tag/item_<type>.php` via the standard `ProductLayoutService::renderLayout()` priority chain (template override > component > plugin source). Site builders can override tag-specific item layouts independently of category layouts at:

```
templates/<tpl>/html/layouts/com_j2commerce/{app_uikit,app_bootstrap5}/list/tag/item_<type>.php
```

## Backwards compatibility

Non-tag callers (categories, products, modules, search, crosssell, upsell, customerbought, article) all leave `contextSub` empty/null, so `$layoutContext` falls back to `'category'` — preserving existing behavior exactly.

## Files Modified

| File | Lines |
|------|-------|
| `plugins/j2commerce/app_uikit/tmpl/tag_uikit/default.php` | +1 / -1 |
| `plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/default.php` | +1 / -1 |
| `components/com_j2commerce/layouts/app_uikit/list/category/item.php` | +1 / -1 |
| `components/com_j2commerce/layouts/app_bootstrap5/list/category/item.php` | +1 / -1 |

## Test plan

- [x] PHP lint clean on all 4 files
- [x] No secrets / FOF remnants / `JFactory::` introduced
- [x] Verified on a live site (waltherj6) `/shop/sale` Producttags menu (`subtemplate=tag_uikit`) with a template override at `templates/yootheme/html/layouts/com_j2commerce/app_uikit/list/tag/item_simple.php` that reorders SKU above price: DOM order changed from `title -> price -> sku` (category layout) to `sku -> title -> price` (tag override) — confirming dispatch reaches the tag layout chain
- [ ] Reviewer: smoke-test a tag menu with `subtemplate=tag_bootstrap5` to confirm the bs5 path also dispatches correctly
- [ ] Reviewer: smoke-test a categories menu (any subtemplate) to confirm the `category` fallback still loads (`contextSub` empty)
- [ ] Reviewer: smoke-test product detail view, modules, and search to confirm none of those callers regress