### PR TITLE
fix(admin-help): repair 32 broken Help links + use translated help refs (fixes #1036)

### DIFF
--- a/administrator/components/com_j2commerce/src/View/Analytics/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Analytics/HtmlView.php
@@ -203,6 +203,6 @@ class HtmlView extends BaseHtmlView
             ToolbarHelper::preferences('com_j2commerce');
         }
 
-        ToolbarHelper::help('J2Commerce', true, 'https://docs.j2commerce.com/v6/');
+        ToolbarHelper::help(Text::_('COM_J2COMMERCE_ANALYTICS'), true, 'https://docs.j2commerce.com/v6/');
     }
 }

--- a/administrator/components/com_j2commerce/src/View/Apps/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Apps/HtmlView.php
@@ -127,7 +127,7 @@ class HtmlView extends BaseHtmlView
         if ($user->authorise('core.admin', 'com_j2commerce') || $user->authorise('core.options', 'com_j2commerce')) {
             $toolbar->preferences('com_j2commerce');
         }
-        $toolbar->help('Apps', true, 'https://docs.j2commerce.com/v6/apps-and-extensions/');
+        $toolbar->help(Text::_('COM_J2COMMERCE_APPS'), true, 'https://docs.j2commerce.com/v6/apps-and-extensions/');
     }
 
     protected function loadAppPluginLanguages(): void

--- a/administrator/components/com_j2commerce/src/View/Countries/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Countries/HtmlView.php
@@ -193,6 +193,6 @@ class HtmlView extends BaseHtmlView
             ToolbarHelper::preferences('com_j2commerce');
         }
 
-        ToolbarHelper::help('Countries', true, 'https://docs.j2commerce.com/v6/localisation/countries');
+        ToolbarHelper::help(Text::_('COM_J2COMMERCE_COUNTRIES'), true, 'https://docs.j2commerce.com/v6/localization/countries/');
     }
 }

--- a/administrator/components/com_j2commerce/src/View/Country/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Country/HtmlView.php
@@ -129,6 +129,6 @@ class HtmlView extends BaseHtmlView
 
         $toolbar->cancel('country.cancel', $isNew ? 'JTOOLBAR_CANCEL' : 'JTOOLBAR_CLOSE');
         $toolbar->divider();
-        ToolbarHelper::help('Countries', true, 'https://docs.j2commerce.com/v6/localisation/countries');
+        ToolbarHelper::help(Text::_('COM_J2COMMERCE_COUNTRIES'), true, 'https://docs.j2commerce.com/v6/localization/countries/');
     }
 }

--- a/administrator/components/com_j2commerce/src/View/Coupon/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Coupon/HtmlView.php
@@ -185,6 +185,6 @@ class HtmlView extends BaseHtmlView
         }
 
         $toolbar->divider();
-        ToolbarHelper::help('Coupons', true, 'https://docs.j2commerce.com/v6/sales/coupons');
+        ToolbarHelper::help(Text::_('COM_J2COMMERCE_COUPONS'), true, 'https://docs.j2commerce.com/v6/sales/coupons');
     }
 }

--- a/administrator/components/com_j2commerce/src/View/Coupons/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Coupons/HtmlView.php
@@ -223,6 +223,6 @@ class HtmlView extends BaseHtmlView
             $toolbar->preferences('com_j2commerce');
         }
 
-        ToolbarHelper::help('Coupons', true, 'https://docs.j2commerce.com/v6/sales/coupons');
+        ToolbarHelper::help(Text::_('COM_J2COMMERCE_COUPONS'), true, 'https://docs.j2commerce.com/v6/sales/coupons');
     }
 }

--- a/administrator/components/com_j2commerce/src/View/Currencies/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Currencies/HtmlView.php
@@ -203,6 +203,6 @@ class HtmlView extends BaseHtmlView
             ToolbarHelper::preferences('com_j2commerce');
         }
 
-        ToolbarHelper::help('Currencies', true, 'https://docs.j2commerce.com/v6/localisation/currencies');
+        ToolbarHelper::help(Text::_('COM_J2COMMERCE_CURRENCIES'), true, 'https://docs.j2commerce.com/v6/localization/currencies/');
     }
 }

--- a/administrator/components/com_j2commerce/src/View/Currency/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Currency/HtmlView.php
@@ -130,6 +130,6 @@ class HtmlView extends BaseHtmlView
 
         $toolbar->cancel('currency.cancel', $isNew ? 'JTOOLBAR_CANCEL' : 'JTOOLBAR_CLOSE');
         $toolbar->divider();
