### PR TITLE
fix(product-options): warn admin + hide upload field for guests when allow_guest_uploads=No

### DIFF
--- a/administrator/components/com_j2commerce/language/en-GB/com_j2commerce.ini
+++ b/administrator/components/com_j2commerce/language/en-GB/com_j2commerce.ini
@@ -2602,6 +2602,7 @@ COM_J2COMMERCE_OPTION_UNIQUE_NAME_DESCRIPTION="A unique identifier for this opti
 COM_J2COMMERCE_OPTION_UNIQUE_NAME_HELP="Unique Name Usage"
 COM_J2COMMERCE_OPTION_UNIQUE_NAME_HELP_TEXT="The unique name is used for programmatic access and should not contain spaces. It is auto-generated from the option name but can be customised."
 COM_J2COMMERCE_OPTION_UNIQUE_NAME_HINT="e.g., size, colour, material"
+COM_J2COMMERCE_OPTION_UPLOAD_GUEST_DISABLED="Guest uploads are disabled. This option will not display to guests on the storefront. Logged-in shoppers will see it normally. <a href=\"%s\">Open Basket settings to enable.</a>"
 COM_J2COMMERCE_OPTION_VALUE="Option Value"
 COM_J2COMMERCE_OPTION_VALUES="Option Values"
 COM_J2COMMERCE_OPTION_VALUES_DESC="Define the available values for this option"

--- a/administrator/components/com_j2commerce/language/en-US/com_j2commerce.ini
+++ b/administrator/components/com_j2commerce/language/en-US/com_j2commerce.ini
@@ -2602,6 +2602,7 @@ COM_J2COMMERCE_OPTION_UNIQUE_NAME_DESCRIPTION="A unique identifier for this opti
 COM_J2COMMERCE_OPTION_UNIQUE_NAME_HELP="Unique Name Usage"
 COM_J2COMMERCE_OPTION_UNIQUE_NAME_HELP_TEXT="The unique name is used for programmatic access and should not contain spaces. It is auto-generated from the option name but can be customized."
 COM_J2COMMERCE_OPTION_UNIQUE_NAME_HINT="e.g., size, color, material"
+COM_J2COMMERCE_OPTION_UPLOAD_GUEST_DISABLED="Guest uploads are disabled. This option will not display to guests on the storefront. Logged-in shoppers will see it normally. <a href=\"%s\">Open Cart settings to enable.</a>"
 COM_J2COMMERCE_OPTION_VALUE="Option Value"
 COM_J2COMMERCE_OPTION_VALUES="Option Values"
 COM_J2COMMERCE_OPTION_VALUES_DESC="Define the available values for this option"

--- a/administrator/components/com_j2commerce/tmpl/option/edit.php
+++ b/administrator/components/com_j2commerce/tmpl/option/edit.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
+use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
@@ -27,6 +28,9 @@ $wa->useScript('keepalive')
 
 $layout  = 'edit';
 $tmpl    = Factory::getApplication()->input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=component' : '';
+
+$guestUploadsEnabled = (int) ComponentHelper::getParams('com_j2commerce')->get('allow_guest_uploads', 0) === 1;
+$configUrl           = Route::_('index.php?option=com_config&view=component&component=com_j2commerce');
 ?>
 
 <form action="<?php echo Route::_('index.php?option=com_j2commerce&view=option&layout=' . $layout . $tmpl . '&id=' . (int) ($this->item->id ?? $this->item->j2commerce_option_id ?? 0)); ?>" method="post" name="adminForm" id="option-form" aria-label="<?php echo Text::_('COM_J2COMMERCE_OPTION_FORM_' . ((int) ($this->item->id ?? $this->item->j2commerce_option_id ?? 0) === 0 ? 'NEW' : 'EDIT'), true); ?>" class="form-validate">
@@ -42,6 +46,17 @@ $tmpl    = Factory::getApplication()->input->get('tmpl', '', 'cmd') === 'compone
                     <?php echo $this->form->renderField('option_name'); ?>
                     <?php echo $this->form->renderField('option_unique_name'); ?>
                     <?php echo $this->form->renderField('type'); ?>
+
+                    <?php if (!$guestUploadsEnabled) : ?>
+                        <div id="j2c-guest-upload-warning"
+                             class="alert alert-warning d-none"
+                             role="alert"
+                             data-j2c-guest-upload-warning>
+                            <span class="fa-solid fa-triangle-exclamation me-1" aria-hidden="true"></span>
+                            <?php echo Text::sprintf('COM_J2COMMERCE_OPTION_UPLOAD_GUEST_DISABLED', $this->escape($configUrl)); ?>
+                        </div>
+                    <?php endif; ?>
+
                     <?php echo $this->form->renderField('published'); ?>
 
                     <div class="alert alert-info">
