### PR TITLE
fix(invoicetemplates): repair items loop, IFNOT removal, h1 [SITENAME], form filter (fixes #712)

### DIFF
--- a/administrator/components/com_j2commerce/forms/invoicetemplate.xml
+++ b/administrator/components/com_j2commerce/forms/invoicetemplate.xml
@@ -112,7 +112,7 @@
             label="COM_J2COMMERCE_INVOICETEMPLATE_BODY"
             description="COM_J2COMMERCE_INVOICETEMPLATE_BODY_DESC"
             required="true"
-            filter="JComponentHelper::filterText"
+            filter="Joomla\CMS\Component\ComponentHelper::filterText"
             buttons="true"
             syntax="html"
             height="400"

--- a/administrator/components/com_j2commerce/layouts/templates/invoice/modern.html
+++ b/administrator/components/com_j2commerce/layouts/templates/invoice/modern.html
@@ -39,7 +39,7 @@
                 </td>
               </tr>
             </table>
-            <h1 style="margin: 14px 0 4px 0; font-size: 24px; font-weight: bold; color: #ffffff; text-transform: uppercase; letter-spacing: 1px;">Invoice</h1>
+            <h1 style="margin: 14px 0 4px 0; font-size: 24px; font-weight: bold; color: #ffffff; text-transform: uppercase; letter-spacing: 1px;">[SITENAME]</h1>
             <p style="margin: 0; font-size: 14px; color: rgba(255,255,255,0.85);">
               Order #[ORDERID] &bull; [ORDERDATE]
             </p>

--- a/administrator/components/com_j2commerce/sql/install/mysql/invoicetemplates.sql
+++ b/administrator/components/com_j2commerce/sql/install/mysql/invoicetemplates.sql
@@ -61,7 +61,7 @@ VALUES  (1, 'Packing Slip', 'packingslip', '*', '1', '*', '<!-- J2Commerce Packi
 </tr>
 <!-- Items Card (NO PRICES) -->
 <tr>
-<td class="mobile-padding" style="padding: 16px 20px;">[ITEMS_LOOP] [/ITEMS_LOOP]
+<td class="mobile-padding" style="padding: 16px 20px;">
 <table style="background-color: #ffffff; border: 1px solid #e5e7eb; border-radius: 10px; overflow: hidden;" border="0" width="100%" cellspacing="0" cellpadding="0"><!-- Card Header -->
 <tbody>
 <tr>
@@ -74,16 +74,8 @@ VALUES  (1, 'Packing Slip', 'packingslip', '*', '1', '*', '<!-- J2Commerce Packi
 <td style="padding: 10px 20px; font-size: 11px; font-weight: bold; color: #9ca3af; text-transform: uppercase; letter-spacing: 0.5px; text-align: center; width: 70px;">Packed ✓</td>
 </tr>
 <!-- Items -->
-<tr>
-<td style="padding: 12px 0 12px 20px; border-top: 1px solid #f3f4f6; vertical-align: top; width: 60px;">[IF:ITEM_IMAGE] <img class="item-img" style="border-radius: 6px; object-fit: cover; display: block; border: 1px solid #f3f4f6;" src="[ITEM_IMAGE]" alt="[ITEM_NAME]" width="50" height="50"> [/IF:ITEM_IMAGE] [IFNOT:ITEM_IMAGE]
-<table border="0" cellspacing="0" cellpadding="0">
-<tbody>
-<tr>
-<td style="width: 50px; height: 50px; background-color: #f3f4f6; border-radius: 6px; text-align: center; vertical-align: middle; font-size: 20px; color: #d1d5db;">📦</td>
-</tr>
-</tbody>
-</table>
-[/IFNOT:ITEM_IMAGE]</td>
+[ITEMS_LOOP]<tr>
+<td style="padding: 12px 0 12px 20px; border-top: 1px solid #f3f4f6; vertical-align: top; width: 60px;">[IF:ITEM_IMAGE] <img class="item-img" style="border-radius: 6px; object-fit: cover; display: block; border: 1px solid #f3f4f6;" src="[ITEM_IMAGE]" alt="[ITEM_NAME]" width="50" height="50"> [/IF:ITEM_IMAGE]</td>
 <td style="padding: 12px 10px; border-top: 1px solid #f3f4f6; vertical-align: top;"><span style="font-size: 14px; font-weight: 600; color: #1f2937;">[ITEM_NAME]</span> [IF:ITEM_SKU]<br><span style="font-size: 12px; color: #9ca3af;">SKU: [ITEM_SKU]</span>[/IF:ITEM_SKU] [IF:ITEM_OPTIONS]<br><span style="font-size: 12px; color: #6b7280;">[ITEM_OPTIONS]</span>[/IF:ITEM_OPTIONS] [IF:ITEM_WEIGHT]<br><span style="font-size: 12px; color: #9ca3af;">Weight: [ITEM_WEIGHT]</span>[/IF:ITEM_WEIGHT]</td>
 <td style="padding: 12px 10px; border-top: 1px solid #f3f4f6; text-align: center; vertical-align: top; font-size: 18px; font-weight: bold; color: #1f2937;">[ITEM_QTY]</td>
 <td style="padding: 12px 20px; border-top: 1px solid #f3f4f6; text-align: center; vertical-align: top;"><!-- Checkbox placeholder for warehouse staff -->
@@ -95,7 +87,7 @@ VALUES  (1, 'Packing Slip', 'packingslip', '*', '1', '*', '<!-- J2Commerce Packi
 </tbody>
 </table>
 </td>
-</tr>
+</tr>[/ITEMS_LOOP]
 <!-- Total Items Count -->
 <tr>
 <td style="padding: 14px 20px; background-color: #f9fafb; border-top: 1px solid #e5e7eb;" colspan="4">
@@ -199,7 +191,7 @@ VALUES  (1, 'Packing Slip', 'packingslip', '*', '1', '*', '<!-- J2Commerce Packi
 </tr>
 </tbody>
 </table>
-<h1 style="margin: 14px 0 4px 0; font-size: 24px; font-weight: bold; color: #ffffff; text-transform: uppercase; letter-spacing: 1px;">Invoice</h1>
+<h1 style="margin: 14px 0 4px 0; font-size: 24px; font-weight: bold; color: #ffffff; text-transform: uppercase; letter-spacing: 1px;">[SITENAME]</h1>
 <p style="margin: 0; font-size: 14px; color: rgba(255,255,255,0.85);">Order #[ORDERID] • [ORDERDATE]</p>
 </td>
 </tr>
@@ -241,7 +233,7 @@ VALUES  (1, 'Packing Slip', 'packingslip', '*', '1', '*', '<!-- J2Commerce Packi
 </tr>
 <!-- Items Table WITH Prices -->
 <tr>
-<td class="mobile-padding" style="padding: 16px 20px;">[ITEMS_LOOP] [/ITEMS_LOOP]
+<td class="mobile-padding" style="padding: 16px 20px;">
 <table style="background-color: #ffffff; border: 1px solid #e5e7eb; border-radius: 10px; overflow: hidden;" border="0" width="100%" cellspacing="0" cellpadding="0">
 <tbody>
 <tr>
@@ -253,21 +245,13 @@ VALUES  (1, 'Packing Slip', 'packingslip', '*', '1', '*', '<!-- J2Commerce Packi
 <td style="padding: 10px 10px; font-size: 11px; font-weight: bold; color: #9ca3af; text-transform: uppercase; letter-spacing: 0.5px; text-align: right; width: 80px;">Price</td>
 <td style="padding: 10px 20px; font-size: 11px; font-weight: bold; color: #9ca3af; text-transform: uppercase; letter-spacing: 0.5px; text-align: right; width: 90px;">Total</td>
 </tr>
-<tr>
-<td style="padding: 12px 0 12px 20px; border-top: 1px solid #f3f4f6; vertical-align: top; width: 60px;">[IF:ITEM_IMAGE] <img style="border-radius: 6px; object-fit: cover; display: block; border: 1px solid #f3f4f6;" alt="[ITEM_NAME]" width="50" height="50"  src="[ITEM_IMAGE]"> [/IF:ITEM_IMAGE] [IFNOT:ITEM_IMAGE]
-<table border="0" cellspacing="0" cellpadding="0">
-<tbody>
-<tr>
-<td style="width: 50px; height: 50px; background-color: #f3f4f6; border-radius: 6px; text-align: center; vertical-align: middle; font-size: 20px; color: #d1d5db;">📦</td>
-</tr>
-</tbody>
-</table>
-[/IFNOT:ITEM_IMAGE]</td>
+[ITEMS_LOOP]<tr>
+<td style="padding: 12px 0 12px 20px; border-top: 1px solid #f3f4f6; vertical-align: top; width: 60px;">[IF:ITEM_IMAGE] <img style="border-radius: 6px; object-fit: cover; display: block; border: 1px solid #f3f4f6;" alt="[ITEM_NAME]" width="50" height="50"  src="[ITEM_IMAGE]"> [/IF:ITEM_IMAGE]</td>
 <td style="padding: 12px 10px; border-top: 1px solid #f3f4f6; vertical-align: top;"><span style="font-size: 14px; font-weight: 600; color: #1f2937;">[ITEM_NAME]</span> [IF:ITEM_SKU]<br><span style="font-size: 12px; color: #9ca3af;">SKU: [ITEM_SKU]</span>[/IF:ITEM_SKU] [IF:ITEM_OPTIONS]<br><span style="font-size: 12px; color: #6b7280;">[ITEM_OPTIONS]</span>[/IF:ITEM_OPTIONS]</td>
 <td style="padding: 12px 10px; border-top: 1px solid #f3f4f6; text-align: center; vertical-align: top; font-size: 14px; color: #1f2937;">[ITEM_QTY]</td>
 <td style="padding: 12px 10px; border-top: 1px solid #f3f4f6; text-align: right; vertical-align: top; font-size: 14px; color: #1f2937;">[ITEM_PRICE]</td>
 <td style="padding: 12px 20px; border-top: 1px solid #f3f4f6; text-align: right; vertical-align: top; font-size: 14px; font-weight: 600; color: #1f2937;">[ITEM_TOTAL]</td>
-</tr>
+</tr>[/ITEMS_LOOP]
 <!-- Totals -->
 <tr>
 <td style="padding: 0 20px; border-top: 2px solid #e5e7eb;" colspan="5">[IF:SHIPPING_AMOUNT] [/IF:SHIPPING_AMOUNT] [IF:TAX_AMOUNT] [/IF:TAX_AMOUNT] [IF:DISCOUNT_AMOUNT] [/IF:DISCOUNT_AMOUNT]
@@ -467,7 +451,7 @@ VALUES  (1, 'Packing Slip', 'packingslip', '*', '1', '*', '<!-- J2Commerce Packi
 </tr>
 <!-- Items Table -->
 <tr>
-<td class="mobile-padding" style="padding: 16px 20px;">[ITEMS_LOOP] [/ITEMS_LOOP]
+<td class="mobile-padding" style="padding: 16px 20px;">
 <table style="background-color: #ffffff; border: 1px solid #e5e7eb; border-radius: 10px; overflow: hidden;" border="0" width="100%" cellspacing="0" cellpadding="0">
 <tbody>
 <tr>
@@ -479,12 +463,12 @@ VALUES  (1, 'Packing Slip', 'packingslip', '*', '1', '*', '<!-- J2Commerce Packi
 <td style="padding: 10px 10px; font-size: 11px; font-weight: bold; color: #9ca3af; text-transform: uppercase; letter-spacing: 0.5px; text-align: right; width: 80px;">Price</td>
 <td style="padding: 10px 20px; font-size: 11px; font-weight: bold; color: #9ca3af; text-transform: uppercase; letter-spacing: 0.5px; text-align: right; width: 90px;">Total</td>
 </tr>
-<tr>
+[ITEMS_LOOP]<tr>
 <td style="padding: 12px 20px; border-top: 1px solid #f3f4f6; vertical-align: top;"><span style="font-size: 14px; font-weight: 600; color: #1f2937;">[ITEM_NAME]</span> [IF:ITEM_SKU]<br><span style="font-size: 12px; color: #9ca3af;">SKU: [ITEM_SKU]</span>[/IF:ITEM_SKU] [IF:ITEM_OPTIONS]<br><span style="font-size: 12px; color: #6b7280;">[ITEM_OPTIONS]</span>[/IF:ITEM_OPTIONS]</td>
 <td style="padding: 12px 10px; border-top: 1px solid #f3f4f6; text-align: center; vertical-align: top; font-size: 14px; color: #1f2937;">[ITEM_QTY]</td>
 <td style="padding: 12px 10px; border-top: 1px solid #f3f4f6; text-align: right; vertical-align: top; font-size: 14px; color: #1f2937;">[ITEM_PRICE]</td>
 <td style="padding: 12px 20px; border-top: 1px solid #f3f4f6; text-align: right; vertical-align: top; font-size: 14px; font-weight: 600; color: #1f2937;">[ITEM_TOTAL]</td>
-</tr>
+</tr>[/ITEMS_LOOP]
 <!-- Totals -->
 <tr>
 <td style="padding: 0 20px; border-top: 2px solid #e5e7eb;" colspan="4">[IF:SHIPPING_AMOUNT] [/IF:SHIPPING_AMOUNT] [IF:TAX_AMOUNT] [/IF:TAX_AMOUNT] [IF:DISCOUNT_AMOUNT] [/IF:DISCOUNT_AMOUNT]

--- a/administrator/components/com_j2commerce/sql/updates/mysql/6.2.3-2026-05-11-2.sql
+++ b/administrator/components/com_j2commerce/sql/updates/mysql/6.2.3-2026-05-11-2.sql
@@ -1,0 +1,94 @@
+--
+-- Fix ITEMS_LOOP placement in seeded invoice templates so order items render
+-- correctly (issue #712).
+--
+-- The empty [ITEMS_LOOP] [/ITEMS_LOOP] marker placed before the items <table>
+-- caused EmailHelper::wrapItemRowInLoop() to pick the inner <tr> nested inside
+-- the [IFNOT:ITEM_IMAGE] fallback table when scanning for the item row. The
+-- chosen loop boundary was wrong, so per-item expansion duplicated only the
+-- fallback row, both IF and IFNOT image blocks rendered together, and the
+-- qty/price/total cells fell outside the loop body and were stripped as
+-- unprocessed tags.
+--
+-- This migration moves the ITEMS_LOOP markers directly around the item <tr>
+-- of templates id=1 (Packing Slip), id=2 (Invoice), and id=4 (Receipt Full
+-- Page). Template id=3 (Receipt Thermal) already has correct ITEMS_LOOP
+-- placement and is not touched.
+--
+-- Also replaces the hard-coded "Invoice" h1 banner in the Modern Invoice
+-- Template (id=2) with [SITENAME] so the store/company name appears above
+-- the order number.
+--
+-- Each UPDATE is guarded by LIKE checks so user-edited templates (those that
+-- no longer contain the canonical seed body) are NOT touched.
+--
+-- All string literals and CONCAT/CHAR results are coerced to
+-- utf8mb4_unicode_ci to match the `body` column collation. Without this,
+-- MySQL throws "Illegal mix of collations" during the inner REPLACE.
+--
+-- Tracking: GitHub issue #712
+--
+
+-- id=1 Packing Slip: remove empty marker + wrap item <tr> with ITEMS_LOOP
+UPDATE `#__j2commerce_invoicetemplates`
+   SET `body` = REPLACE(
+       REPLACE(
+           REPLACE(`body`,
+               '[ITEMS_LOOP] [/ITEMS_LOOP]' COLLATE utf8mb4_unicode_ci,
+               '' COLLATE utf8mb4_unicode_ci
+           ),
+           CONCAT('<tr>', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4), '<td style="padding: 12px 0 12px 20px; border-top: 1px solid #f3f4f6; vertical-align: top; width: 60px;">[IF:ITEM_IMAGE] <img class="item-img"') COLLATE utf8mb4_unicode_ci,
+           CONCAT('[ITEMS_LOOP]<tr>', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4), '<td style="padding: 12px 0 12px 20px; border-top: 1px solid #f3f4f6; vertical-align: top; width: 60px;">[IF:ITEM_IMAGE] <img class="item-img"') COLLATE utf8mb4_unicode_ci
+       ),
+       CONCAT('</tr>', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4), '<!-- Total Items Count -->') COLLATE utf8mb4_unicode_ci,
+       CONCAT('</tr>[/ITEMS_LOOP]', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4), '<!-- Total Items Count -->') COLLATE utf8mb4_unicode_ci
+   ),
+       `body_json` = ''
+ WHERE `j2commerce_invoicetemplate_id` = 1
+   AND `body` LIKE '%[ITEMS_LOOP] [/ITEMS_LOOP]%'
+   AND `body` LIKE '%<img class="item-img"%';
+
+-- id=2 Invoice: remove empty marker + wrap item <tr> with ITEMS_LOOP
+UPDATE `#__j2commerce_invoicetemplates`
+   SET `body` = REPLACE(
+       REPLACE(
+           REPLACE(`body`,
+               '[ITEMS_LOOP] [/ITEMS_LOOP]' COLLATE utf8mb4_unicode_ci,
+               '' COLLATE utf8mb4_unicode_ci
+           ),
+           CONCAT('<tr>', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4), '<td style="padding: 12px 0 12px 20px; border-top: 1px solid #f3f4f6; vertical-align: top; width: 60px;">[IF:ITEM_IMAGE]') COLLATE utf8mb4_unicode_ci,
+           CONCAT('[ITEMS_LOOP]<tr>', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4), '<td style="padding: 12px 0 12px 20px; border-top: 1px solid #f3f4f6; vertical-align: top; width: 60px;">[IF:ITEM_IMAGE]') COLLATE utf8mb4_unicode_ci
+       ),
+       CONCAT('</tr>', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4), '<!-- Totals -->', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4), '<tr>', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4), '<td style="padding: 0 20px; border-top: 2px solid #e5e7eb;" colspan="5">') COLLATE utf8mb4_unicode_ci,
+       CONCAT('</tr>[/ITEMS_LOOP]', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4), '<!-- Totals -->', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4), '<tr>', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4), '<td style="padding: 0 20px; border-top: 2px solid #e5e7eb;" colspan="5">') COLLATE utf8mb4_unicode_ci
+   ),
+       `body_json` = ''
+ WHERE `j2commerce_invoicetemplate_id` = 2
+   AND `body` LIKE '%[ITEMS_LOOP] [/ITEMS_LOOP]%';
+
+-- id=2 Invoice: replace hard-coded "Invoice" h1 with [SITENAME]
+UPDATE `#__j2commerce_invoicetemplates`
+   SET `body` = REPLACE(`body`,
+           '>Invoice</h1>' COLLATE utf8mb4_unicode_ci,
+           '>[SITENAME]</h1>' COLLATE utf8mb4_unicode_ci),
+       `body_json` = ''
+ WHERE `j2commerce_invoicetemplate_id` = 2
+   AND `body` LIKE '%>Invoice</h1>%';
+
+-- id=4 Receipt (Full Page): remove empty marker + wrap item <tr> with ITEMS_LOOP
+UPDATE `#__j2commerce_invoicetemplates`
+   SET `body` = REPLACE(
+       REPLACE(
+           REPLACE(`body`,
+               '[ITEMS_LOOP] [/ITEMS_LOOP]' COLLATE utf8mb4_unicode_ci,
+               '' COLLATE utf8mb4_unicode_ci
+           ),
+           CONCAT('<tr>', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4), '<td style="padding: 12px 20px; border-top: 1px solid #f3f4f6; vertical-align: top;"><span style="font-size: 14px; font-weight: 600; color: #1f2937;">[ITEM_NAME]</span>') COLLATE utf8mb4_unicode_ci,
+           CONCAT('[ITEMS_LOOP]<tr>', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4), '<td style="padding: 12px 20px; border-top: 1px solid #f3f4f6; vertical-align: top;"><span style="font-size: 14px; font-weight: 600; color: #1f2937;">[ITEM_NAME]</span>') COLLATE utf8mb4_unicode_ci
+       ),
+       CONCAT('</tr>', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4), '<!-- Totals -->', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4), '<tr>', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4), '<td style="padding: 0 20px; border-top: 2px solid #e5e7eb;" colspan="4">') COLLATE utf8mb4_unicode_ci,
+       CONCAT('</tr>[/ITEMS_LOOP]', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4), '<!-- Totals -->', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4), '<tr>', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4), '<td style="padding: 0 20px; border-top: 2px solid #e5e7eb;" colspan="4">') COLLATE utf8mb4_unicode_ci
+   ),
+       `body_json` = ''
+ WHERE `j2commerce_invoicetemplate_id` = 4
+   AND `body` LIKE '%[ITEMS_LOOP] [/ITEMS_LOOP]%';

