### PR TITLE
chore(mod_j2commerce_menu): extract inline CSS/JS to media files

### DIFF
--- a/administrator/modules/mod_j2commerce_menu/tmpl/default.php
+++ b/administrator/modules/mod_j2commerce_menu/tmpl/default.php
@@ -33,12 +33,16 @@ foreach ($menuItems as $idx => $item) {
 
 $wa = $app->getDocument()->getWebAssetManager();
 
-$wa->addInlineStyle('#j2commerceOffcanvas{width:320px;max-inline-size:320px;min-block-size:auto;overflow:visible;flex:none;z-index:1045}#j2commerceOffcanvas .offcanvas-header{border-bottom:1px solid rgb(255 255 255 / .1)}#j2commerceOffcanvas .offcanvas-title{color:var(--sidebar-item-color)}#j2commerceOffcanvas .btn-close{filter:invert(1) grayscale(100%) brightness(200%)}#j2commerceOffcanvas .j2c-nav .has-arrow .sidebar-item-title{margin-inline-end:auto}#j2commerceOffcanvas .j2c-nav .has-arrow:after{content:"\f105";justify-content:center;align-items:center;inline-size:2rem;font-family:"Font Awesome 6 Free";font-weight:900;display:flex}#j2commerceOffcanvas .j2c-nav .mm-active>.has-arrow:after{content:"\f107"}#j2commerceOffcanvas .j2c-nav a.mm-active{background-color:var(--main-nav-mm-active-bg)}#j2commerceOffcanvas .j2c-nav .mm-collapse{display:none}#j2commerceOffcanvas .j2c-nav .mm-collapse.mm-collapsed,#j2commerceOffcanvas .j2c-nav .mm-collapse.mm-show{display:block;padding-left:0}#j2commerceOffcanvas .j2c-nav .mm-collapsing{height:0;transition:all .35s;position:relative;overflow:hidden}#j2commerceOffcanvas .item-level-1.parent{flex-direction:column}#j2commerceOffcanvas .item-level-2>a{padding-inline-start:1.5rem}');
+$wa->registerAndUseStyle(
+    'mod_j2commerce_menu',
+    'media/com_j2commerce/css/administrator/mod-menu.css'
+);
 
-$wa->addInlineScript(
-    'new MetisMenu("#j2commerceNav", { toggle: true });',
-    ['position' => 'after'],
-    ['type' => 'module'],
+$wa->registerAndUseScript(
+    'mod_j2commerce_menu',
+    'media/com_j2commerce/js/administrator/mod-menu.js',
+    [],
+    ['defer' => true],
     ['metismenujs']
 );
 ?>

--- a/media/com_j2commerce/css/administrator/mod-menu.css
+++ b/media/com_j2commerce/css/administrator/mod-menu.css
@@ -1,0 +1,75 @@
+/**
+ * @package     J2Commerce
+ * @subpackage  mod_j2commerce_menu
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+#j2commerceOffcanvas {
+    width: 320px;
+    max-inline-size: 320px;
+    min-block-size: auto;
+    overflow: visible;
+    flex: none;
+    z-index: 1045;
+}
+
+#j2commerceOffcanvas .offcanvas-header {
+    border-bottom: 1px solid rgb(255 255 255 / .1);
+}
+
+#j2commerceOffcanvas .offcanvas-title {
+    color: var(--sidebar-item-color);
+}
+
+#j2commerceOffcanvas .btn-close {
+    filter: invert(1) grayscale(100%) brightness(200%);
+}
+
+#j2commerceOffcanvas .j2c-nav .has-arrow .sidebar-item-title {
+    margin-inline-end: auto;
+}
+
+#j2commerceOffcanvas .j2c-nav .has-arrow::after {
+    content: "\f105";
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    inline-size: 2rem;
+    font-family: "Font Awesome 6 Free";
+    font-weight: 900;
+}
+
+#j2commerceOffcanvas .j2c-nav .mm-active > .has-arrow::after {
+    content: "\f107";
+}
+
+#j2commerceOffcanvas .j2c-nav a.mm-active {
+    background-color: var(--main-nav-mm-active-bg);
+}
+
+#j2commerceOffcanvas .j2c-nav .mm-collapse {
+    display: none;
+}
+
+#j2commerceOffcanvas .j2c-nav .mm-collapse.mm-collapsed,
+#j2commerceOffcanvas .j2c-nav .mm-collapse.mm-show {
+    display: block;
+    padding-left: 0;
+}
+
+#j2commerceOffcanvas .j2c-nav .mm-collapsing {
+    height: 0;
+    position: relative;
+    overflow: hidden;
+    transition: all .35s;
+}
+
+#j2commerceOffcanvas .item-level-1.parent {
+    flex-direction: column;
+}
+
+#j2commerceOffcanvas .item-level-2 > a {
+    padding-inline-start: 1.5rem;
+}

--- a/media/com_j2commerce/js/administrator/mod-menu.js
+++ b/media/com_j2commerce/js/administrator/mod-menu.js
@@ -1,0 +1,23 @@
+/**
+ * @package     J2Commerce
+ * @subpackage  mod_j2commerce_menu
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+const initJ2CommerceMenu = () => {
+    const nav = document.getElementById('j2commerceNav');
+
+    if (!nav || typeof MetisMenu === 'undefined') {
+        return;
+    }
+
+    new MetisMenu(nav, { toggle: true });
+};
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initJ2CommerceMenu, { once: true });
+} else {
+    initJ2CommerceMenu();
+}


### PR DESCRIPTION
## Summary

Fixes #1029

Follow-up to #792. Moves the inline `<style>` block and MetisMenu initialiser
out of `administrator/modules/mod_j2commerce_menu/tmpl/default.php` into real
media files so they can be cached, minified, and shared.

## Changes

- **New** `media/com_j2commerce/css/administrator/mod-menu.css` — offcanvas, MetisMenu arrow indicators, collapse animations, and nav item rules (previously inlined as a minified one-liner).
- **New** `media/com_j2commerce/js/administrator/mod-menu.js` — MetisMenu init, gated on `DOMContentLoaded` plus `#j2commerceNav` and `MetisMenu` presence checks so it is safe whether MetisMenu loads before or after.
- **Modified** `administrator/modules/mod_j2commerce_menu/tmpl/default.php` — replaces `$wa->addInlineStyle(...)` / `$wa->addInlineScript(...)` with `registerAndUseStyle` / `registerAndUseScript` using direct media paths. `metismenujs` dependency preserved, `defer` enabled.

Same path/registration convention `mod_j2commerce_chart` already uses; no new module manifest `<media>` block needed because `media/com_j2commerce/` is already bundled by `build/build_package.php`.

## Testing

1. Log into `/administrator/`
2. Click the J2Commerce header item — offcanvas opens, nav renders with identical styling
3. Click a parent item (e.g. Products) — MetisMenu expands/collapses with the arrow toggle
4. Open a child view (e.g. Orders) — parent section auto-expanded with `mm-active`
5. View source — no inline `<style>`/`<script>` blocks; `mod-menu.css` and `mod-menu.js` are linked through WAM

## Files Changed

| File | Change |
|------|--------|
| `administrator/modules/mod_j2commerce_menu/tmpl/default.php` | inline blocks → `registerAndUseStyle` + `registerAndUseScript` |
| `media/com_j2commerce/css/administrator/mod-menu.css` | new — extracted CSS, expanded for readability |
| `media/com_j2commerce/js/administrator/mod-menu.js` | new — guarded MetisMenu init |

## Pre-Flight

- [x] PHP `php -l` passes on the modified template
- [x] No secrets detected
- [x] No FOF remnants / `JFactory::` calls
- [x] Core files only (3 committed, no non-core leakage)
- [x] No language string changes (sync N/A)