### PR TITLE
chore(gitignore): remove translate_ini local-tooling rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,17 +19,6 @@
 !build/
 !build/**
 
-# translate_ini local-only tooling - NEVER push to j2commerce repo
-# (the script + its README live in build/scripts/ but are local-only;
-#  they read DeepL credentials from .mcp.json and produce locale files that
-#  ARE pushed, but the tooling itself stays out of the core repo)
-build/scripts/translate_ini.py
-build/scripts/README_translate_ini.md
-build/scripts/.translation_cache/
-build/scripts/.translation_cache/**
-build/scripts/__pycache__/
-build/scripts/__pycache__/**
-
 # ===========================================================================
 # J2Commerce component files
 # Must un-ignore parent directories in order for negation to work


### PR DESCRIPTION
Reverts the 11 lines that were inadvertently merged in #996.

The `build/scripts/translate_ini.py` tooling and its cache directories are local-only translation infrastructure and have no place in the upstream `j2commerce/j2commerce` `.gitignore`. Removing them keeps the core `.gitignore` aligned with what the core repo actually ships.

### Changes
- `-11` lines in `.gitignore` (the `translate_ini` block)

### Pre-Flight
- [x] Single-file diff (`.gitignore` only)
- [x] No code/asset changes
- [x] No secrets