--- a/administrator/components/com_j2commerce/sql/updates/mysql/6.2.3-2026-05-11-3.sql
+++ b/administrator/components/com_j2commerce/sql/updates/mysql/6.2.3-2026-05-11-3.sql
@@ -1,0 +1,127 @@
+--
+-- Repair corrupted emoji + unicode glyphs in seeded invoice templates that
+-- were stored as `?` characters because the installer connection charset
+-- was not utf8mb4 when invoicetemplates.sql ran (issue #870 follow-up).
+--
+-- Prior migration 6.2.2-2026-04-27.sql repaired ONLY the HTML comment dividers
+-- containing em-dashes (e.g. `<!-- ... ??? Modern Template -->`). This migration
+-- repairs the remaining body content corruptions: 📦 📞 ✓ ⚠ • © em-dash glyphs.
+--
+-- Each UPDATE uses CONVERT(UNHEX('<utf8mb4 hex>') USING utf8mb4) to inject the
+-- correct UTF-8 byte sequence regardless of this file's own encoding, then
+-- COLLATE utf8mb4_unicode_ci to match the `body` column collation. Without
+-- the COLLATE clause MySQL throws "Illegal mix of collations" during REPLACE.
+-- LIKE guards make each statement idempotent so user-edited rows are not
+-- touched.
+--
+-- UTF-8 hex used:
+--   📦 = F09F93A6   📞 = F09F939E   📄 = F09F9384
+--   ⚠  = E29AA0     ✓ = E29C93     • = E280A2
+--   —  = E28094     © = C2A9
+--
+-- Tracking: GitHub issue #870 (follow-up to invoice/email template seed)
+--
+
+-- id=1 (Packing Slip) HTML comment header em-dash
+UPDATE `#__j2commerce_invoicetemplates`
+   SET `body` = REPLACE(`body`,
+       '<!-- J2Commerce Packing Slip ??? Modern Template -->' COLLATE utf8mb4_unicode_ci,
+       CONCAT('<!-- J2Commerce Packing Slip ', CONVERT(UNHEX('E28094') USING utf8mb4), ' Modern Template -->') COLLATE utf8mb4_unicode_ci)
+ WHERE `j2commerce_invoicetemplate_id` = 1
+   AND `body` LIKE '%<!-- J2Commerce Packing Slip ??? Modern Template -->%';
+
+-- id=1 banner box icon 📦
+UPDATE `#__j2commerce_invoicetemplates`
+   SET `body` = REPLACE(`body`,
+       'font-size: 24px; color: #ffffff;">????</td>' COLLATE utf8mb4_unicode_ci,
+       CONCAT('font-size: 24px; color: #ffffff;">', CONVERT(UNHEX('F09F93A6') USING utf8mb4), '</td>') COLLATE utf8mb4_unicode_ci)
+ WHERE `j2commerce_invoicetemplate_id` = 1
+   AND `body` LIKE '%font-size: 24px; color: #ffffff;">????</td>%';
+
+-- id=1 shipping phone icon 📞
+UPDATE `#__j2commerce_invoicetemplates`
+   SET `body` = REPLACE(`body`,
+       '<br>???? [SHIPPING_PHONE]' COLLATE utf8mb4_unicode_ci,
+       CONCAT('<br>', CONVERT(UNHEX('F09F939E') USING utf8mb4), ' [SHIPPING_PHONE]') COLLATE utf8mb4_unicode_ci)
+ WHERE `j2commerce_invoicetemplate_id` = 1
+   AND `body` LIKE '%<br>???? [SHIPPING_PHONE]%';
+
+-- id=1 "Packed ???" check mark ✓
+UPDATE `#__j2commerce_invoicetemplates`
+   SET `body` = REPLACE(`body`,
+       'Packed ???</td>' COLLATE utf8mb4_unicode_ci,
+       CONCAT('Packed ', CONVERT(UNHEX('E29C93') USING utf8mb4), '</td>') COLLATE utf8mb4_unicode_ci)
+ WHERE `j2commerce_invoicetemplate_id` = 1
+   AND `body` LIKE '%Packed ???</td>%';
+
+-- id=1 items fallback box icon 📦
+UPDATE `#__j2commerce_invoicetemplates`
+   SET `body` = REPLACE(`body`,
+       'color: #d1d5db;">????</td>' COLLATE utf8mb4_unicode_ci,
+       CONCAT('color: #d1d5db;">', CONVERT(UNHEX('F09F93A6') USING utf8mb4), '</td>') COLLATE utf8mb4_unicode_ci)
+ WHERE `j2commerce_invoicetemplate_id` = 1
+   AND `body` LIKE '%color: #d1d5db;">????</td>%';
+
+-- id=1 Customer Note warning ⚠
+UPDATE `#__j2commerce_invoicetemplates`
+   SET `body` = REPLACE(`body`,
+       '">??? Customer Note</td>' COLLATE utf8mb4_unicode_ci,
+       CONCAT('">', CONVERT(UNHEX('E29AA0') USING utf8mb4), ' Customer Note</td>') COLLATE utf8mb4_unicode_ci)
+ WHERE `j2commerce_invoicetemplate_id` = 1
+   AND `body` LIKE '%">??? Customer Note</td>%';
+
+-- id=1 footer © and • (combined replacement so anchors stay unique)
+UPDATE `#__j2commerce_invoicetemplates`
+   SET `body` = REPLACE(`body`,
+       'margin: 0;">?? [CURRENT_YEAR] [SITENAME] ??? [SITEURL]</p>' COLLATE utf8mb4_unicode_ci,
+       CONCAT('margin: 0;">', CONVERT(UNHEX('C2A9') USING utf8mb4), ' [CURRENT_YEAR] [SITENAME] ', CONVERT(UNHEX('E280A2') USING utf8mb4), ' [SITEURL]</p>') COLLATE utf8mb4_unicode_ci)
+ WHERE `j2commerce_invoicetemplate_id` = 1
+   AND `body` LIKE '%margin: 0;">?? [CURRENT_YEAR] [SITENAME] ??? [SITEURL]</p>%';
+
+-- id=3 (Receipt Thermal) HTML comment header em-dash
+UPDATE `#__j2commerce_invoicetemplates`
+   SET `body` = REPLACE(`body`,
+       '<!-- J2Commerce Receipt ??? Thermal / POS Template -->' COLLATE utf8mb4_unicode_ci,
+       CONCAT('<!-- J2Commerce Receipt ', CONVERT(UNHEX('E28094') USING utf8mb4), ' Thermal / POS Template -->') COLLATE utf8mb4_unicode_ci)
+ WHERE `j2commerce_invoicetemplate_id` = 3
+   AND `body` LIKE '%<!-- J2Commerce Receipt ??? Thermal / POS Template -->%';
+
+-- id=4 (Receipt Full Page) HTML comment header em-dash
+UPDATE `#__j2commerce_invoicetemplates`
+   SET `body` = REPLACE(`body`,
+       '<!-- J2Commerce Receipt ??? Modern Template -->' COLLATE utf8mb4_unicode_ci,
+       CONCAT('<!-- J2Commerce Receipt ', CONVERT(UNHEX('E28094') USING utf8mb4), ' Modern Template -->') COLLATE utf8mb4_unicode_ci)
+ WHERE `j2commerce_invoicetemplate_id` = 4
+   AND `body` LIKE '%<!-- J2Commerce Receipt ??? Modern Template -->%';
+
+-- id=4 banner check ✓ (3 chars = `???`, distinct from id=1's 4-char `????`)
+UPDATE `#__j2commerce_invoicetemplates`
+   SET `body` = REPLACE(`body`,
+       'font-size: 24px; color: #ffffff;">???</td>' COLLATE utf8mb4_unicode_ci,
+       CONCAT('font-size: 24px; color: #ffffff;">', CONVERT(UNHEX('E29C93') USING utf8mb4), '</td>') COLLATE utf8mb4_unicode_ci)
+ WHERE `j2commerce_invoicetemplate_id` = 4
+   AND `body` LIKE '%font-size: 24px; color: #ffffff;">???</td>%';
+
+-- id=4 Order date separator • bullet
+UPDATE `#__j2commerce_invoicetemplates`
+   SET `body` = REPLACE(`body`,
+       '[ORDERID] ??? [ORDERDATE]' COLLATE utf8mb4_unicode_ci,
+       CONCAT('[ORDERID] ', CONVERT(UNHEX('E280A2') USING utf8mb4), ' [ORDERDATE]') COLLATE utf8mb4_unicode_ci)
+ WHERE `j2commerce_invoicetemplate_id` = 4
+   AND `body` LIKE '%[ORDERID] ??? [ORDERDATE]%';
+
+-- id=4 Payment received check ✓
+UPDATE `#__j2commerce_invoicetemplates`
+   SET `body` = REPLACE(`body`,
+       'text-align: center;">??? <strong>Payment received</strong>' COLLATE utf8mb4_unicode_ci,
+       CONCAT('text-align: center;">', CONVERT(UNHEX('E29C93') USING utf8mb4), ' <strong>Payment received</strong>') COLLATE utf8mb4_unicode_ci)
+ WHERE `j2commerce_invoicetemplate_id` = 4
+   AND `body` LIKE '%text-align: center;">??? <strong>Payment received</strong>%';
+
+-- id=4 footer © and •
+UPDATE `#__j2commerce_invoicetemplates`
+   SET `body` = REPLACE(`body`,
+       'margin: 0;">?? [CURRENT_YEAR] [SITENAME] ??? [SITEURL]</p>' COLLATE utf8mb4_unicode_ci,
+       CONCAT('margin: 0;">', CONVERT(UNHEX('C2A9') USING utf8mb4), ' [CURRENT_YEAR] [SITENAME] ', CONVERT(UNHEX('E280A2') USING utf8mb4), ' [SITEURL]</p>') COLLATE utf8mb4_unicode_ci)
+ WHERE `j2commerce_invoicetemplate_id` = 4
+   AND `body` LIKE '%margin: 0;">?? [CURRENT_YEAR] [SITENAME] ??? [SITEURL]</p>%';

--- a/administrator/components/com_j2commerce/sql/updates/mysql/6.2.3-2026-05-11-4.sql
+++ b/administrator/components/com_j2commerce/sql/updates/mysql/6.2.3-2026-05-11-4.sql
@@ -1,0 +1,126 @@
+--
+-- Remove [IFNOT:ITEM_IMAGE] fallback block (📦 box icon) from seeded invoice
+-- templates (issue #712 follow-up).
+--
+-- The fallback block's inner <table><tr><td>📦</td></tr></table> introduced a
+-- nested <tr> that confused EmailHelper::wrapItemRowInLoop()'s tr-counting
+-- walker, causing the items loop to wrap the wrong <tr>. Removing the block
+-- eliminates the nested <tr> (so wrap detection always picks the correct outer
+-- item row) AND drops the visible box icon that rendered below product images.
+--
+-- Two variants are removed per row: one with the proper 📦 utf8mb4 byte
+-- sequence and one with the `????` corruption (issue #870) — so this works
+-- regardless of whether the install ran with a utf8mb4 connection.
+--
+-- LIKE guards make this idempotent. Rows already cleaned are skipped.
+--
+-- All string operands are COLLATE utf8mb4_unicode_ci to match the `body`
+-- column collation and avoid "Illegal mix of collations" errors during
+-- REPLACE.
+--
+-- Tracking: GitHub issue #712
+--
+
+-- Variant A: block with real 📦 emoji (utf8mb4-installed rows)
+UPDATE `#__j2commerce_invoicetemplates`
+   SET `body` = REPLACE(`body`,
+       CONCAT(' [IFNOT:ITEM_IMAGE]', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4),
+              '<table border="0" cellspacing="0" cellpadding="0">', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4),
+              '<tbody>', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4),
+              '<tr>', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4),
+              '<td style="width: 50px; height: 50px; background-color: #f3f4f6; border-radius: 6px; text-align: center; vertical-align: middle; font-size: 20px; color: #d1d5db;">',
+              CONVERT(UNHEX('F09F93A6') USING utf8mb4),
+              '</td>', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4),
+              '</tr>', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4),
+              '</tbody>', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4),
+              '</table>', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4),
+              '[/IFNOT:ITEM_IMAGE]') COLLATE utf8mb4_unicode_ci,
+       '' COLLATE utf8mb4_unicode_ci),
+       `body_json` = ''
+ WHERE `invoice_type` IN ('invoice', 'packingslip')
+   AND `body` LIKE '%[IFNOT:ITEM_IMAGE]%';
+
+-- Variant B: block with corrupted `????` placeholder (latin1-installed rows)
+UPDATE `#__j2commerce_invoicetemplates`
+   SET `body` = REPLACE(`body`,
+       CONCAT(' [IFNOT:ITEM_IMAGE]', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4),
+              '<table border="0" cellspacing="0" cellpadding="0">', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4),
+              '<tbody>', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4),
+              '<tr>', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4),
+              '<td style="width: 50px; height: 50px; background-color: #f3f4f6; border-radius: 6px; text-align: center; vertical-align: middle; font-size: 20px; color: #d1d5db;">????</td>', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4),
+              '</tr>', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4),
+              '</tbody>', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4),
+              '</table>', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4),
+              '[/IFNOT:ITEM_IMAGE]') COLLATE utf8mb4_unicode_ci,
+       '' COLLATE utf8mb4_unicode_ci),
+       `body_json` = ''
+ WHERE `invoice_type` IN ('invoice', 'packingslip')
+   AND `body` LIKE '%[IFNOT:ITEM_IMAGE]%';
+
+-- Defensive: re-attempt items <tr> wrap for any row that still has the empty
+-- marker (covers installs that received earlier migration variants that
+-- failed due to attribute-order mismatch in the original anchor). Shorter
+-- cell-open anchor matches regardless of <img> attribute ordering.
+
+-- id=1 Packing Slip
+UPDATE `#__j2commerce_invoicetemplates`
+   SET `body` = REPLACE(
+       REPLACE(
+           REPLACE(`body`,
+               '[ITEMS_LOOP] [/ITEMS_LOOP]' COLLATE utf8mb4_unicode_ci,
+               '' COLLATE utf8mb4_unicode_ci
+           ),
+           CONCAT('<tr>', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4), '<td style="padding: 12px 0 12px 20px; border-top: 1px solid #f3f4f6; vertical-align: top; width: 60px;">[IF:ITEM_IMAGE]') COLLATE utf8mb4_unicode_ci,
+           CONCAT('[ITEMS_LOOP]<tr>', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4), '<td style="padding: 12px 0 12px 20px; border-top: 1px solid #f3f4f6; vertical-align: top; width: 60px;">[IF:ITEM_IMAGE]') COLLATE utf8mb4_unicode_ci
+       ),
+       CONCAT('</tr>', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4), '<!-- Total Items Count -->') COLLATE utf8mb4_unicode_ci,
+       CONCAT('</tr>[/ITEMS_LOOP]', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4), '<!-- Total Items Count -->') COLLATE utf8mb4_unicode_ci
+   ),
+       `body_json` = ''
+ WHERE `j2commerce_invoicetemplate_id` = 1
+   AND `body` LIKE '%[ITEMS_LOOP] [/ITEMS_LOOP]%';
+
+-- id=2 Invoice
+UPDATE `#__j2commerce_invoicetemplates`
+   SET `body` = REPLACE(
+       REPLACE(
+           REPLACE(`body`,
+               '[ITEMS_LOOP] [/ITEMS_LOOP]' COLLATE utf8mb4_unicode_ci,
+               '' COLLATE utf8mb4_unicode_ci
+           ),
+           CONCAT('<tr>', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4), '<td style="padding: 12px 0 12px 20px; border-top: 1px solid #f3f4f6; vertical-align: top; width: 60px;">[IF:ITEM_IMAGE]') COLLATE utf8mb4_unicode_ci,
+           CONCAT('[ITEMS_LOOP]<tr>', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4), '<td style="padding: 12px 0 12px 20px; border-top: 1px solid #f3f4f6; vertical-align: top; width: 60px;">[IF:ITEM_IMAGE]') COLLATE utf8mb4_unicode_ci
+       ),
+       CONCAT('</tr>', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4), '<!-- Totals -->', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4), '<tr>', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4), '<td style="padding: 0 20px; border-top: 2px solid #e5e7eb;" colspan="5">') COLLATE utf8mb4_unicode_ci,
+       CONCAT('</tr>[/ITEMS_LOOP]', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4), '<!-- Totals -->', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4), '<tr>', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4), '<td style="padding: 0 20px; border-top: 2px solid #e5e7eb;" colspan="5">') COLLATE utf8mb4_unicode_ci
+   ),
+       `body_json` = ''
+ WHERE `j2commerce_invoicetemplate_id` = 2
+   AND `body` LIKE '%[ITEMS_LOOP] [/ITEMS_LOOP]%';
+
+-- id=4 Receipt (Full Page)
+UPDATE `#__j2commerce_invoicetemplates`
+   SET `body` = REPLACE(
+       REPLACE(
+           REPLACE(`body`,
+               '[ITEMS_LOOP] [/ITEMS_LOOP]' COLLATE utf8mb4_unicode_ci,
+               '' COLLATE utf8mb4_unicode_ci
+           ),
+           CONCAT('<tr>', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4), '<td style="padding: 12px 20px; border-top: 1px solid #f3f4f6; vertical-align: top;"><span style="font-size: 14px; font-weight: 600; color: #1f2937;">[ITEM_NAME]</span>') COLLATE utf8mb4_unicode_ci,
+           CONCAT('[ITEMS_LOOP]<tr>', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4), '<td style="padding: 12px 20px; border-top: 1px solid #f3f4f6; vertical-align: top;"><span style="font-size: 14px; font-weight: 600; color: #1f2937;">[ITEM_NAME]</span>') COLLATE utf8mb4_unicode_ci
+       ),
+       CONCAT('</tr>', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4), '<!-- Totals -->', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4), '<tr>', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4), '<td style="padding: 0 20px; border-top: 2px solid #e5e7eb;" colspan="4">') COLLATE utf8mb4_unicode_ci,
+       CONCAT('</tr>[/ITEMS_LOOP]', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4), '<!-- Totals -->', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4), '<tr>', CHAR(13 USING utf8mb4), CHAR(10 USING utf8mb4), '<td style="padding: 0 20px; border-top: 2px solid #e5e7eb;" colspan="4">') COLLATE utf8mb4_unicode_ci
+   ),
+       `body_json` = ''
+ WHERE `j2commerce_invoicetemplate_id` = 4
+   AND `body` LIKE '%[ITEMS_LOOP] [/ITEMS_LOOP]%';
+
+-- id=2 Invoice: replace hard-coded "Invoice" h1 with [SITENAME] (idempotent)
+UPDATE `#__j2commerce_invoicetemplates`
+   SET `body` = REPLACE(`body`,
+           '>Invoice</h1>' COLLATE utf8mb4_unicode_ci,
+           '>[SITENAME]</h1>' COLLATE utf8mb4_unicode_ci),
+       `body_json` = ''
+ WHERE `j2commerce_invoicetemplate_id` = 2
+   AND `body` LIKE '%>Invoice</h1>%';


