### PR TITLE
fix(js): expose doAjaxPrice as global for variable product options

### DIFF
--- a/media/com_j2commerce/js/site/j2commerce.js
+++ b/media/com_j2commerce/js/site/j2commerce.js
@@ -1224,6 +1224,10 @@ function get_matching_variant(variants, selected) {
     return J2Commerce.getMatchingVariant(variants, selected);
 }
 
+function doAjaxPrice(productId, elementId) {
+    return J2Commerce.doAjaxPrice(productId, elementId);
+}
+
 // =========================================================================
 // INITIALIZATION
 // =========================================================================


### PR DESCRIPTION
## Summary
Fixes #1071

Variable-type product options were not updating the displayed price on the frontend. Console showed `doAjaxPrice is not defined`.

Root cause: `doAjaxPrice` was refactored into the `J2Commerce` namespace object (`media/com_j2commerce/js/site/j2commerce.js:545`), but no global wrapper was added in the "Backwards Compatibility" section. The variable-option templates (`view_variableoptions.php`, `item_variableoptions.php`, etc.) emit inline `onclick="doAjaxPrice(...)"` handlers, which require a global function.

Flexivariable products were unaffected because the `app_flexivariable` plugin ships its own `doFlexiAjaxPrice` global wrapper.

## Changes
- Added global `doAjaxPrice(productId, elementId)` wrapper in `media/com_j2commerce/js/site/j2commerce.js` alongside `get_matching_variant`, `getCategoryFilterToggle`, etc.

## Testing
1. Hard refresh frontend (bust the `j2commerce.js` cache).
2. View a `variable`-type product (product view or a category listing containing one).
3. Change a product option (select / radio / checkbox).
4. Verify: no `doAjaxPrice is not defined` error in the console, and the displayed price updates to match the selected option.
5. Regression check: flexivariable-type products still update price correctly.

## Files Changed
- `media/com_j2commerce/js/site/j2commerce.js` — added global `doAjaxPrice` wrapper (additive only)