### PR TITLE
fix(emailtemplate): keep Save/Apply visible after save on legacy schemas

### DIFF
--- a/administrator/components/com_j2commerce/src/View/Emailtemplate/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Emailtemplate/HtmlView.php
@@ -208,7 +208,7 @@ class HtmlView extends BaseHtmlView
         $isNew      = ($this->item->j2commerce_emailtemplate_id == 0);
         $canDo      = ContentHelper::getActions('com_j2commerce', 'emailtemplate', $this->item->j2commerce_emailtemplate_id);
         $user       = Factory::getApplication()->getIdentity();
-        $checkedOut = !(($this->item->checked_out ?? null) === null || ($this->item->checked_out ?? 0) == $user->id);
+        $checkedOut = !empty($this->item->checked_out) && (int) $this->item->checked_out !== (int) $user->id;
 
         Factory::getApplication()->getInput()->set('hidemainmenu', true);
 


### PR DESCRIPTION
## Summary

Fixes #1030

The email-template edit toolbar stripped **Apply** + **Save** after any save on installs whose `#__j2commerce_emailtemplates.checked_out` column was created as `int UNSIGNED NOT NULL DEFAULT 0` (older J2Commerce/J2Store schemas before the column became NULLable). Joomla's `checkin()` writes `NULL`, which non-strict MySQL silently coerces back to `0` on those columns, so the strict `=== null` comparison treated the row as checked-out-by-someone-else and hid Apply + Save — leaving only Save & New / Save as Copy, matching the OP's screenshot.

## Changes

- `administrator/components/com_j2commerce/src/View/Emailtemplate/HtmlView.php` (line 211) — replace strict-null `$checkedOut` test with `empty()` + int-cast equality so `null`, `0`, `"0"`, `""` all count as "not checked out" while the own-record exception still works.

```diff
-        $checkedOut = !(($this->item->checked_out ?? null) === null || ($this->item->checked_out ?? 0) == $user->id);
+        $checkedOut = !empty($this->item->checked_out) && (int) $this->item->checked_out !== (int) $user->id;
```

## Testing

1. On a site that reproduces (live linux, joomla-test-3 — confirmed by OP), open an existing email template (admin → J2Commerce → Email Templates → any row).
2. Click **Save** (or Save & Close, then reopen).
3. Verify **Apply** + **Save** are both still in the toolbar after the page reloads.
4. Regression on a site that didn't reproduce (column already NULLable) — confirm toolbar behaviour unchanged.
5. As a non-edit user, Apply + Save still hide based on permission only.

## Files Changed

- `administrator/components/com_j2commerce/src/View/Emailtemplate/HtmlView.php` — one-line `$checkedOut` comparison swap

## Pre-Flight

- [x] `php -l` passes
- [x] No secrets detected
- [x] No FOF remnants / `JFactory::` calls
- [x] Core files only (1 committed, no non-core leakage)
- [x] No language string changes (sync N/A)
- [x] Rebased on upstream/main (clean, single commit)

## Related

The same buggy expression is duplicated verbatim in 20 other admin edit views; sweep is tracked separately in #1032 to keep this PR minimal and scoped to the reported issue.