### PR TITLE
feat(core): fix plugin discount events + persist cart-level discounts

### DIFF
--- a/administrator/components/com_j2commerce/src/Helper/CartOrder.php
+++ b/administrator/components/com_j2commerce/src/Helper/CartOrder.php
@@ -465,7 +465,7 @@ class CartOrder
                 // Allow plugins to modify item price and add discounts
                 // onJ2CommerceGetDiscountedPrice signature: (&$price, &$item, $add_totals, &$order)
                 // Plugins can modify $price by reference and set $item->orderitem_discount
-                J2CommerceHelper::plugin()->event('onJ2CommerceGetDiscountedPrice', [
+                J2CommerceHelper::plugin()->event('GetDiscountedPrice', [
                     &$itemPrice,
                     &$item,
                     true, // $add_totals - accumulate discount totals
@@ -523,7 +523,7 @@ class CartOrder
                 $itemPrice = (float) ($item->price ?? $item->variant_price ?? 0) + (float) ($item->option_price ?? 0);
 
                 // Allow plugins to modify item price even for items without pricing object
-                J2CommerceHelper::plugin()->event('onJ2CommerceGetDiscountedPrice', [
+                J2CommerceHelper::plugin()->event('GetDiscountedPrice', [
                     &$itemPrice,
                     &$item,
                     true,
@@ -593,75 +593,13 @@ class CartOrder
 
     private function getCustomerGeozones(): array
     {
-        $session   = Factory::getApplication()->getSession();
-        $countryId = 0;
-        $zoneId    = 0;
-        $postcode  = '';
+        $address = TaxHelper::getCustomerAddress();
 
-        // Priority 1: saved shipping address
-        $addressId = (int) $session->get('shipping_address_id', 0, 'j2commerce');
+        $this->customerCountryId = (int) $address->country_id;
+        $this->customerZoneId    = (int) $address->zone_id;
+        $this->customerPostcode  = (string) $address->postcode;
 
-        if ($addressId > 0) {
-            $db    = Factory::getContainer()->get(DatabaseInterface::class);
-            $query = $db->getQuery(true)
-                ->select([$db->quoteName('country_id'), $db->quoteName('zone_id'), $db->quoteName('zip')])
-                ->from($db->quoteName('#__j2commerce_addresses'))
-                ->where($db->quoteName('j2commerce_address_id') . ' = :addrId')
-                ->bind(':addrId', $addressId, ParameterType::INTEGER);
-
-            $db->setQuery($query);
-            $address = $db->loadObject();
-
-            if ($address) {
-                $countryId = (int) ($address->country_id ?? 0);
-                $zoneId    = (int) ($address->zone_id ?? 0);
-                $postcode  = (string) ($address->zip ?? '');
-            }
-        }
-
-        // Priority 2: guest shipping address
-        if ($countryId === 0) {
-            $guestShipping = $session->get('guest_shipping', [], 'j2commerce');
-
-            if (!empty($guestShipping) && \is_array($guestShipping)) {
-                $countryId = (int) ($guestShipping['country_id'] ?? 0);
-                $zoneId    = (int) ($guestShipping['zone_id'] ?? 0);
-                $postcode  = (string) ($guestShipping['zip'] ?? $guestShipping['postcode'] ?? '');
-            }
-        }
-
-        // Priority 3: estimate flow flat session keys
-        if ($countryId === 0) {
-            $countryId = (int) $session->get('shipping_country_id', 0, 'j2commerce');
-            $zoneId    = (int) $session->get('shipping_zone_id', 0, 'j2commerce');
-            $postcode  = (string) $session->get('shipping_postcode', '', 'j2commerce');
-        }
-
-        // Cache resolved address for downstream tax-event dispatch.
-        $this->customerCountryId = $countryId;
-        $this->customerZoneId    = $zoneId;
-        $this->customerPostcode  = $postcode;
-
-        if ($countryId === 0) {
-            return [];
-        }
-
-        // Query geozonerules for matching geozones
-        $db    = Factory::getContainer()->get(DatabaseInterface::class);
-        $query = $db->getQuery(true)
-            ->select('DISTINCT ' . $db->quoteName('geozone_id'))
-            ->from($db->quoteName('#__j2commerce_geozonerules'))
-            ->where($db->quoteName('country_id') . ' = :countryId')
-            ->where(
-                '(' . $db->quoteName('zone_id') . ' = 0 OR '
-                . $db->quoteName('zone_id') . ' = :zoneId)'
-            )
-            ->bind(':countryId', $countryId, ParameterType::INTEGER)
-            ->bind(':zoneId', $zoneId, ParameterType::INTEGER);
-
-        $db->setQuery($query);
-
-        return $db->loadColumn() ?: [];
+        return TaxHelper::getCustomerGeozones($address);
     }
 
     /**
@@ -685,69 +623,18 @@ class CartOrder
      */
     private function getTaxRatesForProfile(int $taxprofileId, array $geozoneIds): array
     {
-        $ratesets = [];
+        $address = (object) [
+            'country_id' => $this->customerCountryId,
+            'zone_id'    => $this->customerZoneId,
+            'postcode'   => $this->customerPostcode,
+        ];
 
-        $taxInfo = $this->getTaxRateForGeozone($taxprofileId, $geozoneIds);
-
-        if ($taxInfo !== null) {
-            $rate                         = new \stdClass();
-            $rate->j2commerce_taxrate_id  = (int) ($taxInfo->j2commerce_taxrate_id ?? 0);
-            $rate->name                   = (string) ($taxInfo->taxrate_name ?? '');
-            $rate->taxrate_name           = $rate->name;
-            $rate->rate                   = (float) ($taxInfo->tax_percent ?? 0);
-            $rate->tax_percent            = $rate->rate;
-            $rate->taxprofile_name        = (string) ($taxInfo->taxprofile_name ?? '');
-            $ratesets[]                   = $rate;
-        }
-
-        $event = J2CommerceHelper::plugin()->event('AfterGetTaxRateItems', [
-            'result'        => $ratesets,
-            'address_type'  => 'shipping',
-            'country_id'    => $this->customerCountryId,
-            'zone_id'       => $this->customerZoneId,
-            'postcode'      => $this->customerPostcode,
-            'taxprofile_id' => $taxprofileId,
-        ]);
-
-        $merged = $event->getEventResult();
-
-        return \is_array($merged) ? $merged : $ratesets;
+        return TaxHelper::getTaxRatesForProfile($taxprofileId, $geozoneIds, $address);
     }
 
     private function getTaxRateForGeozone(int $taxprofileId, array $geozoneIds): ?object
     {
-        if (empty($geozoneIds)) {
-            return null;
-        }
-
-        $db    = Factory::getContainer()->get(DatabaseInterface::class);
-        $query = $db->getQuery(true)
-            ->select([
-                $db->quoteName('rt.j2commerce_taxrate_id'),
-                $db->quoteName('rt.taxrate_name'),
-                $db->quoteName('rt.tax_percent'),
-                $db->quoteName('rt.geozone_id'),
-                $db->quoteName('tp.taxprofile_name'),
-            ])
-            ->from($db->quoteName('#__j2commerce_taxrules', 'tr'))
-            ->join(
-                'INNER',
-                $db->quoteName('#__j2commerce_taxrates', 'rt'),
-                $db->quoteName('rt.j2commerce_taxrate_id') . ' = ' . $db->quoteName('tr.taxrate_id')
-            )
-            ->join(
-                'INNER',
-                $db->quoteName('#__j2commerce_taxprofiles', 'tp'),
-                $db->quoteName('tp.j2commerce_taxprofile_id') . ' = ' . $db->quoteName('tr.taxprofile_id')
-            )
-            ->where($db->quoteName('tr.taxprofile_id') . ' = :profileId')
-            ->whereIn($db->quoteName('rt.geozone_id'), array_map('intval', $geozoneIds))
-            ->bind(':profileId', $taxprofileId, ParameterType::INTEGER)
-            ->order($db->quoteName('tr.ordering') . ' ASC');
-
-        $db->setQuery($query, 0, 1);
-
-        return $db->loadObject() ?: null;
+        return TaxHelper::getTaxRateForGeozone($taxprofileId, $geozoneIds);
     }
 
     /**
@@ -1367,16 +1254,44 @@ class CartOrder
             ];
         }
 
-        // Add cart-level discounts (bulk discounts, etc.) from plugins
-        if ($this->discount_cart > 0) {
-            $bulkDiscountTitle = $this->coupon_discount_amounts['bulk_discount_title']
+        // Add cart-level discounts from plugins — one line per discount code with its own title.
+        // Each plugin that calls addOrderDiscounts() / increase_coupon_discount_amount() can set
+        // $order->coupon_discount_amounts['<code>_title'] to override the default label.
+        $renderedAmount = 0.0;
+
+        foreach ($this->coupon_discount_amounts as $code => $amount) {
+            if (!\is_string($code) || str_ends_with($code, '_title')) {
+                continue;
+            }
+
+            if (!is_numeric($amount) || (float) $amount <= 0) {
+                continue;
+            }
+
+            $title = $this->coupon_discount_amounts[$code . '_title']
+                ?? ($code === 'bulk_discount' ? ($this->coupon_discount_amounts['bulk_discount_title'] ?? null) : null)
                 ?? Text::_('COM_J2COMMERCE_CART_BULK_DISCOUNT');
 
             $discounts[] = (object) [
                 'discount_type'   => 'cart_discount',
-                'discount_code'   => 'bulk_discount',
-                'discount_title'  => $bulkDiscountTitle,
-                'discount_amount' => $this->discount_cart,
+                'discount_code'   => $code,
+                'discount_title'  => $title,
+                'discount_amount' => (float) $amount,
+            ];
+
+            $renderedAmount += (float) $amount;
+        }
+
+        // Back-compat: legacy plugins may bump discount_cart without writing a per-code entry.
+        $unrendered = $this->discount_cart - $renderedAmount;
+
+        if ($unrendered > 0.001) {
+            $discounts[] = (object) [
+                'discount_type'  => 'cart_discount',
+                'discount_code'  => 'bulk_discount',
+                'discount_title' => $this->coupon_discount_amounts['bulk_discount_title']
+                    ?? Text::_('COM_J2COMMERCE_CART_BULK_DISCOUNT'),
+                'discount_amount' => $unrendered,
             ];
         }
 
@@ -1950,6 +1865,7 @@ class CartOrder
                 'title'      => $coupon->coupon_name ?? $coupon->coupon_code ?? '',
                 'code'       => $coupon->coupon_code ?? '',
                 'amount'     => (float) ($coupon->discount ?? 0),
+                'tax'        => 0.0,
                 'value_type' => 'fixed',
             ];
         }
@@ -1961,6 +1877,33 @@ class CartOrder
                 'title'      => $voucher->voucher_name ?? $voucher->voucher_code ?? '',
                 'code'       => $voucher->voucher_code ?? '',
                 'amount'     => (float) ($voucher->discount ?? 0),
+                'tax'        => 0.0,
+                'value_type' => 'fixed',
+            ];
+        }
+
+        // Persist plugin cart-level discounts (paymentdiscount, bulkdiscount, bogoboost, etc.).
+        // Each code in coupon_discount_amounts that isn't a *_title sidecar and has a positive
+        // amount gets its own orderdiscounts row, using the optional <code>_title sidecar value.
+        foreach ($this->coupon_discount_amounts as $code => $amount) {
+            if (!\is_string($code) || str_ends_with($code, '_title')) {
+                continue;
+            }
+
+            if (!is_numeric($amount) || (float) $amount <= 0) {
+                continue;
+            }
+
+            $title = (string) ($this->coupon_discount_amounts[$code . '_title']
+                ?? ($code === 'bulk_discount' ? Text::_('COM_J2COMMERCE_CART_BULK_DISCOUNT') : $code));
+
+            $allDiscounts[] = [
+                'type'       => 'cart_discount',
+                'entity_id'  => 0,
+                'title'      => $title,
+                'code'       => $code,
+                'amount'     => (float) $amount,
+                'tax'        => (float) ($this->coupon_discount_tax_amounts[$code] ?? 0),
                 'value_type' => 'fixed',
             ];
         }
@@ -1985,7 +1928,7 @@ class CartOrder
                     $db->quote($userEmail),
                     $userId,
                     (float) $discount['amount'],
-                    0, // discount_tax
+                    (float) ($discount['tax'] ?? 0),
                     $db->quote('{}'),
                 ]));
 
@@ -2335,7 +2278,7 @@ class CartOrder
     protected function calculateDiscountTotals(): void
     {
         // Allow plugins to add discount totals (bulk discounts, volume discounts, etc.)
-        J2CommerceHelper::plugin()->event('onJ2CommerceCalculateDiscountTotals', [$this]);
+        J2CommerceHelper::plugin()->event('CalculateDiscountTotals', [$this]);
 
         // If plugins added discounts, recalculate tax on discounted amount
         if ($this->discount_cart > 0) {

--- a/administrator/components/com_j2commerce/src/Helper/TaxHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/TaxHelper.php
@@ -1,0 +1,294 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Administrator\Helper;
+
+\defined('_JEXEC') or die;
+
+use Joomla\CMS\Factory;
+use Joomla\Database\DatabaseInterface;
+use Joomla\Database\ParameterType;
+
+/**
+ * Public tax-calculation API for com_j2commerce.
+ *
+ * Centralises the tax-compute math that CartOrder uses during checkout so that
+ * code paths outside the cart/checkout flow (plugins applying discounts, custom
+ * report generators, third-party integrations) can resolve the same rates,
+ * fire the same dispatcher event, and produce the same totals as core.
+ *
+ * @since  6.3.0
+ */
+final class TaxHelper
+{
+    /**
+     * Resolve the active customer shipping address from the J2Commerce session.
+     *
+     * Lookup order mirrors CartOrder:
+     *   1. saved shipping_address_id      → `#__j2commerce_addresses`
+     *   2. guest_shipping array           → session
+     *   3. flat shipping_country_id keys  → estimate-shipping flow
+     *
+     * @return  \stdClass  { country_id:int, zone_id:int, postcode:string }
+     *
+     * @since   6.3.0
+     */
+    public static function getCustomerAddress(): \stdClass
+    {
+        $session   = Factory::getApplication()->getSession();
+        $countryId = 0;
+        $zoneId    = 0;
+        $postcode  = '';
+
+        $addressId = (int) $session->get('shipping_address_id', 0, 'j2commerce');
+
+        if ($addressId > 0) {
+            $db    = Factory::getContainer()->get(DatabaseInterface::class);
+            $query = $db->getQuery(true)
+                ->select([$db->quoteName('country_id'), $db->quoteName('zone_id'), $db->quoteName('zip')])
+                ->from($db->quoteName('#__j2commerce_addresses'))
+                ->where($db->quoteName('j2commerce_address_id') . ' = :addrId')
+                ->bind(':addrId', $addressId, ParameterType::INTEGER);
+
+            $db->setQuery($query);
+            $address = $db->loadObject();
+
+            if ($address) {
+                $countryId = (int) ($address->country_id ?? 0);
+                $zoneId    = (int) ($address->zone_id ?? 0);
+                $postcode  = (string) ($address->zip ?? '');
+            }
+        }
+
+        if ($countryId === 0) {
+            $guestShipping = $session->get('guest_shipping', [], 'j2commerce');
+
+            if (!empty($guestShipping) && \is_array($guestShipping)) {
+                $countryId = (int) ($guestShipping['country_id'] ?? 0);
+                $zoneId    = (int) ($guestShipping['zone_id'] ?? 0);
+                $postcode  = (string) ($guestShipping['zip'] ?? $guestShipping['postcode'] ?? '');
+            }
+        }
+
+        if ($countryId === 0) {
+            $countryId = (int) $session->get('shipping_country_id', 0, 'j2commerce');
+            $zoneId    = (int) $session->get('shipping_zone_id', 0, 'j2commerce');
+            $postcode  = (string) $session->get('shipping_postcode', '', 'j2commerce');
+        }
+
+        return (object) [
+            'country_id' => $countryId,
+            'zone_id'    => $zoneId,
+            'postcode'   => $postcode,
+        ];
+    }
+
+    /**
+     * Resolve the geozone IDs that match the given customer address.
+     *
+     * @param   \stdClass|null  $address  Pre-resolved address; null → use getCustomerAddress().
+     *
+     * @return  array  Geozone IDs (may be empty).
+     *
+     * @since   6.3.0
+     */
+    public static function getCustomerGeozones(?\stdClass $address = null): array
+    {
+        $address ??= self::getCustomerAddress();
+
+        $countryId = (int) ($address->country_id ?? 0);
+        $zoneId    = (int) ($address->zone_id ?? 0);
+
+        if ($countryId === 0) {
+            return [];
+        }
+
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
+        $query = $db->getQuery(true)
+            ->select('DISTINCT ' . $db->quoteName('geozone_id'))
+            ->from($db->quoteName('#__j2commerce_geozonerules'))
+            ->where($db->quoteName('country_id') . ' = :countryId')
+            ->where(
+                '(' . $db->quoteName('zone_id') . ' = 0 OR '
+                . $db->quoteName('zone_id') . ' = :zoneId)'
+            )
+            ->bind(':countryId', $countryId, ParameterType::INTEGER)
+            ->bind(':zoneId', $zoneId, ParameterType::INTEGER);
+
+        $db->setQuery($query);
+
+        return $db->loadColumn() ?: [];
+    }
+
+    /**
+     * Load the matching `#__j2commerce_taxrates` row for a profile + geozone set.
+     *
+     * @return  \stdClass|null  Raw row or null when nothing matches.
+     *
+     * @since   6.3.0
+     */
+    public static function getTaxRateForGeozone(int $taxprofileId, array $geozoneIds): ?\stdClass
+    {
+        if ($taxprofileId <= 0 || empty($geozoneIds)) {
+            return null;
+        }
+
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
+        $query = $db->getQuery(true)
+            ->select([
+                $db->quoteName('rt.j2commerce_taxrate_id'),
+                $db->quoteName('rt.taxrate_name'),
+                $db->quoteName('rt.tax_percent'),
+                $db->quoteName('rt.geozone_id'),
+                $db->quoteName('tp.taxprofile_name'),
+            ])
+            ->from($db->quoteName('#__j2commerce_taxrules', 'tr'))
+            ->join(
+                'INNER',
+                $db->quoteName('#__j2commerce_taxrates', 'rt'),
+                $db->quoteName('rt.j2commerce_taxrate_id') . ' = ' . $db->quoteName('tr.taxrate_id')
+            )
+            ->join(
+                'INNER',
+                $db->quoteName('#__j2commerce_taxprofiles', 'tp'),
+                $db->quoteName('tp.j2commerce_taxprofile_id') . ' = ' . $db->quoteName('tr.taxprofile_id')
+            )
+            ->where($db->quoteName('tr.taxprofile_id') . ' = :profileId')
+            ->whereIn($db->quoteName('rt.geozone_id'), array_map('intval', $geozoneIds))
+            ->bind(':profileId', $taxprofileId, ParameterType::INTEGER)
+            ->order($db->quoteName('tr.ordering') . ' ASC');
+
+        $db->setQuery($query, 0, 1);
+
+        return $db->loadObject() ?: null;
+    }
+
+    /**
+     * Resolve rate objects for a profile + geozone set, then dispatch
+     * `onJ2CommerceAfterGetTaxRateItems` so tax-engine plugins (Avalara,
+     * app_taxrate, EU VAT, etc.) can append, override, or replace the rates.
+     *
+     * @param   \stdClass|null  $address  Optional pre-resolved address used for the event payload.
+     *
+     * @return  array  Array of rate stdClass objects.
+     *
+     * @since   6.3.0
+     */
+    public static function getTaxRatesForProfile(
+        int $taxprofileId,
+        array $geozoneIds,
+        ?\stdClass $address = null
+    ): array {
+        $address ??= self::getCustomerAddress();
+        $ratesets = [];
+
+        $taxInfo = self::getTaxRateForGeozone($taxprofileId, $geozoneIds);
+
+        if ($taxInfo !== null) {
+            $rate                         = new \stdClass();
+            $rate->j2commerce_taxrate_id  = (int) ($taxInfo->j2commerce_taxrate_id ?? 0);
+            $rate->name                   = (string) ($taxInfo->taxrate_name ?? '');
+            $rate->taxrate_name           = $rate->name;
+            $rate->rate                   = (float) ($taxInfo->tax_percent ?? 0);
+            $rate->tax_percent            = $rate->rate;
+            $rate->taxprofile_name        = (string) ($taxInfo->taxprofile_name ?? '');
+            $ratesets[]                   = $rate;
+        }
+
+        $event = J2CommerceHelper::plugin()->event('AfterGetTaxRateItems', [
+            'result'        => $ratesets,
+            'address_type'  => 'shipping',
+            'country_id'    => (int) ($address->country_id ?? 0),
+            'zone_id'       => (int) ($address->zone_id ?? 0),
+            'postcode'      => (string) ($address->postcode ?? ''),
+            'taxprofile_id' => $taxprofileId,
+        ]);
+
+        $merged = $event->getEventResult();
+
+        return \is_array($merged) ? $merged : $ratesets;
+    }
+
+    /**
+     * Compute tax for an arbitrary amount under a given tax profile.
+     *
+     * Honours both J2Commerce pricing modes:
+     *   - exclusive (config_including_tax=0): tax_amount = amount × pct / 100
+     *   - inclusive (config_including_tax=1): tax_amount = amount − amount / (1 + pct/100)
+     *
+     * Multi-rate carts: each entry in `rates[]` carries its own `tax_amount` so
+     * compound VAT, GST+PST, and EU multi-rate stores reconcile per-rate totals.
+     *
+     * @param   float        $amount         Taxable amount (per-unit or per-line; caller decides).
+     * @param   int          $taxprofileId   `#__j2commerce_taxprofiles.j2commerce_taxprofile_id`.
+     * @param   array|null   $geozoneIds     Pre-resolved geozones; null → resolve from session.
+     * @param   bool         $taxInclusive   Whether `$amount` is already tax-inclusive.
+     *
+     * @return  \stdClass  { taxtotal:float, rates:array<int,\stdClass> }
+     *                    rates[i] = { j2commerce_taxrate_id, name, taxrate_name, rate,
+     *                                 tax_percent, taxprofile_name, tax_amount }
+     *
+     * @since   6.3.0
+     */
+    public static function computeTax(
+        float $amount,
+        int $taxprofileId,
+        ?array $geozoneIds = null,
+        bool $taxInclusive = false
+    ): \stdClass {
+        $result           = new \stdClass();
+        $result->taxtotal = 0.0;
+        $result->rates    = [];
+
+        if ($taxprofileId <= 0 || $amount === 0.0) {
+            return $result;
+        }
+
+        $address     = self::getCustomerAddress();
+        $geozoneIds ??= self::getCustomerGeozones($address);
+
+        if (empty($geozoneIds)) {
+            return $result;
+        }
+
+        $ratesets = self::getTaxRatesForProfile($taxprofileId, $geozoneIds, $address);
+
+        if (empty($ratesets)) {
+            return $result;
+        }
+
+        $totalPercent = 0.0;
+
+        foreach ($ratesets as $rate) {
+            $totalPercent += (float) ($rate->rate ?? $rate->tax_percent ?? 0);
+        }
+
+        if ($totalPercent <= 0.0) {
+            $result->rates = $ratesets;
+            return $result;
+        }
+
+        $totalTax = $taxInclusive
+            ? $amount - ($amount / (1 + ($totalPercent / 100)))
+            : $amount * ($totalPercent / 100);
+
+        foreach ($ratesets as $rate) {
+            $ratePercent      = (float) ($rate->rate ?? $rate->tax_percent ?? 0);
+            $rate->tax_amount = $totalTax * ($ratePercent / $totalPercent);
+        }
+
+        $result->taxtotal = $totalTax;
+        $result->rates    = $ratesets;
+
+        return $result;
+    }
+}

--- a/administrator/components/com_j2commerce/src/Model/CouponModel.php
+++ b/administrator/components/com_j2commerce/src/Model/CouponModel.php
@@ -636,7 +636,7 @@ class CouponModel extends AdminModel
             PluginHelper::importPlugin('j2commerce');
 
             $couponStatus = false;
-            J2CommerceHelper::plugin()->event('onJ2CommerceBeforeCouponIsValid', [$this, $order, &$couponStatus]);
+            J2CommerceHelper::plugin()->event('BeforeCouponIsValid', [$this, $order, &$couponStatus]);
 
             if ($couponStatus) {
                 return true;
@@ -1314,7 +1314,7 @@ class CouponModel extends AdminModel
         if (!empty($this->coupon->free_shipping) && method_exists($order, 'allow_free_shipping')) {
             $order->allow_free_shipping();
         }
-        J2CommerceHelper::plugin()->event('onJ2CommerceGetCouponDiscountAmount', [
+        J2CommerceHelper::plugin()->event('GetCouponDiscountAmount', [
             &$discount,
             $discountingAmount,
             $cartItem,

--- a/components/com_j2commerce/src/Controller/CheckoutController.php
+++ b/components/com_j2commerce/src/Controller/CheckoutController.php
@@ -1678,6 +1678,42 @@ class CheckoutController extends BaseController
     }
 
     // =========================================================================
+    // AJAX: Save Payment Selection
+    // =========================================================================
+
+    public function savePaymentSelection(): void
+    {
+        UtilitiesHelper::sendNoCacheHeaders();
+        header('Content-Type: application/json; charset=utf-8');
+
+        $json = [];
+
+        if (!$this->validateAjaxToken()) {
+            $json['success'] = false;
+            $json['message'] = Text::_('JINVALID_TOKEN');
+            echo json_encode($json);
+            $this->app->close();
+
+            return;
+        }
+
+        try {
+            $session       = $this->app->getSession();
+            $paymentPlugin = $this->input->getString('payment_plugin', '');
+
+            $session->set('payment_method', $paymentPlugin, 'j2commerce');
+
+            $json['success'] = true;
+        } catch (\Exception $e) {
+            $json['success'] = false;
+            $json['message'] = $e->getMessage();
+        }
+
+        echo json_encode($json);
+        $this->app->close();
+    }
+
+    // =========================================================================
     // AJAX: Sidecart Refresh
     // =========================================================================
 

--- a/components/com_j2commerce/tmpl/checkout/bootstrap5/default.php
+++ b/components/com_j2commerce/tmpl/checkout/bootstrap5/default.php
@@ -1307,6 +1307,25 @@ document.addEventListener('DOMContentLoaded', function() {
             .catch(function(e) { console.error('Shipping selection error:', e); });
     });
 
+    // === PAYMENT RADIO CHANGE: save selection to session + refresh sidecart ===
+    document.addEventListener('change', function(e) {
+        var radio = e.target;
+        if (radio.type !== 'radio' || radio.name !== 'payment_plugin') return;
+
+        var formData = new FormData();
+        formData.append('option', 'com_j2commerce');
+        formData.append('task', 'checkout.savePaymentSelection');
+        formData.append(token, '1');
+        formData.append('payment_plugin', radio.value);
+
+        fetch(baseUrl, { method: 'POST', body: formData, headers: {'X-Requested-With': 'XMLHttpRequest'} })
+            .then(function(r) { return r.json(); })
+            .then(function(data) {
+                if (data.success) refreshSidecart();
+            })
+            .catch(function(e) { console.error('Payment selection error:', e); });
+    });
+
     // === SIDECART REFRESH ===
     function refreshSidecart() {
         var formData = new FormData();

--- a/components/com_j2commerce/tmpl/checkout/uikit3/default.php
+++ b/components/com_j2commerce/tmpl/checkout/uikit3/default.php
@@ -1305,6 +1305,25 @@ document.addEventListener('DOMContentLoaded', function() {
             .catch(function(e) { console.error('Shipping selection error:', e); });
     });
 
+    // === PAYMENT RADIO CHANGE: save selection to session + refresh sidecart ===
+    document.addEventListener('change', function(e) {
+        var radio = e.target;
+        if (radio.type !== 'radio' || radio.name !== 'payment_plugin') return;
+
+        var formData = new FormData();
+        formData.append('option', 'com_j2commerce');
+        formData.append('task', 'checkout.savePaymentSelection');
+        formData.append(token, '1');
+        formData.append('payment_plugin', radio.value);
+
+        fetch(baseUrl, { method: 'POST', body: formData, headers: {'X-Requested-With': 'XMLHttpRequest'} })
+            .then(function(r) { return r.json(); })
+            .then(function(data) {
+                if (data.success) refreshSidecart();
+            })
+            .catch(function(e) { console.error('Payment selection error:', e); });
+    });
+
     // === SIDECART REFRESH ===
     function refreshSidecart() {
         var formData = new FormData();


### PR DESCRIPTION
## Core Update

### Changes

**`CartOrder.php`**
- Strip double-prefix from `event()` calls: `'onJ2CommerceCalculateDiscountTotals'` -> `'CalculateDiscountTotals'`, same for `'GetDiscountedPrice'` (two sites). `PluginHelper::event()` unconditionally prepends `onJ2Commerce`, so passing the fully-prefixed name produced `onJ2CommerceonJ2Commerce*` — which no plugin listens for. paymentdiscount, bulkdiscount, bogoboost, and subscriptionproduct discount-totals listeners were silently dead.
- `getOrderDiscounts()` now iterates `coupon_discount_amounts` per discount code, emitting one labeled line per plugin code (looking up `<code>_title` for the human label). Back-compat: legacy plugins that bump `discount_cart` without writing a per-code entry still get one bulk-discount line for the remainder.
- `saveOrderDiscounts()` persists plugin cart-level discounts to `#__j2commerce_orderdiscounts` with type `cart_discount`, code, title, and tax. Previously only coupons + vouchers were saved — plugin discounts never appeared on the confirmation page or in stored orders.

**`CouponModel.php`**
- Strip the same double-prefix on `BeforeCouponIsValid` and `GetCouponDiscountAmount` event dispatch.

**`CheckoutController.php`**
- Add `savePaymentSelection()` AJAX task mirroring `saveShippingSelection()`. Writes selected payment plugin to `j2commerce.payment_method` session key so downstream discount plugins (and any other plugin reading the live selection) get a current value.

**`tmpl/checkout/{bootstrap5,uikit3}/default.php`**
- Add `change` listener on `name="payment_plugin"` radio that POSTs `checkout.savePaymentSelection` then calls `refreshSidecart()`. Without this the sidecart only refreshed for shipping changes; switching payment did not re-fire `onJ2CommerceCalculateDiscountTotals`, so payment-method-specific discounts never updated.

**`TaxHelper.php` (new)**
- Public tax-calculation API centralising the rate-resolution + dispatcher event used by `CartOrder`. Plugins applying discounts, custom report generators, and third-party integrations can reuse the same math instead of re-implementing it.

### Files Modified
| Type | Count |
|------|-------|
| PHP files | 5 modified, 1 new |
| JS/CSS assets | 0 |
| Language files | 0 |
| XML/Config | 0 |

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Code style (php-cs-fixer) passed on modified files
- [x] Core files only (non-core excluded)