### PR TITLE
feat(product-options): propagate upload widget refactor to remaining BS5 + UIkit templates

### DIFF
--- a/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/view_variableoptions.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/view_variableoptions.php
@@ -12,7 +12,10 @@ declare(strict_types=1);
 defined('_JEXEC') or die;
 
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
+use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
+use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
 use Joomla\Registry\Registry;
 
@@ -24,11 +27,17 @@ if (empty($options)) {
     return;
 }
 
-$platform = J2CommerceHelper::platform();
-$productId = (int) $this->product->j2commerce_product_id;
-$product_helper = J2CommerceHelper::product();
+$platform         = J2CommerceHelper::platform();
+$productId        = (int) $this->product->j2commerce_product_id;
+$product_helper   = J2CommerceHelper::product();
 $showOptionImages = (int) ($this->params->get('image_for_product_options', 0) ?? 0);
-$esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+$esc              = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+
+$mediaParams = ComponentHelper::getParams('com_media');
+$uploadMaxMB = (float) $mediaParams->get('upload_maxsize', 0);
+$fileExts    = strtolower((string) $mediaParams->get('restrict_uploads_extensions', ''));
+$imageExts   = strtolower((string) $mediaParams->get('image_extensions', 'bmp,gif,jpg,png,jpeg,webp,avif'));
+$uploadAjax  = Route::_('index.php?option=com_j2commerce&view=carts&task=carts.upload&product_id=' . $productId, false);
 ?>
 <div class="options" id="variable-options-<?php echo $productId; ?>">
     <?php foreach ($options as $option) : ?>
@@ -223,48 +232,29 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
         <?php endif; ?>
 
         <?php if ($option['type'] === 'file') : ?>
-            <div id="option-<?php echo (int) $option['productoption_id']; ?>" class="option mb-3">
-                <label class="form-label fw-semibold pb-1 mb-2">
-                    <?php echo $esc(Text::_($option['option_name'])); ?>
-                    <?php if ($option['required']) : ?>
-                        <span class="text-danger">*</span>
-                    <?php endif; ?>
-                </label>
-                <div>
-                    <button type="button"
-                            id="product-option-<?php echo (int) $option['productoption_id']; ?>"
-                            data-loading-text="<?php echo $esc(Text::_('COM_J2COMMERCE_LOADING')); ?>"
-                            class="btn btn-outline-secondary btn-sm">
-                        <span class="fa fa-upload" aria-hidden="true"></span> <?php echo Text::_('COM_J2COMMERCE_PRODUCT_OPTION_CHOOSE_FILE'); ?>
-                    </button>
-                    <input type="hidden"
-                           name="product_option[<?php echo (int) $option['productoption_id']; ?>]"
-                           value="" id="input-option<?php echo (int) $option['productoption_id']; ?>" />
-                </div>
-            </div>
+            <?php echo LayoutHelper::render('productoption.upload_file', [
+                'productOptionId' => (int) $option['productoption_id'],
+                'productId'       => $productId,
+                'required'        => (bool) $option['required'],
+                'optionName'      => (string) $option['option_name'],
+                'ajaxUrl'         => $uploadAjax,
+                'maxSizeMB'       => $uploadMaxMB,
+                'allowedExts'     => $fileExts,
+                'framework'       => 'bs5',
+            ]); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] === 'image') : ?>
-            <div id="option-<?php echo (int) $option['productoption_id']; ?>" class="option mb-3">
-                <label class="form-label fw-semibold pb-1 mb-2">
-                    <?php echo $esc(Text::_($option['option_name'])); ?>
-                    <?php if ($option['required']) : ?>
-                        <span class="text-danger">*</span>
-                    <?php endif; ?>
-                </label>
-                <div>
-                    <button type="button"
-                            id="product-option-<?php echo (int) $option['productoption_id']; ?>"
-                            data-loading-text="<?php echo $esc(Text::_('COM_J2COMMERCE_LOADING')); ?>"
-                            data-accept="image/*"
-                            class="btn btn-outline-secondary btn-sm">
-                        <span class="fa fa-image" aria-hidden="true"></span> <?php echo Text::_('COM_J2COMMERCE_PRODUCT_OPTION_CHOOSE_IMAGE'); ?>
-                    </button>
-                    <input type="hidden"
-                           name="product_option[<?php echo (int) $option['productoption_id']; ?>]"
-                           value="" id="input-option<?php echo (int) $option['productoption_id']; ?>" />
-                </div>
-            </div>
+            <?php echo LayoutHelper::render('productoption.upload_image', [
+                'productOptionId' => (int) $option['productoption_id'],
+                'productId'       => $productId,
+                'required'        => (bool) $option['required'],
+                'optionName'      => (string) $option['option_name'],
+                'ajaxUrl'         => $uploadAjax,
+                'maxSizeMB'       => $uploadMaxMB,
+                'allowedExts'     => $imageExts,
+                'framework'       => 'bs5',
+            ]); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] === 'date') : ?>
@@ -328,75 +318,4 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
     <?php endforeach; ?>
 </div>
 
-<script>
-document.addEventListener('DOMContentLoaded', () => {
-    const productId = <?php echo $productId; ?>;
-    const optionsContainer = document.getElementById('variable-options-' + productId);
-    if (!optionsContainer) return;
-
-    // File upload handlers
-    optionsContainer.querySelectorAll('[id^="product-option-"]').forEach(btn => {
-        btn.addEventListener('click', function() {
-            const node = this;
-            const existingForm = document.getElementById('form-upload');
-            if (existingForm) existingForm.remove();
-
-            const form = document.createElement('form');
-            form.enctype = 'multipart/form-data';
-            form.id = 'form-upload';
-            form.style.display = 'none';
-
-            const fileInput = document.createElement('input');
-            fileInput.type = 'file';
-            fileInput.name = 'file';
-            if (node.dataset.accept) {
-                fileInput.accept = node.dataset.accept;
-            }
-            form.appendChild(fileInput);
-            document.body.insertAdjacentElement('afterbegin', form);
-            fileInput.click();
-
-            const timer = setInterval(() => {
-                if (fileInput.value !== '') {
-                    clearInterval(timer);
-                    const formData = new FormData(form);
-                    node.disabled = true;
-                    const originalText = node.innerHTML;
-                    node.innerHTML = node.getAttribute('data-loading-text') || 'Loading...';
-
-                    fetch('index.php?option=com_j2commerce&view=carts&task=carts.upload&product_id=<?php echo $productId; ?>', {
-                        method: 'POST',
-                        body: formData,
-                    })
-                    .then(response => response.json())
-                    .then(json => {
-                        node.disabled = false;
-                        node.innerHTML = originalText;
-                        document.querySelectorAll('.j2file-upload-response').forEach(el => el.remove());
-
-                        const inputField = node.parentElement.querySelector('input[type="hidden"]');
-                        if (json.error && inputField) {
-                            const errorSpan = document.createElement('span');
-                            errorSpan.className = 'j2file-upload-response text-danger';
-                            errorSpan.textContent = json.error;
-                            inputField.insertAdjacentElement('afterend', errorSpan);
-                        }
-                        if (json.success && inputField) {
-                            const successSpan = document.createElement('span');
-                            successSpan.className = 'j2file-upload-response text-success';
-                            successSpan.textContent = json.success + ' ';
-                            inputField.insertAdjacentElement('afterend', successSpan);
-                            inputField.value = json.code;
-                        }
-                    })
-                    .catch(error => {
-                        console.error('File upload error:', error);
-                        node.disabled = false;
-                        node.innerHTML = originalText;
-                    });
-                }
-            }, 500);
-        });
-    });
-});
-</script>
+<?php /* File/image upload widgets are handled by media/com_j2commerce/js/site/option-upload-fields.js */ ?>

--- a/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/view_configurableoptions.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/view_configurableoptions.php
@@ -12,18 +12,27 @@ declare(strict_types=1);
 defined('_JEXEC') or die;
 
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
+use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
+use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
 use Joomla\Registry\Registry;
 
 /** @var \J2Commerce\Component\J2commerce\Site\View\Product\HtmlView $this */
 
-$platform = J2CommerceHelper::platform();
-$options = $this->product->options;
-$productId = (int) $this->product->j2commerce_product_id;
-$product_helper = J2CommerceHelper::product();
+$platform         = J2CommerceHelper::platform();
+$options          = $this->product->options;
+$productId        = (int) $this->product->j2commerce_product_id;
+$product_helper   = J2CommerceHelper::product();
 $showOptionImages = (int) ($this->params->get('image_for_product_options', 0) ?? 0);
-$esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+$esc              = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+
+$mediaParams = ComponentHelper::getParams('com_media');
+$uploadMaxMB = (float) $mediaParams->get('upload_maxsize', 0);
+$fileExts    = strtolower((string) $mediaParams->get('restrict_uploads_extensions', ''));
+$imageExts   = strtolower((string) $mediaParams->get('image_extensions', 'bmp,gif,jpg,png,jpeg,webp,avif'));
+$uploadAjax  = Route::_('index.php?option=com_j2commerce&view=carts&task=carts.upload&product_id=' . $productId, false);
 ?>
 <?php if ($options) : ?>
 
