### PR TITLE
fix(security): harden files/com_j2commerce/.htaccess (#1064)

### DIFF
--- a/administrator/components/com_j2commerce/script.j2commerce.php
+++ b/administrator/components/com_j2commerce/script.j2commerce.php
@@ -522,17 +522,24 @@ class Com_J2commerceInstallerScript extends InstallerScript
         }
 
         $htaccess = <<<'HTACCESS'
-# J2Commerce file storage — never web-served directly.
-Require all denied
+# J2Commerce file storage
+# Disable directory browsing
+Options -Indexes
 
+# Block executable/script files
 <FilesMatch "\.(php|phtml|phar|pl|py|jsp|asp|aspx|sh|cgi|exe|bat)$">
-    Require all denied
-</FilesMatch>
+    <IfModule !mod_authz_core.c>
+        Order allow,deny
+        Deny from all
+    </IfModule>
 
-Options -ExecCGI -Indexes
+    <IfModule mod_authz_core.c>
+        Require all denied
+    </IfModule>
+</FilesMatch>
 HTACCESS;
 
-        $this->writeFileIfMissing($root . '/.htaccess', $htaccess);
+        $this->writeFileOverwrite($root . '/.htaccess', $htaccess);
 
         $readme = <<<'README'
 # J2Commerce Customer Upload Storage
@@ -586,6 +593,14 @@ README;
             return;
         }
 
+        if (@file_put_contents($path, $contents) === false) {
+            $this->debugLog("ENSURE FILES FOLDER: failed to write {$path}");
+        }
+    }
+
+    /** Write file, overwriting any existing copy. Logs and continues on failure. */
+    private function writeFileOverwrite(string $path, string $contents): void
+    {
         if (@file_put_contents($path, $contents) === false) {
             $this->debugLog("ENSURE FILES FOLDER: failed to write {$path}");
         }


### PR DESCRIPTION
## Summary
Fixes #1064

Replaces the blanket `Require all denied` directive in `files/com_j2commerce/.htaccess` (Apache 2.4-only, 500s on older servers, blocks Joomla media manager preview) with @brianteeman's recommended defence-in-depth pattern.

## Changes
- Heredoc in `script.j2commerce.php :: ensureFilesFolder()` now emits:
  - `Options -Indexes` (no directory browsing)
  - `FilesMatch` on dangerous extensions (php, phtml, phar, pl, py, jsp, asp, aspx, sh, cgi, exe, bat)
  - Dual `IfModule mod_authz_core.c` blocks so both Apache 2.2 (`Order/Deny`) and 2.4 (`Require all denied`) work
- Swapped `writeFileIfMissing` → new `writeFileOverwrite` helper for the `.htaccess` so existing installs receive the fix on next update
- Added `writeFileOverwrite()` helper next to `writeFileIfMissing()`

## Testing
1. Pull branch onto a Joomla 6 install with com_j2commerce already installed
2. Reinstall com_j2commerce package (or trigger postflight)
3. Verify `files/com_j2commerce/.htaccess` contents match the new pattern
4. `curl -I <site>/files/com_j2commerce/orders/1/test.php` → 403
5. Joomla admin → Media manager → browse `files/com_j2commerce` → images now visible
6. Simulate Apache without mod_authz_core → no 500

## Files Changed
- `administrator/components/com_j2commerce/script.j2commerce.php` — heredoc + overwrite helper