### PR TITLE
Apply accessibility attributes to live-region elements so that screen readers announce the changes immediately

### DIFF
--- a/administrator/components/com_j2commerce/src/Helper/StrapperHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/StrapperHelper.php
@@ -578,6 +578,7 @@ class StrapperHelper
             $context = $forceContext ?? $this->getViewContext();
 
             $wa->registerAndUseScript('com_j2commerce.site', 'media/com_j2commerce/js/site/j2commerce.js', [], ['defer' => true]);
+            $wa->registerAndUseScript('com_j2commerce.a11y', 'media/com_j2commerce/js/site/j2commerce-a11y.js', [], ['defer' => true]);
             $wa->registerAndUseScript('plg_j2commerce_app_flexivariable.flexivariable', 'media/plg_j2commerce_app_flexivariable/js/flexivariable.js', [], ['defer' => true]);
 
             // Load context-specific scripts
@@ -966,6 +967,7 @@ class StrapperHelper
             $wa = Factory::getApplication()->getDocument()->getWebAssetManager();
 
             $wa->registerAndUseScript('com_j2commerce.site', 'media/com_j2commerce/js/site/j2commerce.js', [], ['defer' => true]);
+            $wa->registerAndUseScript('com_j2commerce.a11y', 'media/com_j2commerce/js/site/j2commerce-a11y.js', [], ['defer' => true]);
 
             // Load core CSS (handles template overrides)
             $this->loadCoreCSS($wa);

--- a/components/com_j2commerce/layouts/app_bootstrap5/list/category/item_flexiprice.php
+++ b/components/com_j2commerce/layouts/app_bootstrap5/list/category/item_flexiprice.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Language\Text;
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 
 extract($displayData);
@@ -44,7 +43,7 @@ $salePrice = $pricing->price ?? 0;
         <?php echo $currency->format($minPrice); ?> - <?php echo $currency->format($maxPrice); ?>
     </div>
 <?php endif; ?>
-<div class="j2commerce-product-price-container j2commerce-flexiprice d-flex align-items-center gap-1">
+<div class="j2commerce-product-price-container j2commerce-flexiprice d-flex align-items-center gap-1" data-j2-a11y-live="polite" data-j2-a11y-atomic="true">
     <?php if ($showSpecialPrice && isset($pricing->price)): ?>
         <div class="sale-price lh-1 fs-5 fw-semibold">
             <?php echo $productHelper->displayPrice((float) $salePrice, $product, $params); ?>

--- a/components/com_j2commerce/layouts/app_bootstrap5/list/tag/item_flexiprice.php
+++ b/components/com_j2commerce/layouts/app_bootstrap5/list/tag/item_flexiprice.php
@@ -31,7 +31,7 @@ $defaultPrice = (float) ($pricing->price ?? 0);
 $hasRange = $minPrice !== null && $maxPrice !== null && $minPrice != $maxPrice;
 $showRange = !empty($product->show_price_range) && $hasRange;
 ?>
-<div class="j2commerce-product-price j2commerce-flexiprice">
+<div class="j2commerce-product-price j2commerce-flexiprice" data-j2-a11y-live="polite" data-j2-a11y-atomic="true">
     <?php if ($showRange): ?>
         <span class="price-range text-muted small">
             <?php echo $currency->format($minPrice); ?> - <?php echo $currency->format($maxPrice); ?>

--- a/components/com_j2commerce/layouts/app_uikit/list/category/item_flexiprice.php
+++ b/components/com_j2commerce/layouts/app_uikit/list/category/item_flexiprice.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Language\Text;
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 
 extract($displayData);
@@ -44,7 +43,7 @@ $salePrice = $pricing->price ?? 0;
         <?php echo $currency->format($minPrice); ?> - <?php echo $currency->format($maxPrice); ?>
     </div>
 <?php endif; ?>
-<div class="j2commerce-product-price-container j2commerce-flexiprice uk-flex uk-flex-middle" style="gap: .25rem;">
+<div class="j2commerce-product-price-container j2commerce-flexiprice uk-flex uk-flex-middle" style="gap: .25rem;" data-j2-a11y-live="polite" data-j2-a11y-atomic="true">
     <?php if ($showSpecialPrice && isset($pricing->price)): ?>
         <div class="sale-price uk-text-large uk-text-bold">
             <?php echo $productHelper->displayPrice((float) $salePrice, $product, $params); ?>

--- a/components/com_j2commerce/layouts/app_uikit/list/tag/item_flexiprice.php
+++ b/components/com_j2commerce/layouts/app_uikit/list/tag/item_flexiprice.php
@@ -31,7 +31,7 @@ $defaultPrice = (float) ($pricing->price ?? 0);
 $hasRange = $minPrice !== null && $maxPrice !== null && $minPrice != $maxPrice;
 $showRange = !empty($product->show_price_range) && $hasRange;
 ?>
