### PR TITLE
fix(order): add spacing between item image and info in admin order view

### DIFF
--- a/administrator/components/com_j2commerce/tmpl/order/view_items.php
+++ b/administrator/components/com_j2commerce/tmpl/order/view_items.php
@@ -43,11 +43,11 @@ $currencyCode = $item->currency_code ?? '';
                             <td class="order-items-cell order-items-cell-image">
                                 <?php if (!empty($orderItemImage)) : ?>
                                     <div class="cart-product-image">
-                                        <img src="<?php echo Uri::root() . $orderItemImage; ?>" alt="<?php echo $this->escape($orderItem->orderitem_name); ?>" class="img-fluid" style="height: 64px;">
+                                        <img src="<?php echo Uri::root() . $orderItemImage; ?>" alt="<?php echo $this->escape($orderItem->orderitem_name); ?>" class="img-fluid">
                                     </div>
                                 <?php endif; ?>
                             </td>
-                            <td class="order-items-cell order-items-cell-info">
+                            <td class="order-items-cell order-items-cell-info ps-2">
                                 <div class="cart-product-info">
                                     <h3 class="cart-product-name mb-1 fs-5"><?php echo $this->escape($orderItem->orderitem_name); ?></h3>
                                     <?php echo J2CommerceHelper::plugin()->eventWithHtml('AfterDisplayLineItemTitle', array($orderItem, $item, $this->params))->getArgument('html', ''); ?>


### PR DESCRIPTION
## Summary
Fixes #1002

Order Items list on the admin order detail page rendered the product thumbnail flush against the title text. This adds breathing room between the image and the info cell.

## Changes
- `administrator/components/com_j2commerce/tmpl/order/view_items.php`
  - Add `ps-2` (0.5rem) padding-inline-start to `.order-items-cell-info` td — combined with the image cell's existing `padding-inline-end: 0.5rem` (admin-order.css) yields ~1rem total gap.
  - Drop inline `style="height: 64px;"` on `<img>` — `img-fluid` + the 80px image-cell width handle sizing.

## Testing
1. Admin → J2Commerce → Orders
2. Open any order with items (screenshot in #1002 used INV-52)
3. Verify visible gap between product thumbnail and product name
4. Confirm image still scales correctly without the hardcoded height

## Files Changed
- `administrator/components/com_j2commerce/tmpl/order/view_items.php` — 2 lines

## Pre-Flight
- [x] PHP syntax check passed
- [x] Core files only
- [x] No secrets
- [x] No FOF remnants
- [x] No new language strings