### PR TITLE
fix(strapper): only load frontend assets when client is 'site' (fixes #973)

### DIFF
--- a/administrator/components/com_j2commerce/src/Helper/StrapperHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/StrapperHelper.php
@@ -265,10 +265,10 @@ class StrapperHelper
         }
 
         try {
-            // Load application-specific scripts
+            // Load application-specific scripts; explicit client checks so cli/api/installation skip.
             if ($this->app->isClient('administrator')) {
                 $this->loadAdminScripts();
-            } else {
+            } elseif ($this->app->isClient('site')) {
                 $this->loadFrontendScripts();
             }
 
@@ -296,10 +296,10 @@ class StrapperHelper
         }
 
         try {
-            // Load application-specific styles
+            // Load application-specific styles; explicit client checks so cli/api/installation skip.
             if ($this->app->isClient('administrator')) {
                 $this->loadAdminCSS();
-            } else {
+            } elseif ($this->app->isClient('site')) {
                 $this->loadFrontendCSS();
             }
 


### PR DESCRIPTION
## Summary
Fixes #973

`StrapperHelper::addJavaScript()` and `addCSS()` used a bare `else` after `isClient('administrator')`, assuming any non-admin client is the site frontend. On `cli`, `api`, `installation`, or `cli_installation` this calls `getDocument()->getWebAssetManager()` in contexts where the document / WAM may not exist; the exception is caught and logged, wasting work and producing log noise.

Branch on the actual `site` client explicitly; all other clients skip silently.

## Changes
- `administrator/components/com_j2commerce/src/Helper/StrapperHelper.php`
  - `addJavaScript()` (line 270): bare `else` → `elseif ($this->app->isClient('site'))`
  - `addCSS()` (line 301): same fix
  - Updated inline comments to flag the explicit-client intent.

## Audit
The rest of the codebase was grep'd for the same `isClient('administrator')` anti-pattern. All other usages are guard / early-return patterns or admin-context branches — none assume `!administrator == site`. No further changes needed.

## Testing
1. **Frontend** — load any J2C frontend page; assets still load.
2. **Backend** — load any J2C admin page; assets still load.
3. **CLI** — run `php cli/joomla.php extension:discover`; no `Error loading frontend scripts` entries in `administrator/logs/j2commerce*.log`.
4. **API** — hit a webservices endpoint; same — no log noise, no document fatal.

## Risk
LOW. Both branches are unchanged for the two client contexts that actually use them. For cli/api the new behavior is to load nothing — which is correct (those clients had no usable document anyway, so the prior code only produced caught exceptions and log noise).