@@ -133,6 +148,22 @@ document.addEventListener('DOMContentLoaded', function() {
                 lastAutoValue = null;
             }
         });
+    }
+
+    // Toggle the guest-uploads-disabled warning whenever the option type
+    // dropdown changes to/from file or image. The wrapper is only present
+    // in the DOM when allow_guest_uploads=0, so when guests are allowed
+    // the warning never appears regardless of type.
+    const typeField = document.getElementById('jform_type');
+    const guestWarning = document.querySelector('[data-j2c-guest-upload-warning]');
+
+    if (typeField && guestWarning) {
+        const toggleGuestWarning = () => {
+            const value = typeField.value;
+            guestWarning.classList.toggle('d-none', value !== 'file' && value !== 'image');
+        };
+        typeField.addEventListener('change', toggleGuestWarning);
+        toggleGuestWarning();
     }
 
     // Add syntax highlighting helper for JSON params field

--- a/administrator/language/en-GB/com_j2commerce.ini
+++ b/administrator/language/en-GB/com_j2commerce.ini
@@ -2602,6 +2602,7 @@ COM_J2COMMERCE_OPTION_UNIQUE_NAME_DESCRIPTION="A unique identifier for this opti
 COM_J2COMMERCE_OPTION_UNIQUE_NAME_HELP="Unique Name Usage"
 COM_J2COMMERCE_OPTION_UNIQUE_NAME_HELP_TEXT="The unique name is used for programmatic access and should not contain spaces. It is auto-generated from the option name but can be customised."
 COM_J2COMMERCE_OPTION_UNIQUE_NAME_HINT="e.g., size, colour, material"
+COM_J2COMMERCE_OPTION_UPLOAD_GUEST_DISABLED="Guest uploads are disabled. This option will not display to guests on the storefront. Logged-in shoppers will see it normally. <a href=\"%s\">Open Basket settings to enable.</a>"
 COM_J2COMMERCE_OPTION_VALUE="Option Value"
 COM_J2COMMERCE_OPTION_VALUES="Option Values"
 COM_J2COMMERCE_OPTION_VALUES_DESC="Define the available values for this option"

--- a/administrator/language/en-US/com_j2commerce.ini
+++ b/administrator/language/en-US/com_j2commerce.ini
@@ -2602,6 +2602,7 @@ COM_J2COMMERCE_OPTION_UNIQUE_NAME_DESCRIPTION="A unique identifier for this opti
 COM_J2COMMERCE_OPTION_UNIQUE_NAME_HELP="Unique Name Usage"
 COM_J2COMMERCE_OPTION_UNIQUE_NAME_HELP_TEXT="The unique name is used for programmatic access and should not contain spaces. It is auto-generated from the option name but can be customized."
 COM_J2COMMERCE_OPTION_UNIQUE_NAME_HINT="e.g., size, color, material"
+COM_J2COMMERCE_OPTION_UPLOAD_GUEST_DISABLED="Guest uploads are disabled. This option will not display to guests on the storefront. Logged-in shoppers will see it normally. <a href=\"%s\">Open Cart settings to enable.</a>"
 COM_J2COMMERCE_OPTION_VALUE="Option Value"
 COM_J2COMMERCE_OPTION_VALUES="Option Values"
 COM_J2COMMERCE_OPTION_VALUES_DESC="Define the available values for this option"

--- a/components/com_j2commerce/layouts/productoption/upload_file.php
+++ b/components/com_j2commerce/layouts/productoption/upload_file.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 \defined('_JEXEC') or die;
 
+use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 
 /**
@@ -26,6 +28,14 @@ use Joomla\CMS\Language\Text;
  * @var string  $displayData['allowedExts']     comma list, lowercase, no dots (e.g. "pdf,doc,zip")
  * @var string  $displayData['framework']       'bs5' (default) | 'uikit'
  */
+
+// Hide the field for guests when allow_guest_uploads=0 — the upload would
+// be rejected server-side by MediaHelper's user-group gate anyway, so the
+// dropzone is misleading. Logged-in users always see it.
+$isGuest = Factory::getApplication()->getIdentity()?->guest ?? true;
+if ($isGuest && (int) ComponentHelper::getParams('com_j2commerce')->get('allow_guest_uploads', 0) !== 1) {
+    return;
+}
 
 $optionId    = (int) ($displayData['productOptionId'] ?? 0);
 $productId   = (int) ($displayData['productId'] ?? 0);

--- a/components/com_j2commerce/layouts/productoption/upload_image.php
+++ b/components/com_j2commerce/layouts/productoption/upload_image.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 \defined('_JEXEC') or die;
 
