### PR TITLE
fix(checkout): wire TOS checkbox + restore terms modal asset registration

### DIFF
--- a/components/com_j2commerce/src/View/Checkout/HtmlView.php
+++ b/components/com_j2commerce/src/View/Checkout/HtmlView.php
@@ -109,6 +109,7 @@ class HtmlView extends BaseHtmlView
         $this->_prepareDocument();
 
         HTMLHelper::_('bootstrap.collapse', 'checkoutSidecartCollapse');
+        HTMLHelper::_('bootstrap.modal');
 
         $this->registerFrameworkTemplatePaths($app);
 

--- a/components/com_j2commerce/tmpl/checkout/bootstrap5/default.php
+++ b/components/com_j2commerce/tmpl/checkout/bootstrap5/default.php
@@ -26,6 +26,7 @@ $token = Session::getFormToken();
 $wa  = Factory::getApplication()->getDocument()->getWebAssetManager();
 $wa->useScript('bootstrap.collapse');
 $wa->useScript('bootstrap.dropdown');
+$wa->useScript('bootstrap.modal');
 
 $wa->registerAndUseStyle('checkout.style', 'media/com_j2commerce/css/site/checkout.css', [], [], []);
 
@@ -45,6 +46,9 @@ if ($this->order && method_exists($this->order, 'get_formatted_order_totals')) {
 
 // Pre-compute JS-safe language strings
 $selectZoneJs = htmlspecialchars(Text::sprintf('COM_J2COMMERCE_SELECT_PLACEHOLDER', Text::_('COM_J2COMMERCE_ZONE')), ENT_QUOTES, 'UTF-8');
+
+// Pass language strings to JS via Joomla.Text (H1 — replaces addslashes inline)
+Text::script('COM_J2COMMERCE_CHECKOUT_ERROR_AGREE_TERMS');
 ?>
 <div class="j2commerce">
     <?php if ($this->params->get('show_page_heading')) : ?>
@@ -1152,10 +1156,30 @@ document.addEventListener('DOMContentLoaded', function() {
             formData.set('customer_note', noteField.value);
         }
 
-        // Include tos_check from confirm step (checkbox may be outside the payment plugin form)
+        // Include tos_check from confirm step (checkbox may be outside the payment plugin form).
+        // Always overwrite: the hidden mirror field in free-order forms starts empty and must
+        // be replaced with the live checkbox state before the request is sent.
         var tosBox = document.getElementById('tos_check');
-        if (tosBox && !formData.has('tos_check')) {
+        if (!tosBox) {
+            var _confirmEl = document.querySelector('.j2commerce-checkout-confirm');
+            if (_confirmEl && _confirmEl.dataset.showTerms === '1' && _confirmEl.dataset.termsDisplayType === 'checkbox') {
+                console.warn('[J2C] tos_check element missing in confirm step — checkbox state cannot be read');
+            }
+        }
+        if (tosBox) {
             formData.set('tos_check', tosBox.checked ? '1' : '0');
+
+            // Client-side pre-check: bail before the fetch if the box is required but unticked.
+            var confirmEl = document.querySelector('.j2commerce-checkout-confirm');
+            var tosRequired  = confirmEl && confirmEl.dataset.showTerms === '1';
+            var tosIsCheckbox = confirmEl && confirmEl.dataset.termsDisplayType === 'checkbox';
+            if (tosRequired && tosIsCheckbox && !tosBox.checked) {
+                hideLoading(btn);
+                btn.disabled = false;
+                var errMsg = Joomla.Text._('COM_J2COMMERCE_CHECKOUT_ERROR_AGREE_TERMS');
+                showFieldError(document.getElementById('confirm').querySelector('.checkout-content'), 'tos_check', errMsg);
+                return;
+            }
         }
 
         showLoading(btn);
@@ -1189,9 +1213,15 @@ document.addEventListener('DOMContentLoaded', function() {
             form.querySelectorAll('.j2error, .j2success, .j2warning, .warning, .alert-danger, .alert-success').forEach(function(el) { el.remove(); });
 
             if (json.error) {
-                var msg = typeof json.error === 'string' ? json.error : Object.values(json.error).join(', ');
-                showWarning(form, msg, json._detail);
-                btn.disabled = false;
+                var confirmContent = document.getElementById('confirm') && document.getElementById('confirm').querySelector('.checkout-content');
+                if (json.error.tos_check) {
+                    showFieldError(confirmContent || form, 'tos_check', json.error.tos_check);
+                    btn.disabled = false;
+                } else {
+                    var msg = typeof json.error === 'string' ? json.error : Object.values(json.error).join(', ');
+                    showWarning(form, msg, json._detail);
+                    btn.disabled = false;
+                }
             }
 
             if (json.redirect) {
@@ -1237,7 +1267,7 @@ document.addEventListener('DOMContentLoaded', function() {
             syncField.value = noteField.value;
         }
 
-        // Sync tos_check to the hidden mirror field in the free order form
+        // Always sync tos_check to the hidden mirror field in the free order form.
         var tosBox = document.getElementById('tos_check');
         var tosSyncField = form.querySelector('.j2commerce-tos-sync');
         if (tosBox && tosSyncField) {

--- a/components/com_j2commerce/tmpl/checkout/bootstrap5/default_confirm.php
+++ b/components/com_j2commerce/tmpl/checkout/bootstrap5/default_confirm.php
@@ -31,8 +31,20 @@ $termsUrl         = $showTerms && $termsArticleId
 $termsText        = trim((string) ($this->termsText ?? ''));
 $showCustomerNote = (bool) ($this->showCustomerNote ?? true);
 
+// bootstrap.modal is registered on the initial /checkout page load in HtmlView::display().
+
+// Build the terms modal URL from the already-computed $termsUrl (M4 — avoids 4 Route::_ calls).
+$termsModalUrl = '';
+if ($showTerms && $termsArticleId) {
+    $sep           = str_contains($termsUrl, '?') ? '&' : '?';
+    $termsModalUrl = $termsUrl . $sep . 'tmpl=component';
+}
+
 ?>
-<div class="j2commerce-checkout-confirm">
+<div class="j2commerce-checkout-confirm"
+     data-show-terms="<?php echo $showTerms; ?>"
+     data-terms-display-type="<?php echo htmlspecialchars($termsDisplayType, ENT_QUOTES, 'UTF-8'); ?>"
+>
 
 <?php if (empty($errors)) : ?>
 
@@ -46,10 +58,10 @@ $showCustomerNote = (bool) ($this->showCustomerNote ?? true);
                     <?php if ($termsText !== '') : ?>
                         <?php // Raw HTML — admin-controlled via filter="raw" ?>
                         <?php echo $termsText; ?>
-                    <?php elseif ($termsUrl !== '') : ?>
+                    <?php elseif ($termsModalUrl !== '') : ?>
                         <?php echo Text::sprintf(
                             'COM_J2COMMERCE_CHECKOUT_AGREE_TERMS_LINK',
-                            '<a href="' . htmlspecialchars($termsUrl) . '" target="_blank" rel="noopener">'
+                            '<a href="' . $termsUrl . '" data-bs-toggle="modal" data-bs-target="#j2c-terms-modal">'
                                 . htmlspecialchars(Text::_('COM_J2COMMERCE_CHECKOUT_TERMS_AND_CONDITIONS'))
                                 . '</a>'
                         ); ?>
@@ -64,10 +76,17 @@ $showCustomerNote = (bool) ($this->showCustomerNote ?? true);
             <?php if ($termsText !== '') : ?>
                 <?php // Raw HTML — admin-controlled via filter="raw" ?>
                 <?php echo $termsText; ?>
+            <?php elseif ($termsModalUrl !== '') : ?>
+                <?php echo Text::sprintf(
+                    'COM_J2COMMERCE_CHECKOUT_AGREE_TERMS_LINK',
+                    '<a href="' . $termsUrl . '" data-bs-toggle="modal" data-bs-target="#j2c-terms-modal">'
+                        . htmlspecialchars(Text::_('COM_J2COMMERCE_CHECKOUT_TERMS_AND_CONDITIONS'))
+                        . '</a>'
+                ); ?>
             <?php else : ?>
                 <?php echo Text::sprintf(
                     'COM_J2COMMERCE_CHECKOUT_AGREE_TERMS_LINK',
-                    '<a href="' . htmlspecialchars($termsUrl) . '" target="_blank" rel="noopener">'
+                    '<a href="' . $termsUrl . '" target="_blank" rel="noopener">'
                         . htmlspecialchars(Text::_('COM_J2COMMERCE_CHECKOUT_TERMS_AND_CONDITIONS'))
                         . '</a>'
                 ); ?>
@@ -109,3 +128,26 @@ $showCustomerNote = (bool) ($this->showCustomerNote ?? true);
 <?php echo J2CommerceHelper::plugin()->eventWithHtml('AfterCheckoutConfirm', [$this]); ?>
 
 </div>
+
+<?php if ($showTerms === 1 && $termsModalUrl !== '') : ?>
+<div class="modal fade" id="j2c-terms-modal" tabindex="-1"
+     aria-labelledby="j2c-terms-modal-label" aria-modal="true" role="dialog">
+    <div class="modal-dialog modal-lg modal-dialog-scrollable">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="j2c-terms-modal-label">
+                    <?php echo htmlspecialchars(Text::_('COM_J2COMMERCE_CHECKOUT_TERMS_AND_CONDITIONS'), ENT_QUOTES, 'UTF-8'); ?>
+                </h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"
+                        aria-label="<?php echo htmlspecialchars(Text::_('JCLOSE'), ENT_QUOTES, 'UTF-8'); ?>"></button>
+            </div>
+            <div class="modal-body p-0">
+                <iframe src="<?php echo htmlspecialchars($termsModalUrl, ENT_QUOTES, 'UTF-8'); ?>"
+                        title="<?php echo htmlspecialchars(Text::_('COM_J2COMMERCE_CHECKOUT_TERMS_AND_CONDITIONS'), ENT_QUOTES, 'UTF-8'); ?>"
+                        class="w-100 border-0" style="height:60vh;"
+                        loading="lazy"></iframe>
+            </div>
+        </div>
+    </div>
+</div>
+<?php endif; ?>

--- a/components/com_j2commerce/tmpl/checkout/uikit3/default.php
+++ b/components/com_j2commerce/tmpl/checkout/uikit3/default.php
@@ -43,6 +43,9 @@ if ($this->order && method_exists($this->order, 'get_formatted_order_totals')) {
 
 // Pre-compute JS-safe language strings
 $selectZoneJs = htmlspecialchars(Text::sprintf('COM_J2COMMERCE_SELECT_PLACEHOLDER', Text::_('COM_J2COMMERCE_ZONE')), ENT_QUOTES, 'UTF-8');
+
+// Pass language strings to JS via Joomla.Text (H1 — replaces addslashes inline)
+Text::script('COM_J2COMMERCE_CHECKOUT_ERROR_AGREE_TERMS');
 ?>
 <div class="j2commerce">
     <?php if ($this->params->get('show_page_heading')) : ?>
@@ -1151,10 +1154,30 @@ document.addEventListener('DOMContentLoaded', function() {
             formData.set('customer_note', noteField.value);
         }
 
-        // Include tos_check from confirm step (checkbox may be outside the payment plugin form)
+        // Include tos_check from confirm step (checkbox may be outside the payment plugin form).
+        // Always overwrite: the hidden mirror field in free-order forms starts empty and must
+        // be replaced with the live checkbox state before the request is sent.
         var tosBox = document.getElementById('tos_check');
-        if (tosBox && !formData.has('tos_check')) {
+        if (!tosBox) {
+            var _confirmEl = document.querySelector('.j2commerce-checkout-confirm');
+            if (_confirmEl && _confirmEl.dataset.showTerms === '1' && _confirmEl.dataset.termsDisplayType === 'checkbox') {
+                console.warn('[J2C] tos_check element missing in confirm step — checkbox state cannot be read');
+            }
+        }
+        if (tosBox) {
             formData.set('tos_check', tosBox.checked ? '1' : '0');
+
+            // Client-side pre-check: bail before the fetch if the box is required but unticked.
+            var confirmEl = document.querySelector('.j2commerce-checkout-confirm');
+            var tosRequired  = confirmEl && confirmEl.dataset.showTerms === '1';
+            var tosIsCheckbox = confirmEl && confirmEl.dataset.termsDisplayType === 'checkbox';
+            if (tosRequired && tosIsCheckbox && !tosBox.checked) {
+                hideLoading(btn);
+                btn.disabled = false;
+                var errMsg = Joomla.Text._('COM_J2COMMERCE_CHECKOUT_ERROR_AGREE_TERMS');
+                showFieldError(document.getElementById('confirm').querySelector('.checkout-content'), 'tos_check', errMsg);
+                return;
+            }
         }
 
         showLoading(btn);
@@ -1188,9 +1211,15 @@ document.addEventListener('DOMContentLoaded', function() {
             form.querySelectorAll('.j2error, .j2success, .j2warning, .warning, .uk-alert-danger, .uk-alert-success').forEach(function(el) { el.remove(); });
 
             if (json.error) {
-                var msg = typeof json.error === 'string' ? json.error : Object.values(json.error).join(', ');
-                showWarning(form, msg, json._detail);
-                btn.disabled = false;
+                var confirmContent = document.getElementById('confirm') && document.getElementById('confirm').querySelector('.checkout-content');
+                if (json.error.tos_check) {
+                    showFieldError(confirmContent || form, 'tos_check', json.error.tos_check);
+                    btn.disabled = false;
+                } else {
+                    var msg = typeof json.error === 'string' ? json.error : Object.values(json.error).join(', ');
+                    showWarning(form, msg, json._detail);
+                    btn.disabled = false;
+                }
             }
 
             if (json.redirect) {
@@ -1236,7 +1265,7 @@ document.addEventListener('DOMContentLoaded', function() {
             syncField.value = noteField.value;
         }
 
-        // Sync tos_check to the hidden mirror field in the free order form
+        // Always sync tos_check to the hidden mirror field in the free order form.
         var tosBox = document.getElementById('tos_check');
         var tosSyncField = form.querySelector('.j2commerce-tos-sync');
         if (tosBox && tosSyncField) {

--- a/components/com_j2commerce/tmpl/checkout/uikit3/default_confirm.php
+++ b/components/com_j2commerce/tmpl/checkout/uikit3/default_confirm.php
@@ -15,6 +15,7 @@ use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 use Joomla\Component\Content\Site\Helper\RouteHelper;
+// UIkit JS is already loaded by app_uikit; no additional WAM dependency needed for uk-modal.
 
 /** @var \J2Commerce\Component\J2commerce\Site\View\Checkout\HtmlView $this */
 
@@ -30,8 +31,19 @@ $termsUrl         = $showTerms && $termsArticleId
     : '';
 $termsText        = trim((string) ($this->termsText ?? ''));
 $showCustomerNote = (bool) ($this->showCustomerNote ?? true);
+
+// Build the terms modal URL from the already-computed $termsUrl (M4 — avoids 4 Route::_ calls).
+$termsModalUrl = '';
+if ($showTerms && $termsArticleId) {
+    $sep           = str_contains($termsUrl, '?') ? '&' : '?';
+    $termsModalUrl = $termsUrl . $sep . 'tmpl=component';
+}
+
 ?>
-<div class="j2commerce-checkout-confirm">
+<div class="j2commerce-checkout-confirm"
+     data-show-terms="<?php echo $showTerms; ?>"
+     data-terms-display-type="<?php echo htmlspecialchars($termsDisplayType, ENT_QUOTES, 'UTF-8'); ?>"
+>
 
 <?php if (empty($errors)) : ?>
 
@@ -45,10 +57,10 @@ $showCustomerNote = (bool) ($this->showCustomerNote ?? true);
                     <?php if ($termsText !== '') : ?>
                         <?php // Raw HTML — admin-controlled via filter="raw" ?>
                         <?php echo $termsText; ?>
-                    <?php elseif ($termsUrl !== '') : ?>
+                    <?php elseif ($termsModalUrl !== '') : ?>
                         <?php echo Text::sprintf(
                             'COM_J2COMMERCE_CHECKOUT_AGREE_TERMS_LINK',
-                            '<a href="' . htmlspecialchars($termsUrl) . '" target="_blank" rel="noopener">'
+                            '<a href="' . $termsUrl . '" uk-toggle="target: #j2c-terms-modal; preventdefault: true">'
                                 . htmlspecialchars(Text::_('COM_J2COMMERCE_CHECKOUT_TERMS_AND_CONDITIONS'))
                                 . '</a>'
                         ); ?>
@@ -63,10 +75,17 @@ $showCustomerNote = (bool) ($this->showCustomerNote ?? true);
             <?php if ($termsText !== '') : ?>
                 <?php // Raw HTML — admin-controlled via filter="raw" ?>
                 <?php echo $termsText; ?>
+            <?php elseif ($termsModalUrl !== '') : ?>
+                <?php echo Text::sprintf(
+                    'COM_J2COMMERCE_CHECKOUT_AGREE_TERMS_LINK',
+                    '<a href="' . $termsUrl . '" uk-toggle="target: #j2c-terms-modal; preventdefault: true">'
+                        . htmlspecialchars(Text::_('COM_J2COMMERCE_CHECKOUT_TERMS_AND_CONDITIONS'))
+                        . '</a>'
+                ); ?>
             <?php else : ?>
                 <?php echo Text::sprintf(
                     'COM_J2COMMERCE_CHECKOUT_AGREE_TERMS_LINK',
-                    '<a href="' . htmlspecialchars($termsUrl) . '" target="_blank" rel="noopener">'
+                    '<a href="' . $termsUrl . '" target="_blank" rel="noopener">'
                         . htmlspecialchars(Text::_('COM_J2COMMERCE_CHECKOUT_TERMS_AND_CONDITIONS'))
                         . '</a>'
                 ); ?>
@@ -108,3 +127,19 @@ $showCustomerNote = (bool) ($this->showCustomerNote ?? true);
 <?php echo J2CommerceHelper::plugin()->eventWithHtml('AfterCheckoutConfirm', [$this]); ?>
 
 </div>
+
+<?php if ($showTerms === 1 && $termsModalUrl !== '') : ?>
+<div id="j2c-terms-modal" uk-modal>
+    <div class="uk-modal-dialog uk-modal-body">
+        <button class="uk-modal-close-default" type="button" uk-close
+                aria-label="<?php echo htmlspecialchars(Text::_('JCLOSE'), ENT_QUOTES, 'UTF-8'); ?>"></button>
+        <h5 class="uk-modal-title">
+            <?php echo htmlspecialchars(Text::_('COM_J2COMMERCE_CHECKOUT_TERMS_AND_CONDITIONS'), ENT_QUOTES, 'UTF-8'); ?>
+        </h5>
+        <iframe src="<?php echo htmlspecialchars($termsModalUrl, ENT_QUOTES, 'UTF-8'); ?>"
+                title="<?php echo htmlspecialchars(Text::_('COM_J2COMMERCE_CHECKOUT_TERMS_AND_CONDITIONS'), ENT_QUOTES, 'UTF-8'); ?>"
+                class="uk-width-1-1" style="height:60vh; border:0;"
+                loading="lazy"></iframe>
+    </div>
+</div>
+<?php endif; ?>


### PR DESCRIPTION
## Summary

Restores the Terms & Conditions modal trigger on the confirm step and exposes the show_terms / terms_display_type config to the JS layer via data attributes on the confirm wrapper.

## Why

Prior to this change:
- The terms link on the confirm step had `data-bs-toggle="modal"` but `bootstrap.modal` was never enqueued on `/checkout`, so the click defaulted to anchor navigation and opened `/component/content/article/...` directly instead of the modal.
- The plugin-side TOS preflight could not detect `show_terms === '1' && terms_display_type === 'checkbox'` because the wrapper did not expose those values.

## Changes

| File | What |
|------|------|
| `components/com_j2commerce/src/View/Checkout/HtmlView.php` | Register the bootstrap.modal asset for the checkout view |
| `components/com_j2commerce/tmpl/checkout/bootstrap5/default.php` | `$wa->useScript('bootstrap.modal')` next to the existing collapse + dropdown calls |
| `components/com_j2commerce/tmpl/checkout/bootstrap5/default_confirm.php` | `data-show-terms` + `data-terms-display-type` on the wrapper; terms link uses `data-bs-toggle="modal"`; modal iframe panel appended |
| `components/com_j2commerce/tmpl/checkout/uikit3/default.php` | Mirror of the bootstrap5 changes for the UIkit framework option |
| `components/com_j2commerce/tmpl/checkout/uikit3/default_confirm.php` | Mirror of the bootstrap5 confirm changes (uk-toggle + uk-modal variant) |

## Files Modified
| Type | Count |
|------|-------|
| PHP (src) | 1 |
| PHP (tmpl) | 4 |
| JS/CSS | 0 |
| Language | 0 |

## Pre-Flight
- [x] PHP syntax check passed (5/5 files)
- [x] No secrets detected
- [x] No FOF / `JFactory::` remnants
- [x] Core files only

## Test plan
- [ ] Place an order with TOS = checkbox enabled, box checked — order completes, no false "agree to terms" error
- [ ] Place an order with TOS = checkbox enabled, box NOT checked — clear error shown beside the checkbox
- [ ] Click the Terms & Conditions link in the confirm step — modal opens with the article content (bootstrap5 + uikit3)