@@ -186,46 +195,29 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
         <?php endif; ?>
 
         <?php if ($option['type'] == 'file') : ?>
-            <!-- File -->
-            <div id="option-<?php echo $optionId; ?>" class="option">
-                <?php if ($option['required']) : ?>
-                <span class="required">*</span>
-                <?php endif; ?>
-                <b><?php echo $esc(Text::_($option['option_name'])); ?>:</b><br>
-                <button type="button"
-                    id="product-option-<?php echo $optionId; ?>"
-                    data-loading-text="<?php echo $esc(Text::_('COM_J2COMMERCE_LOADING')); ?>"
-                    data-product-id="<?php echo $productId; ?>"
-                    class="btn btn-default j2commerce-file-upload-btn">
-                    <span class="fa fa-upload" aria-hidden="true"></span> <?php echo Text::_('COM_J2COMMERCE_PRODUCT_OPTION_CHOOSE_FILE'); ?>
-                </button>
-                <input type="hidden"
-                    name="product_option[<?php echo $optionId; ?>]"
-                    value="" id="input-option<?php echo $optionId; ?>" />
-            </div>
-            <br>
+            <?php echo LayoutHelper::render('productoption.upload_file', [
+                'productOptionId' => $optionId,
+                'productId'       => $productId,
+                'required'        => (bool) $option['required'],
+                'optionName'      => (string) $option['option_name'],
+                'ajaxUrl'         => $uploadAjax,
+                'maxSizeMB'       => $uploadMaxMB,
+                'allowedExts'     => $fileExts,
+                'framework'       => 'bs5',
+            ]); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] == 'image') : ?>
-            <!-- Image -->
-            <div id="option-<?php echo $optionId; ?>" class="option">
-                <?php if ($option['required']) : ?>
-                <span class="required">*</span>
-                <?php endif; ?>
-                <b><?php echo $esc(Text::_($option['option_name'])); ?>:</b><br>
-                <button type="button"
-                    id="product-option-<?php echo $optionId; ?>"
-                    data-loading-text="<?php echo $esc(Text::_('COM_J2COMMERCE_LOADING')); ?>"
-                    data-product-id="<?php echo $productId; ?>"
-                    data-accept="image/*"
-                    class="btn btn-default j2commerce-file-upload-btn">
-                    <span class="fa fa-image" aria-hidden="true"></span> <?php echo Text::_('COM_J2COMMERCE_PRODUCT_OPTION_CHOOSE_IMAGE'); ?>
-                </button>
-                <input type="hidden"
-                    name="product_option[<?php echo $optionId; ?>]"
-                    value="" id="input-option<?php echo $optionId; ?>" />
-            </div>
-            <br>
+            <?php echo LayoutHelper::render('productoption.upload_image', [
+                'productOptionId' => $optionId,
+                'productId'       => $productId,
+                'required'        => (bool) $option['required'],
+                'optionName'      => (string) $option['option_name'],
+                'ajaxUrl'         => $uploadAjax,
+                'maxSizeMB'       => $uploadMaxMB,
+                'allowedExts'     => $imageExts,
+                'framework'       => 'bs5',
+            ]); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] == 'date') : ?>
@@ -322,90 +314,6 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     });
 
-    // File upload handlers
-    document.querySelectorAll('.j2commerce-file-upload-btn').forEach(function(btn) {
-        btn.addEventListener('click', function() {
-            var node = this;
-            var productId = parseInt(this.dataset.productId, 10);
-
-            // Remove existing form if it exists
-            var existingForm = document.getElementById('form-upload');
-            if (existingForm) {
-                existingForm.remove();
-            }
-
-            // Create a new form element
-            var form = document.createElement('form');
-            form.enctype = 'multipart/form-data';
-            form.id = 'form-upload';
-            form.style.display = 'none';
-
-            var fileInput = document.createElement('input');
-            fileInput.type = 'file';
-            fileInput.name = 'file';
-            if (node.dataset.accept) {
-                fileInput.accept = node.dataset.accept;
-            }
-            form.appendChild(fileInput);
-
-            // Prepend form to body
-            document.body.insertAdjacentElement('afterbegin', form);
-
-            // Trigger file input click
-            fileInput.click();
-
-            // Polling until a file is selected
-            var timer = setInterval(function() {
-                if (fileInput.value !== '') {
-                    clearInterval(timer);
-
-                    // Prepare FormData
-                    var formData = new FormData(form);
-
-                    // Set loading state
-                    node.disabled = true;
-                    var originalText = node.innerHTML;
-                    node.innerHTML = node.getAttribute('data-loading-text') || 'Loading...';
-
-                    fetch('index.php?option=com_j2commerce&view=carts&task=carts.upload&product_id=' + productId, {
-                        method: 'POST',
-                        body: formData,
-                    })
-                    .then(function(response) { return response.json(); })
-                    .then(function(json) {
-                        // Reset button state
-                        node.disabled = false;
-                        node.innerHTML = originalText;
-
-                        // Remove any existing response messages
-                        document.querySelectorAll('.j2file-upload-response').forEach(function(el) { el.remove(); });
-
-                        var inputField = node.parentElement.querySelector('input[type="hidden"]');
-
-                        if (json.error && inputField) {
-                            var errorSpan = document.createElement('span');
-                            errorSpan.className = 'j2file-upload-response text-danger';
-                            errorSpan.textContent = json.error;
-                            inputField.insertAdjacentElement('afterend', errorSpan);
-                        }
-
-                        if (json.success && inputField) {
-                            var successSpan = document.createElement('span');
-                            successSpan.className = 'j2file-upload-response text-success';
-                            successSpan.textContent = json.success + ' ';
-                            inputField.insertAdjacentElement('afterend', successSpan);
-                            inputField.value = json.code;
-                        }
-                    })
-                    .catch(function(error) {
-                        alert(error.message + '\r\n' + error);
-                        // Reset button on error
-                        node.disabled = false;
-                        node.innerHTML = originalText;
-                    });
-                }
-            }, 500);
-        });
-    });
+    // File/image upload widgets are handled by media/com_j2commerce/js/site/option-upload-fields.js
 });
 </script>

--- a/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/view_variableoptions.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/view_variableoptions.php
@@ -12,7 +12,10 @@ declare(strict_types=1);
 defined('_JEXEC') or die;
 
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
+use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
+use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
 use Joomla\Registry\Registry;
 
@@ -24,11 +27,17 @@ if (empty($options)) {
     return;
 }
 
-$platform = J2CommerceHelper::platform();
-$productId = (int) $this->product->j2commerce_product_id;
-$product_helper = J2CommerceHelper::product();
+$platform         = J2CommerceHelper::platform();
+$productId        = (int) $this->product->j2commerce_product_id;
+$product_helper   = J2CommerceHelper::product();
 $showOptionImages = (int) ($this->params->get('image_for_product_options', 0) ?? 0);
-$esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+$esc              = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+
+$mediaParams = ComponentHelper::getParams('com_media');
+$uploadMaxMB = (float) $mediaParams->get('upload_maxsize', 0);
+$fileExts    = strtolower((string) $mediaParams->get('restrict_uploads_extensions', ''));
+$imageExts   = strtolower((string) $mediaParams->get('image_extensions', 'bmp,gif,jpg,png,jpeg,webp,avif'));
+$uploadAjax  = Route::_('index.php?option=com_j2commerce&view=carts&task=carts.upload&product_id=' . $productId, false);
 ?>
 <div class="options" id="variable-options-<?php echo $productId; ?>">
     <?php foreach ($options as $option) : ?>
@@ -223,48 +232,29 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
         <?php endif; ?>
 
         <?php if ($option['type'] === 'file') : ?>