-<div class="j2commerce-product-price j2commerce-flexiprice">
+<div class="j2commerce-product-price j2commerce-flexiprice" data-j2-a11y-live="polite" data-j2-a11y-atomic="true">
     <?php if ($showRange): ?>
         <span class="price-range uk-text-muted uk-text-small">
             <?php echo $currency->format($minPrice); ?> - <?php echo $currency->format($maxPrice); ?>

--- a/components/com_j2commerce/tmpl/products/default.php
+++ b/components/com_j2commerce/tmpl/products/default.php
@@ -27,6 +27,7 @@ $app = Factory::getApplication();
 $wa = $app->getDocument()->getWebAssetManager();
 $wa->registerAndUseStyle('com_j2commerce.site,css', 'media/com_j2commerce/css/site/j2commerce.css');
 $wa->registerAndUseScript('com_j2commerce.site', 'media/com_j2commerce/js/site/j2commerce.js', [], ['defer' => true], []);
+$wa->registerAndUseScript('com_j2commerce.a11y', 'media/com_j2commerce/js/site/j2commerce-a11y.js', [], ['defer' => true]);
 $wa->registerAndUseScript('com_j2commerce.filters', 'media/com_j2commerce/js/site/j2commerce-filters.es6.js', [], ['defer' => true], []);
 
 $itemId = isset($this->active_menu->id) ? (int) $this->active_menu->id : 0;

--- a/media/com_j2commerce/js/site/j2commerce-a11y.js
+++ b/media/com_j2commerce/js/site/j2commerce-a11y.js
@@ -1,0 +1,151 @@
+/**
+ * J2Commerce Site Accessibility JavaScript
+ *
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ *
+ */
+
+/**
+    Applies accessibility attributes to known live-region elements and any future element that opts in via selectors or data attributes.
+
+    By default, it adds aria-live="assertive" to .j2commerce-notifications so screen readers announce cart error messages (e.g. "already in cart") immediately.
+    If we were to apply it to flexi prices, we would add aria-live="polite" to the flexi-price element so screen readers announce the price change immediately.
+
+    usage:
+       1. To apply attributes to existing elements, add rules to the Joomla options:
+        From javascript:
+            Joomla.loadOptions('com_j2commerce.a11yLiveRegions', [
+                {
+                    selector: '.my-custom-live-region',
+                    attributes: {
+                        'role': 'alert',
+                        'aria-live': 'assertive',
+                        'aria-atomic': 'true'
+                    }
+                }
+            ]);
+        Or from PHP:
+            $options = [
+                [
+                    'selector' => '.my-custom-live-region',
+                    'attributes' => [
+                        'role' => 'status',
+                        'aria-live' => 'polite',
+                        'aria-atomic' => 'true',
+                    ],
+                ],
+            ];
+           $document->addScriptOptions('com_j2commerce.a11yLiveRegions', $options);
+
+        2. To apply attributes to specific elements, add data attributes:
+            <div data-j2-a11y-live="assertive" data-j2-a11y-atomic="true">...</div>
+
+            Supports markup-driven opt-in on any element using:
+            data-j2-a11y-live
+            data-j2-a11y-role
+            data-j2-a11y-atomic
+            data-j2-a11y-relevant
+ */
+document.addEventListener('DOMContentLoaded', function () {
+    const defaultRules = [
+        {
+            selector: '.j2commerce-notifications',
+            attributes: {
+                'role': 'alert',
+                'aria-live': 'assertive',
+                'aria-atomic': 'true'
+            }
+        }
+    ];
+
+    const configuredRules = window.Joomla?.getOptions?.('com_j2commerce.a11yLiveRegions', []);
+    const a11yRules = [...defaultRules, ...configuredRules].filter(function (rule) {
+        return rule && typeof rule.selector === 'string' && rule.selector.trim() !== '' && typeof rule.attributes === 'object';
+    });
+
+    const dataAttributeSelector = '[data-j2-a11y-live], [data-j2-a11y-role], [data-j2-a11y-atomic], [data-j2-a11y-relevant]';
+
+    function applyAttributes(el, attributes) {
+        if (!el || !attributes) {
+            return;
+        }
+
+        Object.entries(attributes).forEach(function ([name, value]) {
+            if (value === null || typeof value === 'undefined' || value === false) {
+                el.removeAttribute(name);
+                return;
+            }
+
+            el.setAttribute(name, String(value));
+        });
+    }
+
+    function applyDataAttributes(el) {
+        if (!el?.dataset) {
+            return;
+        }
+
+        const attributes = {};
+
+        if (el.dataset.j2A11yRole) {
+            attributes.role = el.dataset.j2A11yRole;
+        }
+
+        if (el.dataset.j2A11yLive) {
+            attributes['aria-live'] = el.dataset.j2A11yLive;
+        }
+
+        if (el.dataset.j2A11yAtomic) {
+            attributes['aria-atomic'] = el.dataset.j2A11yAtomic;
+        }
+
+        if (el.dataset.j2A11yRelevant) {
+            attributes['aria-relevant'] = el.dataset.j2A11yRelevant;
+        }
+
+        applyAttributes(el, attributes);
+    }
+
+    function applyRules(root) {
+        a11yRules.forEach(function (rule) {
+            root.querySelectorAll(rule.selector).forEach(function (el) {
+                applyAttributes(el, rule.attributes);
+            });
+        });
+
+        root.querySelectorAll(dataAttributeSelector).forEach(applyDataAttributes);
+    }
+
+    function applyToNode(node) {
+        if (!node || node.nodeType !== 1) {
+            return;
+        }
+
+        if (typeof node.matches === 'function') {
+            a11yRules.forEach(function (rule) {
+                if (node.matches(rule.selector)) {
+                    applyAttributes(node, rule.attributes);
+                }
+            });
+
+            if (node.matches(dataAttributeSelector)) {
+                applyDataAttributes(node);
+            }
+        }
+
+        if (typeof node.querySelectorAll === 'function') {
+            applyRules(node);
+        }
+    }
+
+    applyRules(document);
+
+    new MutationObserver(function (mutations) {
+        mutations.forEach(function (mutation) {
+            mutation.addedNodes.forEach(applyToNode);
+        });
+    }).observe(document.body, { childList: true, subtree: true });
+});