+use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 
 /**
@@ -26,6 +28,14 @@ use Joomla\CMS\Language\Text;
  * @var string  $displayData['allowedExts']     comma list (e.g. "jpg,png,webp")
  * @var string  $displayData['framework']       'bs5' (default) | 'uikit'
  */
+
+// Hide the field for guests when allow_guest_uploads=0 — the upload would
+// be rejected server-side by MediaHelper's user-group gate anyway, so the
+// dropzone is misleading. Logged-in users always see it.
+$isGuest = Factory::getApplication()->getIdentity()?->guest ?? true;
+if ($isGuest && (int) ComponentHelper::getParams('com_j2commerce')->get('allow_guest_uploads', 0) !== 1) {
+    return;
+}
 
 $optionId    = (int) ($displayData['productOptionId'] ?? 0);
 $productId   = (int) ($displayData['productId'] ?? 0);


### PR DESCRIPTION
## Summary

Fixes #1053

Companion to #1050. With **Allow Guest Uploads** disabled (the default), guests previously saw the file/image upload dropzone on a product detail page but the actual upload silently failed server-side because `MediaHelper::canUpload` enforces the Joomla media user-group gate. Admins also had no visible warning that the option type they picked would not work for unauthenticated buyers — they had to find out by reading the issue tracker.

## Changes

### Frontend gate (applied at layout level)

`components/com_j2commerce/layouts/productoption/upload_file.php` and `upload_image.php` early-return when the visitor is a guest and `allow_guest_uploads=0`. Because the gate sits in the shared layout instead of each subtemplate, all 12 product-option callers (BS5 + UIkit, options/configurable/variable, tag + non-tag) inherit the behaviour from a single source of truth — no per-template edits, and any future third-party caller is covered automatically.

Logged-in users always see the field. Guests with the flag enabled see the field. Required-field validation is unaffected: verified `CartModel` has no required-option enforcement (the `required` flag is cosmetic), so hiding the field for guests will not block Add to Cart even when the option is flagged required.

### Admin warning (inside option edit view)

`administrator/components/com_j2commerce/tmpl/option/edit.php` gains a Bootstrap `alert-warning` block immediately below the **Option Type** dropdown. It surfaces only when (a) `allow_guest_uploads=0` AND (b) the currently-selected type is `file` or `image`. When the flag is enabled, the alert div is server-suppressed entirely (zero DOM cost). The alert links directly to the component config page.

The visibility toggle is wired through the existing inline `<script>` block on the edit view using the standard event-delegation pattern — no inline `onchange` handler, no innerHTML, and the JS short-circuits when the alert div is absent (flag=1 path).

### Language

One new key `COM_J2COMMERCE_OPTION_UPLOAD_GUEST_DISABLED` added to all four admin language files (component canonical + `administrator/language/` mirror, en-US + en-GB). en-US uses "Open Cart settings to enable", en-GB uses British "Open Basket settings to enable".

## Testing

1. **Admin alert appears live** — In **Components → J2Commerce → Options**, set `Allow Guest Uploads = No` in the config first. Open a new Option, change the **Type** dropdown to **File** → yellow warning alert appears below the dropdown with a link to the config page. Switch to **Image** → still shown. Switch to **Text** or **Radio** → alert hidden. Switch back to **File** → alert reappears.
2. **Admin alert suppressed when enabled** — Set `Allow Guest Uploads = Yes`, reload the Option edit page. Switch Type to **File** or **Image** → no alert appears (the wrapper div is not in the DOM at all).
3. **Frontend hides field for guests** — As a guest with the flag set to **No**, view a product that has a file or image option. The upload field is not present in the rendered DOM. Log in → field appears. Flip the flag to **Yes** → guests see the field again.
4. **Required option still adds to cart** — Mark the upload option `required`, browse as a guest with the flag set to **No**, click Add to Cart on the product → the cart accepts the item (server has no required-option enforcement to block on).
5. **PHP lint** — passes on all three modified PHP files.
6. **Language parity** — `COM_J2COMMERCE_OPTION_UPLOAD_GUEST_DISABLED` present in all four admin ini files (verified by grep -c).

## Files Changed

- `components/com_j2commerce/layouts/productoption/upload_file.php` — gate (+10 lines)
- `components/com_j2commerce/layouts/productoption/upload_image.php` — gate (+10 lines)
- `administrator/components/com_j2commerce/tmpl/option/edit.php` — alert + JS toggle (+31 lines)
- `administrator/components/com_j2commerce/language/en-US/com_j2commerce.ini` — +1 line
- `administrator/components/com_j2commerce/language/en-GB/com_j2commerce.ini` — +1 line
- `administrator/language/en-US/com_j2commerce.ini` — +1 line (mirror)
- `administrator/language/en-GB/com_j2commerce.ini` — +1 line (mirror)