-            <div id="option-<?php echo $option['productoption_id']; ?>" class="option mb-3">
-                <label class="form-label fw-semibold pb-1 mb-2">
-                    <?php echo $esc(Text::_($option['option_name'])); ?>
-                    <?php if ($option['required']) : ?>
-                        <span class="text-danger">*</span>
-                    <?php endif; ?>
-                </label>
-                <div>
-                    <button type="button"
-                            id="product-option-<?php echo $option['productoption_id']; ?>"
-                            data-loading-text="<?php echo $esc(Text::_('COM_J2COMMERCE_LOADING')); ?>"
-                            class="btn btn-outline-secondary btn-sm">
-                        <span class="fa fa-upload" aria-hidden="true"></span> <?php echo Text::_('COM_J2COMMERCE_PRODUCT_OPTION_CHOOSE_FILE'); ?>
-                    </button>
-                    <input type="hidden"
-                           name="product_option[<?php echo $option['productoption_id']; ?>]"
-                           value="" id="input-option<?php echo $option['productoption_id']; ?>" />
-                </div>
-            </div>
+            <?php echo LayoutHelper::render('productoption.upload_file', [
+                'productOptionId' => (int) $option['productoption_id'],
+                'productId'       => $productId,
+                'required'        => (bool) $option['required'],
+                'optionName'      => (string) $option['option_name'],
+                'ajaxUrl'         => $uploadAjax,
+                'maxSizeMB'       => $uploadMaxMB,
+                'allowedExts'     => $fileExts,
+                'framework'       => 'bs5',
+            ]); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] === 'image') : ?>
-            <div id="option-<?php echo $option['productoption_id']; ?>" class="option mb-3">
-                <label class="form-label fw-semibold pb-1 mb-2">
-                    <?php echo $esc(Text::_($option['option_name'])); ?>
-                    <?php if ($option['required']) : ?>
-                        <span class="text-danger">*</span>
-                    <?php endif; ?>
-                </label>
-                <div>
-                    <button type="button"
-                            id="product-option-<?php echo $option['productoption_id']; ?>"
-                            data-loading-text="<?php echo $esc(Text::_('COM_J2COMMERCE_LOADING')); ?>"
-                            data-accept="image/*"
-                            class="btn btn-outline-secondary btn-sm">
-                        <span class="fa fa-image" aria-hidden="true"></span> <?php echo Text::_('COM_J2COMMERCE_PRODUCT_OPTION_CHOOSE_IMAGE'); ?>
-                    </button>
-                    <input type="hidden"
-                           name="product_option[<?php echo $option['productoption_id']; ?>]"
-                           value="" id="input-option<?php echo $option['productoption_id']; ?>" />
-                </div>
-            </div>
+            <?php echo LayoutHelper::render('productoption.upload_image', [
+                'productOptionId' => (int) $option['productoption_id'],
+                'productId'       => $productId,
+                'required'        => (bool) $option['required'],
+                'optionName'      => (string) $option['option_name'],
+                'ajaxUrl'         => $uploadAjax,
+                'maxSizeMB'       => $uploadMaxMB,
+                'allowedExts'     => $imageExts,
+                'framework'       => 'bs5',
+            ]); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] === 'date') : ?>
@@ -328,75 +318,4 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
     <?php endforeach; ?>
 </div>
 
-<script>
-document.addEventListener('DOMContentLoaded', () => {
-    const productId = <?php echo $productId; ?>;
-    const optionsContainer = document.getElementById('variable-options-' + productId);
-    if (!optionsContainer) return;
-
-    // File upload handlers
-    optionsContainer.querySelectorAll('[id^="product-option-"]').forEach(btn => {
-        btn.addEventListener('click', function() {
-            const node = this;
-            const existingForm = document.getElementById('form-upload');
-            if (existingForm) existingForm.remove();
-
-            const form = document.createElement('form');
-            form.enctype = 'multipart/form-data';
-            form.id = 'form-upload';
-            form.style.display = 'none';
-
-            const fileInput = document.createElement('input');
-            fileInput.type = 'file';
-            fileInput.name = 'file';
-            if (node.dataset.accept) {
-                fileInput.accept = node.dataset.accept;
-            }
-            form.appendChild(fileInput);
-            document.body.insertAdjacentElement('afterbegin', form);
-            fileInput.click();
-
-            const timer = setInterval(() => {
-                if (fileInput.value !== '') {
-                    clearInterval(timer);
-                    const formData = new FormData(form);
-                    node.disabled = true;
-                    const originalText = node.innerHTML;
-                    node.innerHTML = node.getAttribute('data-loading-text') || 'Loading...';
-
-                    fetch('index.php?option=com_j2commerce&view=carts&task=carts.upload&product_id=<?php echo $productId; ?>', {
-                        method: 'POST',
-                        body: formData,
-                    })
-                    .then(response => response.json())
-                    .then(json => {
-                        node.disabled = false;
-                        node.innerHTML = originalText;
-                        document.querySelectorAll('.j2file-upload-response').forEach(el => el.remove());
-
-                        const inputField = node.parentElement.querySelector('input[type="hidden"]');
-                        if (json.error && inputField) {
-                            const errorSpan = document.createElement('span');
-                            errorSpan.className = 'j2file-upload-response text-danger';
-                            errorSpan.textContent = json.error;
-                            inputField.insertAdjacentElement('afterend', errorSpan);
-                        }
-                        if (json.success && inputField) {
-                            const successSpan = document.createElement('span');
-                            successSpan.className = 'j2file-upload-response text-success';
-                            successSpan.textContent = json.success + ' ';
-                            inputField.insertAdjacentElement('afterend', successSpan);
-                            inputField.value = json.code;
-                        }
-                    })
-                    .catch(error => {
-                        console.error('File upload error:', error);
-                        node.disabled = false;
-                        node.innerHTML = originalText;
-                    });
-                }
-            }, 500);
-        });
-    });
-});
-</script>
+<?php /* File/image upload widgets are handled by media/com_j2commerce/js/site/option-upload-fields.js */ ?>

--- a/plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_configurableoptions.php
+++ b/plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_configurableoptions.php
@@ -12,18 +12,27 @@ declare(strict_types=1);
 defined('_JEXEC') or die;
 
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
+use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
+use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
 use Joomla\Registry\Registry;
 
 /** @var \J2Commerce\Component\J2commerce\Site\View\Product\HtmlView $this */
 
-$platform = J2CommerceHelper::platform();
-$options = $this->product->options;
-$productId = $this->product->j2commerce_product_id;
-$product_helper = J2CommerceHelper::product();
+$platform         = J2CommerceHelper::platform();
+$options          = $this->product->options;
+$productId        = (int) $this->product->j2commerce_product_id;
+$product_helper   = J2CommerceHelper::product();
 $showOptionImages = (int) ($this->params->get('image_for_product_options', 0) ?? 0);
-$esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+$esc              = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+
+$mediaParams = ComponentHelper::getParams('com_media');
+$uploadMaxMB = (float) $mediaParams->get('upload_maxsize', 0);
+$fileExts    = strtolower((string) $mediaParams->get('restrict_uploads_extensions', ''));
+$imageExts   = strtolower((string) $mediaParams->get('image_extensions', 'bmp,gif,jpg,png,jpeg,webp,avif'));
+$uploadAjax  = Route::_('index.php?option=com_j2commerce&view=carts&task=carts.upload&product_id=' . $productId, false);
 ?>
 <?php if ($options) : ?>
 
@@ -189,40 +198,29 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
         <?php endif; ?>
 
         <?php if ($option['type'] == 'file') : ?>
-            <div id="option-<?php echo $option['productoption_id']; ?>" class="option uk-margin-small-bottom">
-                <?php if ($option['required']) : ?>
-                <span class="uk-text-danger">*</span>
-                <?php endif; ?>
-                <b><?php echo $this->escape(Text::_($option['option_name'])); ?>:</b><br>
-                <button type="button"
-                    id="product-option-<?php echo $option['productoption_id']; ?>"
-                    data-loading-text="<?php echo Text::_('COM_J2COMMERCE_LOADING'); ?>"
-                    class="uk-button uk-button-default">
-                    <span uk-icon="icon: upload"></span> <?php echo Text::_('COM_J2COMMERCE_PRODUCT_OPTION_CHOOSE_FILE'); ?>
-                </button>
-                <input type="hidden"
-                    name="product_option[<?php echo $option['productoption_id']; ?>]"
-                    value="" id="input-option<?php echo $option['productoption_id']; ?>" />
-            </div>
+            <?php echo LayoutHelper::render('productoption.upload_file', [
+                'productOptionId' => (int) $option['productoption_id'],
+                'productId'       => $productId,
+                'required'        => (bool) $option['required'],
+                'optionName'      => (string) $option['option_name'],
+                'ajaxUrl'         => $uploadAjax,
+                'maxSizeMB'       => $uploadMaxMB,
+                'allowedExts'     => $fileExts,
+                'framework'       => 'uikit',
+            ]); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] == 'image') : ?>
-            <div id="option-<?php echo $option['productoption_id']; ?>" class="option uk-margin-small-bottom">
-                <?php if ($option['required']) : ?>
-                <span class="uk-text-danger">*</span>
-                <?php endif; ?>
-                <b><?php echo $this->escape(Text::_($option['option_name'])); ?>:</b><br>
-                <button type="button"
-                    id="product-option-<?php echo $option['productoption_id']; ?>"
-                    data-loading-text="<?php echo Text::_('COM_J2COMMERCE_LOADING'); ?>"
-                    data-accept="image/*"
-                    class="uk-button uk-button-default">
-                    <span uk-icon="icon: image"></span> <?php echo Text::_('COM_J2COMMERCE_PRODUCT_OPTION_CHOOSE_IMAGE'); ?>
-                </button>
-                <input type="hidden"
-                    name="product_option[<?php echo $option['productoption_id']; ?>]"
-                    value="" id="input-option<?php echo $option['productoption_id']; ?>" />
-            </div>
+            <?php echo LayoutHelper::render('productoption.upload_image', [
+                'productOptionId' => (int) $option['productoption_id'],
+                'productId'       => $productId,
+                'required'        => (bool) $option['required'],
+                'optionName'      => (string) $option['option_name'],
+                'ajaxUrl'         => $uploadAjax,
+                'maxSizeMB'       => $uploadMaxMB,
+                'allowedExts'     => $imageExts,
+                'framework'       => 'uikit',
+            ]); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] == 'date') : ?>
@@ -280,77 +278,4 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
 </div>
 <?php endif; ?>
 