--- a/plugins/j2commerce/app_bootstrap5/layouts/list/category/item_flexiprice.php
+++ b/plugins/j2commerce/app_bootstrap5/layouts/list/category/item_flexiprice.php
@@ -44,7 +44,7 @@ $salePrice = $pricing->price ?? 0;
         <?php echo $currency->format($minPrice); ?> - <?php echo $currency->format($maxPrice); ?>
     </div>
 <?php endif; ?>
-<div class="j2commerce-product-price-container j2commerce-flexiprice d-flex align-items-center gap-1">
+<div class="j2commerce-product-price-container j2commerce-flexiprice d-flex align-items-center gap-1" data-j2-a11y-live="polite" data-j2-a11y-atomic="true">
     <?php if ($showSpecialPrice && isset($pricing->price)): ?>
         <div class="sale-price lh-1 fs-5 fw-semibold">
             <?php echo $productHelper->displayPrice((float) $salePrice, $product, $params); ?>

--- a/plugins/j2commerce/app_bootstrap5/layouts/list/tag/item_flexiprice.php
+++ b/plugins/j2commerce/app_bootstrap5/layouts/list/tag/item_flexiprice.php
@@ -31,7 +31,7 @@ $defaultPrice = (float) ($pricing->price ?? 0);
 $hasRange = $minPrice !== null && $maxPrice !== null && $minPrice != $maxPrice;
 $showRange = !empty($product->show_price_range) && $hasRange;
 ?>
-<div class="j2commerce-product-price j2commerce-flexiprice">
+<div class="j2commerce-product-price j2commerce-flexiprice" data-j2-a11y-live="polite" data-j2-a11y-atomic="true">
     <?php if ($showRange): ?>
         <span class="price-range text-muted small">
             <?php echo $currency->format($minPrice); ?> - <?php echo $currency->format($maxPrice); ?>

--- a/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/default.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/default.php
@@ -27,6 +27,7 @@ $app = Factory::getApplication();
 $wa = $app->getDocument()->getWebAssetManager();
 $wa->registerAndUseStyle('com_j2commerce.site', 'media/com_j2commerce/css/site/j2commerce.css');
 $wa->registerAndUseScript('com_j2commerce.site', 'media/com_j2commerce/js/site/j2commerce.js', [], ['defer' => true], []);
+$wa->registerAndUseScript('com_j2commerce.a11y', 'media/com_j2commerce/js/site/j2commerce-a11y.js', [], ['defer' => true]);
 $wa->registerAndUseScript('com_j2commerce.filters', 'media/com_j2commerce/js/site/j2commerce-filters.es6.js', [], ['defer' => true], []);
 
 $itemId = isset($this->active_menu->id) ? (int) $this->active_menu->id : 0;

--- a/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/default.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/default.php
@@ -27,6 +27,7 @@ $app = Factory::getApplication();
 $wa = $app->getDocument()->getWebAssetManager();
 $wa->registerAndUseStyle('com_j2commerce.site', 'media/com_j2commerce/css/site/j2commerce.css');
 $wa->registerAndUseScript('com_j2commerce.site', 'media/com_j2commerce/js/site/j2commerce.js', [], ['defer' => true], []);