### PR DESCRIPTION
## Summary

Fixes #712. Multiple related issues in the seeded **Modern Invoice / Packing Slip / Receipt** templates:

1. **Items section was rendering as a stacked column of images with no name/SKU/qty/price/total values.** The empty \`[ITEMS_LOOP] [/ITEMS_LOOP]\` marker placed before the items \`<table>\` forced \`EmailHelper::wrapItemRowInLoop()\` to walk \`<tr>\` tags looking for the item row. The \`[IFNOT:ITEM_IMAGE]\` fallback block contained a nested \`<table><tr>\` that confused the walker, so the loop ended up wrapping only the box-icon row. Per-item tags fell outside the loop body and were stripped by the "remove unprocessed tags" pass.
2. **Box emoji (📦) rendered below every product image.** The \`[IFNOT:ITEM_IMAGE]\` fallback block was visible alongside real product images.
3. **Invoice template banner showed the literal word "Invoice"** above the order number — should be the store name (\`[SITENAME]\`).
4. **Editing any invoice template threw a deprecation fatal**: \`field 'body' calls a deprecated filter class JComponentHelper\`.

## Changes

| File | What changed |
|---|---|
| \`administrator/components/com_j2commerce/sql/install/mysql/invoicetemplates.sql\` | id=1 / id=2 / id=4: wrap item \`<tr>\` directly with \`[ITEMS_LOOP]\` ... \`[/ITEMS_LOOP]\` and drop the empty marker; strip \`[IFNOT:ITEM_IMAGE]\` fallback block from id=1 + id=2; replace \`>Invoice</h1>\` with \`>[SITENAME]</h1>\` on id=2 |
| \`administrator/components/com_j2commerce/layouts/templates/invoice/modern.html\` | h1 banner: \`Invoice\` → \`[SITENAME]\` |
| \`administrator/components/com_j2commerce/forms/invoicetemplate.xml\` | \`filter="JComponentHelper::filterText"\` → \`filter="Joomla\CMS\Component\ComponentHelper::filterText"\` |
| \`administrator/components/com_j2commerce/sql/updates/mysql/6.2.3-2026-05-11-2.sql\` | NEW — idempotent migration that wraps item \`<tr>\` for existing rows. Attribute-order-agnostic anchor. Uses \`COLLATE utf8mb4_unicode_ci\` + \`CHAR(13 USING utf8mb4)\` to match the \`body\` column charset/collation. |
| \`administrator/components/com_j2commerce/sql/updates/mysql/6.2.3-2026-05-11-3.sql\` | NEW — repairs emoji corruption (📦 📞 ✓ ⚠ • © em-dash) introduced when issue #870's connection charset wasn't utf8mb4 at install time. Uses \`CONVERT(UNHEX('<hex>') USING utf8mb4) COLLATE utf8mb4_unicode_ci\`. |
| \`administrator/components/com_j2commerce/sql/updates/mysql/6.2.3-2026-05-11-4.sql\` | NEW — defensive removal of \`[IFNOT:ITEM_IMAGE]\` block from existing DB rows (real 📦 + \`????\` corruption variants) and retry items wrap with shorter cell-open anchor for installs where earlier migration variants failed due to attribute-order mismatch. |

## Why the migrations need explicit collation handling

- The \`body\` column is \`utf8mb4_unicode_ci\` (IMPLICIT).
- \`CHAR(13)\` / \`CHAR(10)\` return BINARY by default, and \`CONVERT(... USING utf8mb4)\` results default to \`utf8mb4_general_ci\` (COERCIBLE).
- Mixing those collations in \`REPLACE(body, search, replacement)\` throws \`Illegal mix of collations\` (different IMPLICIT collations) or \`COLLATION 'utf8mb4_unicode_ci' is not valid for CHARACTER SET 'binary'\` (BINARY can't take \`utf8mb4_*\` collation).
- Fix: explicitly cast every CHAR/CONCAT/CONVERT result to \`utf8mb4\` charset and \`utf8mb4_unicode_ci\` collation.

## Test plan

- [x] Fresh install via \`pkg_j2commerce_6-2-3_beta_12.zip\` — no install errors
- [x] Open an order → View Invoice → banner shows store name, items table populated with name/SKU/qty/price/total, no box-icon fallback below products
- [x] Open Packing Slip → items render with qty only (no prices), no box-icon fallback
- [x] Open Receipt (Full Page) → all item details render
- [x] Open Receipt (Thermal) → unchanged, still works
- [x] Open admin → Invoice Templates → edit any template → no JComponentHelper deprecation fatal on form load or save
- [x] Existing installs (running migrations): all four migrations are LIKE-guarded so user-edited templates are not touched