-<?php if (isset($options) && !empty($options)) : ?>
-    <?php foreach ($options as $option) : ?>
-        <?php if ($option['type'] == 'file' || $option['type'] == 'image') : ?>
-            <script>
-                (function() {
-                    const productOptionBtn = document.getElementById('product-option-<?php echo $option['productoption_id']; ?>');
-
-                    if (!productOptionBtn) return;
-
-                    productOptionBtn.addEventListener('click', function() {
-                        const node = this;
-                        const existingForm = document.getElementById('form-upload');
-                        if (existingForm) existingForm.remove();
-
-                        const form = document.createElement('form');
-                        form.enctype = 'multipart/form-data';
-                        form.id = 'form-upload';
-                        form.style.display = 'none';
-
-                        const fileInput = document.createElement('input');
-                        fileInput.type = 'file';
-                        fileInput.name = 'file';
-                        if (node.dataset.accept) {
-                            fileInput.accept = node.dataset.accept;
-                        }
-                        form.appendChild(fileInput);
-                        document.body.insertAdjacentElement('afterbegin', form);
-                        fileInput.click();
-
-                        const timer = setInterval(() => {
-                            if (fileInput.value !== '') {
-                                clearInterval(timer);
-                                const formData = new FormData(form);
-                                node.disabled = true;
-                                const originalText = node.innerHTML;
-                                node.innerHTML = node.getAttribute('data-loading-text') || 'Loading...';
-
-                                fetch('index.php?option=com_j2commerce&view=carts&task=carts.upload&product_id=<?php echo $this->product->j2commerce_product_id; ?>', {
-                                    method: 'POST',
-                                    body: formData,
-                                })
-                                .then(response => response.json())
-                                .then(json => {
-                                    node.disabled = false;
-                                    node.innerHTML = originalText;
-                                    document.querySelectorAll('.j2file-upload-response').forEach(el => el.remove());
-                                    const inputField = node.parentElement.querySelector('input[type="hidden"]');
-                                    if (json.error && inputField) {
-                                        const errorSpan = document.createElement('span');
-                                        errorSpan.className = 'j2file-upload-response uk-text-danger';
-                                        errorSpan.textContent = json.error;
-                                        inputField.insertAdjacentElement('afterend', errorSpan);
-                                    }
-                                    if (json.success && inputField) {
-                                        const successSpan = document.createElement('span');
-                                        successSpan.className = 'j2file-upload-response uk-text-success';
-                                        successSpan.textContent = json.success + ' ';
-                                        inputField.insertAdjacentElement('afterend', successSpan);
-                                        inputField.value = json.code;
-                                    }
-                                })
-                                .catch(error => {
-                                    alert(error.message + '\r\n' + error);
-                                    node.disabled = false;
-                                    node.innerHTML = originalText;
-                                });
-                            }
-                        }, 500);
-                    });
-                })();
-            </script>
-        <?php endif; ?>
-    <?php endforeach; ?>
-<?php endif; ?>
+<?php /* File/image upload widgets are handled by media/com_j2commerce/js/site/option-upload-fields.js */ ?>

--- a/plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_options.php
+++ b/plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_options.php
@@ -12,17 +12,25 @@ declare(strict_types=1);
 defined('_JEXEC') or die;
 
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
+use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
 
 /** @var \J2Commerce\Component\J2commerce\Site\View\Product\HtmlView $this */
 
-$platform = J2CommerceHelper::platform();
-$options = $this->product->options;
-$productId = $this->product->j2commerce_product_id;
+$platform       = J2CommerceHelper::platform();
+$options        = $this->product->options;
+$productId      = (int) $this->product->j2commerce_product_id;
 $product_helper = J2CommerceHelper::product();
-$ajax_url = Route::_('index.php', false);
+$esc            = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+
+$mediaParams = ComponentHelper::getParams('com_media');
+$uploadMaxMB = (float) $mediaParams->get('upload_maxsize', 0);
+$fileExts    = strtolower((string) $mediaParams->get('restrict_uploads_extensions', ''));
+$imageExts   = strtolower((string) $mediaParams->get('image_extensions', 'bmp,gif,jpg,png,jpeg,webp,avif'));
+$uploadAjax  = Route::_('index.php?option=com_j2commerce&view=carts&task=carts.upload&product_id=' . $productId, false);
 ?>
 <?php if ($options) : ?>
 
@@ -159,42 +167,29 @@ $ajax_url = Route::_('index.php', false);
         <?php endif; ?>
 
         <?php if ($option['type'] == 'file') : ?>
-            <div id="option-<?php echo $option['productoption_id']; ?>" class="option uk-margin-small-bottom">
-                <?php if ($option['required']) : ?>
-                <span class="uk-text-danger">*</span>
-                <?php endif; ?>
-                <label class="uk-form-label uk-text-bold"><?php echo Text::_($option['option_name']); ?>:</label>
-                <button type="button"
-                    id="product-option-<?php echo $option['productoption_id']; ?>"
-                    data-loading-text="<?php echo Text::_('COM_J2COMMERCE_LOADING'); ?>"
-                    data-ajax-url="<?php echo $ajax_url; ?>?option=com_j2commerce&view=carts&task=carts.upload&product_id=<?php echo $productId; ?>"
-                    class="uk-button uk-button-default j2commerce-file-upload-btn">
-                    <span uk-icon="icon: upload"></span> <?php echo Text::_('COM_J2COMMERCE_PRODUCT_OPTION_CHOOSE_FILE'); ?>
-                </button>
-                <input type="hidden"
-                    name="product_option[<?php echo $option['productoption_id']; ?>]"
-                    value="" id="input-option<?php echo $option['productoption_id']; ?>" />
-            </div>
+            <?php echo LayoutHelper::render('productoption.upload_file', [
+                'productOptionId' => (int) $option['productoption_id'],
+                'productId'       => $productId,
+                'required'        => (bool) $option['required'],
+                'optionName'      => (string) $option['option_name'],
+                'ajaxUrl'         => $uploadAjax,
+                'maxSizeMB'       => $uploadMaxMB,
+                'allowedExts'     => $fileExts,
+                'framework'       => 'uikit',
+            ]); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] == 'image') : ?>
-            <div id="option-<?php echo $option['productoption_id']; ?>" class="option uk-margin-small-bottom">
-                <?php if ($option['required']) : ?>
-                <span class="uk-text-danger">*</span>
-                <?php endif; ?>
-                <label class="uk-form-label uk-text-bold"><?php echo Text::_($option['option_name']); ?>:</label>
-                <button type="button"
-                    id="product-option-<?php echo $option['productoption_id']; ?>"
-                    data-loading-text="<?php echo Text::_('COM_J2COMMERCE_LOADING'); ?>"
-                    data-ajax-url="<?php echo $ajax_url; ?>?option=com_j2commerce&view=carts&task=carts.upload&product_id=<?php echo $productId; ?>"
-                    data-accept="image/*"
-                    class="uk-button uk-button-default j2commerce-file-upload-btn">
-                    <span uk-icon="icon: image"></span> <?php echo Text::_('COM_J2COMMERCE_PRODUCT_OPTION_CHOOSE_IMAGE'); ?>
-                </button>
-                <input type="hidden"
-                    name="product_option[<?php echo $option['productoption_id']; ?>]"
-                    value="" id="input-option<?php echo $option['productoption_id']; ?>" />
-            </div>
+            <?php echo LayoutHelper::render('productoption.upload_image', [
+                'productOptionId' => (int) $option['productoption_id'],
+                'productId'       => $productId,
+                'required'        => (bool) $option['required'],
+                'optionName'      => (string) $option['option_name'],
+                'ajaxUrl'         => $uploadAjax,
+                'maxSizeMB'       => $uploadMaxMB,
+                'allowedExts'     => $imageExts,
+                'framework'       => 'uikit',
+            ]); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] == 'date') : ?>
@@ -281,67 +276,7 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     });
 
