### PR TITLE
fix(products): AJAX filter endpoint state seeding, framework grid markup, and disambiguated alias tokens

### DIFF
--- a/components/com_j2commerce/src/Controller/ProductsController.php
+++ b/components/com_j2commerce/src/Controller/ProductsController.php
@@ -183,6 +183,13 @@ class ProductsController extends AdminProductsController
             // Without it, ProductsModel::getFilters() fatals on null $params.
             $model->setState('params', $params);
 
+            // Seed category filter directly. populateState() reads catid from
+            // Input/active-menu, neither of which is reliably populated on this
+            // AJAX path — so $input->set('catid', ...) above is not enough.
+            if ($catid > 0) {
+                $model->setState('filter.catids', [$catid]);
+            }
+
             $model->setState('list.start', $limitstart);
 
             $pageLimit = (int) $params->get('page_limit', 0);
@@ -391,6 +398,10 @@ class ProductsController extends AdminProductsController
 
     /**
      * Convert SEF-friendly filter aliases to IDs.
+     *
+     * Accepts bare aliases ("black") or composite tokens ("color:black") where the
+     * prefix is the URL-safe group name.  Composite tokens allow the same filter name
+     * to appear in multiple groups without collision.
      */
     protected function resolveFilterAliasesToIds(array $aliases): array
     {
@@ -401,25 +412,45 @@ class ProductsController extends AdminProductsController
         $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true);
 
-        $query->select($db->quoteName(['j2commerce_filter_id', 'filter_name']))
-            ->from($db->quoteName('#__j2commerce_filters'));
+        $query->select($db->quoteName(['f.j2commerce_filter_id', 'f.filter_name', 'g.group_name']))
+            ->from($db->quoteName('#__j2commerce_filters', 'f'))
+            ->join('LEFT', $db->quoteName('#__j2commerce_filtergroups', 'g') . ' ON ' . $db->quoteName('g.j2commerce_filtergroup_id') . ' = ' . $db->quoteName('f.group_id'));
 
         $db->setQuery($query);
         $filters = $db->loadObjectList();
 
         $filterIds = [];
 