+$wa->registerAndUseScript('com_j2commerce.a11y', 'media/com_j2commerce/js/site/j2commerce-a11y.js', [], ['defer' => true]);
 $wa->registerAndUseScript('com_j2commerce.filters', 'media/com_j2commerce/js/site/j2commerce-filters.es6.js', [], ['defer' => true], []);
 
 $itemId = isset($this->active_menu->id) ? (int) $this->active_menu->id : 0;

--- a/plugins/j2commerce/app_uikit/layouts/list/category/item_flexiprice.php
+++ b/plugins/j2commerce/app_uikit/layouts/list/category/item_flexiprice.php
@@ -44,7 +44,7 @@ $salePrice = $pricing->price ?? 0;
         <?php echo $currency->format($minPrice); ?> - <?php echo $currency->format($maxPrice); ?>
     </div>
 <?php endif; ?>
-<div class="j2commerce-product-price-container j2commerce-flexiprice uk-flex uk-flex-middle" style="gap: .25rem;">
+<div class="j2commerce-product-price-container j2commerce-flexiprice uk-flex uk-flex-middle" style="gap: .25rem;" data-j2-a11y-live="polite" data-j2-a11y-atomic="true">
     <?php if ($showSpecialPrice && isset($pricing->price)): ?>
         <div class="sale-price uk-text-large uk-text-bold">
             <?php echo $productHelper->displayPrice((float) $salePrice, $product, $params); ?>

--- a/plugins/j2commerce/app_uikit/layouts/list/tag/item_flexiprice.php
+++ b/plugins/j2commerce/app_uikit/layouts/list/tag/item_flexiprice.php
@@ -31,7 +31,7 @@ $defaultPrice = (float) ($pricing->price ?? 0);
 $hasRange = $minPrice !== null && $maxPrice !== null && $minPrice != $maxPrice;
 $showRange = !empty($product->show_price_range) && $hasRange;
 ?>
-<div class="j2commerce-product-price j2commerce-flexiprice">
+<div class="j2commerce-product-price j2commerce-flexiprice" data-j2-a11y-live="polite" data-j2-a11y-atomic="true">
     <?php if ($showRange): ?>
         <span class="price-range uk-text-muted uk-text-small">
             <?php echo $currency->format($minPrice); ?> - <?php echo $currency->format($maxPrice); ?>

--- a/plugins/j2commerce/app_uikit/tmpl/tag_uikit/default.php
+++ b/plugins/j2commerce/app_uikit/tmpl/tag_uikit/default.php
@@ -27,6 +27,7 @@ $app = Factory::getApplication();
 $wa = $app->getDocument()->getWebAssetManager();
 $wa->registerAndUseStyle('com_j2commerce.site', 'media/com_j2commerce/css/site/j2commerce.css');
 $wa->registerAndUseScript('com_j2commerce.site', 'media/com_j2commerce/js/site/j2commerce.js', [], ['defer' => true], []);
+$wa->registerAndUseScript('com_j2commerce.a11y', 'media/com_j2commerce/js/site/j2commerce-a11y.js', [], ['defer' => true]);
 $wa->registerAndUseScript('com_j2commerce.filters', 'media/com_j2commerce/js/site/j2commerce-filters.es6.js', [], ['defer' => true], []);
 
 $itemId = isset($this->active_menu->id) ? (int) $this->active_menu->id : 0;

--- a/plugins/j2commerce/app_uikit/tmpl/uikit/default.php
+++ b/plugins/j2commerce/app_uikit/tmpl/uikit/default.php
@@ -27,6 +27,7 @@ $app = Factory::getApplication();
 $wa = $app->getDocument()->getWebAssetManager();
 $wa->registerAndUseStyle('com_j2commerce.site', 'media/com_j2commerce/css/site/j2commerce.css');
 $wa->registerAndUseScript('com_j2commerce.site', 'media/com_j2commerce/js/site/j2commerce.js', [], ['defer' => true], []);
+$wa->registerAndUseScript('com_j2commerce.a11y', 'media/com_j2commerce/js/site/j2commerce-a11y.js', [], ['defer' => true]);
 $wa->registerAndUseScript('com_j2commerce.filters', 'media/com_j2commerce/js/site/j2commerce-filters.es6.js', [], ['defer' => true], []);
 
 $itemId = isset($this->active_menu->id) ? (int) $this->active_menu->id : 0;


### PR DESCRIPTION
Thank you Angie for submitting an earlier version of the script.
It was modified to allow any live region (known or not yet available) to be listened to.

Usage examples can be found in the script.

We applied the script to flexi prices, which can change on-the-fly.
There are many areas this could be applied to and greatly improve accessibility.

Accessibility attributes are applied to `.j2commerce-notifications` areas by default.