-    document.querySelectorAll('.j2commerce-file-upload-btn').forEach(btn => {
-        btn.addEventListener('click', function() {
-            const node = this;
-            const ajaxUrl = node.dataset.ajaxUrl;
-
-            const existingForm = document.getElementById('form-upload');
-            if (existingForm) existingForm.remove();
-
-            const form = document.createElement('form');
-            form.enctype = 'multipart/form-data';
-            form.id = 'form-upload';
-            form.style.display = 'none';
-
-            const fileInput = document.createElement('input');
-            fileInput.type = 'file';
-            fileInput.name = 'file';
-            if (node.dataset.accept) {
-                fileInput.accept = node.dataset.accept;
-            }
-            form.appendChild(fileInput);
-            document.body.insertAdjacentElement('afterbegin', form);
-            fileInput.click();
-
-            const timer = setInterval(() => {
-                if (fileInput.value !== '') {
-                    clearInterval(timer);
-                    const formData = new FormData(form);
-                    node.disabled = true;
-                    const originalText = node.innerHTML;
-                    node.innerHTML = node.dataset.loadingText || 'Loading...';
-
-                    fetch(ajaxUrl, { method: 'POST', body: formData })
-                    .then(response => response.json())
-                    .then(json => {
-                        node.disabled = false;
-                        node.innerHTML = originalText;
-                        document.querySelectorAll('.j2file-upload-response').forEach(el => el.remove());
-                        const inputField = node.parentElement.querySelector('input[type="hidden"]');
-                        if (json.error && inputField) {
-                            const errorSpan = document.createElement('span');
-                            errorSpan.className = 'j2file-upload-response uk-text-danger';
-                            errorSpan.textContent = json.error;
-                            inputField.insertAdjacentElement('afterend', errorSpan);
-                        }
-                        if (json.success && inputField) {
-                            const successSpan = document.createElement('span');
-                            successSpan.className = 'j2file-upload-response uk-text-success';
-                            successSpan.textContent = json.success + ' ';
-                            inputField.insertAdjacentElement('afterend', successSpan);
-                            inputField.value = json.code;
-                        }
-                    })
-                    .catch(error => {
-                        alert(error.message);
-                        node.disabled = false;
-                        node.innerHTML = originalText;
-                    });
-                }
-            }, 500);
-        });
-    });
+    // File/image upload widgets are handled by media/com_j2commerce/js/site/option-upload-fields.js
 });
 </script>
 <?php endif; ?>

--- a/plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_variableoptions.php
+++ b/plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_variableoptions.php
@@ -12,7 +12,10 @@ declare(strict_types=1);
 defined('_JEXEC') or die;
 
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
+use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
+use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
 
 /** @var \J2Commerce\Component\J2commerce\Site\View\Product\HtmlView $this */
@@ -23,11 +26,17 @@ if (empty($options)) {
     return;
 }
 
-$platform = J2CommerceHelper::platform();
-$productId = $this->product->j2commerce_product_id;
-$product_helper = J2CommerceHelper::product();
+$platform         = J2CommerceHelper::platform();
+$productId        = (int) $this->product->j2commerce_product_id;
+$product_helper   = J2CommerceHelper::product();
 $showOptionImages = (int) ($this->params->get('image_for_product_options', 0) ?? 0);
-$esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+$esc              = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+
+$mediaParams = ComponentHelper::getParams('com_media');
+$uploadMaxMB = (float) $mediaParams->get('upload_maxsize', 0);
+$fileExts    = strtolower((string) $mediaParams->get('restrict_uploads_extensions', ''));
+$imageExts   = strtolower((string) $mediaParams->get('image_extensions', 'bmp,gif,jpg,png,jpeg,webp,avif'));
+$uploadAjax  = Route::_('index.php?option=com_j2commerce&view=carts&task=carts.upload&product_id=' . $productId, false);
 ?>
 <div class="options" id="variable-options-<?php echo $productId; ?>">
     <?php foreach ($options as $option) : ?>
@@ -218,48 +227,29 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
         <?php endif; ?>
 
         <?php if ($option['type'] === 'file') : ?>
-            <div id="option-<?php echo $option['productoption_id']; ?>" class="option uk-margin-small-bottom">
-                <label class="uk-form-label uk-text-bold uk-margin-small-bottom uk-display-block">
-                    <?php echo $esc(Text::_($option['option_name'])); ?>
-                    <?php if ($option['required']) : ?>
-                        <span class="uk-text-danger">*</span>
-                    <?php endif; ?>
-                </label>
-                <div>
-                    <button type="button"
-                            id="product-option-<?php echo $option['productoption_id']; ?>"
-                            data-loading-text="<?php echo $esc(Text::_('COM_J2COMMERCE_LOADING')); ?>"
-                            class="uk-button uk-button-default uk-button-small">
-                        <span uk-icon="icon: upload" class="uk-margin-small-right"></span><?php echo Text::_('COM_J2COMMERCE_PRODUCT_OPTION_CHOOSE_FILE'); ?>
-                    </button>
-                    <input type="hidden"
-                           name="product_option[<?php echo $option['productoption_id']; ?>]"
-                           value="" id="input-option<?php echo $option['productoption_id']; ?>" />
-                </div>
-            </div>
+            <?php echo LayoutHelper::render('productoption.upload_file', [
+                'productOptionId' => (int) $option['productoption_id'],
+                'productId'       => $productId,
+                'required'        => (bool) $option['required'],
+                'optionName'      => (string) $option['option_name'],
+                'ajaxUrl'         => $uploadAjax,
+                'maxSizeMB'       => $uploadMaxMB,
+                'allowedExts'     => $fileExts,
+                'framework'       => 'uikit',
+            ]); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] === 'image') : ?>
-            <div id="option-<?php echo $option['productoption_id']; ?>" class="option uk-margin-small-bottom">
-                <label class="uk-form-label uk-text-bold uk-margin-small-bottom uk-display-block">
-                    <?php echo $esc(Text::_($option['option_name'])); ?>
-                    <?php if ($option['required']) : ?>
-                        <span class="uk-text-danger">*</span>
-                    <?php endif; ?>
-                </label>
-                <div>
-                    <button type="button"
-                            id="product-option-<?php echo $option['productoption_id']; ?>"
-                            data-loading-text="<?php echo $esc(Text::_('COM_J2COMMERCE_LOADING')); ?>"
-                            data-accept="image/*"
-                            class="uk-button uk-button-default uk-button-small">
-                        <span uk-icon="icon: image" class="uk-margin-small-right"></span><?php echo Text::_('COM_J2COMMERCE_PRODUCT_OPTION_CHOOSE_IMAGE'); ?>
-                    </button>
-                    <input type="hidden"
-                           name="product_option[<?php echo $option['productoption_id']; ?>]"
-                           value="" id="input-option<?php echo $option['productoption_id']; ?>" />
-                </div>
-            </div>
+            <?php echo LayoutHelper::render('productoption.upload_image', [
+                'productOptionId' => (int) $option['productoption_id'],
+                'productId'       => $productId,
+                'required'        => (bool) $option['required'],
+                'optionName'      => (string) $option['option_name'],
+                'ajaxUrl'         => $uploadAjax,
+                'maxSizeMB'       => $uploadMaxMB,
+                'allowedExts'     => $imageExts,
+                'framework'       => 'uikit',
+            ]); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] === 'date') : ?>
@@ -323,75 +313,4 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
     <?php endforeach; ?>
 </div>
 
-<script>
-document.addEventListener('DOMContentLoaded', () => {
-    const productId = <?php echo $productId; ?>;
-    const optionsContainer = document.getElementById('variable-options-' + productId);
-    if (!optionsContainer) return;
-
-    // File upload handlers
-    optionsContainer.querySelectorAll('[id^="product-option-"]').forEach(btn => {
-        btn.addEventListener('click', function() {
-            const node = this;
-            const existingForm = document.getElementById('form-upload');
-            if (existingForm) existingForm.remove();
-
-            const form = document.createElement('form');
-            form.enctype = 'multipart/form-data';
-            form.id = 'form-upload';
-            form.style.display = 'none';
-
-            const fileInput = document.createElement('input');
-            fileInput.type = 'file';
-            fileInput.name = 'file';
-            if (node.dataset.accept) {
-                fileInput.accept = node.dataset.accept;
-            }
-            form.appendChild(fileInput);
-            document.body.insertAdjacentElement('afterbegin', form);
-            fileInput.click();
-
-            const timer = setInterval(() => {
-                if (fileInput.value !== '') {
-                    clearInterval(timer);
-                    const formData = new FormData(form);
-                    node.disabled = true;
-                    const originalText = node.innerHTML;
-                    node.innerHTML = node.getAttribute('data-loading-text') || 'Loading...';
-
-                    fetch('index.php?option=com_j2commerce&view=carts&task=carts.upload&product_id=<?php echo $productId; ?>', {
-                        method: 'POST',
-                        body: formData,
-                    })
-                    .then(response => response.json())
-                    .then(json => {
-                        node.disabled = false;
-                        node.innerHTML = originalText;
-                        document.querySelectorAll('.j2file-upload-response').forEach(el => el.remove());
-
-                        const inputField = node.parentElement.querySelector('input[type="hidden"]');
-                        if (json.error && inputField) {
-                            const errorSpan = document.createElement('span');
-                            errorSpan.className = 'j2file-upload-response uk-text-danger';
-                            errorSpan.textContent = json.error;
-                            inputField.insertAdjacentElement('afterend', errorSpan);
-                        }
-                        if (json.success && inputField) {
-                            const successSpan = document.createElement('span');
-                            successSpan.className = 'j2file-upload-response uk-text-success';
-                            successSpan.textContent = json.success + ' ';
-                            inputField.insertAdjacentElement('afterend', successSpan);
-                            inputField.value = json.code;
-                        }
-                    })
-                    .catch(error => {
-                        console.error('File upload error:', error);
-                        node.disabled = false;
-                        node.innerHTML = originalText;
-                    });
-                }
-            }, 500);
-        });
-    });
-});
-</script>
+<?php /* File/image upload widgets are handled by media/com_j2commerce/js/site/option-upload-fields.js */ ?>

