### PR TITLE
refactor(products): consolidate filter-state parsing into ProductFilterRequestHelper

### DIFF
--- a/components/com_j2commerce/src/Controller/ProductsController.php
+++ b/components/com_j2commerce/src/Controller/ProductsController.php
@@ -16,6 +16,7 @@ namespace J2Commerce\Component\J2commerce\Site\Controller;
 
 use J2Commerce\Component\J2commerce\Administrator\Controller\ProductsController as AdminProductsController;
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
+use J2Commerce\Component\J2commerce\Site\Helper\ProductFilterRequestHelper;
 use J2Commerce\Component\J2commerce\Site\Service\ProductLayoutService;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
@@ -87,42 +88,18 @@ class ProductsController extends AdminProductsController
         try {
             $session = $app->getSession();
 
-            $manufacturerIds = $input->get('manufacturer_ids', [], 'array');
-            if (empty($manufacturerIds)) {
-                $brandsParam = $input->getString('brands', '');
-                if (!empty($brandsParam)) {
-                    $manufacturerIds = array_filter(explode(',', $brandsParam), 'is_numeric');
-                }
-            }
+            // Single source of truth for filter parsing — same helper used by ProductsModel::populateState().
+            $filterState      = ProductFilterRequestHelper::resolveFromRequest($input);
+            $manufacturerIds  = $filterState['manufacturer_ids'];
+            $vendorIds        = $filterState['vendor_ids'];
+            $productfilterIds = $filterState['productfilter_ids'];
+            $tagIds           = $filterState['tag_ids'];
+            $tagMatch         = $filterState['tag_match'];
+            $priceFrom        = $filterState['price_from'];
+            $priceTo          = $filterState['price_to'];
 
-            $vendorIds = $input->get('vendor_ids', [], 'array');
-            if (empty($vendorIds)) {
-                $vendorsParam = $input->getString('vendors', '');
-                if (!empty($vendorsParam)) {
-                    $vendorIds = array_filter(explode(',', $vendorsParam), 'is_numeric');
-                }
-            }
-
-            $productfilterIds = $input->get('productfilter_ids', [], 'array');
-            if (empty($productfilterIds)) {
-                $filtersParam = $input->getString('filters', '');
-                if (!empty($filtersParam)) {
-                    $filterValues   = explode(',', $filtersParam);
-                    $numericFilters = array_filter($filterValues, 'is_numeric');
-                    if (\count($numericFilters) === \count($filterValues)) {
-                        $productfilterIds = $numericFilters;
-                    } else {
-                        $productfilterIds = $this->resolveFilterAliasesToIds($filterValues);
-                    }
-                }
-            }
-
-            $catid     = $input->getInt('filter_catid', 0);
-            $tagIds    = $input->get('tag_ids', [], 'array');
-            $tagMatch  = $input->getString('tag_match', 'any');
-            $priceFrom = $input->getFloat('pricefrom', 0);
-            $priceTo   = $input->getFloat('priceto', 0);
-            $search    = $input->getString('search', '');
+            $catid  = $input->getInt('filter_catid', 0);
+            $search = $input->getString('search', '');
 
             $sortby = $input->getString('sortby', '');
             if (empty($sortby)) {
@@ -197,19 +174,8 @@ class ProductsController extends AdminProductsController
                 $model->setState('list.limit', $pageLimit);
             }
 
-            if (!empty($manufacturerIds)) {
-                $model->setState('filter.manufacturer_ids', array_map('intval', $manufacturerIds));
-            }
-            if (!empty($vendorIds)) {
-                $model->setState('filter.vendor_ids', array_map('intval', $vendorIds));
-            }
-            if (!empty($productfilterIds)) {
-                $model->setState('filter.productfilter_ids', array_map('intval', $productfilterIds));
-            }
-            if ($priceFrom > 0 || $priceTo > 0) {
-                $model->setState('filter.price_from', $priceFrom);
-                $model->setState('filter.price_to', $priceTo);
-            }
+            // filter.manufacturer_ids / vendor_ids / productfilter_ids / price_from / price_to
+            // are seeded by ProductsModel::populateState() via ProductFilterRequestHelper.
             if (!empty($search)) {
                 $model->setState('filter.search', $search);
             }
@@ -396,67 +362,4 @@ class ProductsController extends AdminProductsController
         $app->close();
     }
 
