### PR TITLE
fix(admin views): keep Save/Apply visible after save on legacy schemas

### DIFF
--- a/administrator/components/com_j2commerce/src/View/Country/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Country/HtmlView.php
@@ -97,7 +97,7 @@ class HtmlView extends BaseHtmlView
         $isNew      = ($this->item->j2commerce_country_id == 0);
         $canDo      = ContentHelper::getActions('com_j2commerce');
         $user       = Factory::getApplication()->getIdentity();
-        $checkedOut = !(($this->item->checked_out ?? null) === null || ($this->item->checked_out ?? 0) == $user->id);
+        $checkedOut = !empty($this->item->checked_out) && (int) $this->item->checked_out !== (int) $user->id;
         $toolbar    = $this->getDocument()->getToolbar();
 
         $title = $isNew ? Text::_('COM_J2COMMERCE_TOOLBAR_NEW').' '.Text::_('COM_J2COMMERCE_COUNTRY') : Text::_('COM_J2COMMERCE_TOOLBAR_EDIT').' '.Text::_('COM_J2COMMERCE_COUNTRY');

--- a/administrator/components/com_j2commerce/src/View/Coupon/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Coupon/HtmlView.php
@@ -108,7 +108,7 @@ class HtmlView extends BaseHtmlView
         $user       = Factory::getApplication()->getIdentity();
         $isNew      = ($this->item->j2commerce_coupon_id == 0);
         $canDo      = ContentHelper::getActions('com_j2commerce');
-        $checkedOut = !(($this->item->checked_out ?? null) === null || ($this->item->checked_out ?? 0) == $user->id);
+        $checkedOut = !empty($this->item->checked_out) && (int) $this->item->checked_out !== (int) $user->id;
         $toolbar    = $this->getDocument()->getToolbar();
 
         $layout          = Factory::getApplication()->getInput()->get('layout', 'history');

--- a/administrator/components/com_j2commerce/src/View/Currency/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Currency/HtmlView.php
@@ -96,7 +96,7 @@ class HtmlView extends BaseHtmlView
         $isNew      = ($this->item->j2commerce_currency_id == 0);
         $canDo      = ContentHelper::getActions('com_j2commerce');
         $user       = Factory::getApplication()->getIdentity();
-        $checkedOut = !(($this->item->checked_out ?? null) === null || ($this->item->checked_out ?? 0) == $user->id);
+        $checkedOut = !empty($this->item->checked_out) && (int) $this->item->checked_out !== (int) $user->id;
         $toolbar    = $this->getDocument()->getToolbar();
 
         // Title: "New Currency" or "Edit Currency"

--- a/administrator/components/com_j2commerce/src/View/Customer/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Customer/HtmlView.php
@@ -154,7 +154,7 @@ class HtmlView extends BaseHtmlView
         $isNew      = ($this->item->j2commerce_address_id == 0);
         $canDo      = ContentHelper::getActions('com_j2commerce');
         $user       = Factory::getApplication()->getIdentity();