--- a/plugins/j2commerce/app_uikit/tmpl/uikit/view_configurableoptions.php
+++ b/plugins/j2commerce/app_uikit/tmpl/uikit/view_configurableoptions.php
@@ -12,18 +12,27 @@ declare(strict_types=1);
 defined('_JEXEC') or die;
 
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
+use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
+use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
 use Joomla\Registry\Registry;
 
 /** @var \J2Commerce\Component\J2commerce\Site\View\Product\HtmlView $this */
 
-$platform = J2CommerceHelper::platform();
-$options = $this->product->options;
-$productId = $this->product->j2commerce_product_id;
-$product_helper = J2CommerceHelper::product();
+$platform         = J2CommerceHelper::platform();
+$options          = $this->product->options;
+$productId        = (int) $this->product->j2commerce_product_id;
+$product_helper   = J2CommerceHelper::product();
 $showOptionImages = (int) ($this->params->get('image_for_product_options', 0) ?? 0);
-$esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+$esc              = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+
+$mediaParams = ComponentHelper::getParams('com_media');
+$uploadMaxMB = (float) $mediaParams->get('upload_maxsize', 0);
+$fileExts    = strtolower((string) $mediaParams->get('restrict_uploads_extensions', ''));
+$imageExts   = strtolower((string) $mediaParams->get('image_extensions', 'bmp,gif,jpg,png,jpeg,webp,avif'));
+$uploadAjax  = Route::_('index.php?option=com_j2commerce&view=carts&task=carts.upload&product_id=' . $productId, false);
 ?>
 <?php if ($options) : ?>
 
@@ -189,40 +198,29 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
         <?php endif; ?>
 
         <?php if ($option['type'] == 'file') : ?>
-            <div id="option-<?php echo $option['productoption_id']; ?>" class="option uk-margin-small-bottom">
-                <?php if ($option['required']) : ?>
-                <span class="uk-text-danger">*</span>
-                <?php endif; ?>
-                <b><?php echo $this->escape(Text::_($option['option_name'])); ?>:</b><br>
-                <button type="button"
-                    id="product-option-<?php echo $option['productoption_id']; ?>"
-                    data-loading-text="<?php echo Text::_('COM_J2COMMERCE_LOADING'); ?>"
-                    class="uk-button uk-button-default">
-                    <span uk-icon="icon: upload"></span> <?php echo Text::_('COM_J2COMMERCE_PRODUCT_OPTION_CHOOSE_FILE'); ?>
-                </button>
-                <input type="hidden"
-                    name="product_option[<?php echo $option['productoption_id']; ?>]"
-                    value="" id="input-option<?php echo $option['productoption_id']; ?>" />
-            </div>
+            <?php echo LayoutHelper::render('productoption.upload_file', [
+                'productOptionId' => (int) $option['productoption_id'],
+                'productId'       => $productId,
+                'required'        => (bool) $option['required'],
+                'optionName'      => (string) $option['option_name'],
+                'ajaxUrl'         => $uploadAjax,
+                'maxSizeMB'       => $uploadMaxMB,
+                'allowedExts'     => $fileExts,
+                'framework'       => 'uikit',
+            ]); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] == 'image') : ?>
-            <div id="option-<?php echo $option['productoption_id']; ?>" class="option uk-margin-small-bottom">
-                <?php if ($option['required']) : ?>
-                <span class="uk-text-danger">*</span>
-                <?php endif; ?>
-                <b><?php echo $this->escape(Text::_($option['option_name'])); ?>:</b><br>
-                <button type="button"
-                    id="product-option-<?php echo $option['productoption_id']; ?>"
-                    data-loading-text="<?php echo Text::_('COM_J2COMMERCE_LOADING'); ?>"
-                    data-accept="image/*"
-                    class="uk-button uk-button-default">
-                    <span uk-icon="icon: image"></span> <?php echo Text::_('COM_J2COMMERCE_PRODUCT_OPTION_CHOOSE_IMAGE'); ?>
-                </button>
-                <input type="hidden"
-                    name="product_option[<?php echo $option['productoption_id']; ?>]"
-                    value="" id="input-option<?php echo $option['productoption_id']; ?>" />
-            </div>
+            <?php echo LayoutHelper::render('productoption.upload_image', [
+                'productOptionId' => (int) $option['productoption_id'],
+                'productId'       => $productId,
+                'required'        => (bool) $option['required'],
+                'optionName'      => (string) $option['option_name'],
+                'ajaxUrl'         => $uploadAjax,
+                'maxSizeMB'       => $uploadMaxMB,
+                'allowedExts'     => $imageExts,
+                'framework'       => 'uikit',
+            ]); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] == 'date') : ?>
@@ -280,87 +278,4 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
 </div>
 <?php endif; ?>
 
-<?php if (isset($options) && !empty($options)) : ?>
-    <?php foreach ($options as $option) : ?>
-        <?php if ($option['type'] == 'file' || $option['type'] == 'image') : ?>
-            <script type="text/javascript">
-                (function() {
-                    const productOptionBtn = document.getElementById('product-option-<?php echo $option['productoption_id']; ?>');
-
-                    if (!productOptionBtn) return;
-
-                    productOptionBtn.addEventListener('click', function() {
-                        const node = this;
-
-                        const existingForm = document.getElementById('form-upload');
-                        if (existingForm) {
-                            existingForm.remove();
-                        }
-
-                        const form = document.createElement('form');
-                        form.enctype = 'multipart/form-data';
-                        form.id = 'form-upload';
-                        form.style.display = 'none';
-
-                        const fileInput = document.createElement('input');
-                        fileInput.type = 'file';
-                        fileInput.name = 'file';
-                        if (node.dataset.accept) {
-                            fileInput.accept = node.dataset.accept;
-                        }
-                        form.appendChild(fileInput);
-
-                        document.body.insertAdjacentElement('afterbegin', form);
-                        fileInput.click();
-
-                        const timer = setInterval(() => {
-                            if (fileInput.value !== '') {
-                                clearInterval(timer);
-
-                                const formData = new FormData(form);
-
-                                node.disabled = true;
-                                const originalText = node.innerHTML;
-                                node.innerHTML = node.getAttribute('data-loading-text') || 'Loading...';
-
-                                fetch('index.php?option=com_j2commerce&view=carts&task=carts.upload&product_id=<?php echo $this->product->j2commerce_product_id; ?>', {
-                                    method: 'POST',
-                                    body: formData,
-                                })
-                                .then(response => response.json())
-                                .then(json => {
-                                    node.disabled = false;
-                                    node.innerHTML = originalText;
-
-                                    document.querySelectorAll('.j2file-upload-response').forEach(el => el.remove());
-
-                                    const inputField = node.parentElement.querySelector('input[type="hidden"]');
-
-                                    if (json.error && inputField) {
-                                        const errorSpan = document.createElement('span');
-                                        errorSpan.className = 'j2file-upload-response uk-text-danger';
-                                        errorSpan.textContent = json.error;
-                                        inputField.insertAdjacentElement('afterend', errorSpan);
-                                    }
-
-                                    if (json.success && inputField) {
-                                        const successSpan = document.createElement('span');
-                                        successSpan.className = 'j2file-upload-response uk-text-success';
-                                        successSpan.textContent = json.success + ' ';
-                                        inputField.insertAdjacentElement('afterend', successSpan);
-                                        inputField.value = json.code;
-                                    }
-                                })
-                                .catch(error => {
-                                    alert(error.message + '\r\n' + error);
-                                    node.disabled = false;
-                                    node.innerHTML = originalText;
-                                });
-                            }
-                        }, 500);
-                    });
-                })();
-            </script>
-        <?php endif; ?>
-    <?php endforeach; ?>
-<?php endif; ?>
+<?php /* File/image upload widgets are handled by media/com_j2commerce/js/site/option-upload-fields.js */ ?>

