### PR TITLE
fix(grapesjs): improve RTE actionbar contrast in admin builder

### DIFF
--- a/media/com_j2commerce/css/administrator/grapesjs-j2commerce.css
+++ b/media/com_j2commerce/css/administrator/grapesjs-j2commerce.css
@@ -716,12 +716,13 @@
 }
 
 .gjs-rte-actionbar .gjs-rte-action {
-    color: var(--gjs-toolbar-color);
+    color: var(--gjs-text-primary);
     border-inline-end-color: var(--gjs-border);
 }
 
 .gjs-rte-actionbar .gjs-rte-action:hover {
     color: var(--gjs-accent);
+    background-color: var(--gjs-block-hover-bg);
 }
 
 


### PR DESCRIPTION
## Summary

Rich-text editor actionbar buttons inside the GrapesJS admin builder used
\`--gjs-toolbar-color\` which washed out against the toolbar background,
making the icons hard to read. Switched to \`--gjs-text-primary\` and added
\`--gjs-block-hover-bg\` on \`:hover\` so the active state is visible.

## Changes

- \`media/com_j2commerce/css/administrator/grapesjs-j2commerce.css\`
  - \`.gjs-rte-actionbar .gjs-rte-action\` color → \`--gjs-text-primary\`
  - \`.gjs-rte-actionbar .gjs-rte-action:hover\` adds \`background-color: var(--gjs-block-hover-bg)\`

## Test plan

- [ ] Open any admin page that loads the GrapesJS builder (e.g. an editable
      product description or article-bound shortcode template)
- [ ] Select text inside the canvas → RTE actionbar appears
- [ ] Action icons (bold / italic / etc.) are clearly visible against
      toolbar background
- [ ] Hover an action → visible hover background highlights the button

## Files changed

| File | +/- |
|------|-----|
| \`media/com_j2commerce/css/administrator/grapesjs-j2commerce.css\` | +2 / -1 |