-        ToolbarHelper::help('Currencies', true, 'https://docs.j2commerce.com/v6/localisation/currencies');
+        ToolbarHelper::help(Text::_('COM_J2COMMERCE_CURRENCIES'), true, 'https://docs.j2commerce.com/v6/localization/currencies/');
     }
 }

--- a/administrator/components/com_j2commerce/src/View/Customer/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Customer/HtmlView.php
@@ -202,6 +202,6 @@ class HtmlView extends BaseHtmlView
 
         $toolbar->cancel('customer.cancel', $isNew ? 'JTOOLBAR_CANCEL' : 'JTOOLBAR_CLOSE');
 
-        ToolbarHelper::help('Customers', true, 'https://docs.j2commerce.com/v6/sales/customers');
+        ToolbarHelper::help(Text::_('COM_J2COMMERCE_CUSTOMERS'), true, 'https://docs.j2commerce.com/v6/sales/customers');
     }
 }

--- a/administrator/components/com_j2commerce/src/View/Customers/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Customers/HtmlView.php
@@ -165,6 +165,6 @@ class HtmlView extends BaseHtmlView
             $toolbar->preferences('com_j2commerce');
         }
 
-        ToolbarHelper::help('Customers', true, 'https://docs.j2commerce.com/v6/sales/customers');
+        ToolbarHelper::help(Text::_('COM_J2COMMERCE_CUSTOMERS'), true, 'https://docs.j2commerce.com/v6/sales/customers');
     }
 }

--- a/administrator/components/com_j2commerce/src/View/Customfield/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Customfield/HtmlView.php
@@ -134,6 +134,6 @@ class HtmlView extends BaseHtmlView
 
         $toolbar->cancel('customfield.cancel', $isNew ? 'JTOOLBAR_CANCEL' : 'JTOOLBAR_CLOSE');
         $toolbar->divider();
-        ToolbarHelper::help('Custom_Fields', true, 'https://docs.j2commerce.com/v6/configuration/custom-fields');
+        ToolbarHelper::help(Text::_('COM_J2COMMERCE_CUSTOM_FIELDS'), true, 'https://docs.j2commerce.com/v6/setup/custom-fields/');
     }
 }

--- a/administrator/components/com_j2commerce/src/View/Customfields/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Customfields/HtmlView.php
@@ -205,6 +205,6 @@ class HtmlView extends BaseHtmlView
             ToolbarHelper::preferences('com_j2commerce');
         }
 
-        ToolbarHelper::help('Custom_Fields', true, 'https://docs.j2commerce.com/v6/configuration/custom-fields');
+        ToolbarHelper::help(Text::_('COM_J2COMMERCE_CUSTOM_FIELDS'), true, 'https://docs.j2commerce.com/v6/setup/custom-fields/');
     }
 }

--- a/administrator/components/com_j2commerce/src/View/Dashboard/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Dashboard/HtmlView.php
@@ -528,6 +528,6 @@ JS);
             ToolbarHelper::preferences('com_j2commerce');
         }
 
-        ToolbarHelper::help('J2Commerce', true, 'https://docs.j2commerce.com/v6/');
+        ToolbarHelper::help(Text::_('COM_J2COMMERCE_DASHBOARD'), true, 'https://docs.j2commerce.com/v6/');
     }
 }

--- a/administrator/components/com_j2commerce/src/View/Emailtemplate/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Emailtemplate/HtmlView.php
@@ -247,6 +247,6 @@ class HtmlView extends BaseHtmlView
 
 
         $toolbar->divider();
-        $toolbar->help('J2Commerce_Email_Template', false, 'https://docs.j2commerce.com/design/email-templates');
+        $toolbar->help(Text::_('COM_J2COMMERCE_EMAILTEMPLATE'), false, 'https://docs.j2commerce.com/v6/design/email-templates/');
     }
 }

--- a/administrator/components/com_j2commerce/src/View/Emailtemplates/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Emailtemplates/HtmlView.php
@@ -189,6 +189,6 @@ class HtmlView extends BaseHtmlView
         }
 
         // Add help button
-        $toolbar->help('J2Commerce_Email_Templates', false, 'https://docs.j2commerce.com/design/email-templates');
+        $toolbar->help(Text::_('COM_J2COMMERCE_EMAILTEMPLATES'), false, 'https://docs.j2commerce.com/v6/design/email-templates/');
     }
 }