--- a/plugins/j2commerce/app_uikit/tmpl/uikit/view_options.php
+++ b/plugins/j2commerce/app_uikit/tmpl/uikit/view_options.php
@@ -12,17 +12,25 @@ declare(strict_types=1);
 defined('_JEXEC') or die;
 
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
+use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
 
 /** @var \J2Commerce\Component\J2commerce\Site\View\Product\HtmlView $this */
 
-$platform = J2CommerceHelper::platform();
-$options = $this->product->options;
-$productId = $this->product->j2commerce_product_id;
+$platform       = J2CommerceHelper::platform();
+$options        = $this->product->options;
+$productId      = (int) $this->product->j2commerce_product_id;
 $product_helper = J2CommerceHelper::product();
-$ajax_url = Route::_('index.php', false);
+$esc            = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+
+$mediaParams = ComponentHelper::getParams('com_media');
+$uploadMaxMB = (float) $mediaParams->get('upload_maxsize', 0);
+$fileExts    = strtolower((string) $mediaParams->get('restrict_uploads_extensions', ''));
+$imageExts   = strtolower((string) $mediaParams->get('image_extensions', 'bmp,gif,jpg,png,jpeg,webp,avif'));
+$uploadAjax  = Route::_('index.php?option=com_j2commerce&view=carts&task=carts.upload&product_id=' . $productId, false);
 ?>
 <?php if ($options) : ?>
 
@@ -159,42 +167,29 @@ $ajax_url = Route::_('index.php', false);
         <?php endif; ?>
 
         <?php if ($option['type'] == 'file') : ?>
-            <div id="option-<?php echo $option['productoption_id']; ?>" class="option uk-margin-small-bottom">
-                <?php if ($option['required']) : ?>
-                <span class="uk-text-danger">*</span>
-                <?php endif; ?>
-                <label class="uk-form-label uk-text-bold"><?php echo Text::_($option['option_name']); ?>:</label>
-                <button type="button"
-                    id="product-option-<?php echo $option['productoption_id']; ?>"
-                    data-loading-text="<?php echo Text::_('COM_J2COMMERCE_LOADING'); ?>"
-                    data-ajax-url="<?php echo $ajax_url; ?>?option=com_j2commerce&view=carts&task=carts.upload&product_id=<?php echo $productId; ?>"
-                    class="uk-button uk-button-default j2commerce-file-upload-btn">
-                    <span uk-icon="icon: upload"></span> <?php echo Text::_('COM_J2COMMERCE_PRODUCT_OPTION_CHOOSE_FILE'); ?>
-                </button>
-                <input type="hidden"
-                    name="product_option[<?php echo $option['productoption_id']; ?>]"
-                    value="" id="input-option<?php echo $option['productoption_id']; ?>" />
-            </div>
+            <?php echo LayoutHelper::render('productoption.upload_file', [
+                'productOptionId' => (int) $option['productoption_id'],
+                'productId'       => $productId,
+                'required'        => (bool) $option['required'],
+                'optionName'      => (string) $option['option_name'],
+                'ajaxUrl'         => $uploadAjax,
+                'maxSizeMB'       => $uploadMaxMB,
+                'allowedExts'     => $fileExts,
+                'framework'       => 'uikit',
+            ]); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] == 'image') : ?>
-            <div id="option-<?php echo $option['productoption_id']; ?>" class="option uk-margin-small-bottom">
-                <?php if ($option['required']) : ?>
-                <span class="uk-text-danger">*</span>
-                <?php endif; ?>
-                <label class="uk-form-label uk-text-bold"><?php echo Text::_($option['option_name']); ?>:</label>
-                <button type="button"
-                    id="product-option-<?php echo $option['productoption_id']; ?>"
-                    data-loading-text="<?php echo Text::_('COM_J2COMMERCE_LOADING'); ?>"
-                    data-ajax-url="<?php echo $ajax_url; ?>?option=com_j2commerce&view=carts&task=carts.upload&product_id=<?php echo $productId; ?>"
-                    data-accept="image/*"
-                    class="uk-button uk-button-default j2commerce-file-upload-btn">
-                    <span uk-icon="icon: image"></span> <?php echo Text::_('COM_J2COMMERCE_PRODUCT_OPTION_CHOOSE_IMAGE'); ?>
-                </button>
-                <input type="hidden"
-                    name="product_option[<?php echo $option['productoption_id']; ?>]"
-                    value="" id="input-option<?php echo $option['productoption_id']; ?>" />
-            </div>
+            <?php echo LayoutHelper::render('productoption.upload_image', [
+                'productOptionId' => (int) $option['productoption_id'],
+                'productId'       => $productId,
+                'required'        => (bool) $option['required'],
+                'optionName'      => (string) $option['option_name'],
+                'ajaxUrl'         => $uploadAjax,
+                'maxSizeMB'       => $uploadMaxMB,
+                'allowedExts'     => $imageExts,
+                'framework'       => 'uikit',
+            ]); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] == 'date') : ?>
@@ -284,86 +279,7 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     });
 
-    // Handle file upload buttons
-    document.querySelectorAll('.j2commerce-file-upload-btn').forEach(btn => {
-        btn.addEventListener('click', function() {
-            const node = this;
-            const ajaxUrl = node.dataset.ajaxUrl;
-
-            const existingForm = document.getElementById('form-upload');
-            if (existingForm) {
-                existingForm.remove();
-            }
-
-            const form = document.createElement('form');
-            form.enctype = 'multipart/form-data';
-            form.id = 'form-upload';
-            form.style.display = 'none';
-
-            const fileInput = document.createElement('input');
-            fileInput.type = 'file';
-            fileInput.name = 'file';
-            if (node.dataset.accept) {
-                fileInput.accept = node.dataset.accept;
-            }
-            form.appendChild(fileInput);
-
-            document.body.insertAdjacentElement('afterbegin', form);
-            fileInput.click();
-
-            const timer = setInterval(() => {
-                if (fileInput.value !== '') {
-                    clearInterval(timer);
-
-                    const formData = new FormData(form);
-
-                    node.disabled = true;
-                    const originalText = node.innerHTML;
-                    node.innerHTML = node.dataset.loadingText || 'Loading...';
-
-                    fetch(ajaxUrl, {
-                        method: 'POST',
-                        body: formData,
-                    })
-                    .then(response => response.json())
-                    .then(json => {
-                        node.disabled = false;
-                        node.innerHTML = originalText;
-
-                        const uploadForm = document.getElementById('form-upload');
-                        if (uploadForm) {
-                            const fileInputEl = uploadForm.querySelector('input[name="file"]');
-                            if (fileInputEl) fileInputEl.remove();
-                        }
-
-                        document.querySelectorAll('.j2file-upload-response').forEach(el => el.remove());
-
-                        const inputField = node.parentElement.querySelector('input[type="hidden"]');
-
-                        if (json.error && inputField) {
-                            const errorSpan = document.createElement('span');
-                            errorSpan.className = 'j2file-upload-response uk-text-danger';
-                            errorSpan.textContent = json.error;
-                            inputField.insertAdjacentElement('afterend', errorSpan);
-                        }
-
-                        if (json.success && inputField) {
-                            const successSpan = document.createElement('span');
-                            successSpan.className = 'j2file-upload-response uk-text-success';
-                            successSpan.textContent = json.success + ' ';
-                            inputField.insertAdjacentElement('afterend', successSpan);
-                            inputField.value = json.code;
-                        }
-                    })
-                    .catch(error => {
-                        alert(error.message + '\r\n' + error);
-                        node.disabled = false;
-                        node.innerHTML = originalText;
-                    });
-                }
-            }, 500);
-        });
-    });
+    // File/image upload widgets are handled by media/com_j2commerce/js/site/option-upload-fields.js
 });
 </script>
 <?php endif; ?>

--- a/plugins/j2commerce/app_uikit/tmpl/uikit/view_variableoptions.php
+++ b/plugins/j2commerce/app_uikit/tmpl/uikit/view_variableoptions.php
@@ -12,7 +12,10 @@ declare(strict_types=1);
 defined('_JEXEC') or die;
 
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
+use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
+use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
 use Joomla\Registry\Registry;
 
@@ -24,11 +27,17 @@ if (empty($options)) {
     return;
 }
 
-$platform = J2CommerceHelper::platform();
-$productId = $this->product->j2commerce_product_id;
-$product_helper = J2CommerceHelper::product();
+$platform         = J2CommerceHelper::platform();
+$productId        = (int) $this->product->j2commerce_product_id;
+$product_helper   = J2CommerceHelper::product();
 $showOptionImages = (int) ($this->params->get('image_for_product_options', 0) ?? 0);
-$esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+$esc              = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+
+$mediaParams = ComponentHelper::getParams('com_media');
+$uploadMaxMB = (float) $mediaParams->get('upload_maxsize', 0);
+$fileExts    = strtolower((string) $mediaParams->get('restrict_uploads_extensions', ''));
+$imageExts   = strtolower((string) $mediaParams->get('image_extensions', 'bmp,gif,jpg,png,jpeg,webp,avif'));
+$uploadAjax  = Route::_('index.php?option=com_j2commerce&view=carts&task=carts.upload&product_id=' . $productId, false);
 ?>
 <div class="options" id="variable-options-<?php echo $productId; ?>">
     <?php foreach ($options as $option) : ?>
