### PR TITLE
feat(core): plugin-driven grid for AJAX product-list filter

### DIFF
--- a/components/com_j2commerce/src/Controller/ProductsController.php
+++ b/components/com_j2commerce/src/Controller/ProductsController.php
@@ -15,6 +15,7 @@ namespace J2Commerce\Component\J2commerce\Site\Controller;
 \defined('_JEXEC') or die;
 
 use J2Commerce\Component\J2commerce\Administrator\Controller\ProductsController as AdminProductsController;
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 use J2Commerce\Component\J2commerce\Site\Service\ProductLayoutService;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
@@ -176,6 +177,12 @@ class ProductsController extends AdminProductsController
                 $model = $this->getModel('Products', 'Site');
                 $model->getState();
             }
+
+            // Seed model state with menu/app params — HtmlView::display() does
+            // this normally, but this AJAX endpoint bypasses the view chain.
+            // Without it, ProductsModel::getFilters() fatals on null $params.
+            $model->setState('params', $params);
+
             $model->setState('list.start', $limitstart);
 
             $pageLimit = (int) $params->get('page_limit', 0);
@@ -293,6 +300,18 @@ class ProductsController extends AdminProductsController
         $itemId   = $app->getInput()->getInt('Itemid', 0);
         $columns  = (int) $params->get('list_no_of_columns', 3);
         $colClass = 'col-md-' . (int) round(12 / $columns);
+
+        // Let subtemplate plugins render the grid in their own framework
+        // (uk-grid for UIkit, etc.). Fall back to Bootstrap markup below
+        // when no plugin claims the event.
+        $pluginHtml = J2CommerceHelper::plugin()->eventWithHtml(
+            'RenderAjaxProductListGrid',
+            [$items, $params, $itemId]
+        )->getArgument('html', '');
+
+        if ($pluginHtml !== '') {
+            return $pluginHtml;
+        }
 
         ob_start();
 

