### PR TITLE
fix(confirmation): surface invalid-token error + clean ugly URL

### DIFF
--- a/components/com_j2commerce/language/en-GB/com_j2commerce.ini
+++ b/components/com_j2commerce/language/en-GB/com_j2commerce.ini
@@ -168,6 +168,7 @@ COM_J2COMMERCE_CONFIRMATION_LOGIN_TO_VIEW="Please log in or use your order token
 COM_J2COMMERCE_CONFIRMATION_ORDER_NOT_FOUND="Order not found or you do not have permission to view this order."
 COM_J2COMMERCE_CONFIRMATION_SHOWING_RECENT="Showing your most recent order."
 COM_J2COMMERCE_CONFIRMATION_TOKEN_HELP="Enter the order token from your confirmation email to view your order details."
+COM_J2COMMERCE_CONFIRMATION_TOKEN_INVALID="That order token is invalid or has expired. Please double-check the token from your confirmation email and try again."
 COM_J2COMMERCE_CONFIRMATION_TOKEN_PLACEHOLDER="Enter order token"
 COM_J2COMMERCE_CONFIRMATION_TOKEN_SUBMIT="View Order"
 COM_J2COMMERCE_CONFIRMATION_VIEW_ALL_ORDERS="View All Orders"

--- a/components/com_j2commerce/language/en-US/com_j2commerce.ini
+++ b/components/com_j2commerce/language/en-US/com_j2commerce.ini
@@ -168,6 +168,7 @@ COM_J2COMMERCE_CONFIRMATION_LOGIN_TO_VIEW="Please log in or use your order token
 COM_J2COMMERCE_CONFIRMATION_ORDER_NOT_FOUND="Order not found or you do not have permission to view this order."
 COM_J2COMMERCE_CONFIRMATION_SHOWING_RECENT="Showing your most recent order."
 COM_J2COMMERCE_CONFIRMATION_TOKEN_HELP="Enter the order token from your confirmation email to view your order details."
+COM_J2COMMERCE_CONFIRMATION_TOKEN_INVALID="That order token is invalid or has expired. Please double-check the token from your confirmation email and try again."
 COM_J2COMMERCE_CONFIRMATION_TOKEN_PLACEHOLDER="Enter order token"
 COM_J2COMMERCE_CONFIRMATION_TOKEN_SUBMIT="View Order"
 COM_J2COMMERCE_CONFIRMATION_VIEW_ALL_ORDERS="View All Orders"

--- a/components/com_j2commerce/src/View/Confirmation/HtmlView.php
+++ b/components/com_j2commerce/src/View/Confirmation/HtmlView.php
@@ -55,6 +55,21 @@ class HtmlView extends BaseHtmlView
         $this->order = $model->getOrder();
 
         if ($this->order === null) {
+            $submittedToken = (string) $model->getState('token', '');
+
+            // A token was supplied but did not resolve to an authorised order →
+            // surface an error and redirect to the clean URL so the noisy
+            // ?option=...&view=...&token=... query string from the GET form is gone.
+            if ($submittedToken !== '') {
+                $app->enqueueMessage(
+                    Text::_('COM_J2COMMERCE_CONFIRMATION_TOKEN_INVALID'),
+                    'error'
+                );
+                $app->redirect(Route::_('index.php?option=com_j2commerce&view=confirmation', false));
+
+                return;
+            }
+
             $user = $app->getIdentity();
 
             // Guest → redirect to My Profile (has login + guest order lookup form)


### PR DESCRIPTION
## Summary
Fixes #1001

When a visitor enters an invalid or expired order token on the order-confirmation lookup form, the page silently re-rendered with no feedback. The SEF URL also picked up the form's hidden `option`/`view` inputs from the GET submit, producing a noisy `?option=com_j2commerce&view=confirmation&token=...` query string layered on top of the `/order-confirmation` SEF path.

## Changes
- `components/com_j2commerce/src/View/Confirmation/HtmlView.php` — when `getOrder()` returns `null` AND a `token` was submitted, enqueue an error message and redirect to the clean confirmation route. The redirect wipes the noisy query string and the message renders on the fresh page.
- `components/com_j2commerce/language/en-US/com_j2commerce.ini` — new key `COM_J2COMMERCE_CONFIRMATION_TOKEN_INVALID`.
- `components/com_j2commerce/language/en-GB/com_j2commerce.ini` — same key (identical British English copy).

Valid-token path and "no token at all" path (logged-in user → lookup form, guest → My Profile redirect) are untouched.

## Testing
1. Browse to `/order-confirmation` while logged in as a customer with at least one order.
2. Type any garbage in the token box → click **View Order**.
3. Expect: URL returns to clean `/order-confirmation` (no `?option=...&token=...`) and a red error message "That order token is invalid or has expired..." appears.
4. Log out, repeat step 2 as guest → same outcome.
5. Enter a real token from a confirmation email → loads the matching order (regression check on happy path).
6. Visit `/order-confirmation` with no query string at all → no error, original behaviour intact (form for logged-in users, redirect to My Profile for guests).

## Files Changed
- `components/com_j2commerce/src/View/Confirmation/HtmlView.php` — invalid-token branch added.
- `components/com_j2commerce/language/en-US/com_j2commerce.ini` — new TOKEN_INVALID string.
- `components/com_j2commerce/language/en-GB/com_j2commerce.ini` — new TOKEN_INVALID string.