@@ -219,48 +228,29 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
         <?php endif; ?>
 
         <?php if ($option['type'] === 'file') : ?>
-            <div id="option-<?php echo $option['productoption_id']; ?>" class="option uk-margin-small-bottom">
-                <label class="uk-form-label uk-text-bold uk-margin-small-bottom uk-display-block">
-                    <?php echo $esc(Text::_($option['option_name'])); ?>
-                    <?php if ($option['required']) : ?>
-                        <span class="uk-text-danger">*</span>
-                    <?php endif; ?>
-                </label>
-                <div>
-                    <button type="button"
-                            id="product-option-<?php echo $option['productoption_id']; ?>"
-                            data-loading-text="<?php echo $esc(Text::_('COM_J2COMMERCE_LOADING')); ?>"
-                            class="uk-button uk-button-default uk-button-small">
-                        <span uk-icon="icon: upload" class="uk-margin-small-right"></span><?php echo Text::_('COM_J2COMMERCE_PRODUCT_OPTION_CHOOSE_FILE'); ?>
-                    </button>
-                    <input type="hidden"
-                           name="product_option[<?php echo $option['productoption_id']; ?>]"
-                           value="" id="input-option<?php echo $option['productoption_id']; ?>" />
-                </div>
-            </div>
+            <?php echo LayoutHelper::render('productoption.upload_file', [
+                'productOptionId' => (int) $option['productoption_id'],
+                'productId'       => $productId,
+                'required'        => (bool) $option['required'],
+                'optionName'      => (string) $option['option_name'],
+                'ajaxUrl'         => $uploadAjax,
+                'maxSizeMB'       => $uploadMaxMB,
+                'allowedExts'     => $fileExts,
+                'framework'       => 'uikit',
+            ]); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] === 'image') : ?>
-            <div id="option-<?php echo $option['productoption_id']; ?>" class="option uk-margin-small-bottom">
-                <label class="uk-form-label uk-text-bold uk-margin-small-bottom uk-display-block">
-                    <?php echo $esc(Text::_($option['option_name'])); ?>
-                    <?php if ($option['required']) : ?>
-                        <span class="uk-text-danger">*</span>
-                    <?php endif; ?>
-                </label>
-                <div>
-                    <button type="button"
-                            id="product-option-<?php echo $option['productoption_id']; ?>"
-                            data-loading-text="<?php echo $esc(Text::_('COM_J2COMMERCE_LOADING')); ?>"
-                            data-accept="image/*"
-                            class="uk-button uk-button-default uk-button-small">
-                        <span uk-icon="icon: image" class="uk-margin-small-right"></span><?php echo Text::_('COM_J2COMMERCE_PRODUCT_OPTION_CHOOSE_IMAGE'); ?>
-                    </button>
-                    <input type="hidden"
-                           name="product_option[<?php echo $option['productoption_id']; ?>]"
-                           value="" id="input-option<?php echo $option['productoption_id']; ?>" />
-                </div>
-            </div>
+            <?php echo LayoutHelper::render('productoption.upload_image', [
+                'productOptionId' => (int) $option['productoption_id'],
+                'productId'       => $productId,
+                'required'        => (bool) $option['required'],
+                'optionName'      => (string) $option['option_name'],
+                'ajaxUrl'         => $uploadAjax,
+                'maxSizeMB'       => $uploadMaxMB,
+                'allowedExts'     => $imageExts,
+                'framework'       => 'uikit',
+            ]); ?>
         <?php endif; ?>
 
         <?php if ($option['type'] === 'date') : ?>
@@ -324,75 +314,4 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
     <?php endforeach; ?>
 </div>
 
-<script>
-document.addEventListener('DOMContentLoaded', () => {
-    const productId = <?php echo $productId; ?>;
-    const optionsContainer = document.getElementById('variable-options-' + productId);
-    if (!optionsContainer) return;
-
-    // File upload handlers
-    optionsContainer.querySelectorAll('[id^="product-option-"]').forEach(btn => {
-        btn.addEventListener('click', function() {
-            const node = this;
-            const existingForm = document.getElementById('form-upload');
-            if (existingForm) existingForm.remove();
-
-            const form = document.createElement('form');
-            form.enctype = 'multipart/form-data';
-            form.id = 'form-upload';
-            form.style.display = 'none';
-
-            const fileInput = document.createElement('input');
-            fileInput.type = 'file';
-            fileInput.name = 'file';
-            if (node.dataset.accept) {
-                fileInput.accept = node.dataset.accept;
-            }
-            form.appendChild(fileInput);
-            document.body.insertAdjacentElement('afterbegin', form);
-            fileInput.click();
-
-            const timer = setInterval(() => {
-                if (fileInput.value !== '') {
-                    clearInterval(timer);
-                    const formData = new FormData(form);
-                    node.disabled = true;
-                    const originalText = node.innerHTML;
-                    node.innerHTML = node.getAttribute('data-loading-text') || 'Loading...';
-
-                    fetch('index.php?option=com_j2commerce&view=carts&task=carts.upload&product_id=<?php echo $productId; ?>', {
-                        method: 'POST',
-                        body: formData,
-                    })
-                    .then(response => response.json())
-                    .then(json => {
-                        node.disabled = false;
-                        node.innerHTML = originalText;
-                        document.querySelectorAll('.j2file-upload-response').forEach(el => el.remove());
-
-                        const inputField = node.parentElement.querySelector('input[type="hidden"]');
-                        if (json.error && inputField) {
-                            const errorSpan = document.createElement('span');
-                            errorSpan.className = 'j2file-upload-response uk-text-danger';
-                            errorSpan.textContent = json.error;
-                            inputField.insertAdjacentElement('afterend', errorSpan);
-                        }
-                        if (json.success && inputField) {
-                            const successSpan = document.createElement('span');
-                            successSpan.className = 'j2file-upload-response uk-text-success';
-                            successSpan.textContent = json.success + ' ';
-                            inputField.insertAdjacentElement('afterend', successSpan);
-                            inputField.value = json.code;
-                        }
-                    })
-                    .catch(error => {
-                        console.error('File upload error:', error);
-                        node.disabled = false;
-                        node.innerHTML = originalText;
-                    });
-                }
-            }, 500);
-        });
-    });
-});
-</script>
+<?php /* File/image upload widgets are handled by media/com_j2commerce/js/site/option-upload-fields.js */ ?>


### PR DESCRIPTION
## Summary

Replaces #1046 (closed in favor of this rebased PR — #1046 was branched off pre-#1045 main and showed stale diff once #1044/#1045/#1047 merged).

Migrates every remaining core product-option subtemplate that still rendered the legacy `.j2commerce-file-upload-btn` pattern onto the shared FileLayouts + unified JS introduced in #1045 (now merged on main).

## Bootstrap 5 (3 files)
- `plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/view_variableoptions.php`
- `plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/view_configurableoptions.php`
- `plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/view_variableoptions.php`

## UIkit 3 (6 files)
- `plugins/j2commerce/app_uikit/tmpl/uikit/view_options.php`
- `plugins/j2commerce/app_uikit/tmpl/uikit/view_configurableoptions.php`
- `plugins/j2commerce/app_uikit/tmpl/uikit/view_variableoptions.php`
- `plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_options.php`
- `plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_configurableoptions.php`
- `plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_variableoptions.php`

## Each template
- Adds `use Joomla\CMS\Component\ComponentHelper`, `Joomla\CMS\Layout\LayoutHelper`, `Joomla\CMS\Router\Route`.
- Computes `$mediaParams`, `$uploadMaxMB`, `$fileExts`, `$imageExts`, `$uploadAjax` once near the top.
- Replaces the file + image render blocks with single `LayoutHelper::render('productoption.upload_file', [..., 'framework' => 'bs5'|'uikit'])` / `productoption.upload_image` calls.
- Drops the per-template inline `<script>` upload handler. `option-upload-fields.js` now handles drag-drop, the picker, file validation, image preview swap, and the fetch.

## Diff stat
- 9 files changed, +307 / -1032 (~1000 lines of duplicated inline JS removed).

## Verification
- `php -l` clean on all 9 files.
- `grep "j2commerce-file-upload-btn" plugins/j2commerce/` returns zero hits across both BS5 + UIkit.
- All 16 `LayoutHelper::render('productoption.upload_*')` calls present (8 file + 8 image, 2 per template).
- Synced to `joomla-test-3` and validated.

## Out of scope
- `view_variablesubscriptionproductoptions.php` lives in the non-core `app_subscriptionproduct` plugin (gitignored here). Local copies were updated for parity.