### PR TITLE
fix(sampledata): populate orderitem_params with thumb_image

### DIFF
--- a/administrator/components/com_j2commerce/src/Helper/SampleDataHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/SampleDataHelper.php
@@ -1493,6 +1493,24 @@ final class SampleDataHelper
 
         $now = time();
 
+        $imageMap = [];
+        $imageIds = array_column($productIds, 'id');
+        if (!empty($imageIds)) {
+            $imgQuery = $db->getQuery(true)
+                ->select($db->quoteName(['product_id', 'thumb_image']))
+                ->from($db->quoteName('#__j2commerce_productimages'))
+                ->whereIn($db->quoteName('product_id'), $imageIds);
+            $db->setQuery($imgQuery);
+
+            foreach ($db->loadObjectList() as $row) {
+                $thumb = (string) ($row->thumb_image ?? '');
+                if ($thumb !== '' && strpos($thumb, '#') !== false) {
+                    $thumb = substr($thumb, 0, strpos($thumb, '#'));
+                }
+                $imageMap[(int) $row->product_id] = $thumb;
+            }
+        }
+
         for ($i = 0; $i < $count; $i++) {
             $customer   = $customerIds[$i % $custCount];
             $statusId   = $statusPool[$i % \count($statusPool)];
@@ -1667,7 +1685,10 @@ final class SampleDataHelper
                 $oi->orderitem_finalprice             = $item['line_total'];
                 $oi->orderitem_finalprice_with_tax    = round($item['line_total'] * 1.0825, 5);
                 $oi->orderitem_finalprice_without_tax = $item['line_total'];
-                $oi->orderitem_params                 = '{}';
+                $thumbImage                           = $imageMap[(int) $item['product_id']] ?? '';
+                $oi->orderitem_params                 = $thumbImage !== ''
+                    ? json_encode(['thumb_image' => $thumbImage])
+                    : '{}';
                 $oi->created_on                       = $createdOn;
                 $oi->created_by                       = $customer['id'];
                 $oi->orderitem_weight                 = '0';


### PR DESCRIPTION
## Summary
Fixes #1017

Sample-data orders displayed no product image in the admin order view because `SampleDataHelper::createOrders()` hardcoded `orderitem_params` to `'{}'`. Real orders write `{"thumb_image":"<url>"}` into that JSON column via the cart Behavior chain (e.g. `CartSimple::beforeAddToCart`), and the order line-item layout reads it from there.

## Changes
- `createOrders()` now batch-loads `thumb_image` from `#__j2commerce_productimages` keyed by `product_id` (one query for all sample products).
- Each order item is written with `orderitem_params = json_encode(['thumb_image' => $thumb])` — falls back to `'{}'` only when a product has no image row.
- Strips Joomla's `#joomlaImage...` media-handler suffix if present, matching `CartSimple::beforeAddToCart`.

## Testing
1. Admin → System → Install → Sample Data.
2. Remove any previously loaded J2Commerce sample data, then run the 4-step J2Commerce sample-data wizard.
3. J2Commerce → Orders → open any of the new sample orders.
4. Verify the product thumbnail renders next to each line item (matches the look of real, customer-placed orders).
5. Optional DB check: `SELECT orderitem_params FROM j6_j2commerce_orderitems WHERE order_id LIKE 'TXN-SAMPLE%' LIMIT 5;` should return JSON like `{"thumb_image":"media/plg_sampledata_j2commerce/images/electronics/1.svg"}`.

## Files Changed
- `administrator/components/com_j2commerce/src/Helper/SampleDataHelper.php` — batch image lookup + per-item params write.

## Risk
Low. Self-contained in the sample-data generation path; no schema change, no language strings, no impact on real-customer orders.