-        $checkedOut = !(($this->item->checked_out ?? null) === null || ($this->item->checked_out ?? 0) == $user->id);
+        $checkedOut = !empty($this->item->checked_out) && (int) $this->item->checked_out !== (int) $user->id;
         $toolbar    = $this->getDocument()->getToolbar();
 
         ToolbarHelper::title(

--- a/administrator/components/com_j2commerce/src/View/Customfield/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Customfield/HtmlView.php
@@ -100,7 +100,7 @@ class HtmlView extends BaseHtmlView
         $isNew      = ($this->item->j2commerce_customfield_id == 0);
         $canDo      = ContentHelper::getActions('com_j2commerce');
         $user       = Factory::getApplication()->getIdentity();
-        $checkedOut = !(($this->item->checked_out ?? null) === null || ($this->item->checked_out ?? 0) == $user->id);
+        $checkedOut = !empty($this->item->checked_out) && (int) $this->item->checked_out !== (int) $user->id;
         $toolbar    = $this->getDocument()->getToolbar();
 
         // Title: "New Custom Field" or "Edit Custom Field"

--- a/administrator/components/com_j2commerce/src/View/Filtergroup/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Filtergroup/HtmlView.php
@@ -111,7 +111,7 @@ class HtmlView extends BaseHtmlView
                  && (empty($this->item->id) || $this->item->id == 0);
 
         $canDo      = ContentHelper::getActions('com_j2commerce', 'filtergroup', $this->item->j2commerce_filtergroup_id ?? 0);
-        $checkedOut = !(($this->item->checked_out ?? null) === null || ($this->item->checked_out ?? 0) == $user->id);
+        $checkedOut = !empty($this->item->checked_out) && (int) $this->item->checked_out !== (int) $user->id;
 
         ToolbarHelper::title(
             Text::_('COM_J2COMMERCE_FILTERGROUP') . ': ' . ($isNew ? Text::_('JTOOLBAR_NEW') : Text::_('JTOOLBAR_EDIT')),

--- a/administrator/components/com_j2commerce/src/View/Geozone/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Geozone/HtmlView.php
@@ -95,7 +95,7 @@ class HtmlView extends BaseHtmlView
         $isNew      = ($this->item->j2commerce_geozone_id == 0);
         $canDo      = ContentHelper::getActions('com_j2commerce');
         $user       = Factory::getApplication()->getIdentity();
-        $checkedOut = !(($this->item->checked_out ?? null) === null || ($this->item->checked_out ?? 0) == $user->id);
+        $checkedOut = !empty($this->item->checked_out) && (int) $this->item->checked_out !== (int) $user->id;
         $toolbar    = $this->getDocument()->getToolbar();
 
         $title = $isNew ? Text::_('COM_J2COMMERCE_TOOLBAR_NEW').' '.Text::_('COM_J2COMMERCE_GEOZONE') : Text::_('COM_J2COMMERCE_TOOLBAR_EDIT').' '.Text::_('COM_J2COMMERCE_GEOZONE');

--- a/administrator/components/com_j2commerce/src/View/Invoicetemplate/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Invoicetemplate/HtmlView.php
@@ -125,7 +125,7 @@ class HtmlView extends BaseHtmlView
         $isNew      = ($this->item->j2commerce_invoicetemplate_id == 0);
         $canDo      = ContentHelper::getActions('com_j2commerce', 'invoicetemplate', $this->item->j2commerce_invoicetemplate_id ?? 0);
         $user       = Factory::getApplication()->getIdentity();
-        $checkedOut = !(($this->item->checked_out ?? null) === null || ($this->item->checked_out ?? 0) == $user->id);
+        $checkedOut = !empty($this->item->checked_out) && (int) $this->item->checked_out !== (int) $user->id;
 
         Factory::getApplication()->getInput()->set('hidemainmenu', true);
 

--- a/administrator/components/com_j2commerce/src/View/Length/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Length/HtmlView.php
@@ -95,7 +95,7 @@ class HtmlView extends BaseHtmlView
         $isNew      = ($this->item->j2commerce_length_id == 0);
         $canDo      = ContentHelper::getActions('com_j2commerce');
         $user       = Factory::getApplication()->getIdentity();
-        $checkedOut = !(($this->item->checked_out ?? null) === null || ($this->item->checked_out ?? 0) == $user->id);
+        $checkedOut = !empty($this->item->checked_out) && (int) $this->item->checked_out !== (int) $user->id;
         $toolbar    = $this->getDocument()->getToolbar();
 
         $title = $isNew ? Text::_('COM_J2COMMERCE_TOOLBAR_NEW').' '.Text::_('COM_J2COMMERCE_LENGTH') : Text::_('COM_J2COMMERCE_TOOLBAR_EDIT').' '.Text::_('COM_J2COMMERCE_LENGTH');

--- a/administrator/components/com_j2commerce/src/View/Manufacturer/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Manufacturer/HtmlView.php
@@ -112,7 +112,7 @@ class HtmlView extends BaseHtmlView
         $isNew      = ($this->item->j2commerce_manufacturer_id == 0);
         $canDo      = ContentHelper::getActions('com_j2commerce');
         $user       = Factory::getApplication()->getIdentity();
-        $checkedOut = !(($this->item->checked_out ?? null) === null || ($this->item->checked_out ?? 0) == $user->id);
+        $checkedOut = !empty($this->item->checked_out) && (int) $this->item->checked_out !== (int) $user->id;
         $toolbar    = $this->getDocument()->getToolbar();
 
         // Title: "New Manufacturer" or "Edit Manufacturer"

--- a/administrator/components/com_j2commerce/src/View/Option/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Option/HtmlView.php
@@ -109,7 +109,7 @@ class HtmlView extends BaseHtmlView
         $isNew = (empty($this->item->j2commerce_option_id) || $this->item->j2commerce_option_id == 0)
                  && (empty($this->item->id) || $this->item->id == 0);
         $canDo      = ContentHelper::getActions('com_j2commerce', 'option', $this->item->j2commerce_option_id ?? 0);
-        $checkedOut = !(($this->item->checked_out ?? null) === null || ($this->item->checked_out ?? 0) == $user->id);
+        $checkedOut = !empty($this->item->checked_out) && (int) $this->item->checked_out !== (int) $user->id;
 
         ToolbarHelper::title(
             Text::_('COM_J2COMMERCE_OPTION') . ': ' . ($isNew ? Text::_('JTOOLBAR_NEW') : Text::_('JTOOLBAR_EDIT')),

--- a/administrator/components/com_j2commerce/src/View/Order/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Order/HtmlView.php
@@ -150,7 +150,7 @@ class HtmlView extends BaseHtmlView
         $canDo         = ContentHelper::getActions('com_j2commerce');
         $canEditOrders = J2CommerceHelper::canAccess('j2commerce.editorders');
         $user          = Factory::getApplication()->getIdentity();
-        $checkedOut    = !(($this->item->checked_out ?? null) === null || ($this->item->checked_out ?? 0) == $user->id);
+        $checkedOut    = !empty($this->item->checked_out) && (int) $this->item->checked_out !== (int) $user->id;
         $toolbar       = $this->getDocument()->getToolbar();
 
         $orderDisplay = $this->item->order_id ?? $this->item->invoice ?? Text::_('COM_J2COMMERCE_ORDER');

--- a/administrator/components/com_j2commerce/src/View/Orderstatus/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Orderstatus/HtmlView.php
@@ -100,7 +100,7 @@ class HtmlView extends BaseHtmlView
         $isNew      = ($this->item->j2commerce_orderstatus_id == 0);
         $canDo      = ContentHelper::getActions('com_j2commerce');
         $user       = Factory::getApplication()->getIdentity();
-        $checkedOut = !(($this->item->checked_out ?? null) === null || ($this->item->checked_out ?? 0) == $user->id);
+        $checkedOut = !empty($this->item->checked_out) && (int) $this->item->checked_out !== (int) $user->id;
         $toolbar    = $this->getDocument()->getToolbar();
 
         // Title: "New Order Status" or "Edit Order Status"

--- a/administrator/components/com_j2commerce/src/View/Product/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Product/HtmlView.php
@@ -102,7 +102,7 @@ class HtmlView extends BaseHtmlView
         $isNew      = empty($this->item->j2commerce_product_id);
         $canDo      = ContentHelper::getActions('com_j2commerce');
         $user       = Factory::getApplication()->getIdentity();
-        $checkedOut = !(($this->item->checked_out ?? null) === null || ($this->item->checked_out ?? 0) == $user->id);
+        $checkedOut = !empty($this->item->checked_out) && (int) $this->item->checked_out !== (int) $user->id;
         $toolbar    = $this->getDocument()->getToolbar();
 
         ToolbarHelper::title(

--- a/administrator/components/com_j2commerce/src/View/Taxprofile/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Taxprofile/HtmlView.php
@@ -95,7 +95,7 @@ class HtmlView extends BaseHtmlView
         $isNew      = ($this->item->j2commerce_taxprofile_id == 0);
         $canDo      = ContentHelper::getActions('com_j2commerce');
         $user       = Factory::getApplication()->getIdentity();
-        $checkedOut = !(($this->item->checked_out ?? null) === null || ($this->item->checked_out ?? 0) == $user->id);
+        $checkedOut = !empty($this->item->checked_out) && (int) $this->item->checked_out !== (int) $user->id;
         $toolbar    = $this->getDocument()->getToolbar();
 
         $title = $isNew ? Text::_('COM_J2COMMERCE_TOOLBAR_NEW').' '.Text::_('COM_J2COMMERCE_TAXPROFILE') : Text::_('COM_J2COMMERCE_TOOLBAR_EDIT').' '.Text::_('COM_J2COMMERCE_TAXPROFILE');

--- a/administrator/components/com_j2commerce/src/View/Taxrate/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Taxrate/HtmlView.php
@@ -95,7 +95,7 @@ class HtmlView extends BaseHtmlView
         $isNew      = ($this->item->j2commerce_taxrate_id == 0);
         $canDo      = ContentHelper::getActions('com_j2commerce');
         $user       = Factory::getApplication()->getIdentity();
-        $checkedOut = !(($this->item->checked_out ?? null) === null || ($this->item->checked_out ?? 0) == $user->id);
+        $checkedOut = !empty($this->item->checked_out) && (int) $this->item->checked_out !== (int) $user->id;
         $toolbar    = $this->getDocument()->getToolbar();
 
         $title = $isNew ? Text::_('COM_J2COMMERCE_TOOLBAR_NEW').' '.Text::_('COM_J2COMMERCE_TAXRATE') : Text::_('COM_J2COMMERCE_TOOLBAR_EDIT').' '.Text::_('COM_J2COMMERCE_TAXRATE');

--- a/administrator/components/com_j2commerce/src/View/Vendor/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Vendor/HtmlView.php
@@ -111,7 +111,7 @@ class HtmlView extends BaseHtmlView
         $isNew      = ($this->item->j2commerce_vendor_id == 0);
         $canDo      = ContentHelper::getActions('com_j2commerce');
         $user       = Factory::getApplication()->getIdentity();
-        $checkedOut = !(($this->item->checked_out ?? null) === null || ($this->item->checked_out ?? 0) == $user->id);
+        $checkedOut = !empty($this->item->checked_out) && (int) $this->item->checked_out !== (int) $user->id;
         $toolbar    = $this->getDocument()->getToolbar();
 
         // Title: "New Vendor" or "Edit Vendor"

--- a/administrator/components/com_j2commerce/src/View/Voucher/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Voucher/HtmlView.php
@@ -106,7 +106,7 @@ class HtmlView extends BaseHtmlView
 
         $user       = Factory::getApplication()->getIdentity();
         $isNew      = (empty($this->item->j2commerce_voucher_id) || $this->item->j2commerce_voucher_id == 0);
-        $checkedOut = !(($this->item->checked_out ?? null) === null || ($this->item->checked_out ?? 0) == $user->id);
+        $checkedOut = !empty($this->item->checked_out) && (int) $this->item->checked_out !== (int) $user->id;
         $canDo      = ContentHelper::getActions('com_j2commerce', 'voucher', $this->item->j2commerce_voucher_id ?? 0);
 
         $layout          = Factory::getApplication()->getInput()->get('layout', 'history');

--- a/administrator/components/com_j2commerce/src/View/Weight/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Weight/HtmlView.php
@@ -95,7 +95,7 @@ class HtmlView extends BaseHtmlView
         $isNew      = ($this->item->j2commerce_weight_id == 0);
         $canDo      = ContentHelper::getActions('com_j2commerce');
         $user       = Factory::getApplication()->getIdentity();
-        $checkedOut = !(($this->item->checked_out ?? null) === null || ($this->item->checked_out ?? 0) == $user->id);
+        $checkedOut = !empty($this->item->checked_out) && (int) $this->item->checked_out !== (int) $user->id;
         $toolbar    = $this->getDocument()->getToolbar();
 
         $title = $isNew ? Text::_('COM_J2COMMERCE_TOOLBAR_NEW').' '.Text::_('COM_J2COMMERCE_WEIGHT') : Text::_('COM_J2COMMERCE_TOOLBAR_EDIT').' '.Text::_('COM_J2COMMERCE_WEIGHT');

--- a/administrator/components/com_j2commerce/src/View/Zone/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Zone/HtmlView.php
@@ -95,7 +95,7 @@ class HtmlView extends BaseHtmlView
         $isNew      = ($this->item->j2commerce_zone_id == 0);
         $canDo      = ContentHelper::getActions('com_j2commerce');
         $user       = Factory::getApplication()->getIdentity();
-        $checkedOut = !(($this->item->checked_out ?? null) === null || ($this->item->checked_out ?? 0) == $user->id);
+        $checkedOut = !empty($this->item->checked_out) && (int) $this->item->checked_out !== (int) $user->id;
         $toolbar    = $this->getDocument()->getToolbar();
 
         // Title: "New Zone" or "Edit Zone"


### PR DESCRIPTION
## Summary

Fixes #1032

Sweep of the same `checked_out` comparison fix that PR #1033 applied to the emailtemplate view, across the remaining 20 admin edit views. Identical expression was duplicated verbatim in every one. On any install whose `checked_out` column was created as `int UNSIGNED NOT NULL DEFAULT 0` (older J2Commerce / J2Store schemas, before the column became NULLable), Joomla's `checkin()` writes `NULL` which non-strict MySQL coerces back to `0`, the strict `=== null` test fails, `$canEdit` becomes `false`, and **Apply** + **Save** are stripped from the toolbar — leaving only Save & New / Save as Copy.

## Changes

Replace, per file, the same one-line `$checkedOut` expression:

```diff
-        $checkedOut = !(($this->item->checked_out ?? null) === null || ($this->item->checked_out ?? 0) == $user->id);
+        $checkedOut = !empty($this->item->checked_out) && (int) $this->item->checked_out !== (int) $user->id;
```

`empty()` treats `null`, `0`, `"0"`, `""` all as "not checked out"; the strict int-cast equality keeps the own-record exception working regardless of column type or strict-mode behaviour.

`Order/HtmlView.php` keeps its 4-space alignment after `$checkedOut`. `Emailtemplate/HtmlView.php` is **not** included — already fixed by #1033.

## Files Changed (20)

- `administrator/components/com_j2commerce/src/View/Country/HtmlView.php`
- `administrator/components/com_j2commerce/src/View/Coupon/HtmlView.php`
- `administrator/components/com_j2commerce/src/View/Currency/HtmlView.php`
- `administrator/components/com_j2commerce/src/View/Customer/HtmlView.php`
- `administrator/components/com_j2commerce/src/View/Customfield/HtmlView.php`
- `administrator/components/com_j2commerce/src/View/Filtergroup/HtmlView.php`
- `administrator/components/com_j2commerce/src/View/Geozone/HtmlView.php`
- `administrator/components/com_j2commerce/src/View/Invoicetemplate/HtmlView.php`
- `administrator/components/com_j2commerce/src/View/Length/HtmlView.php`
- `administrator/components/com_j2commerce/src/View/Manufacturer/HtmlView.php`
- `administrator/components/com_j2commerce/src/View/Option/HtmlView.php`
- `administrator/components/com_j2commerce/src/View/Order/HtmlView.php`
- `administrator/components/com_j2commerce/src/View/Orderstatus/HtmlView.php`
- `administrator/components/com_j2commerce/src/View/Product/HtmlView.php`
- `administrator/components/com_j2commerce/src/View/Taxprofile/HtmlView.php`
- `administrator/components/com_j2commerce/src/View/Taxrate/HtmlView.php`
- `administrator/components/com_j2commerce/src/View/Vendor/HtmlView.php`
- `administrator/components/com_j2commerce/src/View/Voucher/HtmlView.php`
- `administrator/components/com_j2commerce/src/View/Weight/HtmlView.php`
- `administrator/components/com_j2commerce/src/View/Zone/HtmlView.php`

20 files changed, 20 insertions(+), 20 deletions(-).

## Testing

On a site whose `checked_out` columns store `0` (joomla-test-3 reproduces) — all 20 views share identical pre/post code, so spot coverage is sufficient:

1. Admin → J2Commerce → **Products** → open any product → Save → confirm Apply + Save still in toolbar.
2. Admin → J2Commerce → **Orders** → open any order → Save → confirm Apply + Save remain.
3. Admin → J2Commerce → **Coupons** → open any coupon → Save → confirm.
4. Admin → J2Commerce → **Customers** → open any customer → Save → confirm.
5. Admin → J2Commerce → **Currency** → open any currency → Save → confirm.
6. Regression on dev folder (NULLable column) — behaviour unchanged.
7. As a non-edit user, Apply + Save still hide based on permission gate only.

## Pre-Flight

- [x] `php -l` passes on all 20 modified files
- [x] No secrets detected
- [x] No FOF remnants / `JFactory::` calls
- [x] Core files only (20 committed, no non-core leakage)
- [x] No language string changes (sync N/A)
- [x] Grep confirms zero remaining occurrences of the old strict-null pattern across `administrator/components/com_j2commerce/src/View/`

## Related

- #1030 — original report (emailtemplate only)
- #1033 — emailtemplate fix (merged)