### PR TITLE
fix(checkout): render store logo when alt text is empty

### DIFF
--- a/components/com_j2commerce/tmpl/checkout/bootstrap5/default.php
+++ b/components/com_j2commerce/tmpl/checkout/bootstrap5/default.php
@@ -72,7 +72,7 @@ Text::script('COM_J2COMMERCE_CHECKOUT_ERROR_AGREE_TERMS');
                 }
                 $logoFile = $storeLogo->imagefile ?? '';
                 $logoAlt  = $storeLogo->alt_text ?? '';
-                if ($logoFile && $logoAlt !== '') :
+                if ($logoFile) :
             ?>
             <div class="text-center mb-3">
                 <img src="<?php echo Uri::root() . htmlspecialchars($logoFile, ENT_QUOTES, 'UTF-8'); ?>"

--- a/components/com_j2commerce/tmpl/checkout/uikit3/default.php
+++ b/components/com_j2commerce/tmpl/checkout/uikit3/default.php
@@ -69,7 +69,7 @@ Text::script('COM_J2COMMERCE_CHECKOUT_ERROR_AGREE_TERMS');
                 }
                 $logoFile = $storeLogo->imagefile ?? '';
                 $logoAlt  = $storeLogo->alt_text ?? '';
-                if ($logoFile && $logoAlt !== '') :
+                if ($logoFile) :
             ?>
             <div class="uk-text-center uk-margin-bottom">
                 <img src="<?php echo Uri::root() . htmlspecialchars($logoFile, ENT_QUOTES, 'UTF-8'); ?>"


### PR DESCRIPTION
## Summary
Fixes #1051

The store logo on checkout pages was hidden whenever the alt text was empty. Empty alt is valid HTML for decorative images (WCAG); logo presence must not depend on alt text.

## Changes
- Tighten render guard from `if ($logoFile && $logoAlt !== '')` to `if ($logoFile)` in both checkout templates.
- Decorative logos (empty alt) now render with `alt=""`.

## Testing
1. Admin → System → Config → J2Commerce → upload store logo, leave alt text empty, save.
2. Frontend → add product to cart → `/checkout`.
3. Verify logo renders at the top of the checkout column with `alt=""`.
4. Set alt text → save → reload `/checkout` → verify `alt` attribute is populated.
5. Repeat on UIkit3 frontend if dual-template active.

## Files Changed
- `components/com_j2commerce/tmpl/checkout/bootstrap5/default.php` — guard relaxed to `$logoFile` only
- `components/com_j2commerce/tmpl/checkout/uikit3/default.php` — guard relaxed to `$logoFile` only

## Pre-Flight
- [x] PHP syntax check passed (`php -l` clean on both files)
- [x] No secrets / FOF remnants (template-only change)
- [x] Core files only
- [x] No language strings affected