-    /**
-     * Convert SEF-friendly filter aliases to IDs.
-     *
-     * Accepts bare aliases ("black") or composite tokens ("color:black") where the
-     * prefix is the URL-safe group name.  Composite tokens allow the same filter name
-     * to appear in multiple groups without collision.
-     */
-    protected function resolveFilterAliasesToIds(array $aliases): array
-    {
-        if (empty($aliases)) {
-            return [];
-        }
-
-        $db    = Factory::getContainer()->get(DatabaseInterface::class);
-        $query = $db->getQuery(true);
-
-        $query->select($db->quoteName(['f.j2commerce_filter_id', 'f.filter_name', 'g.group_name']))
-            ->from($db->quoteName('#__j2commerce_filters', 'f'))
-            ->join('LEFT', $db->quoteName('#__j2commerce_filtergroups', 'g') . ' ON ' . $db->quoteName('g.j2commerce_filtergroup_id') . ' = ' . $db->quoteName('f.group_id'));
-
-        $db->setQuery($query);
-        $filters = $db->loadObjectList();
-
-        $filterIds = [];
-
-        foreach ($aliases as $token) {
-            $token = trim($token);
-
-            if (is_numeric($token)) {
-                $filterIds[] = (int) $token;
-                continue;
-            }
-
-            // Composite token: "groupAlias:filterAlias"
-            if (str_contains($token, ':')) {
-                [$groupAliasToken, $filterAliasToken] = explode(':', $token, 2);
-
-                foreach ($filters as $filter) {
-                    $groupAlias  = \Joomla\CMS\Filter\OutputFilter::stringURLSafe($filter->group_name ?? '');
-                    $filterAlias = \Joomla\CMS\Filter\OutputFilter::stringURLSafe($filter->filter_name ?? '');
-
-                    if ($groupAlias === $groupAliasToken && $filterAlias === $filterAliasToken) {
-                        $filterIds[] = (int) $filter->j2commerce_filter_id;
-                        break;
-                    }
-                }
-
-                continue;
-            }
-
-            // Bare alias — match on filter name alone (backward compat)
-            foreach ($filters as $filter) {
-                $filterAlias = \Joomla\CMS\Filter\OutputFilter::stringURLSafe($filter->filter_name ?? '');
-
-                if ($filterAlias === $token) {
-                    $filterIds[] = (int) $filter->j2commerce_filter_id;
-                    break;
-                }
-            }
-        }
-
-        return array_unique($filterIds);
-    }
 }