--- a/administrator/components/com_j2commerce/src/View/Filtergroup/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Filtergroup/HtmlView.php
@@ -139,6 +139,6 @@ class HtmlView extends BaseHtmlView
             ToolbarHelper::cancel('filtergroup.cancel', 'JTOOLBAR_CLOSE');
         }
 
-        ToolbarHelper::help('Filtergroup', true, 'https://docs.j2commerce.com/v6/catalog/filters');
+        ToolbarHelper::help(Text::_('COM_J2COMMERCE_FILTERGROUP'), true, 'https://docs.j2commerce.com/v6/catalog/creating-filters/');
     }
 }

--- a/administrator/components/com_j2commerce/src/View/Filtergroups/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Filtergroups/HtmlView.php
@@ -191,6 +191,6 @@ class HtmlView extends BaseHtmlView
             $toolbar->preferences('com_j2commerce');
         }
 
-        $toolbar->help('Filtergroups');
+        $toolbar->help(Text::_('COM_J2COMMERCE_FILTERGROUPS'), true, 'https://docs.j2commerce.com/v6/catalog/creating-filters/');
     }
 }

--- a/administrator/components/com_j2commerce/src/View/Geozone/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Geozone/HtmlView.php
@@ -127,6 +127,6 @@ class HtmlView extends BaseHtmlView
 
         $toolbar->cancel('geozone.cancel', $isNew ? 'JTOOLBAR_CANCEL' : 'JTOOLBAR_CLOSE');
         $toolbar->divider();
-        ToolbarHelper::help('Geozones', true, 'https://docs.j2commerce.com/v6/localisation/geozones');
+        ToolbarHelper::help(Text::_('COM_J2COMMERCE_GEOZONES'), true, 'https://docs.j2commerce.com/v6/localization/geozones/');
     }
 }

--- a/administrator/components/com_j2commerce/src/View/Geozones/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Geozones/HtmlView.php
@@ -184,6 +184,6 @@ class HtmlView extends BaseHtmlView
             ToolbarHelper::preferences('com_j2commerce');
         }
 
-        ToolbarHelper::help('Geozones', true, 'https://docs.j2commerce.com/v6/localisation/geozones');
+        ToolbarHelper::help(Text::_('COM_J2COMMERCE_GEOZONES'), true, 'https://docs.j2commerce.com/v6/localization/geozones/');
     }
 }

--- a/administrator/components/com_j2commerce/src/View/Inventory/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Inventory/HtmlView.php
@@ -187,7 +187,7 @@ class HtmlView extends BaseHtmlView
             $toolbar->preferences('com_j2commerce');
         }
 
