### PR TITLE
chore(inventory): extract inline CSS + JS to media files (fixes #792)

### DIFF
--- a/administrator/components/com_j2commerce/tmpl/inventory/default.php
+++ b/administrator/components/com_j2commerce/tmpl/inventory/default.php
@@ -33,181 +33,19 @@ $wa->useScript('core')
 
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
-// Add custom CSS and JavaScript for inventory management
-$wa->addInlineStyle('
-.inventory-row { border-bottom: 1px solid #ddd; }
-.inventory-row:hover { background-color: #f9f9f9; }
-.save-btn { margin: 2px; padding: 4px 8px; font-size: 12px; }
-.quantity-input, .stock-select { width: 80px; margin: 2px; }
-.manage-stock-toggle { margin: 2px; }
-.product-link { font-weight: bold; }
-.inventory-actions { text-align: center; min-width: 100px; }
-.j2commerce-inventory-quantity > .control-group, .j2commerce-inventory-manage-stock > .control-group, .j2commerce-inventory-stock_status > .control-group {margin-bottom: 0;}
-.variants-row { background-color: #f8f9fa; }
-.variant-item {margin-bottom: 5px; }
-.inventory-row .control-group .controls {min-width:80px; min-inline-size:80px;}
-.inventory-row .switcher {width:auto;}
-.j2commerce-inventory-quantity > .control-group, .j2commerce-inventory-quantity > .control-group input, .variant-item .quantity-input  {max-width:100px;}
-.variants-container { padding: 10px; background-color: #fff; border: 1px solid #dee2e6; border-radius: 3px; }
-.has-variants .inventory-fields { display: none; }
-');
 
-$wa->addInlineScript('
-document.addEventListener("DOMContentLoaded", function() {
-    const csrfToken = "' . Session::getFormToken() . '";
+// Register external CSS + JS — extracted from inline blocks (#792).
+$wa->registerAndUseStyle('com_j2commerce.admin.inventory', 'media/com_j2commerce/css/administrator/inventory.css');
+$wa->registerAndUseScript('com_j2commerce.admin.inventory', 'media/com_j2commerce/js/administrator/inventory.js', [], ['defer' => true]);
 
-    function getFieldValue(row, selector) {
-        const el = row.querySelector(selector);
-        return el ? el.value : "";
-    }
-
-    function getManageStockValue(row) {
-        // Check for Joomla radio switcher (btn-check inputs)
-        const checked = row.querySelector(".manage-stock-toggle:checked, input[name*=manage_stock]:checked");
-        if (checked) return checked.value;
-        // Fallback: look for any checked radio in the manage-stock cell
-        const cell = row.querySelector(".j2commerce-inventory-manage-stock, [class*=manage]");
-        if (cell) {
-            const radio = cell.querySelector("input[type=radio]:checked");
-            if (radio) return radio.value;
-        }
-        return "0";
-    }
-
-    function showSystemMessage(message, type) {
-        const container = document.getElementById("system-message-container");
-        if (!container) return;
-        const alertClass = type === "success" ? "alert-success" : "alert-danger";
-        container.innerHTML = "<div class=\"alert " + alertClass + " alert-dismissible fade show\" role=\"alert\">"
-            + message
-            + "<button type=\"button\" class=\"btn-close\" data-bs-dismiss=\"alert\" aria-label=\"Close\"></button>"
-            + "</div>";
-        setTimeout(function() {
-            const alert = container.querySelector(".alert");
-            if (alert) { alert.style.transition = "opacity 0.5s"; alert.style.opacity = "0"; setTimeout(function() { alert.remove(); }, 500); }
-        }, 5000);
-    }
-
-    function setBtnState(btn, state, originalText) {
-        btn.classList.remove("btn-primary", "btn-success", "btn-danger");
-        if (state === "saving") {
-            btn.classList.add("btn-primary");
-            btn.disabled = true;
-            btn.textContent = "' . Text::_('COM_J2COMMERCE_SAVING') . '...";
-        } else if (state === "success") {
-            btn.classList.add("btn-success");
-            btn.textContent = "' . Text::_('COM_J2COMMERCE_SAVED') . '";
-            setTimeout(function() { btn.classList.remove("btn-success"); btn.classList.add("btn-primary"); btn.textContent = originalText; }, 2000);
-        } else if (state === "error") {
-            btn.classList.add("btn-danger");
-            btn.textContent = "' . Text::_('COM_J2COMMERCE_ERROR') . '";
-            setTimeout(function() { btn.classList.remove("btn-danger"); btn.classList.add("btn-primary"); btn.textContent = originalText; }, 3000);
-        }
-    }
-
-    // AJAX save for individual inventory items
-    window.saveInventoryItem = function(productId, variantId) {
-        const row = document.getElementById("inventory-row-" + productId);
-        if (!row) return;
-        const quantity = getFieldValue(row, ".quantity-input, input[name*=quantity]");
-        const manageStock = getManageStockValue(row);
-        const availability = getFieldValue(row, ".stock-select, select[name*=availability]");
-        const saveBtn = row.querySelector(".save-btn");
-        if (!saveBtn) return;
-        const originalText = saveBtn.textContent;
-        setBtnState(saveBtn, "saving", originalText);
-
-        const body = new URLSearchParams();
-        body.set("product_id", productId);
-        body.set("variant_id", variantId);
-        body.set("quantity", quantity);
-        body.set("manage_stock", manageStock);
-        body.set("availability", availability);
-        body.set(csrfToken, "1");
-
-        fetch("index.php?option=com_j2commerce&task=inventory.saveItem", {
-            method: "POST",
-            headers: { "Content-Type": "application/x-www-form-urlencoded", "Accept": "application/json" },
-            body: body.toString()
-        })
-        .then(function(r) { return r.json(); })
-        .then(function(response) {
-            if (response.success) {
-                setBtnState(saveBtn, "success", originalText);
-                if (response.message) showSystemMessage(response.message, "success");
-            } else {
-                setBtnState(saveBtn, "error", originalText);
-                if (response.message) showSystemMessage(response.message, "error");
-            }
-        })
-        .catch(function() {
-            setBtnState(saveBtn, "error", originalText);
-            showSystemMessage("' . Text::_('COM_J2COMMERCE_INVENTORY_AJAX_ERROR') . '", "error");
-        })
-        .finally(function() { saveBtn.disabled = false; });
-    };
-
-    // AJAX save for individual variant items
-    window.saveVariantItem = function(variantId, productId) {
-        const row = document.getElementById("variant-row-" + variantId);
-        if (!row) return;
-        const quantity = getFieldValue(row, ".quantity-input, input[name*=quantity]");
-        const manageStock = getManageStockValue(row);
-        const availability = getFieldValue(row, ".stock-select, select[name*=availability]");
-        const saveBtn = row.querySelector(".save-btn");
-        if (!saveBtn) return;
-        const originalText = saveBtn.textContent;
-        setBtnState(saveBtn, "saving", originalText);
-
-        const body = new URLSearchParams();
-        body.set("product_id", productId);
-        body.set("variant_id", variantId);
-        body.set("quantity", quantity);
-        body.set("manage_stock", manageStock);
-        body.set("availability", availability);
-        body.set(csrfToken, "1");
-
-        fetch("index.php?option=com_j2commerce&task=inventory.saveItem", {
-            method: "POST",
-            headers: { "Content-Type": "application/x-www-form-urlencoded", "Accept": "application/json" },
-            body: body.toString()
-        })
-        .then(function(r) { return r.json(); })
-        .then(function(response) {
-            if (response.success) {
-                setBtnState(saveBtn, "success", originalText);
-                if (response.message) showSystemMessage(response.message, "success");
-            } else {
-                setBtnState(saveBtn, "error", originalText);
-                if (response.message) showSystemMessage(response.message, "error");
-            }
-        })
-        .catch(function() {
-            setBtnState(saveBtn, "error", originalText);
-            showSystemMessage("' . Text::_('COM_J2COMMERCE_INVENTORY_AJAX_ERROR') . '", "error");
-        })
-        .finally(function() { saveBtn.disabled = false; });
-    };
-
-    // Toggle variant visibility (fallback — Bootstrap collapse handles this via data-bs-toggle)
-    window.toggleVariants = function(productId) {
-        const variantsRow = document.getElementById("variants-" + productId);
-        const toggleBtn = document.getElementById("toggle-variants-" + productId);
-        if (!variantsRow) return;
-        const isVisible = variantsRow.style.display !== "none" && variantsRow.classList.contains("show");
-        if (isVisible) {
-            variantsRow.classList.remove("show");
-            if (toggleBtn) toggleBtn.textContent = "' . Text::_('COM_J2COMMERCE_SHOW_VARIANTS') . '";
-        } else {
-            variantsRow.classList.add("show");
-            if (toggleBtn) toggleBtn.textContent = "' . Text::_('COM_J2COMMERCE_HIDE_VARIANTS') . '";
-        }
-    };
-});
-');
-
-
-
+// Pass CSRF token + language strings to inventory.js via Joomla's standard channels.
+$document->addScriptOptions('com_j2commerce.inventory', ['csrfToken' => Session::getFormToken()]);
+Text::script('COM_J2COMMERCE_SAVING');
+Text::script('COM_J2COMMERCE_SAVED');
+Text::script('COM_J2COMMERCE_ERROR');
+Text::script('COM_J2COMMERCE_INVENTORY_AJAX_ERROR');
+Text::script('COM_J2COMMERCE_SHOW_VARIANTS');
+Text::script('COM_J2COMMERCE_HIDE_VARIANTS');
 
 ?>
 
@@ -391,7 +229,11 @@ document.addEventListener("DOMContentLoaded", function() {
                                         <?php endif; ?>
                                     </td>
                                     <td class="text-center inventory-actions">
-                                        <button type="button" class="btn btn-sm btn-primary save-btn" onclick="saveInventoryItem(<?php echo $item->j2commerce_product_id; ?>, <?php echo $item->j2commerce_variant_id ?: 0; ?>)">
+                                        <button type="button"
+                                                class="btn btn-sm btn-primary save-btn"
+                                                data-j2c-action="save-inventory"
+                                                data-product-id="<?php echo (int) $item->j2commerce_product_id; ?>"
+                                                data-variant-id="<?php echo (int) ($item->j2commerce_variant_id ?: 0); ?>">
                                             <?php echo Text::_('COM_J2COMMERCE_SAVE'); ?>
                                         </button>
                                     </td>
@@ -500,7 +342,9 @@ document.addEventListener("DOMContentLoaded", function() {
                                                     <div class="col-md-2 text-end">
                                                         <button type="button"
                                                                 class="btn btn-sm btn-primary save-btn"
-                                                                onclick="saveVariantItem(<?php echo $variant->j2commerce_variant_id; ?>, <?php echo (int) $variant->product_id; ?>)">
+                                                                data-j2c-action="save-variant"
+                                                                data-product-id="<?php echo (int) $variant->product_id; ?>"
+                                                                data-variant-id="<?php echo (int) $variant->j2commerce_variant_id; ?>">
                                                             <?php echo Text::_('COM_J2COMMERCE_SAVE'); ?>
                                                         </button>
                                                     </div>

--- a/media/com_j2commerce/css/administrator/inventory.css
+++ b/media/com_j2commerce/css/administrator/inventory.css
@@ -1,0 +1,29 @@
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ *
+ * Inventory list view (administrator). Extracted from inline styles (#792).
+ */
+
+.inventory-row { border-bottom: 1px solid #ddd; }
+.inventory-row:hover { background-color: #f9f9f9; }
+.save-btn { margin: 2px; padding: 4px 8px; font-size: 12px; }
+.quantity-input, .stock-select { width: 80px; margin: 2px; }
+.manage-stock-toggle { margin: 2px; }
+.product-link { font-weight: bold; }
+.inventory-actions { text-align: center; min-width: 100px; }
+.j2commerce-inventory-quantity > .control-group,
+.j2commerce-inventory-manage-stock > .control-group,
+.j2commerce-inventory-stock_status > .control-group { margin-bottom: 0; }
+.variants-row { background-color: #f8f9fa; }
+.variant-item { margin-bottom: 5px; }
+.inventory-row .control-group .controls { min-width: 80px; min-inline-size: 80px; }
+.inventory-row .switcher { width: auto; }
+.j2commerce-inventory-quantity > .control-group,
+.j2commerce-inventory-quantity > .control-group input,
+.variant-item .quantity-input { max-width: 100px; }
+.variants-container { padding: 10px; background-color: #fff; border: 1px solid #dee2e6; border-radius: 3px; }
+.has-variants .inventory-fields { display: none; }

--- a/media/com_j2commerce/js/administrator/inventory.js
+++ b/media/com_j2commerce/js/administrator/inventory.js
@@ -1,0 +1,189 @@
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ *
+ * Inventory list view (administrator). Extracted from inline script (#792).
+ *
+ * Depends on:
+ *   - <input type="hidden" id="inventory-csrf-token" value="<TOKEN>"> on the page,
+ *     OR Joomla.getOptions('com_j2commerce.inventory').csrfToken
+ *   - Joomla.Text._() with COM_J2COMMERCE_SAVING / _SAVED / _ERROR /
+ *     _INVENTORY_AJAX_ERROR / _SHOW_VARIANTS / _HIDE_VARIANTS preloaded via Text::script()
+ */
+(function () {
+    'use strict';
+
+    document.addEventListener('DOMContentLoaded', function () {
+        const options   = (window.Joomla && Joomla.getOptions) ? Joomla.getOptions('com_j2commerce.inventory', {}) : {};
+        const csrfToken = options.csrfToken
+            || (document.getElementById('inventory-csrf-token') && document.getElementById('inventory-csrf-token').value)
+            || '';
+
+        function t(key, fallback) {
+            return (window.Joomla && Joomla.Text && Joomla.Text._) ? Joomla.Text._(key, fallback || key) : (fallback || key);
+        }
+
+        function getFieldValue(row, selector) {
+            const el = row.querySelector(selector);
+            return el ? el.value : '';
+        }
+
+        function getManageStockValue(row) {
+            const checked = row.querySelector('.manage-stock-toggle:checked, input[name*=manage_stock]:checked');
+            if (checked) {
+                return checked.value;
+            }
+            const cell = row.querySelector('.j2commerce-inventory-manage-stock, [class*=manage]');
+            if (cell) {
+                const radio = cell.querySelector('input[type=radio]:checked');
+                if (radio) {
+                    return radio.value;
+                }
+            }
+            return '0';
+        }
+
+        function showSystemMessage(message, type) {
+            const container = document.getElementById('system-message-container');
+            if (!container) {
+                return;
+            }
+
+            const alert = document.createElement('div');
+            alert.className = 'alert ' + (type === 'success' ? 'alert-success' : 'alert-danger') + ' alert-dismissible fade show';
+            alert.setAttribute('role', 'alert');
+            alert.appendChild(document.createTextNode(message));
+
+            const close = document.createElement('button');
+            close.type = 'button';
+            close.className = 'btn-close';
+            close.setAttribute('data-bs-dismiss', 'alert');
+            close.setAttribute('aria-label', 'Close');
+            alert.appendChild(close);
+
+            container.replaceChildren(alert);
+
+            setTimeout(function () {
+                alert.style.transition = 'opacity 0.5s';
+                alert.style.opacity = '0';
+                setTimeout(function () { alert.remove(); }, 500);
+            }, 5000);
+        }
+
+        function setBtnState(btn, state, originalText) {
+            btn.classList.remove('btn-primary', 'btn-success', 'btn-danger');
+            if (state === 'saving') {
+                btn.classList.add('btn-primary');
+                btn.disabled = true;
+                btn.textContent = t('COM_J2COMMERCE_SAVING') + '...';
+            } else if (state === 'success') {
+                btn.classList.add('btn-success');
+                btn.textContent = t('COM_J2COMMERCE_SAVED');
+                setTimeout(function () {
+                    btn.classList.remove('btn-success');
+                    btn.classList.add('btn-primary');
+                    btn.textContent = originalText;
+                }, 2000);
+            } else if (state === 'error') {
+                btn.classList.add('btn-danger');
+                btn.textContent = t('COM_J2COMMERCE_ERROR');
+                setTimeout(function () {
+                    btn.classList.remove('btn-danger');
+                    btn.classList.add('btn-primary');
+                    btn.textContent = originalText;
+                }, 3000);
+            }
+        }
+
+        function postSave(row, saveBtn, productId, variantId) {
+            const quantity     = getFieldValue(row, '.quantity-input, input[name*=quantity]');
+            const manageStock  = getManageStockValue(row);
+            const availability = getFieldValue(row, '.stock-select, select[name*=availability]');
+            const originalText = saveBtn.textContent;
+
+            setBtnState(saveBtn, 'saving', originalText);
+
+            const body = new URLSearchParams();
+            body.set('product_id', productId);
+            body.set('variant_id', variantId);
+            body.set('quantity', quantity);
+            body.set('manage_stock', manageStock);
+            body.set('availability', availability);
+            if (csrfToken) {
+                body.set(csrfToken, '1');
+            }
+
+            fetch('index.php?option=com_j2commerce&task=inventory.saveItem', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded', 'Accept': 'application/json' },
+                body: body.toString()
+            })
+                .then(function (r) { return r.json(); })
+                .then(function (response) {
+                    if (response.success) {
+                        setBtnState(saveBtn, 'success', originalText);
+                        if (response.message) {
+                            showSystemMessage(response.message, 'success');
+                        }
+                    } else {
+                        setBtnState(saveBtn, 'error', originalText);
+                        if (response.message) {
+                            showSystemMessage(response.message, 'error');
+                        }
+                    }
+                })
+                .catch(function () {
+                    setBtnState(saveBtn, 'error', originalText);
+                    showSystemMessage(t('COM_J2COMMERCE_INVENTORY_AJAX_ERROR'), 'error');
+                })
+                .finally(function () { saveBtn.disabled = false; });
+        }
+
+        function saveInventoryItem(saveBtn, productId, variantId) {
+            const row = document.getElementById('inventory-row-' + productId);
+            if (!row) { return; }
+            postSave(row, saveBtn, productId, variantId);
+        }
+
+        function saveVariantItem(saveBtn, variantId, productId) {
+            const row = document.getElementById('variant-row-' + variantId);
+            if (!row) { return; }
+            postSave(row, saveBtn, productId, variantId);
+        }
+
+        document.addEventListener('click', function (event) {
+            const btn = event.target.closest('.save-btn[data-j2c-action]');
+            if (!btn) {
+                return;
+            }
+            event.preventDefault();
+            const productId = parseInt(btn.dataset.productId || '0', 10);
+            const variantId = parseInt(btn.dataset.variantId || '0', 10);
+            if (btn.dataset.j2cAction === 'save-variant') {
+                saveVariantItem(btn, variantId, productId);
+            } else {
+                saveInventoryItem(btn, productId, variantId);
+            }
+        });
+
+        // Manual toggle fallback when Bootstrap data-bs-toggle="collapse" cannot be used.
+        window.toggleVariants = function (productId) {
+            const variantsRow = document.getElementById('variants-' + productId);
+            const toggleBtn   = document.getElementById('toggle-variants-' + productId);
+            if (!variantsRow) {
+                return;
+            }
+            const isVisible = variantsRow.style.display !== 'none' && variantsRow.classList.contains('show');
+            if (isVisible) {
+                variantsRow.classList.remove('show');
+                if (toggleBtn) { toggleBtn.textContent = t('COM_J2COMMERCE_SHOW_VARIANTS'); }
+            } else {
+                variantsRow.classList.add('show');
+                if (toggleBtn) { toggleBtn.textContent = t('COM_J2COMMERCE_HIDE_VARIANTS'); }
+            }
+        };
+    });
+})();


### PR DESCRIPTION
## Summary

Fixes #792

Brian flagged the admin inventory view as having a lot of inline CSS and JS. This PR lifts both blocks into static media files so they can be minified, cached, themed, and re-used, and removes two `onclick=` attributes that were XSS-prone and incompatible with event delegation.

## Changes

- **`administrator/components/com_j2commerce/tmpl/inventory/default.php`**
  - Drop `addInlineStyle` (17 rules) and `addInlineScript` (~150 lines)
  - `registerAndUseStyle` / `registerAndUseScript` for the new media files (JS deferred)
  - CSRF token passed via `Document::addScriptOptions('com_j2commerce.inventory', ['csrfToken' => …])`
  - Six `Text::script()` calls for the language strings the JS consumes (`SAVING`, `SAVED`, `ERROR`, `INVENTORY_AJAX_ERROR`, `SHOW_VARIANTS`, `HIDE_VARIANTS` — all already in en-US + en-GB)
  - Replace `onclick="saveInventoryItem(...)"` / `onclick="saveVariantItem(...)"` with `data-j2c-action` / `data-product-id` / `data-variant-id` attributes

- **`media/com_j2commerce/css/administrator/inventory.css`** (new)
  - Same 17 rules, formatted, with file-level copyright header

- **`media/com_j2commerce/js/administrator/inventory.js`** (new)
  - IIFE + `'use strict'`
  - CSRF token read via `Joomla.getOptions('com_j2commerce.inventory')`
  - Language strings via `Joomla.Text._()` instead of PHP-interpolated string literals
  - `showSystemMessage` rebuilt with `createElement` + `replaceChildren` (no `innerHTML`, per project anti-pattern policy)
  - Single delegated click handler on `.save-btn[data-j2c-action]` replaces the two `window.saveInventoryItem` / `window.saveVariantItem` globals
  - `window.toggleVariants` kept as a fallback for non-bootstrap callers

## Out of scope

Brian noted "the same may be true in other files." That's a follow-up — this PR is intentionally limited to `inventory/default.php`.

## Files Modified

| Type | Count |
|------|-------|
| PHP (admin tmpl) | 1 |
| CSS (admin media) | 1 (new) |
| JS (admin media) | 1 (new) |
| Language | 0 |

## Pre-Flight

- [x] PHP syntax check passed
- [x] JS syntax check passed (`node --check`)
- [x] No `onclick=`, `addInlineStyle`, `addInlineScript`, or `innerHTML` remaining
- [x] No secrets / FOF / `JFactory::` remnants
- [x] Core files only

## Testing

1. Open `/administrator/?option=com_j2commerce&view=inventory`
2. DevTools Network: confirm `inventory.css` + `inventory.js` load with 200
3. View page source: no inline `<style>`/`<script>` blocks for inventory, no `onclick="…"` on Save buttons
4. Edit a non-variant product's quantity → click Save → blue → green flash + success toast
5. Click the Variants badge on a variable/flexivariable product → variant rows expand (bootstrap collapse)
6. Edit a variant's quantity → click that row's Save → same green flash + toast
7. Force a server error (block the URL in DevTools) → button goes red, error toast appears