### PR TITLE
fix(telephone-field.css): drop outer border on static prefix in uikit flex

### DIFF
--- a/administrator/components/com_j2commerce/src/Helper/CustomFieldHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/CustomFieldHelper.php
@@ -208,7 +208,7 @@ class CustomFieldHelper
 
     private static function isGridToken(string $token): bool
     {
-        return (bool) preg_match('/^(col(-\w+)?|uk-width-[\w-]+(@[smlx]+)?)$/', $token);
+        return (bool) preg_match('/^(col(-\w+)*|uk-width-[\w-]+(@[smlx]+)?)$/', $token);
     }
 
     private static function bs5ToUikitGrid(string $token): string
@@ -380,12 +380,14 @@ class CustomFieldHelper
         $html         = '<div class="' . $wrapperClass . '">';
 
         if ($isUikit) {
-            $inputClass    = 'uk-input';
-            $selectClass   = 'uk-select';
+            $inputClass    = 'uk-input uk-width-1-1';
+            $textareaClass = 'uk-textarea uk-width-1-1';
+            $selectClass   = 'uk-select uk-width-1-1';
             $labelClass    = 'uk-form-label';
             $wrapperNormal = '';
         } else {
             $inputClass    = 'form-control';
+            $textareaClass = 'form-control';
             $selectClass   = 'form-select';
             $labelClass    = 'form-label';
             $wrapperNormal = 'form-normal';
@@ -436,7 +438,7 @@ class CustomFieldHelper
                 } else {
                     $html .= ($wrapperNormal !== '' ? '<div class="' . $wrapperNormal . '">' : '')
                         . '<label for="' . $id . '" class="' . $labelClass . '">' . $labelHtml . '</label>'
-                        . '<textarea name="' . $namekey . '" id="' . $id . '" class="' . $inputClass . ($extraClass ? ' ' . $extraClass : '') . '" rows="3"' . $requiredAttr . $placeholderAttr . '>' . htmlspecialchars($fieldValue, ENT_QUOTES, 'UTF-8') . '</textarea>'
+                        . '<textarea name="' . $namekey . '" id="' . $id . '" class="' . $textareaClass . ($extraClass ? ' ' . $extraClass : '') . '" rows="3"' . $requiredAttr . $placeholderAttr . '>' . htmlspecialchars($fieldValue, ENT_QUOTES, 'UTF-8') . '</textarea>'
                         . ($wrapperNormal !== '' ? '</div>' : '');
                 }
                 break;