-        $toolbar->help('COM_J2COMMERCE_HELP_INVENTORY');
+        $toolbar->help(Text::_('COM_J2COMMERCE_INVENTORY'), true, 'https://docs.j2commerce.com/v6/catalog/inventory/');
     }
 
     /**

--- a/administrator/components/com_j2commerce/src/View/Invoicetemplate/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Invoicetemplate/HtmlView.php
@@ -171,6 +171,6 @@ class HtmlView extends BaseHtmlView
                 . '</button>');
 
         $toolbar->divider();
-        $toolbar->help('Print_Template:_Edit');
+        $toolbar->help(Text::_('COM_J2COMMERCE_INVOICETEMPLATES'), true, 'https://docs.j2commerce.com/v6/design/invoice-templates/');
     }
 }

--- a/administrator/components/com_j2commerce/src/View/Invoicetemplates/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Invoicetemplates/HtmlView.php
@@ -187,7 +187,7 @@ class HtmlView extends BaseHtmlView
             $toolbar->preferences('com_j2commerce');
         }
 
-        $toolbar->help('Invoice_Templates', true, 'https://docs.j2commerce.com/design/invoice-template-pro-feature');
+        $toolbar->help(Text::_('COM_J2COMMERCE_INVOICETEMPLATES'), true, 'https://docs.j2commerce.com/v6/design/invoice-templates/');
     }
 
     /**

--- a/administrator/components/com_j2commerce/src/View/Length/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Length/HtmlView.php
@@ -127,6 +127,6 @@ class HtmlView extends BaseHtmlView
 
         $toolbar->cancel('length.cancel', $isNew ? 'JTOOLBAR_CANCEL' : 'JTOOLBAR_CLOSE');
         $toolbar->divider();
-        ToolbarHelper::help('Lengths', true, 'https://docs.j2commerce.com/v6/localisation/lengths');
+        ToolbarHelper::help(Text::_('COM_J2COMMERCE_LENGTHS'), true, 'https://docs.j2commerce.com/v6/localization/lengths/');
     }
 }

--- a/administrator/components/com_j2commerce/src/View/Lengths/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Lengths/HtmlView.php
@@ -192,6 +192,6 @@ class HtmlView extends BaseHtmlView
             ToolbarHelper::preferences('com_j2commerce');
         }
 
-        ToolbarHelper::help('Lengths', true, 'https://docs.j2commerce.com/v6/localisation/lengths');
+        ToolbarHelper::help(Text::_('COM_J2COMMERCE_LENGTHS'), true, 'https://docs.j2commerce.com/v6/localization/lengths/');
     }
 }

--- a/administrator/components/com_j2commerce/src/View/Manufacturer/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Manufacturer/HtmlView.php
@@ -146,6 +146,6 @@ class HtmlView extends BaseHtmlView
 
         $toolbar->cancel('manufacturer.cancel', $isNew ? 'JTOOLBAR_CANCEL' : 'JTOOLBAR_CLOSE');
         $toolbar->divider();
-        ToolbarHelper::help('Manufacturer', true, 'https://docs.j2commerce.com/v6/catalog/manufacturers');
+        ToolbarHelper::help(Text::_('COM_J2COMMERCE_MANUFACTURER'), true, 'https://docs.j2commerce.com/v6/catalog/manufacturers');
     }
 }

--- a/administrator/components/com_j2commerce/src/View/Manufacturers/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Manufacturers/HtmlView.php
@@ -189,6 +189,6 @@ class HtmlView extends BaseHtmlView
             ToolbarHelper::preferences('com_j2commerce');
         }
 
-        ToolbarHelper::help('Manufacturers', true, 'https://docs.j2commerce.com/v6/catalog/manufacturers');
+        ToolbarHelper::help(Text::_('COM_J2COMMERCE_MANUFACTURERS'), true, 'https://docs.j2commerce.com/v6/catalog/manufacturers');
     }
 }

--- a/administrator/components/com_j2commerce/src/View/Option/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Option/HtmlView.php
@@ -137,6 +137,6 @@ class HtmlView extends BaseHtmlView
             ToolbarHelper::cancel('option.cancel', 'JTOOLBAR_CLOSE');
         }
 
-        ToolbarHelper::help('Option', false, 'https://docs.j2commerce.com/v6/catalog/options');
+        ToolbarHelper::help(Text::_('COM_J2COMMERCE_OPTION'), false, 'https://docs.j2commerce.com/v6/catalog/creating-options/');
     }
 }

--- a/administrator/components/com_j2commerce/src/View/Options/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Options/HtmlView.php
@@ -188,6 +188,6 @@ class HtmlView extends BaseHtmlView
             $toolbar->preferences('com_j2commerce');
         }
 
-        ToolbarHelper::help('Options', false, 'https://docs.j2commerce.com/v6/catalog/options');
+        ToolbarHelper::help(Text::_('COM_J2COMMERCE_OPTIONS'), false, 'https://docs.j2commerce.com/v6/catalog/creating-options/');
     }
 }

--- a/administrator/components/com_j2commerce/src/View/Order/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Order/HtmlView.php
@@ -200,7 +200,7 @@ class HtmlView extends BaseHtmlView
         }
 
         $toolbar->divider();
-        ToolbarHelper::help('Orders', true, 'https://docs.j2commerce.com/v6/sales/orders');
+        ToolbarHelper::help(Text::_('COM_J2COMMERCE_ORDERS'), true, 'https://docs.j2commerce.com/v6/sales/orders');
     }
 
     protected function getOrderStatuses(): array

--- a/administrator/components/com_j2commerce/src/View/Orders/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Orders/HtmlView.php
@@ -148,7 +148,7 @@ class HtmlView extends BaseHtmlView
             $toolbar->preferences('com_j2commerce');
         }
 
-        ToolbarHelper::help('Orders', true, 'https://docs.j2commerce.com/v6/sales/orders');
+        ToolbarHelper::help(Text::_('COM_J2COMMERCE_ORDERS'), true, 'https://docs.j2commerce.com/v6/sales/orders');
     }
 
     protected function loadOrderStatuses(): array

--- a/administrator/components/com_j2commerce/src/View/Orderstatus/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Orderstatus/HtmlView.php
@@ -136,6 +136,6 @@ class HtmlView extends BaseHtmlView
 
         $toolbar->cancel('orderstatus.cancel', $isNew ? 'JTOOLBAR_CANCEL' : 'JTOOLBAR_CLOSE');
         $toolbar->divider();
-        ToolbarHelper::help('Order Statuses', true, 'https://docs.j2commerce.com/v6/localisation/order-statuses');
+        ToolbarHelper::help(Text::_('COM_J2COMMERCE_ORDER_STATUSES'), true, 'https://docs.j2commerce.com/v6/setup/order-statuses/');
     }
 }

--- a/administrator/components/com_j2commerce/src/View/Orderstatuses/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Orderstatuses/HtmlView.php
@@ -177,6 +177,6 @@ class HtmlView extends BaseHtmlView
             ToolbarHelper::preferences('com_j2commerce');
         }
 
-        ToolbarHelper::help('Order Statuses', true, 'https://docs.j2commerce.com/v6/localisation/order-statuses');
+        ToolbarHelper::help(Text::_('COM_J2COMMERCE_ORDER_STATUSES'), true, 'https://docs.j2commerce.com/v6/setup/order-statuses/');
     }
 }

--- a/administrator/components/com_j2commerce/src/View/Overrides/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Overrides/HtmlView.php
@@ -166,6 +166,6 @@ class HtmlView extends BaseHtmlView
             $toolbar->back('JTOOLBAR_BACK', 'index.php?option=com_j2commerce&view=dashboard');
         }
 
-        ToolbarHelper::help('Overrides', true, 'https://docs.j2commerce.com/v6/design/template-overrides');
+        ToolbarHelper::help(Text::_('COM_J2COMMERCE_TEMPLATE_OVERRIDES'), true, 'https://docs.j2commerce.com/v6/design/template-overrides');
     }
 }

--- a/administrator/components/com_j2commerce/src/View/Paymentmethods/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Paymentmethods/HtmlView.php
@@ -192,7 +192,7 @@ class HtmlView extends BaseHtmlView
             $toolbar->preferences('com_j2commerce');
         }
 
-        $toolbar->help('Payment_Methods', true, 'https://docs.j2commerce.com/v6/payment-methods');
+        $toolbar->help(Text::_('COM_J2COMMERCE_PAYMENT_METHODS'), true, 'https://docs.j2commerce.com/v6/payment-methods');
     }
 
     protected function loadPaymentPluginLanguages(): void

--- a/administrator/components/com_j2commerce/src/View/Product/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Product/HtmlView.php
@@ -125,6 +125,6 @@ class HtmlView extends BaseHtmlView
 
         $toolbar->cancel('product.cancel', $isNew ? 'JTOOLBAR_CANCEL' : 'JTOOLBAR_CLOSE');
 
-        $toolbar->help('Product');
+        $toolbar->help(Text::_('COM_J2COMMERCE_PRODUCT'), true, 'https://docs.j2commerce.com/v6/catalog/managing-products/');
     }
 }

--- a/administrator/components/com_j2commerce/src/View/Products/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Products/HtmlView.php
@@ -209,6 +209,6 @@ class HtmlView extends BaseHtmlView
             $toolbar->preferences('com_j2commerce');
         }
 
-        $toolbar->help('Products');
+        $toolbar->help(Text::_('COM_J2COMMERCE_PRODUCTS'), true, 'https://docs.j2commerce.com/v6/catalog/managing-products/');
     }
 }

--- a/administrator/components/com_j2commerce/src/View/Queuelogs/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Queuelogs/HtmlView.php
@@ -90,6 +90,6 @@ class HtmlView extends BaseHtmlView
             ToolbarHelper::preferences('com_j2commerce');
         }
 
-        ToolbarHelper::help('Queue_Logs', true, 'https://docs.j2commerce.com/v6/configuration/queue-logs');
+        ToolbarHelper::help(Text::_('COM_J2COMMERCE_QUEUE_LOGS'), true, 'https://docs.j2commerce.com/v6/setup/queue-hub/');
     }
 }

--- a/administrator/components/com_j2commerce/src/View/Queues/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Queues/HtmlView.php
@@ -115,6 +115,6 @@ class HtmlView extends BaseHtmlView
             ToolbarHelper::preferences('com_j2commerce');
         }
 
-        ToolbarHelper::help('Queue_Hub', true, 'https://docs.j2commerce.com/v6/configuration/queue-hub');
+        ToolbarHelper::help(Text::_('COM_J2COMMERCE_QUEUES'), true, 'https://docs.j2commerce.com/v6/setup/queue-hub/');
     }
 }

--- a/administrator/components/com_j2commerce/src/View/Reports/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Reports/HtmlView.php
@@ -192,7 +192,7 @@ class HtmlView extends BaseHtmlView
             $toolbar->preferences('com_j2commerce');
         }
 
-        $toolbar->help('Reports', true, 'https://docs.j2commerce.com/report-sales');
+        $toolbar->help(Text::_('COM_J2COMMERCE_REPORTS'), true, 'https://docs.j2commerce.com/v6/reports/');
     }
 
     protected function loadReportPluginLanguages(): void

--- a/administrator/components/com_j2commerce/src/View/Shippingmethods/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Shippingmethods/HtmlView.php
@@ -191,7 +191,7 @@ class HtmlView extends BaseHtmlView
             $toolbar->preferences('com_j2commerce');
         }
 
-        $toolbar->help('Shipping_Methods', true, 'https://docs.j2commerce.com/v6/shipping-methods');
+        $toolbar->help(Text::_('COM_J2COMMERCE_SHIPPING_METHODS'), true, 'https://docs.j2commerce.com/v6/shipping-methods');
     }
 
     protected function loadShippingPluginLanguages(): void

--- a/administrator/components/com_j2commerce/src/View/Shippingtroubles/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Shippingtroubles/HtmlView.php
@@ -222,7 +222,7 @@ class HtmlView extends BaseHtmlView
             $toolbar->preferences('com_j2commerce');
         }
 
-        $toolbar->help('Shipping_Troubleshooter', true, 'https://docs.j2commerce.com/troubleshooting-guide/troubleshooting-shipping-methods');
+        $toolbar->help(Text::_('COM_J2COMMERCE_SHIPPING_TROUBLESHOOTER'), true, 'https://docs.j2commerce.com/v6/setup/shipping-troubleshooter/');
     }
 
     /**

--- a/administrator/components/com_j2commerce/src/View/Taxprofile/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Taxprofile/HtmlView.php
@@ -127,6 +127,6 @@ class HtmlView extends BaseHtmlView
 
         $toolbar->cancel('taxprofile.cancel', $isNew ? 'JTOOLBAR_CANCEL' : 'JTOOLBAR_CLOSE');
         $toolbar->divider();
-        ToolbarHelper::help('Tax_Profiles', true, 'https://docs.j2commerce.com/v6/localisation/tax-profiles');
+        ToolbarHelper::help(Text::_('COM_J2COMMERCE_TAX_PROFILES'), true, 'https://docs.j2commerce.com/v6/localization/tax-profiles/');
     }
 }

--- a/administrator/components/com_j2commerce/src/View/Taxprofiles/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Taxprofiles/HtmlView.php
@@ -176,6 +176,6 @@ class HtmlView extends BaseHtmlView
             ToolbarHelper::preferences('com_j2commerce');
         }
 
-        ToolbarHelper::help('Tax_Profiles', true, 'https://docs.j2commerce.com/v6/localisation/tax-profiles');
+        ToolbarHelper::help(Text::_('COM_J2COMMERCE_TAX_PROFILES'), true, 'https://docs.j2commerce.com/v6/localization/tax-profiles/');
     }
 }

--- a/administrator/components/com_j2commerce/src/View/Taxrate/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Taxrate/HtmlView.php
@@ -127,6 +127,6 @@ class HtmlView extends BaseHtmlView
 
         $toolbar->cancel('taxrate.cancel', $isNew ? 'JTOOLBAR_CANCEL' : 'JTOOLBAR_CLOSE');
         $toolbar->divider();
-        ToolbarHelper::help('Tax_Rates', true, 'https://docs.j2commerce.com/v6/localisation/tax-rates');
+        ToolbarHelper::help(Text::_('COM_J2COMMERCE_TAX_RATES'), true, 'https://docs.j2commerce.com/v6/localization/tax-rates/');
     }
 }

--- a/administrator/components/com_j2commerce/src/View/Taxrates/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Taxrates/HtmlView.php
@@ -184,6 +184,6 @@ class HtmlView extends BaseHtmlView
             ToolbarHelper::preferences('com_j2commerce');
         }
 
-        ToolbarHelper::help('Tax_Rates', true, 'https://docs.j2commerce.com/v6/localisation/tax-rates');
+        ToolbarHelper::help(Text::_('COM_J2COMMERCE_TAX_RATES'), true, 'https://docs.j2commerce.com/v6/localization/tax-rates/');
     }
 }

--- a/administrator/components/com_j2commerce/src/View/Taxrule/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Taxrule/HtmlView.php
@@ -126,6 +126,6 @@ class HtmlView extends BaseHtmlView
 
         $toolbar->cancel('taxrule.cancel', $isNew ? 'JTOOLBAR_CANCEL' : 'JTOOLBAR_CLOSE');
         $toolbar->divider();
-        ToolbarHelper::help('Tax_Rules', true, 'https://docs.j2commerce.com/v6/taxation/tax-rules');
+        ToolbarHelper::help(Text::_('COM_J2COMMERCE_TAX_RULES'), true, 'https://docs.j2commerce.com/v6/taxation/tax-rules');
     }
 }

--- a/administrator/components/com_j2commerce/src/View/Taxrules/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Taxrules/HtmlView.php
@@ -167,6 +167,6 @@ class HtmlView extends BaseHtmlView
             ToolbarHelper::preferences('com_j2commerce');
         }
 
-        ToolbarHelper::help('Tax_Rules', true, 'https://docs.j2commerce.com/v6/taxation/tax-rules');
+        ToolbarHelper::help(Text::_('COM_J2COMMERCE_TAX_RULES'), true, 'https://docs.j2commerce.com/v6/taxation/tax-rules');
     }
 }

--- a/administrator/components/com_j2commerce/src/View/Vendor/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Vendor/HtmlView.php
@@ -145,6 +145,6 @@ class HtmlView extends BaseHtmlView
 
         $toolbar->cancel('vendor.cancel', $isNew ? 'JTOOLBAR_CANCEL' : 'JTOOLBAR_CLOSE');
         $toolbar->divider();
-        ToolbarHelper::help('Vendors', true, 'https://docs.j2commerce.com/v6/catalog/vendors');
+        ToolbarHelper::help(Text::_('COM_J2COMMERCE_VENDORS'), true, 'https://docs.j2commerce.com/v6/catalog/vendors');
     }
 }

--- a/administrator/components/com_j2commerce/src/View/Vendors/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Vendors/HtmlView.php
@@ -190,6 +190,6 @@ class HtmlView extends BaseHtmlView
             ToolbarHelper::preferences('com_j2commerce');
         }
 
-        ToolbarHelper::help('Vendors', true, 'https://docs.j2commerce.com/v6/catalog/vendors');
+        ToolbarHelper::help(Text::_('COM_J2COMMERCE_VENDORS'), true, 'https://docs.j2commerce.com/v6/catalog/vendors');
     }
 }

--- a/administrator/components/com_j2commerce/src/View/Voucher/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Voucher/HtmlView.php
@@ -187,6 +187,6 @@ class HtmlView extends BaseHtmlView
         }
 
         $toolbar->divider();
-        $toolbar->help('Voucher', false, 'https://docs.j2commerce.com/sales/vouchers');
+        $toolbar->help(Text::_('COM_J2COMMERCE_VOUCHER'), false, 'https://docs.j2commerce.com/v6/sales/vouchers/');
     }
 }

--- a/administrator/components/com_j2commerce/src/View/Weight/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Weight/HtmlView.php
@@ -127,6 +127,6 @@ class HtmlView extends BaseHtmlView
 
         $toolbar->cancel('weight.cancel', $isNew ? 'JTOOLBAR_CANCEL' : 'JTOOLBAR_CLOSE');
         $toolbar->divider();
-        ToolbarHelper::help('Weights', true, 'https://docs.j2commerce.com/v6/localisation/weights');
+        ToolbarHelper::help(Text::_('COM_J2COMMERCE_WEIGHTS'), true, 'https://docs.j2commerce.com/v6/localization/weights/');
     }
 }

--- a/administrator/components/com_j2commerce/src/View/Weights/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Weights/HtmlView.php
@@ -192,6 +192,6 @@ class HtmlView extends BaseHtmlView
             ToolbarHelper::preferences('com_j2commerce');
         }
 
-        ToolbarHelper::help('Weights', true, 'https://docs.j2commerce.com/v6/localisation/weights');
+        ToolbarHelper::help(Text::_('COM_J2COMMERCE_WEIGHTS'), true, 'https://docs.j2commerce.com/v6/localization/weights/');
     }
 }

--- a/administrator/components/com_j2commerce/src/View/Zone/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Zone/HtmlView.php
@@ -129,6 +129,6 @@ class HtmlView extends BaseHtmlView
 
         $toolbar->cancel('zone.cancel', $isNew ? 'JTOOLBAR_CANCEL' : 'JTOOLBAR_CLOSE');
         $toolbar->divider();
-        ToolbarHelper::help('Zones', true, 'https://docs.j2commerce.com/v6/localisation/zones');
+        ToolbarHelper::help(Text::_('COM_J2COMMERCE_ZONES'), true, 'https://docs.j2commerce.com/v6/localization/zones/');
     }
 }

--- a/administrator/components/com_j2commerce/src/View/Zones/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Zones/HtmlView.php
@@ -191,6 +191,6 @@ class HtmlView extends BaseHtmlView
             ToolbarHelper::preferences('com_j2commerce');
         }
 
-        ToolbarHelper::help('Zones', true, 'https://docs.j2commerce.com/v6/localisation/zones');
+        ToolbarHelper::help(Text::_('COM_J2COMMERCE_ZONES'), true, 'https://docs.j2commerce.com/v6/localization/zones/');
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1036. The Help button on every J2Commerce admin view called `ToolbarHelper::help()` with both a wrong docs URL and a hardcoded English help-ref. An audit of all 54 help links found:

- **26 broken links** (404 → docs homepage)
- **6 legacy non-v6 alias URLs** (still resolved but not canonical)
- **5 views with no URL at all** (defaulted to the generic Joomla wiki)

Full audit at `docs/reports/help-link-audit-2026-05-16.md`.

## URL corrections

| Old path pattern | New path | Views |
|---|---|---|
| `/v6/localisation/<slug>` | `/v6/localization/<slug>/` | 16 (countries, currencies, geozones, lengths, weights, zones, tax-profiles, tax-rates × singular+plural — docs slug is American spelling) |
| `/v6/configuration/custom-fields` | `/v6/setup/custom-fields/` | 2 |
| `/v6/configuration/queue-hub` | `/v6/setup/queue-hub/` | 1 |
| `/v6/configuration/queue-logs` | `/v6/setup/queue-hub/` | 1 (no dedicated logs article) |
| `/v6/localisation/order-statuses` | `/v6/setup/order-statuses/` | 2 |
| `/v6/catalog/filters` | `/v6/catalog/creating-filters/` | 1 |
| `/v6/catalog/options` | `/v6/catalog/creating-options/` | 2 |
| `/design/email-templates` (legacy) | `/v6/design/email-templates/` | 2 |
| `/design/invoice-template-pro-feature` | `/v6/design/invoice-templates/` | 1 |
| `/report-sales` (legacy) | `/v6/reports/` | 1 |
| `/troubleshooting-guide/...` (legacy) | `/v6/setup/shipping-troubleshooter/` | 1 |
| `/sales/vouchers` (legacy) | `/v6/sales/vouchers/` | 1 |
| *(no URL — Joomla wiki fallback)* | `/v6/catalog/inventory/` | Inventory |
| *(no URL)* | `/v6/design/invoice-templates/` | Invoicetemplate |
| *(no URL)* | `/v6/catalog/managing-products/` | Product / Products |
| *(no URL)* | `/v6/catalog/creating-filters/` | Filtergroups |

## Help-ref translation

Every `help()` first argument is now `Text::_('COM_J2COMMERCE_*')` sourced from **existing** strings in `com_j2commerce.ini` (zero new keys created). The key reflects the **current product nomenclature** rather than the legacy term:

- `Customfield` / `Customfields` → `Text::_('COM_J2COMMERCE_CUSTOM_FIELDS')` = **"Checkout Fields"**
- `Invoicetemplate` / `Invoicetemplates` → `Text::_('COM_J2COMMERCE_INVOICETEMPLATES')` = **"Print Templates"**
- `Inventory` → `Text::_('COM_J2COMMERCE_INVENTORY')` = **"Inventory"**
- *(plus 33 more views, each mapped to the existing language key for that area)*

## Verification

- HTTP fetch + `react-helmet` title scrape against `docs.j2commerce.com` confirms every new URL lands on the correct article title (e.g. `Countries | J2Commerce Documentation`), not the 404-fallback `Welcome to J2Commerce`.
- All 54 files pass `php -l`.
- Audit report at `docs/reports/help-link-audit-2026-05-16.md` lists each before/after with disposition.

## Testing

1. Joomla 6 admin → Components → J2Commerce → any view in the navigation (Countries, Customers, Custom Fields / Checkout Fields, Filters, Inventory, Invoice / Print Templates, Options, Orders, Order Statuses, Queue Hub, Reports, Shipping Methods, Shipping Troubleshooter, Tax Profiles / Rates / Rules, Vendors, Vouchers, Weights, Zones, etc.)
2. Click the **Help** button in the toolbar.
3. The new tab should land on the correct article title — not the J2Commerce welcome / homepage.

## Files Changed
54 admin view files modified (1-line each, +54 / -54).