--- a/components/com_j2commerce/src/Helper/ProductFilterRequestHelper.php
+++ b/components/com_j2commerce/src/Helper/ProductFilterRequestHelper.php
@@ -1,0 +1,178 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Site\Helper;
+
+\defined('_JEXEC') or die;
+
+use Joomla\CMS\Factory;
+use Joomla\CMS\Filter\OutputFilter;
+use Joomla\Database\DatabaseInterface;
+use Joomla\Input\Input;
+
+/**
+ * Single source of truth for parsing product-list filter state from an HTTP request.
+ *
+ * Reads:
+ *   - ?filters=group:alias,group:alias    (SEF tokens — composite or bare aliases, or numeric IDs)
+ *   - ?productfilter_ids[]=N              (legacy array form)
+ *   - ?manufacturer_ids[]=N  | ?brands=1,2
+ *   - ?vendor_ids[]=N        | ?vendors=1,2
+ *   - ?tag_ids[]=N           | ?tag_match=any|all
+ *   - ?pricefrom=N           | ?priceto=N
+ *
+ * Called from BOTH:
+ *   - ProductsModel::populateState()  (every page load — fixes cold-paste of filtered URL)
+ *   - ProductsController::filter()    (AJAX sidebar)
+ *
+ * Alias→ID catalog is loaded once per request and cached statically.
+ */
+class ProductFilterRequestHelper
+{
+    private static ?array $aliasCatalog = null;
+
+    public static function resolveFromRequest(?Input $input = null): array
+    {
+        $input ??= Factory::getApplication()->getInput();
+
+        return [
+            'manufacturer_ids'  => self::readIdList($input, 'manufacturer_ids', 'brands'),
+            'vendor_ids'        => self::readIdList($input, 'vendor_ids', 'vendors'),
+            'productfilter_ids' => self::readProductFilterIds($input),
+            'tag_ids'           => array_values(array_filter(array_map('intval', $input->get('tag_ids', [], 'array')))),
+            'tag_match'         => $input->getString('tag_match', 'any') === 'all' ? 'all' : 'any',
+            'price_from'        => $input->getFloat('pricefrom', 0.0),
+            'price_to'          => $input->getFloat('priceto', 0.0),
+        ];
+    }
+
+    public static function resolveAliasesToIds(array $tokens): array
+    {
+        if (empty($tokens)) {
+            return [];
+        }
+
+        $catalog = self::loadAliasCatalog();
+        $ids     = [];
+
+        foreach ($tokens as $token) {
+            $token = trim((string) $token);
+            if ($token === '') {
+                continue;
+            }
+            if (is_numeric($token)) {
+                $ids[] = (int) $token;
+                continue;
+            }
+
+            // Composite token "groupAlias:filterAlias" — disambiguates same filter name across groups.
+            if (str_contains($token, ':')) {
+                [$groupAlias, $filterAlias] = explode(':', $token, 2);
+                foreach ($catalog as $row) {
+                    if ($row['group_alias'] === $groupAlias && $row['filter_alias'] === $filterAlias) {
+                        $ids[] = $row['id'];
+                        break;
+                    }
+                }
+                continue;
+            }
+
+            foreach ($catalog as $row) {
+                if ($row['filter_alias'] === $token) {
+                    $ids[] = $row['id'];
+                    break;
+                }
+            }
+        }
+
+        return array_values(array_unique($ids));
+    }
+
+    public static function clearAliasCache(): void
+    {
+        self::$aliasCatalog = null;
+    }
+
+    private static function readIdList(Input $input, string $arrayKey, string $commaKey): array
+    {
+        $ids = $input->get($arrayKey, [], 'array');
+        if (empty($ids)) {
+            $comma = $input->getString($commaKey, '');
+            if ($comma !== '') {
+                $ids = array_filter(explode(',', $comma), 'is_numeric');
+            }
+        }
+        return array_values(array_filter(array_map('intval', $ids)));
+    }
+
+    private static function readProductFilterIds(Input $input): array
+    {
+        $ids = $input->get('productfilter_ids', [], 'array');
+        if (!empty($ids)) {
+            return array_values(array_filter(array_map('intval', $ids)));
+        }
+
+        $filtersParam = $input->getString('filters', '');
+        if ($filtersParam === '') {
+            return [];
+        }
+
+        $tokens = array_values(array_filter(array_map('trim', explode(',', $filtersParam)), 'strlen'));
+        if (empty($tokens)) {
+            return [];
+        }
+
+        $allNumeric = true;
+        foreach ($tokens as $t) {
+            if (!is_numeric($t)) {
+                $allNumeric = false;
+                break;
+            }
+        }
+        if ($allNumeric) {
+            return array_values(array_filter(array_map('intval', $tokens)));
+        }
+
+        return self::resolveAliasesToIds($tokens);
+    }
+
+    private static function loadAliasCatalog(): array
+    {
+        if (self::$aliasCatalog !== null) {
+            return self::$aliasCatalog;
+        }
+
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
+        $query = $db->getQuery(true)
+            ->select($db->quoteName(['f.j2commerce_filter_id', 'f.filter_name', 'g.group_name']))
+            ->from($db->quoteName('#__j2commerce_filters', 'f'))
+            ->join(
+                'LEFT',
+                $db->quoteName('#__j2commerce_filtergroups', 'g')
+                . ' ON ' . $db->quoteName('g.j2commerce_filtergroup_id')
+                . ' = ' . $db->quoteName('f.group_id')
+            );
+        $db->setQuery($query);
+        $rows = $db->loadObjectList() ?: [];
+
+        $catalog = [];
+        foreach ($rows as $row) {
+            $catalog[] = [
+                'id'           => (int) $row->j2commerce_filter_id,
+                'filter_alias' => OutputFilter::stringURLSafe((string) ($row->filter_name ?? '')),
+                'group_alias'  => OutputFilter::stringURLSafe((string) ($row->group_name ?? '')),
+            ];
+        }
+
+        return self::$aliasCatalog = $catalog;
+    }
+}

