### PR TITLE
feat(core): add 3 product display event hooks for plugin extensibility

### DIFF
--- a/components/com_j2commerce/tmpl/product/default_accordiontabs.php
+++ b/components/com_j2commerce/tmpl/product/default_accordiontabs.php
@@ -22,6 +22,7 @@ $hasLongDesc  = $this->params->get('item_show_ldesc') && !empty(trim(strip_tags(
 $hasDescription = $hasShortDesc || $hasLongDesc;
 $set_specification_active = !$hasDescription;
 ?>
+<?php echo J2CommerceHelper::plugin()->eventWithHtml('BeforeProductContent', [$this->item, J2CommerceHelper::utilities()->getContext('view_content')])->getArgument('html'); ?>
 
 <div class="accordion mt-5" id="j2CommerceAccordion">
     <?php if($hasDescription):?>

--- a/components/com_j2commerce/tmpl/product/default_notabs.php
+++ b/components/com_j2commerce/tmpl/product/default_notabs.php
@@ -8,7 +8,10 @@
  */
 
 defined('_JEXEC') or die;
+
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 ?>
+<?php echo J2CommerceHelper::plugin()->eventWithHtml('BeforeProductContent', [$this->item, J2CommerceHelper::utilities()->getContext('view_content')])->getArgument('html'); ?>
 <div class="row">
     <div class="col-sm-12">
         <?php

--- a/components/com_j2commerce/tmpl/product/default_tabs.php
+++ b/components/com_j2commerce/tmpl/product/default_tabs.php
@@ -12,6 +12,7 @@ defined('_JEXEC') or die;
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 use Joomla\CMS\Language\Text;
 ?>
+<?php echo J2CommerceHelper::plugin()->eventWithHtml('BeforeProductContent', [$this->item, J2CommerceHelper::utilities()->getContext('view_content')])->getArgument('html'); ?>
 <div class="row">
     <div class="col-sm-12">
         <ul class="nav nav-tabs" id="j2commerce-product-detail-tab" role="tablist">

--- a/components/com_j2commerce/tmpl/product/default_title.php
+++ b/components/com_j2commerce/tmpl/product/default_title.php
@@ -10,7 +10,10 @@
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
 // phpcs:enable PSR1.Files.SideEffects
+
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 ?>
+<?php echo J2CommerceHelper::plugin()->eventWithHtml('BeforeProductTitle', [$this->item, J2CommerceHelper::utilities()->getContext('view_title')])->getArgument('html'); ?>
 <?php if ($this->params->get('item_show_title', 1)) : ?>
 	<h<?php echo $this->params->get('item_title_headertag', '2'); ?> class="product-title mb-3 font-j2commerce text-capitalize"><?php echo $this->escape($this->item->product_name); ?></h<?php echo $this->params->get('item_title_headertag', '2'); ?>>
 <?php endif; ?>

--- a/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/view_accordions.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/view_accordions.php
@@ -25,6 +25,7 @@ $hasLongDesc  = $this->params->get('item_show_ldesc', 1) && !empty(trim(strip_ta
 $hasDescription = $hasShortDesc || $hasLongDesc;
 $set_specification_active = !$hasDescription;
 ?>
+<?php echo J2CommerceHelper::plugin()->eventWithHtml('BeforeProductContent', [$this->product, J2CommerceHelper::utilities()->getContext('view_content')])->getArgument('html', ''); ?>
 <div class="accordion mt-5" id="j2CommerceAccordion">
     <?php if($hasDescription):?>
         <div class="accordion-item border-0 mb-2">

--- a/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/view_images.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/view_images.php
@@ -179,3 +179,5 @@ $thumbsId  = 'product-gallery-thumbs-' . $productId;
         if (thumbsEl) thumbsEl._swiper = thumbSwiper;
     });
 </script>
+
+<?php echo J2CommerceHelper::plugin()->eventWithHtml('AfterProductGallery', [$this->product, J2CommerceHelper::utilities()->getContext('view_images')])->getArgument('html'); ?>

--- a/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/view_notabs.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/view_notabs.php
@@ -11,12 +11,14 @@ declare(strict_types=1);
 
 defined('_JEXEC') or die;
 
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 use Joomla\CMS\Language\Text;
 
 /** @var \J2Commerce\Component\J2commerce\Site\View\Product\HtmlView $this */
 
 $productfilters = $this->product->productfilters ?? [];
 ?>
+<?php echo J2CommerceHelper::plugin()->eventWithHtml('BeforeProductContent', [$this->product, J2CommerceHelper::utilities()->getContext('view_content')])->getArgument('html', ''); ?>
 <div class="row">
     <div class="col-sm-12">
         <?php if ($this->params->get('item_show_ldesc', 1)) : ?>

--- a/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/view_tabs.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/view_tabs.php
@@ -25,6 +25,7 @@ $hasLongDesc  = $this->params->get('item_show_ldesc', 1) && !empty(trim(strip_ta
 $hasDescription = $hasShortDesc || $hasLongDesc;
 $set_specification_active = !$hasDescription;
 ?>
+<?php echo J2CommerceHelper::plugin()->eventWithHtml('BeforeProductContent', [$this->product, $this->context])->getArgument('html', ''); ?>
 <?php echo J2CommerceHelper::plugin()->eventWithHtml('BeforeProductTabs', [$this->product, $this->context])->getArgument('html', ''); ?>
 
 <div class="j2commerce-product-tabs">

--- a/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/view_title.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/view_title.php
@@ -11,9 +11,12 @@ declare(strict_types=1);
 
 defined('_JEXEC') or die;
 
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
+
 /** @var \J2Commerce\Component\J2commerce\Site\View\Product\HtmlView $this */
 
 ?>
+<?php echo J2CommerceHelper::plugin()->eventWithHtml('BeforeProductTitle', [$this->product, J2CommerceHelper::utilities()->getContext('view_title')])->getArgument('html', ''); ?>
 <?php if ($this->params->get('item_show_title', 1)) : ?>
     <h<?php echo $this->params->get('item_title_headertag', '2'); ?> class="product-title">
         <?php echo $this->escape($this->product->product_name); ?>

--- a/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/view_accordions.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/view_accordions.php
@@ -25,6 +25,7 @@ $hasLongDesc  = $this->params->get('item_show_ldesc', 1) && !empty(trim(strip_ta
 $hasDescription = $hasShortDesc || $hasLongDesc;
 $set_specification_active = !$hasDescription;
 ?>
+<?php echo J2CommerceHelper::plugin()->eventWithHtml('BeforeProductContent', [$this->product, J2CommerceHelper::utilities()->getContext('view_content')])->getArgument('html', ''); ?>
 <div class="accordion mt-5" id="j2CommerceAccordion">
     <?php if($hasDescription):?>
         <div class="accordion-item border-0 mb-2">

--- a/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/view_images.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/view_images.php
@@ -179,3 +179,5 @@ $thumbsId  = 'product-gallery-thumbs-' . $productId;
         if (thumbsEl) thumbsEl._swiper = thumbSwiper;
     });
 </script>
+
+<?php echo J2CommerceHelper::plugin()->eventWithHtml('AfterProductGallery', [$this->product, J2CommerceHelper::utilities()->getContext('view_images')])->getArgument('html'); ?>

--- a/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/view_notabs.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/view_notabs.php
@@ -11,12 +11,14 @@ declare(strict_types=1);
 
 defined('_JEXEC') or die;
 
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 use Joomla\CMS\Language\Text;
 
 /** @var \J2Commerce\Component\J2commerce\Site\View\Product\HtmlView $this */
 
 $productfilters = $this->product->productfilters ?? [];
 ?>
+<?php echo J2CommerceHelper::plugin()->eventWithHtml('BeforeProductContent', [$this->product, J2CommerceHelper::utilities()->getContext('view_content')])->getArgument('html', ''); ?>
 <div class="row">
     <div class="col-sm-12">
         <?php if ($this->params->get('item_show_ldesc', 1)) : ?>

--- a/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/view_tabs.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/view_tabs.php
@@ -25,6 +25,7 @@ $hasLongDesc  = $this->params->get('item_show_ldesc', 1) && !empty(trim(strip_ta
 $hasDescription = $hasShortDesc || $hasLongDesc;
 $set_specification_active = !$hasDescription;
 ?>
+<?php echo J2CommerceHelper::plugin()->eventWithHtml('BeforeProductContent', [$this->product, $this->context])->getArgument('html', ''); ?>
 
 <div class="j2commerce-product-tabs">
     <ul class="nav nav-tabs d-flex justify-content-center border-0 rounded-0 bg-transparent" id="j2commerce-product-detail-tab" role="tablist">

--- a/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/view_title.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/view_title.php
@@ -11,9 +11,12 @@ declare(strict_types=1);
 
 defined('_JEXEC') or die;
 
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
+
 /** @var \J2Commerce\Component\J2commerce\Site\View\Product\HtmlView $this */
 
 ?>
+<?php echo J2CommerceHelper::plugin()->eventWithHtml('BeforeProductTitle', [$this->product, J2CommerceHelper::utilities()->getContext('view_title')])->getArgument('html', ''); ?>
 <?php if ($this->params->get('item_show_title', 1)) : ?>
     <h<?php echo $this->params->get('item_title_headertag', '2'); ?> class="product-title">
         <?php echo $this->escape($this->product->product_name); ?>

--- a/plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_images.php
+++ b/plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_images.php
@@ -179,3 +179,5 @@ $thumbsId  = 'product-gallery-thumbs-' . $productId;
         if (thumbsEl) thumbsEl._swiper = thumbSwiper;
     });
 </script>
+
+<?php echo J2CommerceHelper::plugin()->eventWithHtml('AfterProductGallery', [$this->product, J2CommerceHelper::utilities()->getContext('view_images')])->getArgument('html'); ?>

--- a/plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_notabs.php
+++ b/plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_notabs.php
@@ -11,7 +11,10 @@
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
 // phpcs:enable PSR1.Files.SideEffects
+
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 ?>
+<?php echo J2CommerceHelper::plugin()->eventWithHtml('BeforeProductContent', [$this->item, J2CommerceHelper::utilities()->getContext('view_content')])->getArgument('html', ''); ?>
 	<div class="uk-grid" uk-grid>
 		<div class="uk-width-1-1">
 				<?php

--- a/plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_tabs.php
+++ b/plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_tabs.php
@@ -12,8 +12,10 @@
 \defined('_JEXEC') or die;
 // phpcs:enable PSR1.Files.SideEffects
 
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 use Joomla\CMS\Language\Text;
 ?>
+<?php echo J2CommerceHelper::plugin()->eventWithHtml('BeforeProductContent', [$this->item, J2CommerceHelper::utilities()->getContext('view_content')])->getArgument('html', ''); ?>
 	<div class="uk-grid" uk-grid>
 		<div class="uk-width-1-1">
 			<?php

--- a/plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_title.php
+++ b/plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_title.php
@@ -11,7 +11,10 @@
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
 // phpcs:enable PSR1.Files.SideEffects
+
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 ?>
+<?php echo J2CommerceHelper::plugin()->eventWithHtml('BeforeProductTitle', [$this->product, J2CommerceHelper::utilities()->getContext('view_title')])->getArgument('html', ''); ?>
 
 <?php if($this->params->get('item_show_title', 1)): ?>
 	<h<?php echo $this->params->get('item_title_headertag', '2'); ?> class="product-title uk-margin-small">

--- a/plugins/j2commerce/app_uikit/tmpl/uikit/view_accordions.php
+++ b/plugins/j2commerce/app_uikit/tmpl/uikit/view_accordions.php
@@ -21,6 +21,7 @@ $hasLongDesc  = $this->params->get('item_show_ldesc', 1) && !empty(trim(strip_ta
 $hasDescription = $hasShortDesc || $hasLongDesc;
 $set_specification_active = !$hasDescription;
 ?>
+<?php echo J2CommerceHelper::plugin()->eventWithHtml('BeforeProductContent', [$this->product, J2CommerceHelper::utilities()->getContext('view_content')])->getArgument('html', ''); ?>
 <ul class="uk-accordion uk-margin-large-top" id="j2CommerceAccordion" uk-accordion>
     <?php if ($hasDescription) : ?>
         <li class="uk-open">

--- a/plugins/j2commerce/app_uikit/tmpl/uikit/view_images.php
+++ b/plugins/j2commerce/app_uikit/tmpl/uikit/view_images.php
@@ -179,3 +179,5 @@ $thumbsId  = 'product-gallery-thumbs-' . $productId;
         if (thumbsEl) thumbsEl._swiper = thumbSwiper;
     });
 </script>
+
+<?php echo J2CommerceHelper::plugin()->eventWithHtml('AfterProductGallery', [$this->product, J2CommerceHelper::utilities()->getContext('view_images')])->getArgument('html'); ?>

--- a/plugins/j2commerce/app_uikit/tmpl/uikit/view_notabs.php
+++ b/plugins/j2commerce/app_uikit/tmpl/uikit/view_notabs.php
@@ -11,12 +11,14 @@ declare(strict_types=1);
 
 defined('_JEXEC') or die;
 
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 use Joomla\CMS\Language\Text;
 
 /** @var \J2Commerce\Component\J2commerce\Site\View\Product\HtmlView $this */
 
 $productfilters = $this->product->productfilters ?? [];
 ?>
+<?php echo J2CommerceHelper::plugin()->eventWithHtml('BeforeProductContent', [$this->product, J2CommerceHelper::utilities()->getContext('view_content')])->getArgument('html', ''); ?>
 <div class="uk-grid" uk-grid>
     <div class="uk-width-1-1">
         <?php if ($this->params->get('item_show_ldesc', 1)) : ?>

--- a/plugins/j2commerce/app_uikit/tmpl/uikit/view_tabs.php
+++ b/plugins/j2commerce/app_uikit/tmpl/uikit/view_tabs.php
@@ -22,6 +22,7 @@ $hasLongDesc  = $this->params->get('item_show_ldesc', 1) && !empty(trim(strip_ta
 $hasDescription = $hasShortDesc || $hasLongDesc;
 $set_specification_active = !$hasDescription;
 ?>
+<?php echo J2CommerceHelper::plugin()->eventWithHtml('BeforeProductContent', [$this->product, $this->context])->getArgument('html', ''); ?>
 
 <div class="j2commerce-product-tabs uk-margin-top">
     <ul uk-tab class="uk-flex-center">

--- a/plugins/j2commerce/app_uikit/tmpl/uikit/view_title.php
+++ b/plugins/j2commerce/app_uikit/tmpl/uikit/view_title.php
@@ -11,9 +11,12 @@ declare(strict_types=1);
 
 defined('_JEXEC') or die;
 
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
+
 /** @var \J2Commerce\Component\J2commerce\Site\View\Product\HtmlView $this */
 
 ?>
+<?php echo J2CommerceHelper::plugin()->eventWithHtml('BeforeProductTitle', [$this->product, J2CommerceHelper::utilities()->getContext('view_title')])->getArgument('html', ''); ?>
 <?php if ($this->params->get('item_show_title', 1)) : ?>
     <h<?php echo $this->params->get('item_title_headertag', '2'); ?> class="product-title">
         <?php echo $this->escape($this->product->product_name); ?>


### PR DESCRIPTION
## Core Update

Adds three new `eventWithHtml` dispatch sites in the product detail view so J2Commerce plugins (and third-party extensions) can inject HTML at meaningful product-page slots. Original motivation: `plg_j2commerce_app_socialmedia` needs to render social share buttons in 6 distinct locations, but only 2 of those (Before/After Add to Cart Button) currently have hooks.

### New events fired

| Event | Fired in | Anchor |
|---|---|---|
| `onJ2CommerceBeforeProductTitle` | `components/com_j2commerce/tmpl/product/default_title.php` | Just before the `<h?>` product title |
| `onJ2CommerceBeforeProductContent` | `default_tabs.php`, `default_notabs.php`, `default_accordiontabs.php` | Just before the tab/accordion content wrapper opens |
| `onJ2CommerceAfterProductGallery` | `app_bootstrap5/tmpl/{bootstrap5,tag_bootstrap5}/view_images.php` + `app_uikit/tmpl/{uikit,tag_uikit}/view_images.php` | After the Swiper init `</script>` at end of file |

All dispatched via the existing `J2CommerceHelper::plugin()->eventWithHtml(...)->getArgument('html')` pattern, matching how `BeforeAddToCartButton` / `AfterAddToCartButton` / `AfterProductDisplay` / `BeforeRenderingProductDetailImage` etc. are already wired in the codebase.

### Files Modified

| Type | Count |
|------|------:|
| Component product templates | 4 |
| App gallery templates (bootstrap5 + uikit) | 4 |
| **Total** | **8** |

```
components/com_j2commerce/tmpl/product/default_title.php
components/com_j2commerce/tmpl/product/default_accordiontabs.php
components/com_j2commerce/tmpl/product/default_notabs.php
components/com_j2commerce/tmpl/product/default_tabs.php
plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/view_images.php
plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/view_images.php
plugins/j2commerce/app_uikit/tmpl/uikit/view_images.php
plugins/j2commerce/app_uikit/tmpl/tag_uikit/view_images.php
```

### Context tags passed

- `view_title`, `view_content`, `view_images` — mirroring existing `view_cart` convention from `default_cart.php`

### Behavioral impact

**Zero** behavioral change to existing rendering. Hooks fire `eventWithHtml` with empty subscriber set if no plugin listens — output is the empty string. Existing styled output is unchanged.

### Pre-Flight

- [x] PHP syntax check passed on all 8 files (`php -l`)
- [x] No secrets detected (`grep password|secret|api_key|ghp_`)
- [x] No FOF remnants (`grep F0FModel|F0FController|F0FTable|JFactory::`)
- [x] Code style — all 8 files under `tmpl/` so PHPCS exempt per project convention
- [x] Core files only (verified against `build/build_package.php`)
- [x] In sync with `upstream/main` (0 commits behind before push)

### Companion work

Non-core plugin `plg_j2commerce_app_socialmedia` (ships in `j2commerce/j2commerce6extensions`) will be PR'd separately with its `getSubscribedEvents()` already wired to receive these 3 new events.