### PR TITLE
fix(uploads): ship product-option uploads folder + recreate on install/update

### DIFF
--- a/administrator/components/com_j2commerce/j2commerce.xml
+++ b/administrator/components/com_j2commerce/j2commerce.xml
@@ -33,6 +33,7 @@
         <folder>css</folder>
         <folder>js</folder>
         <folder>images</folder>
+        <folder>uploads</folder>
         <folder>vendor</folder>
         <filename>joomla.asset.json</filename>
     </media>

--- a/administrator/components/com_j2commerce/script.j2commerce.php
+++ b/administrator/components/com_j2commerce/script.j2commerce.php
@@ -121,6 +121,9 @@ class Com_J2commerceInstallerScript extends InstallerScript
         $this->setDefaultAcl();
         $this->debugLog("INSTALL: default ACL rules set");
 
+        $this->ensureUploadsFolder();
+        $this->debugLog("INSTALL: product-option uploads folder ensured");
+
         Factory::getApplication()->enqueueMessage(Text::_('COM_J2COMMERCE_INSTALL_SUCCESS'), 'success');
 
         $this->debugLog("=== INSTALL END ===");
@@ -139,10 +142,37 @@ class Com_J2commerceInstallerScript extends InstallerScript
 
         $this->cleanupStaleCheckoutTemplates();
 
+        $this->ensureUploadsFolder();
+        $this->debugLog("UPDATE: product-option uploads folder ensured");
+
         Factory::getApplication()->enqueueMessage(Text::_('COM_J2COMMERCE_UPDATE_SUCCESS'), 'success');
 
         $this->debugLog("=== UPDATE END ===");
         return true;
+    }
+
+    /**
+     * Ensure media/com_j2commerce/uploads/ exists with an index.html stub.
+     * CartModel::uploadFile() also lazy-creates it on first upload, but having
+     * it present on install lets admins verify the path without uploading a
+     * file and prevents directory-listing exposure under Options +Indexes.
+     */
+    private function ensureUploadsFolder(): void
+    {
+        $folder = JPATH_ROOT . '/media/com_j2commerce/uploads';
+
+        if (!is_dir($folder) && !@mkdir($folder, 0755, true) && !is_dir($folder)) {
+            $this->debugLog("UPLOADS: failed to create {$folder}");
+            return;
+        }
+
+        $stub = $folder . '/index.html';
+        if (!is_file($stub)) {
+            @file_put_contents(
+                $stub,
+                "<!--~\n  ~ @package     J2Commerce\n  ~ @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>\n  ~ @license     GNU General Public License version 2 or later; see LICENSE.txt\n  -->\n\n<html>\n<head><title></title></head>\n<body></body>\n</html>\n"
+            );
+        }
     }
 
     /** Remove pre-subfolder checkout templates left behind on existing sites; harmless if absent. */

--- a/media/com_j2commerce/uploads/index.html
+++ b/media/com_j2commerce/uploads/index.html
@@ -1,0 +1,10 @@
+<!--~
+  ~ @package     J2Commerce
+  ~ @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+  ~ @license     GNU General Public License version 2 or later; see LICENSE.txt
+  -->
+
+<html>
+<head><title></title></head>
+<body></body>
+</html>


### PR DESCRIPTION
## Summary

Fixes #1050

Brian flagged that `media/com_j2commerce/uploads/` was missing from his install and asked whether the upload path even works. The runtime mkdir at `CartModel::uploadFile` (~line 822) does lazy-create the folder on the first successful upload, but admins auditing the install before any shopper drops a file saw nothing on disk — confusing, and easy to mistake for "feature is broken." This makes the folder ship with the package and recreates it on install/update if missing.

The companion UX work (admin warning when `allow_guest_uploads=No`, frontend ACL gate so guests never see a dropzone they cannot use) is tracked separately in #1053.

## Changes

- **NEW** `media/com_j2commerce/uploads/index.html` — empty Joomla-standard stub so the folder is present in the package zip and after install.
- **MOD** `administrator/components/com_j2commerce/j2commerce.xml` — adds `<folder>uploads</folder>` to the media section so package install/update copies the folder + stub.
- **MOD** `administrator/components/com_j2commerce/script.j2commerce.php` — adds idempotent `ensureUploadsFolder()` helper (mkdir + write index.html if missing). Wired into both `install()` and `update()` so existing sites pick it up on upgrade and a manually-deleted folder is repaired on the next package install.

The lazy mkdir inside `CartModel::uploadFile` is intentionally left in place as a belt-and-suspenders fallback.

## Testing

1. **Fresh install** — Install com_j2commerce.zip on a clean Joomla 6 → confirm `media/com_j2commerce/uploads/index.html` exists on disk.
2. **Repair on update** — Delete `media/com_j2commerce/uploads/` from an installed site, reinstall the package (`route=update`) → confirm folder + index.html are recreated.
3. **Runtime fallback still works** — Delete folder again, do NOT reinstall, perform a product-option file upload as a logged-in user → upload succeeds, folder + uploaded file appear (CartModel mkdir path).
4. **Guest upload** — Set J2Commerce → Options → Cart → **Allow Guest Uploads** = Yes, repeat upload as a guest → file lands in `media/com_j2commerce/uploads/`, row in `j6_j2commerce_uploads`.

## Files Changed

- `media/com_j2commerce/uploads/index.html` — new stub
- `administrator/components/com_j2commerce/j2commerce.xml` — +1 line
- `administrator/components/com_j2commerce/script.j2commerce.php` — +30 lines (helper + 2 call sites)