### PR TITLE
fix(install): seed email + invoice templates reliably on every install path (fixes #999)

### DIFF
--- a/administrator/components/com_j2commerce/script.j2commerce.php
+++ b/administrator/components/com_j2commerce/script.j2commerce.php
@@ -131,6 +131,9 @@ class Com_J2commerceInstallerScript extends InstallerScript
     {
         $this->debugLog("=== UPDATE START ===");
 
+        $this->installLocalisation($parent);
+        $this->debugLog("UPDATE: localisation seeded (idempotent)");
+
         $this->setDefaultAcl();
         $this->debugLog("UPDATE: default ACL rules set (if empty)");
 

--- a/administrator/components/com_j2commerce/script.j2commerce.php
+++ b/administrator/components/com_j2commerce/script.j2commerce.php
@@ -416,7 +416,7 @@ class Com_J2commerceInstallerScript extends InstallerScript
             }
 
             if ($needsEmails) {
-                $this->executeSqlFileDirect($installer->getPath('source') . '/administrator/components/com_j2commerce/sql/install/mysql/emailtemplates.sql');
+                $this->executeSqlFile($installer->getPath('source') . '/administrator/components/com_j2commerce/sql/install/mysql/emailtemplates.sql');
             }
         } catch (\Exception $e) {
             $this->debugLog("LOCALISATION: email templates error: " . $e->getMessage());
@@ -436,7 +436,7 @@ class Com_J2commerceInstallerScript extends InstallerScript
             }
 
             if ($needsInvoices) {
-                $this->executeSqlFileDirect($installer->getPath('source') . '/administrator/components/com_j2commerce/sql/install/mysql/invoicetemplates.sql');
+                $this->executeSqlFile($installer->getPath('source') . '/administrator/components/com_j2commerce/sql/install/mysql/invoicetemplates.sql');
             }
         } catch (\Exception $e) {
             $this->debugLog("LOCALISATION: invoice templates error: " . $e->getMessage());
@@ -453,32 +453,6 @@ class Com_J2commerceInstallerScript extends InstallerScript
         } catch (\Exception $e) {
             $this->debugLog("LOCALISATION: guided tours error: " . $e->getMessage());
             Log::add('Error installing guided tours: ' . $e->getMessage(), Log::WARNING, 'j2commerce');
-        }
-    }
-
-    private function executeSqlFileDirect(string $sqlPath): void
-    {
-        if (!File::exists($sqlPath)) {
-            $this->debugLog("SQL DIRECT: not found: {$sqlPath}");
-            return;
-        }
-
-        $this->debugLog("SQL DIRECT: executing {$sqlPath} (" . filesize($sqlPath) . " bytes)");
-        $db  = Factory::getContainer()->get(DatabaseInterface::class);
-        $sql = trim(file_get_contents($sqlPath));
-
-        if ($sql === '') {
-            $this->debugLog("SQL DIRECT: file is empty");
-            return;
-        }
-
-        try {
-            $db->setQuery($sql);
-            $db->execute();
-            $this->debugLog("SQL DIRECT: success");
-        } catch (\Exception $e) {
-            $this->debugLog("SQL DIRECT ERROR: " . $e->getMessage());
-            Log::add('SQL Direct Error in ' . basename($sqlPath) . ': ' . $e->getMessage(), Log::WARNING, 'j2commerce');
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #999

J2Commerce installs were leaving `#__j2commerce_emailtemplates` empty and the install log was reporting `SQL DIRECT ERROR: ... syntax error near 'INSERT IGNORE INTO ... at line 2'`. Even on re-installs, both `#__j2commerce_emailtemplates` and `#__j2commerce_invoicetemplates` could end up empty because the seed step only ran on the install route.

## Root cause

Two compounding bugs in `administrator/components/com_j2commerce/script.j2commerce.php`:

1. `executeSqlFileDirect()` piped the whole multi-statement SQL file into a single `$db->setQuery($sql); $db->execute();`. MySQL/PDO does not run multi-statement queries by default, so the driver rejected the 2nd `INSERT` in `emailtemplates.sql` with a syntax error. The 1st INSERT rolled back, leaving the table empty.
2. After a broken install, Joomla routes the next package install to `update()` instead of `install()` because the extension record already exists. `update()` never called `installLocalisation()`, so the seed data was never retried — emails and invoices stayed empty forever.

`emailtemplates.sql` was a single-statement file when the Direct path was introduced in #408. Later issues #893 and #959 appended `UPDATE` statements, breaking the Direct path retroactively.

## Changes

`administrator/components/com_j2commerce/script.j2commerce.php`:

- Swap both `executeSqlFileDirect()` callsites (email + invoice) to `executeSqlFile()` — same `DatabaseDriver::splitSql()` path already used for countries/zones/lengths/weights/guidedtours. Verified locally that `splitSql()` produces 4 well-formed queries from `emailtemplates.sql` and 1 from `invoicetemplates.sql`, with no escape/quote mishandling on the embedded HTML/CSS content.
- Drop the now-orphan `executeSqlFileDirect()` helper.
- Call `installLocalisation()` from `update()` in addition to `install()`. The method is fully idempotent (each seed step gates on `COUNT(*) < 1`) so it is safe to call on every update. This covers fresh installs, update-over-broken-state, and the preflight `repairMissingTables()` repair path with a single change.

## Test plan

- [x] Fresh install on a clean Joomla 6 site: `j6_j2commerce_emailtemplates` = 4 rows (row 1 `is_default=1`), `j6_j2commerce_invoicetemplates` = 4 rows
- [x] Install over a previously-broken install state (route = update): `installLocalisation()` re-seeds both tables; install log shows `SQL FILE: 4 executed, 0 skipped` for emails and `SQL FILE: 1 executed, 0 skipped` for invoices
- [x] No `SQL DIRECT ERROR` lines anywhere in `administrator/logs/j2commerce_install_debug.log`
- [x] Update on a healthy install (tables already seeded): `installLocalisation()` runs, every seed step short-circuits at `COUNT(*) >= 1`, no duplicate rows

## Files Changed

- `administrator/components/com_j2commerce/script.j2commerce.php` — +5 / -28