### PR TITLE
feat(core): expose UPC on Flexivariable variant data

### DIFF
--- a/administrator/components/com_j2commerce/src/Model/Behavior/Flexivariable.php
+++ b/administrator/components/com_j2commerce/src/Model/Behavior/Flexivariable.php
@@ -1006,6 +1006,7 @@ class Flexivariable
         $return['is_main_as_thum'] = $isMainAsThumb;
 
         $return['sku']             = $variant->sku;
+        $return['upc']             = $variant->upc ?? '';
         $return['quantity']        = (float) $quantity;
         $return['price']           = $variant->price;
         $return['availability']    = $variant->availability;


### PR DESCRIPTION
## Core Update

Pass through `variant->upc` (varchar(255) NULL) on the Flexivariable behavior's variant return array so frontend / JS can render UPC where SKU is already shown.

### Changes
| File | Change |
|---|---|
| `administrator/components/com_j2commerce/src/Model/Behavior/Flexivariable.php` | +1 line — add `$return['upc'] = $variant->upc ?? '';` next to `$return['sku']` |

### Files Modified
| Type | Count |
|------|-------|
| PHP files | 1 |
| JS/CSS assets | 0 |
| Language files | 0 |
| XML/Config | 0 |

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Code style (php-cs-fixer) passed
- [x] Core files only (non-core excluded)
- [x] DB column verified — `j6_j2commerce_variants.upc` exists as `varchar(255) NULL`