--- a/plugins/j2commerce/app_bootstrap5/src/Extension/AppBootstrap5.php
+++ b/plugins/j2commerce/app_bootstrap5/src/Extension/AppBootstrap5.php
@@ -69,14 +69,66 @@ final class AppBootstrap5 extends CMSPlugin implements SubscriberInterface
     {
         return [
             'onJ2CommerceTemplateFolderList'     => 'onTemplateFolderList',
-            'onJ2CommerceViewProductListHtml'    => 'onViewProductListHtml',
-            'onJ2CommerceViewProductListTagHtml' => 'onViewProductListTagHtml',
-            'onJ2CommerceViewProductHtml'        => 'onViewProductHtml',
-            'onJ2CommerceViewProductTagHtml'     => 'onViewProductTagHtml',
-            'onJ2CommerceViewCategoryListHtml'   => 'onViewCategoryListHtml',
-            'onJ2CommerceAfterAddCSS'            => 'onAfterAddCSS',
-            'onJ2CommerceAfterAddJS'             => 'onAfterAddJS',
+            'onJ2CommerceViewProductListHtml'        => 'onViewProductListHtml',
+            'onJ2CommerceViewProductListTagHtml'     => 'onViewProductListTagHtml',
+            'onJ2CommerceViewProductHtml'            => 'onViewProductHtml',
+            'onJ2CommerceViewProductTagHtml'         => 'onViewProductTagHtml',
+            'onJ2CommerceViewCategoryListHtml'       => 'onViewCategoryListHtml',
+            'onJ2CommerceRenderAjaxProductListGrid'  => 'onRenderAjaxProductListGrid',
+            'onJ2CommerceAfterAddCSS'                => 'onAfterAddCSS',
+            'onJ2CommerceAfterAddJS'                 => 'onAfterAddJS',
         ];
+    }
+
+    /**
+     * Render the AJAX product-list grid in Bootstrap 5 markup.
+     *
+     * Fires from ProductsController::filter() after the result set is built.
+     * Mirrors the inner grid emitted by tmpl/bootstrap5/default.php so the
+     * AJAX-replaced HTML is identical to the initial server render.
+     *
+     * @param   Event  $event  Args: [items[], params Registry, itemId int]
+     */
+    public function onRenderAjaxProductListGrid(Event $event): void
+    {
+        if (!($event instanceof EventInterface) && !($event instanceof Event)) {
+            return;
+        }
+
+        $args   = $event->getArguments();
+        $items  = $args[0] ?? [];
+        $params = $args[1] ?? null;
+        $itemId = (int) ($args[2] ?? 0);
+
+        if (!($params instanceof Registry) || empty($items)) {
+            return;
+        }
+
+        if ((string) $params->get('subtemplate', '') !== 'bootstrap5') {
+            return;
+        }
+
+        $columns  = (int) $params->get('list_no_of_columns', 3);
+        $colClass = 'col-md-' . (int) round(12 / max($columns, 1));
+
+        ob_start();
+        echo '<div class="j2commerce-products-row row g-4 mb-4">';
+        foreach ($items as $product) {
+            if (!($product->params instanceof Registry)) {
+                $product->params = new Registry($product->params ?? '{}');
+            }
+            echo '<div class="' . $colClass . '">';
+            echo ProductLayoutService::renderProductItem(
+                $product,
+                $params,
+                ProductLayoutService::CONTEXT_LIST,
+                $itemId
+            );
+            echo '</div>';
+        }
+        echo '</div>';
+
+        $event->addResult(ob_get_clean());
     }
 
     /**

--- a/plugins/j2commerce/app_uikit/src/Extension/AppUikit.php
+++ b/plugins/j2commerce/app_uikit/src/Extension/AppUikit.php
@@ -60,12 +60,13 @@ final class AppUikit extends CMSPlugin implements SubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            'onJ2CommerceTemplateFolderList'     => 'onTemplateFolderList',
-            'onJ2CommerceViewProductListHtml'    => 'onViewProductListHtml',
-            'onJ2CommerceViewProductListTagHtml' => 'onViewProductListTagHtml',
-            'onJ2CommerceViewProductHtml'        => 'onViewProductHtml',
-            'onJ2CommerceViewProductTagHtml'     => 'onViewProductTagHtml',
-            'onJ2CommerceViewCategoryListHtml'   => 'onViewCategoryListHtml',
+            'onJ2CommerceTemplateFolderList'        => 'onTemplateFolderList',
+            'onJ2CommerceViewProductListHtml'       => 'onViewProductListHtml',
+            'onJ2CommerceViewProductListTagHtml'    => 'onViewProductListTagHtml',
+            'onJ2CommerceViewProductHtml'           => 'onViewProductHtml',
+            'onJ2CommerceViewProductTagHtml'        => 'onViewProductTagHtml',
+            'onJ2CommerceViewCategoryListHtml'      => 'onViewCategoryListHtml',
+            'onJ2CommerceRenderAjaxProductListGrid' => 'onRenderAjaxProductListGrid',
         ];
     }
 
@@ -303,6 +304,43 @@ final class AppUikit extends CMSPlugin implements SubscriberInterface
         } finally {
             ProductLayoutService::clearSubtemplateOverride();
         }
+    }
+
+    public function onRenderAjaxProductListGrid(Event $event): void
+    {
+        $args    = $event->getArguments();
+        $items   = $args[0] ?? [];
+        $params  = $args[1] ?? null;
+        $itemId  = (int) ($args[2] ?? 0);
+
+        if ((string) $params?->get('subtemplate', '') !== 'uikit') {
+            return;
+        }
+
+        $columns = (int) $params->get('list_no_of_columns', 3);
+
+        ob_start();
+
+        echo '<div class="j2commerce-products-row uk-grid uk-grid-medium uk-child-width-1-' . $columns . '@s uk-margin-bottom" uk-grid>';
+
+        foreach ($items as $product) {
+            if (!($product->params instanceof Registry)) {
+                $product->params = new Registry($product->params ?? '{}');
+            }
+
+            echo '<div>';
+            echo ProductLayoutService::renderProductItem(
+                $product,
+                $params,
+                ProductLayoutService::CONTEXT_LIST,
+                $itemId
+            );
+            echo '</div>';
+        }
+
+        echo '</div>';
+
+        $event->addResult(ob_get_clean());
     }
 
     /**


### PR DESCRIPTION
## Core Update — AJAX product-list grid is now plugin-rendered

Introduces a new core event so subtemplate app plugins can render the grid HTML returned by `ProductsController::filter()` in their own framework markup (Bootstrap 5, UIkit, future others) instead of the controller hard-coding a Bootstrap row.

### New event

`onJ2CommerceRenderAjaxProductListGrid` — positional args:

| idx | type | meaning |
|-----|------|---------|
| 0 | `Product[]` | result items |
| 1 | `Joomla\Registry\Registry` | menu/app params |
| 2 | `int` | menu itemId |

Handlers MUST call `\$event->addResult(\$html)`. Dispatch is via `J2CommerceHelper::plugin()->eventWithHtml()` so the controller reads via `getArgument('html', '')`.

### Changes

- **`components/com_j2commerce/src/Controller/ProductsController.php`**
  - Fire the new event after items + params are assembled; return plugin HTML when a listener claims it. Falls back to inline Bootstrap markup otherwise.
  - **Bug fix:** seed model state with menu/app params before \`ProductsModel::getFilters()\` runs. The AJAX endpoint bypasses the view chain and \`getFilters()\` was fatal-ing on null \`\$params\`.

- **\`plugins/j2commerce/app_bootstrap5/src/Extension/AppBootstrap5.php\`**
  - Listen for the new event. When \`subtemplate=bootstrap5\`, emit byte-identical markup to the first server render (\`row g-4 mb-4\` + \`col-md-N\` children).

- **\`plugins/j2commerce/app_uikit/src/Extension/AppUikit.php\`**
  - Listen for the new event. When \`subtemplate=uikit\`, emit \`uk-grid uk-grid-medium uk-child-width-1-N@s\` so UIkit storefronts stop getting Bootstrap rows after a filter change.

All three handlers go through \`ProductLayoutService::renderProductItem()\` with \`CONTEXT_LIST\` so the per-item render pipeline matches the non-AJAX path. \`params\` is normalised to a \`Registry\` per item in case the model returned a JSON string.

### Files Modified

| Type | Count |
|------|-------|
| PHP files | 3 |
| JS/CSS assets | 0 |
| Language files | 0 |
| XML/Config | 0 |

### Pre-Flight

- [x] \`php -l\` PASS on all 3 files
- [x] No secrets detected
- [x] No FOF / JFactory remnants
- [x] Core files only (3/3 are in build_package.php core allowlist)
- [x] Branch rebased on \`upstream/main\` (\`fe4a72791\`)