### PR TITLE
fix(schemaorg/ecommerce): use store currency for preview price

### DIFF
--- a/plugins/schemaorg/ecommerce/src/Field/EcommerceProductPreviewField.php
+++ b/plugins/schemaorg/ecommerce/src/Field/EcommerceProductPreviewField.php
@@ -10,6 +10,7 @@
 
 namespace Joomla\Plugin\Schemaorg\Ecommerce\Field;
 
+use J2Commerce\Component\J2commerce\Administrator\Helper\CurrencyHelper;
 use J2Commerce\Component\J2commerce\Administrator\Helper\ImageHelper;
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 use Joomla\CMS\Factory;
@@ -175,7 +176,7 @@ class EcommerceProductPreviewField extends FormField
         // Price and currency (from default or master variant)
         $price          = $displayVariant ? $helper->getProductPrice($displayVariant) : 0;
         $currency       = $helper->getCurrencyCode();
-        $formattedPrice = '$' . number_format($price, 2);
+        $formattedPrice = CurrencyHelper::format((float) $price, $currency);
 
         // Availability
         $availability      = $displayVariant ? $helper->mapAvailability($displayVariant) : 'https://schema.org/InStock';
@@ -378,7 +379,7 @@ class EcommerceProductPreviewField extends FormField
             // Format variant name using J2Commerce helper for readable option names
             $variantName         = $this->formatVariantName($variant);
             $variantSku          = $variant->sku ?? '';
-            $variantPrice        = '$' . number_format((float) ($variant->price ?? 0), 2);
+            $variantPrice        = CurrencyHelper::format((float) ($variant->price ?? 0), $currency);
             $variantGtin         = $variant->upc ?? '';
             $variantAvailability = $helper->mapAvailability($variant);
             $variantStatus       = $this->getAvailabilityLabel($variantAvailability);


### PR DESCRIPTION
## Summary
Fixes #976

The Schema.org Ecommerce product-preview field rendered prices with a
hardcoded `$` symbol regardless of the J2Commerce store currency.

## Changes
- Import `CurrencyHelper` in `EcommerceProductPreviewField`
- Replace `'$' . number_format(...)` with `CurrencyHelper::format((float) $price, $currency)` for the main card price (L178)
- Same swap for variant-row prices in the variants table (L381)

`CurrencyHelper::format()` honours `config_currency`, the configured
symbol, symbol position (pre/post), decimal places, and thousands
separator from the store config.

## Testing
1. Admin → System → Config → J2Commerce → set Currency = GBP, save
2. Content → Articles → edit a J2C-linked article → Schema tab → expand "Ecommerce - Product"
3. Verify price now renders `£xx.xx` (not `$xx.xx`); GBP code badge still appears
4. Repeat on a variable product → variants table prices also show `£`
5. Switch currency to EUR → reload → verify symbol matches config (pre/post position respected)

## Files Changed
- `plugins/schemaorg/ecommerce/src/Field/EcommerceProductPreviewField.php` — currency-aware price formatting