### PR TITLE
feat(core): framework-aware checkout payment_icons layout

### DIFF
--- a/components/com_j2commerce/layouts/app_bootstrap5/checkout/payment_icons.php
+++ b/components/com_j2commerce/layouts/app_bootstrap5/checkout/payment_icons.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\Language\Text;
+
+$element   = $displayData['element'] ?? '';
+$cardTypes = $displayData['card_types'] ?? [];
+
+if (empty($cardTypes)) {
+    return;
+}
+?>
+<div id="<?php echo htmlspecialchars($element); ?>_payment_icons"
+     class="checkout-payment-icons d-flex align-items-center justify-content-end gap-1 gap-sm-2">
+    <?php foreach ($cardTypes as $icon) : ?>
+        <div class="payment-icon payment-icon-<?php echo htmlspecialchars($icon['type']); ?>">
+            <img src="<?php echo htmlspecialchars($icon['url']); ?>"
+                 alt="<?php echo htmlspecialchars($icon['type'] . ' ' . Text::_('COM_J2COMMERCE_PAYMENT_OPTION')); ?>"
+                 class="payment-plugin-image">
+        </div>
+    <?php endforeach; ?>
+</div>

--- a/components/com_j2commerce/layouts/app_uikit/checkout/payment_icons.php
+++ b/components/com_j2commerce/layouts/app_uikit/checkout/payment_icons.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\Language\Text;
+
+$element   = $displayData['element'] ?? '';
+$cardTypes = $displayData['card_types'] ?? [];
+
+if (empty($cardTypes)) {
+    return;
+}
+?>
+<div id="<?php echo htmlspecialchars($element); ?>_payment_icons"
+     class="checkout-payment-icons uk-flex uk-flex-middle uk-flex-right" style="gap: .5rem;">
+    <?php foreach ($cardTypes as $icon) : ?>
+        <div class="payment-icon payment-icon-<?php echo htmlspecialchars($icon['type']); ?>">
+            <img src="<?php echo htmlspecialchars($icon['url']); ?>"
+                 alt="<?php echo htmlspecialchars($icon['type'] . ' ' . Text::_('COM_J2COMMERCE_PAYMENT_OPTION')); ?>"
+                 class="payment-plugin-image">
+        </div>
+    <?php endforeach; ?>
+</div>

--- a/components/com_j2commerce/layouts/checkout/payment_icons.php
+++ b/components/com_j2commerce/layouts/checkout/payment_icons.php
@@ -11,22 +11,13 @@
 \defined('_JEXEC') or die;
 // phpcs:enable PSR1.Files.SideEffects
 
-use Joomla\CMS\Language\Text;
+use J2Commerce\Component\J2commerce\Site\Service\ProductLayoutService;
 
-$element   = $displayData['element'] ?? '';
-$cardTypes = $displayData['card_types'] ?? [];
-
-if (empty($cardTypes)) {
-    return;
-}
-?>
-<div id="<?php echo htmlspecialchars($element); ?>_payment_icons"
-     class="checkout-payment-icons d-flex align-items-center justify-content-end gap-1 gap-sm-2">
-    <?php foreach ($cardTypes as $icon) : ?>
-        <div class="payment-icon payment-icon-<?php echo htmlspecialchars($icon['type']); ?>">
-            <img src="<?php echo htmlspecialchars($icon['url']); ?>"
-                 alt="<?php echo htmlspecialchars($icon['type'] . ' ' . Text::_('COM_J2COMMERCE_PAYMENT_OPTION')); ?>"
-                 class="payment-plugin-image">
-        </div>
-    <?php endforeach; ?>
-</div>
+/**
+ * Framework-neutral shim. Delegates to the shared layout resolver, which picks
+ * the active subtemplate's markup (layouts/app_bootstrap5|app_uikit/checkout/).
+ * Kept for backward compatibility with callers that target this path directly.
+ *
+ * @var array $displayData
+ */
+echo ProductLayoutService::renderLayout('checkout.payment_icons', $displayData);


### PR DESCRIPTION
## Core Update

Routes `checkout.payment_icons` through the existing `ProductLayoutService` resolver so UIkit sites render UIkit markup instead of hardcoded Bootstrap 5. Establishes the framework-subfolder + delegation-shim pattern for shared checkout layouts.

### Changes
- **NEW** `components/com_j2commerce/layouts/app_bootstrap5/checkout/payment_icons.php` — Bootstrap 5 markup
- **NEW** `components/com_j2commerce/layouts/app_uikit/checkout/payment_icons.php` — UIkit 3 equivalent (`uk-flex uk-flex-middle uk-flex-right`)
- **MOD** `components/com_j2commerce/layouts/checkout/payment_icons.php` — thin shim delegating to `ProductLayoutService::renderLayout('checkout.payment_icons', \$displayData)`

Resolver cascade gives this layout per-framework template overrides (`templates/{tpl}/html/layouts/com_j2commerce/{app_xxx}/checkout/`) and the `onJ2CommerceRegisterLayoutPaths` event for free. `J2CommerceHelper::getPaymentIcons()` unchanged; CSS hook classes kept framework-neutral; no recursion (resolver searches app_xxx/ folders, never layouts/checkout/).

### Files Modified
| Type | Count |
|------|-------|
| PHP layout files | 3 (2 new, 1 modified) |

### Pre-Flight
- [x] PHP syntax check passed (all 3 files)
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only (non-core build/ + .gitignore excluded)