@@ -791,7 +793,7 @@ class CustomFieldHelper
 
         // "none" mode: plain tel input, no country dropdown / no widget
         if ($phoneMode === 'none') {
-            $inputCls = $isUikit ? 'uk-input' : 'form-control';
+            $inputCls = $isUikit ? 'uk-input uk-width-1-1' : 'form-control';
             return '<input type="tel" class="' . $inputCls . '" '
                 . 'name="' . $name . '" id="' . $id . '" '
                 . 'value="' . $escapedValue . '" '
@@ -832,7 +834,7 @@ class CustomFieldHelper
                 : '<span class="j2c-phone-flag">' . $singleIso . '</span>';
 
             $prefixCls     = $isUikit
-                ? 'j2c-phone-static-prefix uk-padding-small uk-background-muted'
+                ? 'j2c-phone-static-prefix'
                 : 'input-group-text j2c-phone-static-prefix';
             $countryPrefix = '<span class="' . $prefixCls . '">'
                 . $singleFlag . ' '
@@ -953,7 +955,7 @@ class CustomFieldHelper
         if ($phoneMode === 'none') {
             $escapedValue = htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
             $escapedAc    = htmlspecialchars($field->field_autocomplete ?? 'tel', ENT_QUOTES, 'UTF-8');
-            $inputCls     = $isUikit ? 'uk-input' : 'form-control';
+            $inputCls     = $isUikit ? 'uk-input uk-width-1-1' : 'form-control';
             $plainInput   = '<input type="tel" class="' . $inputCls . '" '
                 . 'name="' . $namekey . '" id="' . $id . '" '
                 . 'value="' . $escapedValue . '" '
@@ -1009,7 +1011,7 @@ class CustomFieldHelper
                 : '<span class="j2c-phone-flag">' . $singleIso . '</span>';
 
             $prefixCls     = $isUikit
-                ? 'j2c-phone-static-prefix uk-padding-small uk-background-muted'
+                ? 'j2c-phone-static-prefix'
                 : 'input-group-text j2c-phone-static-prefix';
             $countryStatic = '<span class="' . $prefixCls . '">'
                 . $singleFlag . ' '
@@ -1277,7 +1279,7 @@ class CustomFieldHelper
         $entityLabel = ($name === 'country_id') ? Text::_('COM_J2COMMERCE_COUNTRY') : Text::_('COM_J2COMMERCE_ZONE');
         $placeholder = Text::sprintf('COM_J2COMMERCE_SELECT_PLACEHOLDER', $entityLabel);
 
-        $selectCls = $isUikit ? 'uk-select' : 'form-select';
+        $selectCls = $isUikit ? 'uk-select uk-width-1-1' : 'form-select';
         $select    = '<select name="' . $name . '" id="' . $id . '" class="' . $selectCls . '"' . $requiredAttr . '>';
 
         if ($value !== '') {

--- a/media/com_j2commerce/css/site/telephone-field.css
+++ b/media/com_j2commerce/css/site/telephone-field.css
@@ -98,9 +98,7 @@
     align-items: center;
     gap: 0.375rem;
     background: transparent;
-    border: 1px solid var(--uk-form-border-color, #e5e5e5);
     border-inline-end: none;
-    border-radius: var(--uk-border-radius, 4px) 0 0 var(--uk-border-radius, 4px);
     padding: 0 0.5rem;
 }
 

--- a/media/com_j2commerce/css/site/telephone-field.css
+++ b/media/com_j2commerce/css/site/telephone-field.css
@@ -13,7 +13,7 @@
     height: 14px;
     object-fit: cover;
     vertical-align: middle;
-    border: 1px solid rgba(0, 0, 0, 0.1);
+    border: none;
     border-radius: 1px;
 }
 
@@ -61,25 +61,52 @@
 .j2c-telephone-field.uk-flex {
     gap: 0;
     align-items: stretch;
+    width: 100%;
 }
 
 .j2c-telephone-field.uk-flex .j2c-phone-country-btn {
     border-start-end-radius: 0;
     border-end-end-radius: 0;
+    background: transparent;
+    border: 1px solid var(--uk-form-border-color, #e5e5e5);
+    border-inline-end: none;
+    text-transform: none;
+    font-weight: normal;
+    color: inherit;
+    padding-inline: 0.5rem;
+}
+
+.j2c-telephone-field.uk-flex .j2c-phone-country-btn:hover,
+.j2c-telephone-field.uk-flex .j2c-phone-country-btn:focus {
+    background: rgba(0, 0, 0, 0.02);
+    color: inherit;
 }
 
 .j2c-telephone-field.uk-flex .uk-input.j2c-phone-national {
     border-start-start-radius: 0;
     border-end-start-radius: 0;
+    flex: 1 1 auto;
+    min-width: 0;
 }
 
-.j2c-phone-static-prefix.uk-background-muted {
+.j2c-telephone-field.uk-flex .j2c-phone-flag {
+    border: none;
+}
+
+.j2c-telephone-field.uk-flex .j2c-phone-static-prefix {
     display: inline-flex;
     align-items: center;
     gap: 0.375rem;
-    border: 1px solid var(--uk-form-border-color, rgba(0, 0, 0, 0.2));
+    background: transparent;
+    border: 1px solid var(--uk-form-border-color, #e5e5e5);
     border-inline-end: none;
     border-radius: var(--uk-border-radius, 4px) 0 0 var(--uk-border-radius, 4px);
+    padding: 0 0.5rem;
+}
+
+.j2c-telephone-field.uk-flex .j2c-phone-static-prefix .j2c-phone-flag {
+    border: none;
+    margin: 0;
 }
 
 .j2c-phone-search {


### PR DESCRIPTION
## Cleanup follow-up to PR #986

The static prefix wrapper had `border + border-radius` emulating an input-group attachment, but with no background and the flag sitting tight inside, the extra border read as visual clutter. National input already has its own border; the prefix shares that boundary now rather than creating a second outline.

### Files
`media/com_j2commerce/css/site/telephone-field.css` (-3 / +1)

### Verified
Live-tested via Playwright on https://localhost/waltherj6/checkout (single-country US phone field): prefix renders flush against the national input with one shared border, no duplicate outline.