### PR TITLE
fix(schema): restore params on shippingmethods + add locale parity tool

### DIFF
--- a/administrator/components/com_j2commerce/sql/install.mysql.utf8.sql
+++ b/administrator/components/com_j2commerce/sql/install.mysql.utf8.sql
@@ -1196,6 +1196,7 @@ CREATE TABLE IF NOT EXISTS `#__j2commerce_shippingmethods` (
   `shipping_method_name` varchar(255) NOT NULL,
   `published` tinyint NOT NULL,
   `shipping_method_type` tinyint NOT NULL,
+  `params` longtext NULL,
   `tax_class_id` int NOT NULL,
   `address_override` varchar(255) NOT NULL,
   `subtotal_minimum` decimal(15,3) NOT NULL,

--- a/administrator/components/com_j2commerce/sql/updates/mysql/6.2.3-2026-05-17.sql
+++ b/administrator/components/com_j2commerce/sql/updates/mysql/6.2.3-2026-05-17.sql
@@ -1,0 +1,13 @@
+--
+-- Restore the `params` column on `#__j2commerce_shippingmethods`.
+--
+-- The column was present on the legacy `#__j2store_shippingmethods` table
+-- and on every other j2store->j2c clone, but was accidentally omitted when
+-- the j2commerce_shippingmethods CREATE was authored. Core code (and 3rd
+-- party plugins such as plg_j2commerce_app_restrictbyshipping) expects it
+-- to be available, so this update brings existing 6.x installs back into
+-- parity with the install.mysql.utf8.sql schema.
+--
+
+/** CAN FAIL **/
+ALTER TABLE `#__j2commerce_shippingmethods` ADD COLUMN `params` LONGTEXT NULL AFTER `shipping_method_type`;


### PR DESCRIPTION
## Core Update

Two unrelated core changes bundled in one PR.

### 1. Schema fix — `params` column on `#__j2commerce_shippingmethods`

The `params` LONGTEXT column existed on the legacy `#__j2store_shippingmethods` table and on every other j2store→j2c clone, but was **accidentally omitted** when the `#__j2commerce_shippingmethods` CREATE was authored. Core code and 3rd-party plugins (e.g. `plg_j2commerce_app_restrictbyshipping`) expect it to be available — without it, those plugins silently fail on `setupShippingMethodForm`.

- `administrator/components/com_j2commerce/sql/install.mysql.utf8.sql` — add column to canonical CREATE
- `administrator/components/com_j2commerce/sql/updates/mysql/6.2.3-2026-05-17.sql` — `ALTER TABLE ... ADD COLUMN` (marked `/** CAN FAIL **/` so re-running the updater on a fresh install is idempotent)

### 2. Build tool — `build/check_locale_parity.php`

Audits every shipped locale against the canonical `en-US` reference set. Discovers extensions (component, library, all plugins, all modules), parses `.ini` files, and produces a markdown report at `docs/reports/locale-parity-YYYY-MM-DD.md` listing every key present in `en-US` (and `en-GB`) but missing from each other locale. Also detects en-GB drift ahead of canonical (keys added to en-GB but never back-ported to en-US).

Usage:
```bash
php build/check_locale_parity.php
```

### Files Modified
| Type | Count |
|------|-------|
| SQL (install + update) | 2 |
| PHP (build tool) | 1 |

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only (non-core build/scripts/*.ini working artifacts excluded)