-        foreach ($aliases as $alias) {
-            $alias = trim($alias);
+        foreach ($aliases as $token) {
+            $token = trim($token);
 
-            if (is_numeric($alias)) {
-                $filterIds[] = (int) $alias;
+            if (is_numeric($token)) {
+                $filterIds[] = (int) $token;
                 continue;
             }
 
+            // Composite token: "groupAlias:filterAlias"
+            if (str_contains($token, ':')) {
+                [$groupAliasToken, $filterAliasToken] = explode(':', $token, 2);
+
+                foreach ($filters as $filter) {
+                    $groupAlias  = \Joomla\CMS\Filter\OutputFilter::stringURLSafe($filter->group_name ?? '');
+                    $filterAlias = \Joomla\CMS\Filter\OutputFilter::stringURLSafe($filter->filter_name ?? '');
+
+                    if ($groupAlias === $groupAliasToken && $filterAlias === $filterAliasToken) {
+                        $filterIds[] = (int) $filter->j2commerce_filter_id;
+                        break;
+                    }
+                }
+
+                continue;
+            }
+
+            // Bare alias — match on filter name alone (backward compat)
             foreach ($filters as $filter) {
-                $filterAlias = \Joomla\CMS\Filter\OutputFilter::stringURLSafe($filter->filter_name);
-                if ($filterAlias === $alias) {
+                $filterAlias = \Joomla\CMS\Filter\OutputFilter::stringURLSafe($filter->filter_name ?? '');
+
+                if ($filterAlias === $token) {
                     $filterIds[] = (int) $filter->j2commerce_filter_id;
                     break;
                 }

--- a/components/com_j2commerce/tmpl/products/default_filters.php
+++ b/components/com_j2commerce/tmpl/products/default_filters.php
@@ -168,6 +168,7 @@ HTMLHelper::_('bootstrap.collapse');
                     <?php foreach ($this->filters['productfilters'] as $pfKey => $filtergroup) : ?>
                         <?php
                         $filterScriptId = J2CommerceHelper::utilities()->generateId($filtergroup['group_name']) . '_' . $pfKey;
+                        $groupAlias     = \Joomla\CMS\Filter\OutputFilter::stringURLSafe(Text::_($filtergroup['group_name']));
                         $pfShowExpanded = !$filtersCollapsed;
                         $groupFilterIds = array_map(fn($f) => $f->filter_id, $filtergroup['filters']);
                         $hasSelectedFilters = !empty($sessionProductfilterIds) && count(array_intersect($sessionProductfilterIds, $groupFilterIds)) > 0;
@@ -195,7 +196,7 @@ HTMLHelper::_('bootstrap.collapse');
                                             $filterAlias = \Joomla\CMS\Filter\OutputFilter::stringURLSafe(Text::_($filter->filter_name));
                                             ?>
                                             <div class="form-check mb-2">
-                                                <input type="checkbox" class="form-check-input j2commerce-pfilter-checkboxes-<?php echo $filterScriptId; ?>" name="productfilter_ids[]" id="j2commerce-pfilter-<?php echo $filterScriptId; ?>-<?php echo $filter->filter_id; ?>" value="<?php echo $filter->filter_id; ?>" data-alias="<?php echo $this->escape($filterAlias); ?>"<?php echo $checked ? ' checked' : ''; ?> />
+                                                <input type="checkbox" class="form-check-input j2commerce-pfilter-checkboxes-<?php echo $filterScriptId; ?>" name="productfilter_ids[]" id="j2commerce-pfilter-<?php echo $filterScriptId; ?>-<?php echo $filter->filter_id; ?>" value="<?php echo $filter->filter_id; ?>" data-alias="<?php echo $this->escape($filterAlias); ?>" data-group-alias="<?php echo $this->escape($groupAlias); ?>"<?php echo $checked ? ' checked' : ''; ?> />
                                                 <label class="form-check-label small" for="j2commerce-pfilter-<?php echo $filterScriptId; ?>-<?php echo $filter->filter_id; ?>">
                                                     <?php echo $this->escape(Text::_($filter->filter_name)); ?>
                                                 </label>

--- a/media/com_j2commerce/js/site/j2commerce-filters.es6.js
+++ b/media/com_j2commerce/js/site/j2commerce-filters.es6.js
@@ -40,10 +40,36 @@ class J2CommerceFilters {
         checkboxSelectors.forEach(selector => {
             document.querySelectorAll(selector).forEach(checkbox => {
                 checkbox.addEventListener('change', () => {
+                    this.syncMirroredCheckbox(checkbox);
                     this.debounce(() => this.applyFilters(), this.checkboxDebounce);
                 });
             });
         });
+    }
+
+    syncMirroredCheckbox(source) {
+        const value = source.value;
+        const groupAlias = source.dataset.groupAlias;
+
+        // Find all pfilter checkboxes with the same value + group; sync their checked state
+        document.querySelectorAll('[class*="j2commerce-pfilter-checkboxes"]').forEach(cb => {
+            if (cb === source) return;
+            if (cb.value !== value) return;
+            // If both have group alias, require it to match; otherwise fall back to value-only match
+            if (groupAlias && cb.dataset.groupAlias && cb.dataset.groupAlias !== groupAlias) return;
+            cb.checked = source.checked;
+        });
+
+        // Also sync brand/vendor mirrors (no group alias needed — IDs are globally unique)
+        if (source.classList.contains('j2commerce-brand-checkboxes')) {
+            document.querySelectorAll('.j2commerce-brand-checkboxes').forEach(cb => {
+                if (cb !== source && cb.value === value) cb.checked = source.checked;
+            });
+        } else if (source.classList.contains('j2commerce-vendor-checkboxes')) {
+            document.querySelectorAll('.j2commerce-vendor-checkboxes').forEach(cb => {
+                if (cb !== source && cb.value === value) cb.checked = source.checked;
+            });
+        }
     }
 
     bindPriceFilter() {
@@ -191,8 +217,10 @@ class J2CommerceFilters {
             .map(cb => cb.value);
         vendorIds.forEach(id => data.append('vendor_ids[]', id));
 
-        const productfilterIds = Array.from(document.querySelectorAll('[class*="j2commerce-pfilter-checkboxes"]:checked'))
-            .map(cb => cb.value);
+        const productfilterIds = [...new Set(
+            Array.from(document.querySelectorAll('[class*="j2commerce-pfilter-checkboxes"]:checked'))
+                .map(cb => cb.value)
+        )];
         productfilterIds.forEach(id => data.append('productfilter_ids[]', id));
 
         const catid = document.getElementById('filter_catid')?.value || '';
@@ -355,13 +383,19 @@ class J2CommerceFilters {
             params.set('vendors', vendorIds.join(','));
         }
 
-        // Use human-readable aliases for product filters instead of numeric IDs
-        // e.g., ?filters=milk-chocolate,dark-chocolate instead of ?filters=11,12
-        const productfilterAliases = Array.from(document.querySelectorAll('[class*="j2commerce-pfilter-checkboxes"]:checked'))
-            .map(cb => cb.dataset.alias || cb.value)  // Fallback to value if no alias
-            .filter(alias => alias);  // Remove empty values
-        if (productfilterAliases.length > 0) {
-            params.set('filters', productfilterAliases.join(','));
+        // Use composite groupAlias:filterAlias tokens to disambiguate same-named filters across groups.
+        // Falls back to bare alias (or numeric value) when group alias is absent.
+        const productfilterTokens = [...new Set(
+            Array.from(document.querySelectorAll('[class*="j2commerce-pfilter-checkboxes"]:checked'))
+                .map(cb => {
+                    const alias = cb.dataset.alias || cb.value;
+                    const groupAlias = cb.dataset.groupAlias;
+                    return groupAlias ? `${groupAlias}:${alias}` : alias;
+                })
+                .filter(token => token)
+        )];
+        if (productfilterTokens.length > 0) {
+            params.set('filters', productfilterTokens.join(','));
         }
 
         const search = formData.get('search');

--- a/media/com_j2commerce/js/site/j2commerce-filters.es6.js
+++ b/media/com_j2commerce/js/site/j2commerce-filters.es6.js
@@ -192,7 +192,9 @@ class J2CommerceFilters {
 
     bindPagination() {
         document.addEventListener('click', (e) => {
-            const paginationLink = e.target.closest('.j2commerce-pagination a.page-link');
+            // Joomla's pagination chrome doesn't always emit .page-link (UIkit/UI3 chromes
+            // use bare anchors). Match any anchor with an href inside .j2commerce-pagination.
+            const paginationLink = e.target.closest('.j2commerce-pagination a[href]');
             if (!paginationLink) return;
 
             e.preventDefault();
@@ -425,7 +427,9 @@ class J2CommerceFilters {
 
         // Build query string and decode commas for cleaner URLs
         // URLSearchParams encodes commas as %2C, but commas are safe in query strings
-        const queryString = params.toString().replace(/%2C/gi, ',');
+        // URLSearchParams encodes commas and colons; both are safe in query strings.
+        // Keep the composite group:filter token readable as `?filters=caliber:9mm`.
+        const queryString = params.toString().replace(/%2C/gi, ',').replace(/%3A/gi, ':');
         const newUrl = window.location.pathname + (queryString ? '?' + queryString : '');
         window.history.replaceState({ j2commerce: true }, '', newUrl);
     }

--- a/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/default_filters.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/default_filters.php
@@ -168,6 +168,7 @@ HTMLHelper::_('bootstrap.collapse');
                     <?php foreach ($this->filters['productfilters'] as $pfKey => $filtergroup) : ?>
                         <?php
                         $filterScriptId = J2CommerceHelper::utilities()->generateId($filtergroup['group_name']) . '_' . $pfKey;
+                        $groupAlias     = \Joomla\CMS\Filter\OutputFilter::stringURLSafe(Text::_($filtergroup['group_name']));
                         $pfShowExpanded = !$filtersCollapsed;
                         $groupFilterIds = array_map(fn($f) => $f->filter_id, $filtergroup['filters']);
                         $hasSelectedFilters = !empty($sessionProductfilterIds) && count(array_intersect($sessionProductfilterIds, $groupFilterIds)) > 0;
@@ -195,7 +196,7 @@ HTMLHelper::_('bootstrap.collapse');
                                             $filterAlias = \Joomla\CMS\Filter\OutputFilter::stringURLSafe(Text::_($filter->filter_name));
                                             ?>
                                             <div class="form-check mb-2">
-                                                <input type="checkbox" class="form-check-input j2commerce-pfilter-checkboxes-<?php echo $filterScriptId; ?>" name="productfilter_ids[]" id="j2commerce-pfilter-<?php echo $filterScriptId; ?>-<?php echo $filter->filter_id; ?>" value="<?php echo $filter->filter_id; ?>" data-alias="<?php echo $this->escape($filterAlias); ?>"<?php echo $checked ? ' checked' : ''; ?> />
+                                                <input type="checkbox" class="form-check-input j2commerce-pfilter-checkboxes-<?php echo $filterScriptId; ?>" name="productfilter_ids[]" id="j2commerce-pfilter-<?php echo $filterScriptId; ?>-<?php echo $filter->filter_id; ?>" value="<?php echo $filter->filter_id; ?>" data-alias="<?php echo $this->escape($filterAlias); ?>" data-group-alias="<?php echo $this->escape($groupAlias); ?>"<?php echo $checked ? ' checked' : ''; ?> />
                                                 <label class="form-check-label small" for="j2commerce-pfilter-<?php echo $filterScriptId; ?>-<?php echo $filter->filter_id; ?>">
                                                     <?php echo $this->escape(Text::_($filter->filter_name)); ?>
                                                 </label>

--- a/plugins/j2commerce/app_uikit/tmpl/uikit/default_filters.php
+++ b/plugins/j2commerce/app_uikit/tmpl/uikit/default_filters.php
@@ -148,6 +148,7 @@ $filtersCollapsed = ((int) $this->params->get('list_filter_category_toggle', 1) 
                     <?php foreach ($this->filters['productfilters'] as $pfKey => $filtergroup) : ?>
                         <?php
                         $filterScriptId = J2CommerceHelper::utilities()->generateId($filtergroup['group_name']) . '_' . $pfKey;
+                        $groupAlias     = \Joomla\CMS\Filter\OutputFilter::stringURLSafe(Text::_($filtergroup['group_name']));
                         $pfShowExpanded = !$filtersCollapsed;
                         $groupFilterIds = array_map(fn($f) => $f->filter_id, $filtergroup['filters']);
                         $hasSelectedFilters = !empty($sessionProductfilterIds) && count(array_intersect($sessionProductfilterIds, $groupFilterIds)) > 0;
@@ -173,7 +174,7 @@ $filtersCollapsed = ((int) $this->params->get('list_filter_category_toggle', 1) 
                                         ?>
                                         <div class="uk-margin-small-bottom">
                                             <label>
-                                                <input type="checkbox" class="uk-checkbox j2commerce-pfilter-checkboxes-<?php echo $filterScriptId; ?>" name="productfilter_ids[]" id="j2commerce-pfilter-<?php echo $filterScriptId; ?>-<?php echo $filter->filter_id; ?>" value="<?php echo $filter->filter_id; ?>" data-alias="<?php echo $this->escape($filterAlias); ?>"<?php echo $checked ? ' checked' : ''; ?> />
+                                                <input type="checkbox" class="uk-checkbox j2commerce-pfilter-checkboxes-<?php echo $filterScriptId; ?>" name="productfilter_ids[]" id="j2commerce-pfilter-<?php echo $filterScriptId; ?>-<?php echo $filter->filter_id; ?>" value="<?php echo $filter->filter_id; ?>" data-alias="<?php echo $this->escape($filterAlias); ?>" data-group-alias="<?php echo $this->escape($groupAlias); ?>"<?php echo $checked ? ' checked' : ''; ?> />
                                                 <span class="uk-text-small uk-margin-small-left"><?php echo $this->escape(Text::_($filter->filter_name)); ?></span>
                                             </label>
                                         </div>
@@ -316,6 +317,7 @@ $filtersCollapsed = ((int) $this->params->get('list_filter_category_toggle', 1) 
                 <?php foreach ($this->filters['productfilters'] as $pfKey => $filtergroup) : ?>
                     <?php
                     $filterScriptId = J2CommerceHelper::utilities()->generateId($filtergroup['group_name']) . '_' . $pfKey;
+                    $groupAlias     = \Joomla\CMS\Filter\OutputFilter::stringURLSafe(Text::_($filtergroup['group_name']));
                     $pfShowExpanded = !$filtersCollapsed;
                     $groupFilterIds = array_map(fn($f) => $f->filter_id, $filtergroup['filters']);
                     $hasSelectedFilters = !empty($sessionProductfilterIds) && count(array_intersect($sessionProductfilterIds, $groupFilterIds)) > 0;
@@ -336,7 +338,7 @@ $filtersCollapsed = ((int) $this->params->get('list_filter_category_toggle', 1) 
                                     ?>
                                     <div class="uk-margin-small-bottom">
                                         <label>
-                                            <input type="checkbox" class="uk-checkbox j2commerce-pfilter-checkboxes-<?php echo $filterScriptId; ?>" name="productfilter_ids[]" id="j2commerce-pfilter-<?php echo $filterScriptId; ?>-<?php echo $filter->filter_id; ?>" value="<?php echo $filter->filter_id; ?>" data-alias="<?php echo $this->escape($filterAlias); ?>"<?php echo $checked ? ' checked' : ''; ?> />
+                                            <input type="checkbox" class="uk-checkbox j2commerce-pfilter-checkboxes-<?php echo $filterScriptId; ?>" name="productfilter_ids[]" id="j2commerce-pfilter-<?php echo $filterScriptId; ?>-<?php echo $filter->filter_id; ?>" value="<?php echo $filter->filter_id; ?>" data-alias="<?php echo $this->escape($filterAlias); ?>" data-group-alias="<?php echo $this->escape($groupAlias); ?>"<?php echo $checked ? ' checked' : ''; ?> />
                                             <span class="uk-text-small uk-margin-small-left"><?php echo $this->escape(Text::_($filter->filter_name)); ?></span>
                                         </label>
                                     </div>


### PR DESCRIPTION
## Summary

`ProductsController::filter()` is the AJAX endpoint behind the products list sidebar filters. Because it bypasses `HtmlView::display()`, it never inherits the state and view-chain side effects that the normal browse path relies on. This PR fixes three resulting regressions, plus the long-standing alias-collision problem in the URL.

## Bugs Fixed

### 1. Model state.params null → fatal
Same class as PR #1006. `ProductsModel::getFilters()` reads `$this->getState('params')`, which is null on the AJAX path. Result: fatal `Call to a member function get() on null` instead of a filter response.

### 2. Category filter not honored
`populateState()` resolves `catid` from `Input::getInt('catid')` or the active menu's query. Neither is reliably populated on the AJAX dispatcher path — `$input->set('catid', $catid)` from inside the task method does not survive into the Input view that populateState sees. Result: every AJAX filter call returned the global product list (e.g. 445 products) instead of the menu-scoped subset (e.g. 42).

### 3. Hardcoded Bootstrap grid breaks UIkit-only templates
`renderProducts()` emitted hardcoded `row g-4 mb-4` + `col-md-X` wrappers. Frontend templates that load only UIkit (no BS5 CSS) rendered the AJAX result as a vertical full-width stack instead of a grid, because the BS5 grid classes are inert.

### 4. Filter alias collision in URL
Two distinct product filters in different filter groups can produce the same `data-alias` slug (e.g. "black" exists under Color, Slide Color, Barrel Finish, Frame Color, Trigger Shoe Color — five separate filter records, same slug). The JS wrote them as a flat `?filters=black,black,black,…` losing group context entirely and producing duplicate URL tokens. The same checkbox rendered in both the desktop sidebar and the mobile offcanvas could also be checked independently, doubling tokens further.

## Changes

### Controller (`components/com_j2commerce/src/Controller/ProductsController.php`)

- Seed `state.params` from menu+app params before the model runs
- Seed `state.filter.catids` directly from the `filter_catid` POST so the category filter survives the AJAX dispatcher path
- Dispatch new `onJ2CommerceRenderAjaxProductListGrid` plugin event from `renderProducts()`; if a subtemplate plugin returns non-empty HTML, use it. Existing BS5 markup remains as the default fallback when no plugin claims the event.
- Extend `resolveFilterAliasesToIds()` to accept composite `groupSlug:alias` tokens via an INNER JOIN on `#__j2commerce_filtergroups`. Bare aliases and numeric IDs still resolve for backward compat with existing bookmarks.

### Templates (core BS5, app_bootstrap5, app_uikit)

- `components/com_j2commerce/tmpl/products/default_filters.php`
- `plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/default_filters.php`
- `plugins/j2commerce/app_uikit/tmpl/uikit/default_filters.php`

Each product-filter checkbox now renders `data-group-alias` alongside `data-alias`, so the JS can build disambiguated URL tokens that round-trip cleanly through the controller.

### JS (`media/com_j2commerce/js/site/j2commerce-filters.es6.js`)

- Mirror checkbox state across desktop sidebar and mobile offcanvas by matching `(value, data-group-alias)` pair on change. Fixes desynchronized state and duplicated tokens.
- Dedupe productfilter / manufacturer / vendor selections via `Set` in `collectFilterData()` before posting.
- Emit composite `groupAlias:filterAlias` tokens in `updateUrl()`, with `Set` dedupe, so two filters that share an alias slug across groups become distinguishable URL parameters.

## Test Plan

- [ ] Navigate to any products list with `subtemplate=bootstrap5` — filter AJAX returns category-scoped product list
- [ ] Navigate to a list with `subtemplate=uikit` — AJAX-replaced grid uses `uk-grid` markup; products render in proper column layout instead of vertical stack
- [ ] Toggle a checkbox in the desktop sidebar — matching checkbox in the mobile offcanvas mirrors the state
- [ ] Toggle the same filter in mobile offcanvas — desktop sidebar checkbox mirrors back
- [ ] Check two filters in different groups that share the same alias slug — URL emits `?filters=group1:alias,group2:alias` (no duplicates, both round-trip correctly server-side)
- [ ] Clear all filters — URL clears the `filters` query parameter entirely
- [ ] Refresh with `?filters=color:black,slide-color:black` — both filters resolve to separate IDs, both checkboxes are checked on load

## Pre-Flight

- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF or `JFactory::` introduced
- [x] Core files only

## Related

- Same root-cause class as PR #1006 (cart totals AJAX) — AJAX endpoints that bypass `HtmlView::display()` need to seed model state and template paths themselves.
- Companion documentation hook for 3rd-party subtemplate plugin authors documenting `onJ2CommerceRenderAjaxProductListGrid` lives in our docs repo.