### PR TITLE
fix(core): self-load com_j2commerce lang inside coupon + voucher layouts

### DIFF
--- a/components/com_j2commerce/layouts/form/coupon.php
+++ b/components/com_j2commerce/layouts/form/coupon.php
@@ -17,6 +17,11 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 
+// Self-load com_j2commerce strings — layout may render on non-component pages (cart drawer, mini-cart, custom modules).
+$lang = Factory::getApplication()->getLanguage();
+$lang->load('com_j2commerce', JPATH_SITE)
+    || $lang->load('com_j2commerce', JPATH_SITE . '/components/com_j2commerce');
+
 // Self-register assets (once per request, no matter how many instances)
 static $assetsRegistered = false;
 if (!$assetsRegistered) {

--- a/components/com_j2commerce/layouts/form/voucher.php
+++ b/components/com_j2commerce/layouts/form/voucher.php
@@ -17,6 +17,11 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 
+// Self-load com_j2commerce strings — layout may render on non-component pages (cart drawer, mini-cart, custom modules).
+$lang = Factory::getApplication()->getLanguage();
+$lang->load('com_j2commerce', JPATH_SITE)
+    || $lang->load('com_j2commerce', JPATH_SITE . '/components/com_j2commerce');
+
 // Self-register assets (once per request, no matter how many instances)
 static $assetsRegistered = false;
 if (!$assetsRegistered) {


### PR DESCRIPTION
## Core Update

### Problem

The form layouts at `components/com_j2commerce/layouts/form/coupon.php` and `voucher.php` can be rendered from non-component pages — cart drawer plugins (`plg_j2commerce_app_advancedcart`), mini-cart modules, custom storefront blocks. On those pages the caller has not loaded `com_j2commerce.ini`, so `Text::sprintf()` returns the literal language key (e.g. `COM_J2COMMERCE_COUPON_DISCOUNT_PERCENTAGE`) instead of the translated string.

### Fix

Add an idempotent `Language::load()` call near the top of each layout so the component strings are guaranteed to be available regardless of caller context.

```php
$lang = Factory::getApplication()->getLanguage();
$lang->load('com_j2commerce', JPATH_SITE)
    || $lang->load('com_j2commerce', JPATH_SITE . '/components/com_j2commerce');
```

Joomla's `Language::load()` caches per `(extension, basePath, lang_tag)`, so repeated renders within a request are no-ops. Fallback chain hits the site override first, then the component-local language directory.

### Changes

| Type | Count |
|------|-------|
| PHP files | 2 |
| Lines added | 10 |

### Files Modified

- `components/com_j2commerce/layouts/form/coupon.php`
- `components/com_j2commerce/layouts/form/voucher.php`

### Pre-Flight

- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Code style — layouts excluded from php-cs-fixer per project rule
- [x] Core files only (non-core excluded)
- [x] Rebased on `upstream/main`