--- a/components/com_j2commerce/src/Model/ProductsModel.php
+++ b/components/com_j2commerce/src/Model/ProductsModel.php
@@ -15,6 +15,7 @@ namespace J2Commerce\Component\J2commerce\Site\Model;
 \defined('_JEXEC') or die;
 
 use J2Commerce\Component\J2commerce\Administrator\Helper\ProductHelper;
+use J2Commerce\Component\J2commerce\Site\Helper\ProductFilterRequestHelper;
 use Joomla\CMS\Categories\CategoryNode;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Multilanguage;
@@ -227,6 +228,20 @@ class ProductsModel extends ListModel
 
         $limitstart = $app->getInput()->getInt('limitstart', 0);
         $this->setState('list.start', $limitstart);
+
+        // Filter state — single source of truth via ProductFilterRequestHelper.
+        // Reads ?filters=group:alias, ?productfilter_ids[], ?brands=, ?vendors=, ?tag_ids[], pricefrom/to
+        // from the current request so a cold-pasted filtered URL produces the matching product list.
+        $filterState = ProductFilterRequestHelper::resolveFromRequest($input);
+        $this->setState('filter.manufacturer_ids',  $filterState['manufacturer_ids']);
+        $this->setState('filter.vendor_ids',        $filterState['vendor_ids']);
+        $this->setState('filter.productfilter_ids', $filterState['productfilter_ids']);
+        $this->setState('filter.tag_ids',           $filterState['tag_ids']);
+        $this->setState('filter.tag_match',         $filterState['tag_match']);
+        if ($filterState['price_from'] > 0 || $filterState['price_to'] > 0) {
+            $this->setState('filter.price_from', $filterState['price_from']);
+            $this->setState('filter.price_to',   $filterState['price_to']);
+        }
 
         // Language filter
         $this->setState('filter.language', Multilanguage::isEnabled());


### PR DESCRIPTION
## Summary

Extract the request-parsing logic out of `ProductsController::filter()` into a new static helper so the same code runs on the initial page render (`ProductsModel::populateState()`) and on the AJAX sidebar refresh (`ProductsController::filter()`).

## Why

Two entry points were each maintaining their own copy of the filter-state parsing. Drift between them caused cold-paste of a filtered URL to render with a different state than the AJAX refresh would, particularly for disambiguated alias tokens (`filters=group:alias`).

## Changes

| File | What |
|------|------|
| `components/com_j2commerce/src/Helper/ProductFilterRequestHelper.php` | **NEW** — `resolveFromRequest()` + `resolveAliasesToIds()` with per-request alias catalog cache |
| `components/com_j2commerce/src/Controller/ProductsController.php` | `filter()` now calls the helper; ~110 lines of inline parsing removed |
| `components/com_j2commerce/src/Model/ProductsModel.php` | `populateState()` also calls the helper so the first paint matches the AJAX state |

## Inputs Handled (unchanged behaviour)

- `?filters=group:alias,bare-alias,42` — composite + bare alias + numeric ID tokens
- `?productfilter_ids[]=N` — legacy array form
- `?manufacturer_ids[]=N` | `?brands=1,2`
- `?vendor_ids[]=N` | `?vendors=1,2`
- `?tag_ids[]=N` | `?tag_match=any|all`
- `?pricefrom=N` | `?priceto=N`

## Files Modified
| Type | Count |
|------|-------|
| PHP (src) | 3 (1 new) |
| JS/CSS | 0 |
| Language | 0 |

## Pre-Flight
- [x] PHP syntax check passed (3/3 files)
- [x] No secrets detected
- [x] No FOF / `JFactory::` remnants
- [x] Core files only

## Test plan
- [ ] Cold-paste a filtered URL containing `?filters=group:alias` — page paints with that filter applied
- [ ] Trigger AJAX sidebar refresh on the same page — state matches the cold-paste render
- [ ] Mixed input `?filters=group:alias,123` — both alias and numeric ID resolved
- [ ] Legacy `?productfilter_ids[]=N` still works
- [ ] `?brands=1,2` / `?vendors=1,2` comma form still resolves