### PR TITLE
fix(product-options): align text/textarea wrappers with select/radio per file (fixes #1067)

### DIFF
--- a/components/com_j2commerce/layouts/app_bootstrap5/list/category/item_configurableoptions.php
+++ b/components/com_j2commerce/layouts/app_bootstrap5/list/category/item_configurableoptions.php
@@ -177,10 +177,12 @@ $optionsSummary = $productHelper::getOptionsSummary($options);
             <?php $text_option_params = $platform->getRegistry($option['option_params'] ?? '{}'); ?>
             <?php $textInputId = 'product-option-text-' . $productId . '-' . $optionId; ?>
             <div id="option-<?php echo $optionId; ?>" class="option mb-3">
-                <?php if ($option['required']) : ?>
-                    <span class="text-danger">*</span>
-                <?php endif; ?>
-                <label class="form-label" for="<?php echo $textInputId; ?>"><?php echo $esc(Text::_($option['option_name'])); ?>:</label>
+                <label class="form-label fw-semibold pb-1 mb-1" for="<?php echo $textInputId; ?>">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>
+                    <?php if ($option['required']) : ?>
+                        <span class="text-danger">*</span>
+                    <?php endif; ?>
+                </label>
                 <input id="<?php echo $textInputId; ?>" type="text" class="form-control"
                        name="product_option[<?php echo $optionId; ?>]"
                        value="<?php echo $esc($option['optionvalue'] ?? ''); ?>"
@@ -191,10 +193,12 @@ $optionsSummary = $productHelper::getOptionsSummary($options);
         <?php if ($option['type'] === 'textarea') : ?>
             <?php $textareaInputId = 'product-option-textarea-' . $productId . '-' . $optionId; ?>
             <div id="option-<?php echo $optionId; ?>" class="option mb-3">
-                <?php if ($option['required']) : ?>
-                    <span class="text-danger">*</span>
-                <?php endif; ?>
-                <label class="form-label" for="<?php echo $textareaInputId; ?>"><?php echo $esc(Text::_($option['option_name'])); ?>:</label>
+                <label class="form-label fw-semibold pb-1 mb-1" for="<?php echo $textareaInputId; ?>">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>
+                    <?php if ($option['required']) : ?>
+                        <span class="text-danger">*</span>
+                    <?php endif; ?>
+                </label>
                 <textarea id="<?php echo $textareaInputId; ?>" class="form-control"
                           name="product_option[<?php echo $optionId; ?>]"
                           cols="20" rows="5"><?php echo $esc($option['optionvalue'] ?? ''); ?></textarea>

--- a/components/com_j2commerce/layouts/app_bootstrap5/list/category/item_options.php
+++ b/components/com_j2commerce/layouts/app_bootstrap5/list/category/item_options.php
@@ -178,10 +178,12 @@ $optionsSummary = $productHelper::getOptionsSummary($options);
             <?php $text_option_params = $platform->getRegistry($option['option_params'] ?? '{}'); ?>
             <?php $textInputId = 'product-option-text-' . $productId . '-' . $optionId; ?>
             <div id="option-<?php echo $optionId; ?>" class="option mb-3">
-                <?php if ($option['required']) : ?>
-                    <span class="text-danger">*</span>
-                <?php endif; ?>
-                <label class="form-label" for="<?php echo $textInputId; ?>"><?php echo $esc(Text::_($option['option_name'])); ?>:</label>
+                <label class="form-label fw-semibold pb-1 mb-1" for="<?php echo $textInputId; ?>">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>
+                    <?php if ($option['required']) : ?>
+                        <span class="text-danger">*</span>
+                    <?php endif; ?>
+                </label>
                 <input id="<?php echo $textInputId; ?>" type="text" class="form-control"
                        name="product_option[<?php echo $optionId; ?>]"
                        value="<?php echo $esc($option['optionvalue'] ?? ''); ?>"
@@ -192,10 +194,12 @@ $optionsSummary = $productHelper::getOptionsSummary($options);
         <?php if ($option['type'] === 'textarea') : ?>
             <?php $textareaInputId = 'product-option-textarea-' . $productId . '-' . $optionId; ?>
             <div id="option-<?php echo $optionId; ?>" class="option mb-3">
-                <?php if ($option['required']) : ?>
-                    <span class="text-danger">*</span>
-                <?php endif; ?>
-                <label class="form-label" for="<?php echo $textareaInputId; ?>"><?php echo $esc(Text::_($option['option_name'])); ?>:</label>
+                <label class="form-label fw-semibold pb-1 mb-1" for="<?php echo $textareaInputId; ?>">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>
+                    <?php if ($option['required']) : ?>
+                        <span class="text-danger">*</span>
+                    <?php endif; ?>
+                </label>
                 <textarea id="<?php echo $textareaInputId; ?>" class="form-control"
                     name="product_option[<?php echo $optionId; ?>]"
                     cols="20" rows="5"><?php echo $esc($option['optionvalue'] ?? ''); ?></textarea>

--- a/components/com_j2commerce/layouts/app_bootstrap5/list/tag/item_options.php
+++ b/components/com_j2commerce/layouts/app_bootstrap5/list/tag/item_options.php
@@ -178,10 +178,12 @@ $optionsSummary = $productHelper::getOptionsSummary($options);
             <?php $text_option_params = $platform->getRegistry($option['option_params'] ?? '{}'); ?>
             <?php $textInputId = 'product-option-text-' . $productId . '-' . $optionId; ?>
             <div id="option-<?php echo $optionId; ?>" class="option mb-3">
-                <?php if ($option['required']) : ?>
-                    <span class="text-danger">*</span>
-                <?php endif; ?>
-                <label class="form-label" for="<?php echo $textInputId; ?>"><?php echo $esc(Text::_($option['option_name'])); ?>:</label>
+                <label class="form-label fw-semibold pb-1 mb-1" for="<?php echo $textInputId; ?>">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>
+                    <?php if ($option['required']) : ?>
+                        <span class="text-danger">*</span>
+                    <?php endif; ?>
+                </label>
                 <input id="<?php echo $textInputId; ?>" type="text" class="form-control"
                        name="product_option[<?php echo $optionId; ?>]"
                        value="<?php echo $esc($option['optionvalue'] ?? ''); ?>"
@@ -192,10 +194,12 @@ $optionsSummary = $productHelper::getOptionsSummary($options);
         <?php if ($option['type'] === 'textarea') : ?>
             <?php $textareaInputId = 'product-option-textarea-' . $productId . '-' . $optionId; ?>
             <div id="option-<?php echo $optionId; ?>" class="option mb-3">
-                <?php if ($option['required']) : ?>
-                    <span class="text-danger">*</span>
-                <?php endif; ?>
-                <label class="form-label" for="<?php echo $textareaInputId; ?>"><?php echo $esc(Text::_($option['option_name'])); ?>:</label>
+                <label class="form-label fw-semibold pb-1 mb-1" for="<?php echo $textareaInputId; ?>">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>
+                    <?php if ($option['required']) : ?>
+                        <span class="text-danger">*</span>
+                    <?php endif; ?>
+                </label>
                 <textarea id="<?php echo $textareaInputId; ?>" class="form-control"
                           name="product_option[<?php echo $optionId; ?>]"
                           cols="20" rows="5"><?php echo $esc($option['optionvalue'] ?? ''); ?></textarea>

--- a/components/com_j2commerce/layouts/app_bootstrap5/product/configurablechildoptions.php
+++ b/components/com_j2commerce/layouts/app_bootstrap5/product/configurablechildoptions.php
@@ -143,10 +143,12 @@ $product_id = (int) $product->j2commerce_product_id;
             <?php $text_option_params = $platform->getRegistry($option['option_params'] ?? '{}'); ?>
             <?php $textInputId = 'child-product-option-text-' . $product_id . '-' . $optionId; ?>
             <div id="child-option-<?php echo $optionId; ?>" class="option mb-3">
-                <?php if ($option['required']) : ?>
-                <span class="required">*</span>
-                <?php endif; ?>
-                <label class="form-label" for="<?php echo $textInputId; ?>"><?php echo htmlspecialchars(Text::_($option['option_name']), ENT_QUOTES, 'UTF-8'); ?>:</label>
+                <label class="form-label fw-semibold pb-1 mb-1" for="<?php echo $textInputId; ?>">
+                    <?php echo htmlspecialchars(Text::_($option['option_name']), ENT_QUOTES, 'UTF-8'); ?>
+                    <?php if ($option['required']) : ?>
+                        <span class="text-danger">*</span>
+                    <?php endif; ?>
+                </label>
                 <input id="<?php echo $textInputId; ?>" type="text" class="form-control"
                     name="product_option[<?php echo $optionId; ?>]"
                     value="<?php echo htmlspecialchars($option['optionvalue'] ?? '', ENT_QUOTES, 'UTF-8'); ?>"
@@ -157,10 +159,12 @@ $product_id = (int) $product->j2commerce_product_id;
         <?php if ($option['type'] === 'textarea') : ?>
             <?php $textareaInputId = 'child-product-option-textarea-' . $product_id . '-' . $optionId; ?>
             <div id="child-option-<?php echo $optionId; ?>" class="option mb-3">
-                <?php if ($option['required']) : ?>
-                <span class="required">*</span>
-                <?php endif; ?>
-                <label class="form-label" for="<?php echo $textareaInputId; ?>"><?php echo htmlspecialchars(Text::_($option['option_name']), ENT_QUOTES, 'UTF-8'); ?>:</label>
+                <label class="form-label fw-semibold pb-1 mb-1" for="<?php echo $textareaInputId; ?>">
+                    <?php echo htmlspecialchars(Text::_($option['option_name']), ENT_QUOTES, 'UTF-8'); ?>
+                    <?php if ($option['required']) : ?>
+                        <span class="text-danger">*</span>
+                    <?php endif; ?>
+                </label>
                 <textarea id="<?php echo $textareaInputId; ?>" class="form-control"
                     name="product_option[<?php echo $optionId; ?>]"
                     cols="20" rows="5"><?php echo htmlspecialchars($option['optionvalue'] ?? '', ENT_QUOTES, 'UTF-8'); ?></textarea>

--- a/components/com_j2commerce/layouts/app_uikit/list/category/item_configurableoptions.php
+++ b/components/com_j2commerce/layouts/app_uikit/list/category/item_configurableoptions.php
@@ -168,10 +168,12 @@ $optionsSummary = $productHelper::getOptionsSummary($options);
             <?php $text_option_params = $platform->getRegistry($option['option_params'] ?? '{}'); ?>
             <?php $textInputId = 'product-option-text-' . (int) $productId . '-' . $optionId; ?>
             <div id="option-<?php echo $optionId; ?>" class="option uk-margin-small-bottom">
-                <?php if ($option['required']) : ?>
-                    <span class="uk-text-danger">*</span>
-                <?php endif; ?>
-                <label class="uk-form-label" for="<?php echo $textInputId; ?>"><?php echo $esc(Text::_($option['option_name'])); ?>:</label>
+                <label class="uk-form-label" for="<?php echo $textInputId; ?>">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>
+                    <?php if ($option['required']) : ?>
+                        <span class="uk-text-danger">*</span>
+                    <?php endif; ?>
+                </label>
                 <input id="<?php echo $textInputId; ?>" type="text" class="uk-input"
                        name="product_option[<?php echo $optionId; ?>]"
                        value="<?php echo $esc($option['optionvalue'] ?? ''); ?>"
@@ -182,10 +184,12 @@ $optionsSummary = $productHelper::getOptionsSummary($options);
         <?php if ($option['type'] === 'textarea') : ?>
             <?php $textareaInputId = 'product-option-textarea-' . (int) $productId . '-' . $optionId; ?>
             <div id="option-<?php echo $optionId; ?>" class="option uk-margin-small-bottom">
-                <?php if ($option['required']) : ?>
-                    <span class="uk-text-danger">*</span>
-                <?php endif; ?>
-                <label class="uk-form-label" for="<?php echo $textareaInputId; ?>"><?php echo $esc(Text::_($option['option_name'])); ?>:</label>
+                <label class="uk-form-label" for="<?php echo $textareaInputId; ?>">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>
+                    <?php if ($option['required']) : ?>
+                        <span class="uk-text-danger">*</span>
+                    <?php endif; ?>
+                </label>
                 <textarea id="<?php echo $textareaInputId; ?>" class="uk-textarea"
                           name="product_option[<?php echo $optionId; ?>]"
                           cols="20" rows="5"><?php echo $esc($option['optionvalue'] ?? ''); ?></textarea>

--- a/components/com_j2commerce/layouts/app_uikit/list/category/item_options.php
+++ b/components/com_j2commerce/layouts/app_uikit/list/category/item_options.php
@@ -168,10 +168,12 @@ $optionsSummary = $productHelper::getOptionsSummary($options);
             <?php $text_option_params = $platform->getRegistry($option['option_params'] ?? '{}'); ?>
             <?php $textInputId = 'product-option-text-' . (int) $productId . '-' . $optionId; ?>
             <div id="option-<?php echo $optionId; ?>" class="option uk-margin-small-bottom">
-                <?php if ($option['required']) : ?>
-                    <span class="uk-text-danger">*</span>
-                <?php endif; ?>
-                <label class="uk-form-label" for="<?php echo $textInputId; ?>"><?php echo $esc(Text::_($option['option_name'])); ?>:</label>
+                <label class="uk-form-label" for="<?php echo $textInputId; ?>">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>
+                    <?php if ($option['required']) : ?>
+                        <span class="uk-text-danger">*</span>
+                    <?php endif; ?>
+                </label>
                 <input id="<?php echo $textInputId; ?>" type="text" class="uk-input"
                        name="product_option[<?php echo $optionId; ?>]"
                        value="<?php echo $esc($option['optionvalue'] ?? ''); ?>"
@@ -182,10 +184,12 @@ $optionsSummary = $productHelper::getOptionsSummary($options);
         <?php if ($option['type'] === 'textarea') : ?>
             <?php $textareaInputId = 'product-option-textarea-' . (int) $productId . '-' . $optionId; ?>
             <div id="option-<?php echo $optionId; ?>" class="option uk-margin-small-bottom">
-                <?php if ($option['required']) : ?>
-                    <span class="uk-text-danger">*</span>
-                <?php endif; ?>
-                <label class="uk-form-label" for="<?php echo $textareaInputId; ?>"><?php echo $esc(Text::_($option['option_name'])); ?>:</label>
+                <label class="uk-form-label" for="<?php echo $textareaInputId; ?>">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>
+                    <?php if ($option['required']) : ?>
+                        <span class="uk-text-danger">*</span>
+                    <?php endif; ?>
+                </label>
                 <textarea id="<?php echo $textareaInputId; ?>" class="uk-textarea"
                           name="product_option[<?php echo $optionId; ?>]"
                           cols="20" rows="5"><?php echo $esc($option['optionvalue'] ?? ''); ?></textarea>

--- a/components/com_j2commerce/layouts/app_uikit/list/tag/item_options.php
+++ b/components/com_j2commerce/layouts/app_uikit/list/tag/item_options.php
@@ -168,10 +168,12 @@ $optionsSummary = $productHelper::getOptionsSummary($options);
             <?php $text_option_params = $platform->getRegistry($option['option_params'] ?? '{}'); ?>
             <?php $textInputId = 'product-option-text-' . (int) $productId . '-' . $optionId; ?>
             <div id="option-<?php echo $optionId; ?>" class="option uk-margin-small-bottom">
-                <?php if ($option['required']) : ?>
-                    <span class="uk-text-danger">*</span>
-                <?php endif; ?>
-                <label class="uk-form-label" for="<?php echo $textInputId; ?>"><?php echo $esc(Text::_($option['option_name'])); ?>:</label>
+                <label class="uk-form-label" for="<?php echo $textInputId; ?>">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>
+                    <?php if ($option['required']) : ?>
+                        <span class="uk-text-danger">*</span>
+                    <?php endif; ?>
+                </label>
                 <input id="<?php echo $textInputId; ?>" type="text" class="uk-input"
                        name="product_option[<?php echo $optionId; ?>]"
                        value="<?php echo $esc($option['optionvalue'] ?? ''); ?>"
@@ -182,10 +184,12 @@ $optionsSummary = $productHelper::getOptionsSummary($options);
         <?php if ($option['type'] === 'textarea') : ?>
             <?php $textareaInputId = 'product-option-textarea-' . (int) $productId . '-' . $optionId; ?>
             <div id="option-<?php echo $optionId; ?>" class="option uk-margin-small-bottom">
-                <?php if ($option['required']) : ?>
-                    <span class="uk-text-danger">*</span>
-                <?php endif; ?>
-                <label class="uk-form-label" for="<?php echo $textareaInputId; ?>"><?php echo $esc(Text::_($option['option_name'])); ?>:</label>
+                <label class="uk-form-label" for="<?php echo $textareaInputId; ?>">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>
+                    <?php if ($option['required']) : ?>
+                        <span class="uk-text-danger">*</span>
+                    <?php endif; ?>
+                </label>
                 <textarea id="<?php echo $textareaInputId; ?>" class="uk-textarea"
                           name="product_option[<?php echo $optionId; ?>]"
                           cols="20" rows="5"><?php echo $esc($option['optionvalue'] ?? ''); ?></textarea>

--- a/components/com_j2commerce/layouts/app_uikit/product/configurablechildoptions.php
+++ b/components/com_j2commerce/layouts/app_uikit/product/configurablechildoptions.php
@@ -147,10 +147,12 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
             <?php $text_option_params = $platform->getRegistry($option['option_params'] ?? '{}'); ?>
             <?php $textInputId = 'child-product-option-text-' . (int) $product_id . '-' . $optionId; ?>
             <div id="child-option-<?php echo $optionId; ?>" class="option uk-margin-small-bottom">
-                <?php if ($option['required']) : ?>
-                <span class="required">*</span>
-                <?php endif; ?>
-                <label class="uk-form-label" for="<?php echo $textInputId; ?>"><?php echo $esc(Text::_($option['option_name'])); ?>:</label>
+                <label class="uk-form-label" for="<?php echo $textInputId; ?>">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>
+                    <?php if ($option['required']) : ?>
+                        <span class="uk-text-danger">*</span>
+                    <?php endif; ?>
+                </label>
                 <input id="<?php echo $textInputId; ?>" type="text" class="uk-input"
                     name="product_option[<?php echo $optionId; ?>]"
                     value="<?php echo $esc($option['optionvalue'] ?? ''); ?>"
@@ -161,10 +163,12 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
         <?php if ($option['type'] === 'textarea') : ?>
             <?php $textareaInputId = 'child-product-option-textarea-' . (int) $product_id . '-' . $optionId; ?>
             <div id="child-option-<?php echo $optionId; ?>" class="option uk-margin-small-bottom">
-                <?php if ($option['required']) : ?>
-                <span class="required">*</span>
-                <?php endif; ?>
-                <label class="uk-form-label" for="<?php echo $textareaInputId; ?>"><?php echo $esc(Text::_($option['option_name'])); ?>:</label>
+                <label class="uk-form-label" for="<?php echo $textareaInputId; ?>">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>
+                    <?php if ($option['required']) : ?>
+                        <span class="uk-text-danger">*</span>
+                    <?php endif; ?>
+                </label>
                 <textarea id="<?php echo $textareaInputId; ?>" class="uk-textarea"
                     name="product_option[<?php echo $optionId; ?>]"
                     cols="20" rows="5"><?php echo $esc($option['optionvalue'] ?? ''); ?></textarea>

--- a/plugins/j2commerce/app_bootstrap5/layouts/list/category/item_configurableoptions.php
+++ b/plugins/j2commerce/app_bootstrap5/layouts/list/category/item_configurableoptions.php
@@ -177,10 +177,12 @@ $optionsSummary = $productHelper::getOptionsSummary($options);
             <?php $text_option_params = $platform->getRegistry($option['option_params'] ?? '{}'); ?>
             <?php $textInputId = 'product-option-text-' . $productId . '-' . $optionId; ?>
             <div id="option-<?php echo $optionId; ?>" class="option mb-3">
-                <?php if ($option['required']) : ?>
-                    <span class="text-danger">*</span>
-                <?php endif; ?>
-                <label class="form-label" for="<?php echo $textInputId; ?>"><?php echo $esc(Text::_($option['option_name'])); ?>:</label>
+                <label class="form-label fw-semibold pb-1 mb-1" for="<?php echo $textInputId; ?>">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>
+                    <?php if ($option['required']) : ?>
+                        <span class="text-danger">*</span>
+                    <?php endif; ?>
+                </label>
                 <input id="<?php echo $textInputId; ?>" type="text" class="form-control"
                        name="product_option[<?php echo $optionId; ?>]"
                        value="<?php echo $esc($option['optionvalue'] ?? ''); ?>"
@@ -191,10 +193,12 @@ $optionsSummary = $productHelper::getOptionsSummary($options);
         <?php if ($option['type'] === 'textarea') : ?>
             <?php $textareaInputId = 'product-option-textarea-' . $productId . '-' . $optionId; ?>
             <div id="option-<?php echo $optionId; ?>" class="option mb-3">
-                <?php if ($option['required']) : ?>
-                    <span class="text-danger">*</span>
-                <?php endif; ?>
-                <label class="form-label" for="<?php echo $textareaInputId; ?>"><?php echo $esc(Text::_($option['option_name'])); ?>:</label>
+                <label class="form-label fw-semibold pb-1 mb-1" for="<?php echo $textareaInputId; ?>">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>
+                    <?php if ($option['required']) : ?>
+                        <span class="text-danger">*</span>
+                    <?php endif; ?>
+                </label>
                 <textarea id="<?php echo $textareaInputId; ?>" class="form-control"
                           name="product_option[<?php echo $optionId; ?>]"
                           cols="20" rows="5"><?php echo $esc($option['optionvalue'] ?? ''); ?></textarea>

--- a/plugins/j2commerce/app_bootstrap5/layouts/list/category/item_options.php
+++ b/plugins/j2commerce/app_bootstrap5/layouts/list/category/item_options.php
@@ -178,10 +178,12 @@ $optionsSummary = $productHelper::getOptionsSummary($options);
             <?php $text_option_params = $platform->getRegistry($option['option_params'] ?? '{}'); ?>
             <?php $textInputId = 'product-option-text-' . $productId . '-' . $optionId; ?>
             <div id="option-<?php echo $optionId; ?>" class="option mb-3">
-                <?php if ($option['required']) : ?>
-                    <span class="text-danger">*</span>
-                <?php endif; ?>
-                <label class="form-label" for="<?php echo $textInputId; ?>"><?php echo $esc(Text::_($option['option_name'])); ?>:</label>
+                <label class="form-label fw-semibold pb-1 mb-1" for="<?php echo $textInputId; ?>">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>
+                    <?php if ($option['required']) : ?>
+                        <span class="text-danger">*</span>
+                    <?php endif; ?>
+                </label>
                 <input id="<?php echo $textInputId; ?>" type="text" class="form-control"
                        name="product_option[<?php echo $optionId; ?>]"
                        value="<?php echo $esc($option['optionvalue'] ?? ''); ?>"
@@ -192,10 +194,12 @@ $optionsSummary = $productHelper::getOptionsSummary($options);
         <?php if ($option['type'] === 'textarea') : ?>
             <?php $textareaInputId = 'product-option-textarea-' . $productId . '-' . $optionId; ?>
             <div id="option-<?php echo $optionId; ?>" class="option mb-3">
-                <?php if ($option['required']) : ?>
-                    <span class="text-danger">*</span>
-                <?php endif; ?>
-                <label class="form-label" for="<?php echo $textareaInputId; ?>"><?php echo $esc(Text::_($option['option_name'])); ?>:</label>
+                <label class="form-label fw-semibold pb-1 mb-1" for="<?php echo $textareaInputId; ?>">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>
+                    <?php if ($option['required']) : ?>
+                        <span class="text-danger">*</span>
+                    <?php endif; ?>
+                </label>
                 <textarea id="<?php echo $textareaInputId; ?>" class="form-control"
                     name="product_option[<?php echo $optionId; ?>]"
                     cols="20" rows="5"><?php echo $esc($option['optionvalue'] ?? ''); ?></textarea>

--- a/plugins/j2commerce/app_bootstrap5/layouts/list/tag/item_options.php
+++ b/plugins/j2commerce/app_bootstrap5/layouts/list/tag/item_options.php
@@ -178,10 +178,12 @@ $optionsSummary = $productHelper::getOptionsSummary($options);
             <?php $text_option_params = $platform->getRegistry($option['option_params'] ?? '{}'); ?>
             <?php $textInputId = 'product-option-text-' . $productId . '-' . $optionId; ?>
             <div id="option-<?php echo $optionId; ?>" class="option mb-3">
-                <?php if ($option['required']) : ?>
-                    <span class="text-danger">*</span>
-                <?php endif; ?>
-                <label class="form-label" for="<?php echo $textInputId; ?>"><?php echo $esc(Text::_($option['option_name'])); ?>:</label>
+                <label class="form-label fw-semibold pb-1 mb-1" for="<?php echo $textInputId; ?>">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>
+                    <?php if ($option['required']) : ?>
+                        <span class="text-danger">*</span>
+                    <?php endif; ?>
+                </label>
                 <input id="<?php echo $textInputId; ?>" type="text" class="form-control"
                        name="product_option[<?php echo $optionId; ?>]"
                        value="<?php echo $esc($option['optionvalue'] ?? ''); ?>"
@@ -192,10 +194,12 @@ $optionsSummary = $productHelper::getOptionsSummary($options);
         <?php if ($option['type'] === 'textarea') : ?>
             <?php $textareaInputId = 'product-option-textarea-' . $productId . '-' . $optionId; ?>
             <div id="option-<?php echo $optionId; ?>" class="option mb-3">
-                <?php if ($option['required']) : ?>
-                    <span class="text-danger">*</span>
-                <?php endif; ?>
-                <label class="form-label" for="<?php echo $textareaInputId; ?>"><?php echo $esc(Text::_($option['option_name'])); ?>:</label>
+                <label class="form-label fw-semibold pb-1 mb-1" for="<?php echo $textareaInputId; ?>">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>
+                    <?php if ($option['required']) : ?>
+                        <span class="text-danger">*</span>
+                    <?php endif; ?>
+                </label>
                 <textarea id="<?php echo $textareaInputId; ?>" class="form-control"
                           name="product_option[<?php echo $optionId; ?>]"
                           cols="20" rows="5"><?php echo $esc($option['optionvalue'] ?? ''); ?></textarea>

--- a/plugins/j2commerce/app_bootstrap5/layouts/product/configurablechildoptions.php
+++ b/plugins/j2commerce/app_bootstrap5/layouts/product/configurablechildoptions.php
@@ -143,10 +143,12 @@ $product_id = (int) $product->j2commerce_product_id;
             <?php $text_option_params = $platform->getRegistry($option['option_params'] ?? '{}'); ?>
             <?php $textInputId = 'child-product-option-text-' . $product_id . '-' . $optionId; ?>
             <div id="child-option-<?php echo $optionId; ?>" class="option mb-3">
-                <?php if ($option['required']) : ?>
-                <span class="required">*</span>
-                <?php endif; ?>
-                <label class="form-label" for="<?php echo $textInputId; ?>"><?php echo htmlspecialchars(Text::_($option['option_name']), ENT_QUOTES, 'UTF-8'); ?>:</label>
+                <label class="form-label fw-semibold pb-1 mb-1" for="<?php echo $textInputId; ?>">
+                    <?php echo htmlspecialchars(Text::_($option['option_name']), ENT_QUOTES, 'UTF-8'); ?>
+                    <?php if ($option['required']) : ?>
+                        <span class="text-danger">*</span>
+                    <?php endif; ?>
+                </label>
                 <input id="<?php echo $textInputId; ?>" type="text" class="form-control"
                     name="product_option[<?php echo $optionId; ?>]"
                     value="<?php echo htmlspecialchars($option['optionvalue'] ?? '', ENT_QUOTES, 'UTF-8'); ?>"
@@ -157,10 +159,12 @@ $product_id = (int) $product->j2commerce_product_id;
         <?php if ($option['type'] === 'textarea') : ?>
             <?php $textareaInputId = 'child-product-option-textarea-' . $product_id . '-' . $optionId; ?>
             <div id="child-option-<?php echo $optionId; ?>" class="option mb-3">
-                <?php if ($option['required']) : ?>
-                <span class="required">*</span>
-                <?php endif; ?>
-                <label class="form-label" for="<?php echo $textareaInputId; ?>"><?php echo htmlspecialchars(Text::_($option['option_name']), ENT_QUOTES, 'UTF-8'); ?>:</label>
+                <label class="form-label fw-semibold pb-1 mb-1" for="<?php echo $textareaInputId; ?>">
+                    <?php echo htmlspecialchars(Text::_($option['option_name']), ENT_QUOTES, 'UTF-8'); ?>
+                    <?php if ($option['required']) : ?>
+                        <span class="text-danger">*</span>
+                    <?php endif; ?>
+                </label>
                 <textarea id="<?php echo $textareaInputId; ?>" class="form-control"
                     name="product_option[<?php echo $optionId; ?>]"
                     cols="20" rows="5"><?php echo htmlspecialchars($option['optionvalue'] ?? '', ENT_QUOTES, 'UTF-8'); ?></textarea>

--- a/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/view_configurableoptions.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/view_configurableoptions.php
@@ -159,39 +159,44 @@ $uploadAjax  = Route::_('index.php?option=com_j2commerce&view=carts&task=carts.u
                         )
                     <?php endif; ?>
                 </label>
-                <br>
+
             <?php endforeach; ?>
         </div>
-        <br>
+
         <?php endif; ?>
 
         <?php if ($option['type'] == 'text') : ?>
             <?php $text_option_params = $platform->getRegistry($option['option_params']); ?>
+            <?php $textInputId = 'product-option-text-' . $productId . '-' . $optionId; ?>
             <!-- text -->
-            <div id="option-<?php echo $optionId; ?>" class="option">
-                <?php if ($option['required']) : ?>
-                <span class="required">*</span>
-                <?php endif; ?>
-                <b><?php echo $esc(Text::_($option['option_name'])); ?>:</b><br>
-                <input type="text"
+            <div id="option-<?php echo $optionId; ?>" class="option mb-3">
+                <label class="form-label fw-semibold pb-1 mb-2" for="<?php echo $textInputId; ?>">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>
+                    <?php if ($option['required']) : ?>
+                        <span class="text-danger">*</span>
+                    <?php endif; ?>
+                </label>
+                <input id="<?php echo $textInputId; ?>" type="text" class="form-control"
                     name="product_option[<?php echo $optionId; ?>]"
                     value="<?php echo $esc($option['optionvalue'] ?? ''); ?>"
                     placeholder="<?php echo $esc($text_option_params->get('place_holder', '')); ?>" />
             </div>
-            <br>
         <?php endif; ?>
 
         <?php if ($option['type'] == 'textarea') : ?>
+            <?php $textareaInputId = 'product-option-textarea-' . $productId . '-' . $optionId; ?>
             <!-- textarea -->
-            <div id="option-<?php echo $optionId; ?>" class="option">
-                <?php if ($option['required']) : ?>
-                <span class="required">*</span>
-                <?php endif; ?>
-                <b><?php echo $esc(Text::_($option['option_name'])); ?>:</b><br>
-                <textarea name="product_option[<?php echo $optionId; ?>]"
+            <div id="option-<?php echo $optionId; ?>" class="option mb-3">
+                <label class="form-label fw-semibold pb-1 mb-2" for="<?php echo $textareaInputId; ?>">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>
+                    <?php if ($option['required']) : ?>
+                        <span class="text-danger">*</span>
+                    <?php endif; ?>
+                </label>
+                <textarea id="<?php echo $textareaInputId; ?>" class="form-control"
+                    name="product_option[<?php echo $optionId; ?>]"
                     cols="20" rows="5"><?php echo $esc($option['optionvalue'] ?? ''); ?></textarea>
             </div>
-            <br>
         <?php endif; ?>
 
         <?php if ($option['type'] == 'file') : ?>

--- a/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/view_configurableoptions.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/view_configurableoptions.php
@@ -167,31 +167,36 @@ $uploadAjax  = Route::_('index.php?option=com_j2commerce&view=carts&task=carts.u
 
         <?php if ($option['type'] == 'text') : ?>
             <?php $text_option_params = $platform->getRegistry($option['option_params']); ?>
+            <?php $textInputId = 'product-option-text-' . $productId . '-' . $optionId; ?>
             <!-- text -->
-            <div id="option-<?php echo $optionId; ?>" class="option">
-                <?php if ($option['required']) : ?>
-                <span class="required">*</span>
-                <?php endif; ?>
-                <b><?php echo $esc(Text::_($option['option_name'])); ?>:</b><br>
-                <input type="text"
+            <div id="option-<?php echo $optionId; ?>" class="option mb-3">
+                <label class="form-label fw-semibold pb-1 mb-2" for="<?php echo $textInputId; ?>">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>
+                    <?php if ($option['required']) : ?>
+                        <span class="text-danger">*</span>
+                    <?php endif; ?>
+                </label>
+                <input id="<?php echo $textInputId; ?>" type="text" class="form-control"
                     name="product_option[<?php echo $optionId; ?>]"
                     value="<?php echo $esc($option['optionvalue'] ?? ''); ?>"
                     placeholder="<?php echo $esc($text_option_params->get('place_holder', '')); ?>" />
             </div>
-            <br>
         <?php endif; ?>
 
         <?php if ($option['type'] == 'textarea') : ?>
+            <?php $textareaInputId = 'product-option-textarea-' . $productId . '-' . $optionId; ?>
             <!-- textarea -->
-            <div id="option-<?php echo $optionId; ?>" class="option">
-                <?php if ($option['required']) : ?>
-                <span class="required">*</span>
-                <?php endif; ?>
-                <b><?php echo $esc(Text::_($option['option_name'])); ?>:</b><br>
-                <textarea name="product_option[<?php echo $optionId; ?>]"
+            <div id="option-<?php echo $optionId; ?>" class="option mb-3">
+                <label class="form-label fw-semibold pb-1 mb-2" for="<?php echo $textareaInputId; ?>">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>
+                    <?php if ($option['required']) : ?>
+                        <span class="text-danger">*</span>
+                    <?php endif; ?>
+                </label>
+                <textarea id="<?php echo $textareaInputId; ?>" class="form-control"
+                    name="product_option[<?php echo $optionId; ?>]"
                     cols="20" rows="5"><?php echo $esc($option['optionvalue'] ?? ''); ?></textarea>
             </div>
-            <br>
         <?php endif; ?>
 
         <?php if ($option['type'] == 'file') : ?>

--- a/plugins/j2commerce/app_uikit/layouts/list/category/item_configurableoptions.php
+++ b/plugins/j2commerce/app_uikit/layouts/list/category/item_configurableoptions.php
@@ -168,10 +168,12 @@ $optionsSummary = $productHelper::getOptionsSummary($options);
             <?php $text_option_params = $platform->getRegistry($option['option_params'] ?? '{}'); ?>
             <?php $textInputId = 'product-option-text-' . (int) $productId . '-' . $optionId; ?>
             <div id="option-<?php echo $optionId; ?>" class="option uk-margin-small-bottom">
-                <?php if ($option['required']) : ?>
-                    <span class="uk-text-danger">*</span>
-                <?php endif; ?>
-                <label class="uk-form-label" for="<?php echo $textInputId; ?>"><?php echo $esc(Text::_($option['option_name'])); ?>:</label>
+                <label class="uk-form-label" for="<?php echo $textInputId; ?>">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>
+                    <?php if ($option['required']) : ?>
+                        <span class="uk-text-danger">*</span>
+                    <?php endif; ?>
+                </label>
                 <input id="<?php echo $textInputId; ?>" type="text" class="uk-input"
                        name="product_option[<?php echo $optionId; ?>]"
                        value="<?php echo $esc($option['optionvalue'] ?? ''); ?>"
@@ -182,10 +184,12 @@ $optionsSummary = $productHelper::getOptionsSummary($options);
         <?php if ($option['type'] === 'textarea') : ?>
             <?php $textareaInputId = 'product-option-textarea-' . (int) $productId . '-' . $optionId; ?>
             <div id="option-<?php echo $optionId; ?>" class="option uk-margin-small-bottom">
-                <?php if ($option['required']) : ?>
-                    <span class="uk-text-danger">*</span>
-                <?php endif; ?>
-                <label class="uk-form-label" for="<?php echo $textareaInputId; ?>"><?php echo $esc(Text::_($option['option_name'])); ?>:</label>
+                <label class="uk-form-label" for="<?php echo $textareaInputId; ?>">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>
+                    <?php if ($option['required']) : ?>
+                        <span class="uk-text-danger">*</span>
+                    <?php endif; ?>
+                </label>
                 <textarea id="<?php echo $textareaInputId; ?>" class="uk-textarea"
                           name="product_option[<?php echo $optionId; ?>]"
                           cols="20" rows="5"><?php echo $esc($option['optionvalue'] ?? ''); ?></textarea>

--- a/plugins/j2commerce/app_uikit/layouts/list/category/item_options.php
+++ b/plugins/j2commerce/app_uikit/layouts/list/category/item_options.php
@@ -168,10 +168,12 @@ $optionsSummary = $productHelper::getOptionsSummary($options);
             <?php $text_option_params = $platform->getRegistry($option['option_params'] ?? '{}'); ?>
             <?php $textInputId = 'product-option-text-' . (int) $productId . '-' . $optionId; ?>
             <div id="option-<?php echo $optionId; ?>" class="option uk-margin-small-bottom">
-                <?php if ($option['required']) : ?>
-                    <span class="uk-text-danger">*</span>
-                <?php endif; ?>
-                <label class="uk-form-label" for="<?php echo $textInputId; ?>"><?php echo $esc(Text::_($option['option_name'])); ?>:</label>
+                <label class="uk-form-label" for="<?php echo $textInputId; ?>">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>
+                    <?php if ($option['required']) : ?>
+                        <span class="uk-text-danger">*</span>
+                    <?php endif; ?>
+                </label>
                 <input id="<?php echo $textInputId; ?>" type="text" class="uk-input"
                        name="product_option[<?php echo $optionId; ?>]"
                        value="<?php echo $esc($option['optionvalue'] ?? ''); ?>"
@@ -182,10 +184,12 @@ $optionsSummary = $productHelper::getOptionsSummary($options);
         <?php if ($option['type'] === 'textarea') : ?>
             <?php $textareaInputId = 'product-option-textarea-' . (int) $productId . '-' . $optionId; ?>
             <div id="option-<?php echo $optionId; ?>" class="option uk-margin-small-bottom">
-                <?php if ($option['required']) : ?>
-                    <span class="uk-text-danger">*</span>
-                <?php endif; ?>
-                <label class="uk-form-label" for="<?php echo $textareaInputId; ?>"><?php echo $esc(Text::_($option['option_name'])); ?>:</label>
+                <label class="uk-form-label" for="<?php echo $textareaInputId; ?>">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>
+                    <?php if ($option['required']) : ?>
+                        <span class="uk-text-danger">*</span>
+                    <?php endif; ?>
+                </label>
                 <textarea id="<?php echo $textareaInputId; ?>" class="uk-textarea"
                           name="product_option[<?php echo $optionId; ?>]"
                           cols="20" rows="5"><?php echo $esc($option['optionvalue'] ?? ''); ?></textarea>

--- a/plugins/j2commerce/app_uikit/layouts/list/tag/item_options.php
+++ b/plugins/j2commerce/app_uikit/layouts/list/tag/item_options.php
@@ -168,10 +168,12 @@ $optionsSummary = $productHelper::getOptionsSummary($options);
             <?php $text_option_params = $platform->getRegistry($option['option_params'] ?? '{}'); ?>
             <?php $textInputId = 'product-option-text-' . (int) $productId . '-' . $optionId; ?>
             <div id="option-<?php echo $optionId; ?>" class="option uk-margin-small-bottom">
-                <?php if ($option['required']) : ?>
-                    <span class="uk-text-danger">*</span>
-                <?php endif; ?>
-                <label class="uk-form-label" for="<?php echo $textInputId; ?>"><?php echo $esc(Text::_($option['option_name'])); ?>:</label>
+                <label class="uk-form-label" for="<?php echo $textInputId; ?>">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>
+                    <?php if ($option['required']) : ?>
+                        <span class="uk-text-danger">*</span>
+                    <?php endif; ?>
+                </label>
                 <input id="<?php echo $textInputId; ?>" type="text" class="uk-input"
                        name="product_option[<?php echo $optionId; ?>]"
                        value="<?php echo $esc($option['optionvalue'] ?? ''); ?>"
@@ -182,10 +184,12 @@ $optionsSummary = $productHelper::getOptionsSummary($options);
         <?php if ($option['type'] === 'textarea') : ?>
             <?php $textareaInputId = 'product-option-textarea-' . (int) $productId . '-' . $optionId; ?>
             <div id="option-<?php echo $optionId; ?>" class="option uk-margin-small-bottom">
-                <?php if ($option['required']) : ?>
-                    <span class="uk-text-danger">*</span>
-                <?php endif; ?>
-                <label class="uk-form-label" for="<?php echo $textareaInputId; ?>"><?php echo $esc(Text::_($option['option_name'])); ?>:</label>
+                <label class="uk-form-label" for="<?php echo $textareaInputId; ?>">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>
+                    <?php if ($option['required']) : ?>
+                        <span class="uk-text-danger">*</span>
+                    <?php endif; ?>
+                </label>
                 <textarea id="<?php echo $textareaInputId; ?>" class="uk-textarea"
                           name="product_option[<?php echo $optionId; ?>]"
                           cols="20" rows="5"><?php echo $esc($option['optionvalue'] ?? ''); ?></textarea>

--- a/plugins/j2commerce/app_uikit/layouts/product/configurablechildoptions.php
+++ b/plugins/j2commerce/app_uikit/layouts/product/configurablechildoptions.php
@@ -147,10 +147,12 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
             <?php $text_option_params = $platform->getRegistry($option['option_params'] ?? '{}'); ?>
             <?php $textInputId = 'child-product-option-text-' . (int) $product_id . '-' . $optionId; ?>
             <div id="child-option-<?php echo $optionId; ?>" class="option uk-margin-small-bottom">
-                <?php if ($option['required']) : ?>
-                <span class="required">*</span>
-                <?php endif; ?>
-                <label class="uk-form-label" for="<?php echo $textInputId; ?>"><?php echo $esc(Text::_($option['option_name'])); ?>:</label>
+                <label class="uk-form-label" for="<?php echo $textInputId; ?>">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>
+                    <?php if ($option['required']) : ?>
+                        <span class="uk-text-danger">*</span>
+                    <?php endif; ?>
+                </label>
                 <input id="<?php echo $textInputId; ?>" type="text" class="uk-input"
                     name="product_option[<?php echo $optionId; ?>]"
                     value="<?php echo $esc($option['optionvalue'] ?? ''); ?>"
@@ -161,10 +163,12 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
         <?php if ($option['type'] === 'textarea') : ?>
             <?php $textareaInputId = 'child-product-option-textarea-' . (int) $product_id . '-' . $optionId; ?>
             <div id="child-option-<?php echo $optionId; ?>" class="option uk-margin-small-bottom">
-                <?php if ($option['required']) : ?>
-                <span class="required">*</span>
-                <?php endif; ?>
-                <label class="uk-form-label" for="<?php echo $textareaInputId; ?>"><?php echo $esc(Text::_($option['option_name'])); ?>:</label>
+                <label class="uk-form-label" for="<?php echo $textareaInputId; ?>">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>
+                    <?php if ($option['required']) : ?>
+                        <span class="uk-text-danger">*</span>
+                    <?php endif; ?>
+                </label>
                 <textarea id="<?php echo $textareaInputId; ?>" class="uk-textarea"
                     name="product_option[<?php echo $optionId; ?>]"
                     cols="20" rows="5"><?php echo $esc($option['optionvalue'] ?? ''); ?></textarea>

--- a/plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_configurableoptions.php
+++ b/plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_configurableoptions.php
@@ -173,27 +173,32 @@ $uploadAjax  = Route::_('index.php?option=com_j2commerce&view=carts&task=carts.u
 
         <?php if ($option['type'] == 'text') : ?>
             <?php $text_option_params = $platform->getRegistry($option['option_params']); ?>
+            <?php $textInputId = 'product-option-text-' . $productId . '-' . (int) $option['productoption_id']; ?>
             <div id="option-<?php echo $option['productoption_id']; ?>" class="option uk-margin-small-bottom">
-                <?php if ($option['required']) : ?>
-                <span class="uk-text-danger">*</span>
-                <?php endif; ?>
-                <b><?php echo $this->escape(Text::_($option['option_name'])); ?>:</b><br>
-                <input type="text"
-                    class="uk-input"
+                <label class="uk-form-label uk-text-bold uk-display-block" for="<?php echo $textInputId; ?>">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>
+                    <?php if ($option['required']) : ?>
+                        <span class="uk-text-danger">*</span>
+                    <?php endif; ?>
+                </label>
+                <input id="<?php echo $textInputId; ?>" type="text" class="uk-input"
                     name="product_option[<?php echo $option['productoption_id']; ?>]"
-                    value="<?php echo $option['optionvalue']; ?>"
-                    placeholder="<?php echo $text_option_params->get('place_holder', ''); ?>" />
+                    value="<?php echo $esc((string) ($option['optionvalue'] ?? '')); ?>"
+                    placeholder="<?php echo $esc((string) $text_option_params->get('place_holder', '')); ?>" />
             </div>
         <?php endif; ?>
 
         <?php if ($option['type'] == 'textarea') : ?>
+            <?php $textareaInputId = 'product-option-textarea-' . $productId . '-' . (int) $option['productoption_id']; ?>
             <div id="option-<?php echo $option['productoption_id']; ?>" class="option uk-margin-small-bottom">
-                <?php if ($option['required']) : ?>
-                <span class="uk-text-danger">*</span>
-                <?php endif; ?>
-                <b><?php echo $this->escape(Text::_($option['option_name'])); ?>:</b><br>
-                <textarea class="uk-textarea" name="product_option[<?php echo $option['productoption_id']; ?>]"
-                    cols="20" rows="5"><?php echo $option['optionvalue']; ?></textarea>
+                <label class="uk-form-label uk-text-bold uk-display-block" for="<?php echo $textareaInputId; ?>">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>
+                    <?php if ($option['required']) : ?>
+                        <span class="uk-text-danger">*</span>
+                    <?php endif; ?>
+                </label>
+                <textarea id="<?php echo $textareaInputId; ?>" class="uk-textarea" name="product_option[<?php echo $option['productoption_id']; ?>]"
+                    cols="20" rows="5"><?php echo $esc((string) ($option['optionvalue'] ?? '')); ?></textarea>
             </div>
         <?php endif; ?>
 

--- a/plugins/j2commerce/app_uikit/tmpl/uikit/view_configurableoptions.php
+++ b/plugins/j2commerce/app_uikit/tmpl/uikit/view_configurableoptions.php
@@ -173,27 +173,32 @@ $uploadAjax  = Route::_('index.php?option=com_j2commerce&view=carts&task=carts.u
 
         <?php if ($option['type'] == 'text') : ?>
             <?php $text_option_params = $platform->getRegistry($option['option_params']); ?>
+            <?php $textInputId = 'product-option-text-' . $productId . '-' . (int) $option['productoption_id']; ?>
             <div id="option-<?php echo $option['productoption_id']; ?>" class="option uk-margin-small-bottom">
-                <?php if ($option['required']) : ?>
-                <span class="uk-text-danger">*</span>
-                <?php endif; ?>
-                <b><?php echo $this->escape(Text::_($option['option_name'])); ?>:</b><br>
-                <input type="text"
-                    class="uk-input"
+                <label class="uk-form-label uk-text-bold uk-display-block" for="<?php echo $textInputId; ?>">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>
+                    <?php if ($option['required']) : ?>
+                        <span class="uk-text-danger">*</span>
+                    <?php endif; ?>
+                </label>
+                <input id="<?php echo $textInputId; ?>" type="text" class="uk-input"
                     name="product_option[<?php echo $option['productoption_id']; ?>]"
-                    value="<?php echo $option['optionvalue']; ?>"
-                    placeholder="<?php echo $text_option_params->get('place_holder', ''); ?>" />
+                    value="<?php echo $esc((string) ($option['optionvalue'] ?? '')); ?>"
+                    placeholder="<?php echo $esc((string) $text_option_params->get('place_holder', '')); ?>" />
             </div>
         <?php endif; ?>
 
         <?php if ($option['type'] == 'textarea') : ?>
+            <?php $textareaInputId = 'product-option-textarea-' . $productId . '-' . (int) $option['productoption_id']; ?>
             <div id="option-<?php echo $option['productoption_id']; ?>" class="option uk-margin-small-bottom">
-                <?php if ($option['required']) : ?>
-                <span class="uk-text-danger">*</span>
-                <?php endif; ?>
-                <b><?php echo $this->escape(Text::_($option['option_name'])); ?>:</b><br>
-                <textarea class="uk-textarea" name="product_option[<?php echo $option['productoption_id']; ?>]"
-                    cols="20" rows="5"><?php echo $option['optionvalue']; ?></textarea>
+                <label class="uk-form-label uk-text-bold uk-display-block" for="<?php echo $textareaInputId; ?>">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>
+                    <?php if ($option['required']) : ?>
+                        <span class="uk-text-danger">*</span>
+                    <?php endif; ?>
+                </label>
+                <textarea id="<?php echo $textareaInputId; ?>" class="uk-textarea" name="product_option[<?php echo $option['productoption_id']; ?>]"
+                    cols="20" rows="5"><?php echo $esc((string) ($option['optionvalue'] ?? '')); ?></textarea>
             </div>
         <?php endif; ?>
 


### PR DESCRIPTION
## Summary

Fixes #1067

Aligns the `text` and `textarea` option branches with the `select` / `radio` branches in the same file, per framework. The required-asterisk now lives inside the label (matching select/radio), label classes match the file's canonical pattern, and the wrapper class matches the surrounding option branches.

## Changes

- **Frontend list layouts** (`components/com_j2commerce/layouts/app_*/list/...` + `product/configurablechildoptions.php`, 8 files) — rewritten `text` and `textarea` branches to match each file's `select` branch: BS5 uses `<label class="form-label fw-semibold pb-1 mb-1">` with asterisk inside; UIkit uses `<label class="uk-form-label">` with asterisk inside.
- **Plugin-source layout mirrors** (`plugins/j2commerce/app_bootstrap5/layouts/...` and `plugins/j2commerce/app_uikit/layouts/...`, 8 files) — byte-identical to the components copies, so a future plugin reinstall does not revert the fix.
- **Product-detail view templates** (`plugins/j2commerce/app_*/tmpl/*/view_configurableoptions.php`, 4 files) — rewritten `text` and `textarea` branches to match each file's `select` branch (`form-label fw-semibold pb-1 mb-2` for BS5, `uk-form-label uk-text-bold uk-display-block` for UIkit). BS5 versions also picked up the missing `mb-3` wrapper class.

Side fixes baked into the UIkit `view_configurableoptions.php` edits while in the touched area:
- Added `id` to input/textarea + matching `for=""` on the label (a11y).
- Escaped `$option['optionvalue']` and `$text_option_params->get('place_holder')` via the file's existing `$esc()` helper, replacing two raw echoes.

Files not changed (intentional, per the issue's per-file-parity scope):
- `view_options.php` (BS5, tag_BS5, UIkit, tag_uikit) — already internally consistent: text/textarea match select/radio (asterisk-before-label + `form-label fw-bold` / `uk-form-label uk-text-bold`).
- `view_variableoptions.php`, `view_variablesubscriptionproductoptions.php` — no `text`/`textarea` branches (variant-driven, render select/radio only).

## Test plan

- [ ] Create a test product. Attach a `text` option and a `textarea` option alongside a `select` and a `radio` option.
- [ ] **List/category page:** load a category that surfaces the product. Verify text and textarea labels render with the same boldness and spacing as the select/radio above them, and the red `*` sits **after** the option name (not before it).
- [ ] **List/tag page:** repeat on a tag page.
- [ ] **Product detail (configurable type):** open a configurable product with a text or textarea child option. Verify text/textarea render with the same wrapper, label weight, and asterisk-after as the select/radio child options.
- [ ] **Both frameworks:** repeat the above on a Bootstrap 5 template and a UIkit 3 template.
- [ ] **No regression:** add the product to cart with text/textarea filled in. Confirm values appear in cart line + order details (POST `product_option[<id>]` unchanged).
- [ ] **Lint:** all 20 changed PHP files pass `php -l`.

## Files Changed (20)

### components/com_j2commerce/layouts (8)
- `app_bootstrap5/list/category/item_options.php`
- `app_bootstrap5/list/category/item_configurableoptions.php`
- `app_bootstrap5/list/tag/item_options.php`
- `app_bootstrap5/product/configurablechildoptions.php`
- `app_uikit/list/category/item_options.php`
- `app_uikit/list/category/item_configurableoptions.php`
- `app_uikit/list/tag/item_options.php`
- `app_uikit/product/configurablechildoptions.php`

### plugins/j2commerce/app_*/layouts — mirrors (8)
- `app_bootstrap5/layouts/list/category/item_options.php`
- `app_bootstrap5/layouts/list/category/item_configurableoptions.php`
- `app_bootstrap5/layouts/list/tag/item_options.php`
- `app_bootstrap5/layouts/product/configurablechildoptions.php`
- `app_uikit/layouts/list/category/item_options.php`
- `app_uikit/layouts/list/category/item_configurableoptions.php`
- `app_uikit/layouts/list/tag/item_options.php`
- `app_uikit/layouts/product/configurablechildoptions.php`

### plugins/j2commerce/app_*/tmpl — view_configurableoptions (4)
- `app_bootstrap5/tmpl/bootstrap5/view_configurableoptions.php`
- `app_bootstrap5/tmpl/tag_bootstrap5/view_configurableoptions.php`
- `app_uikit/tmpl/uikit/view_configurableoptions.php`
- `app_uikit/tmpl/tag_uikit/view_configurableoptions.php`
