### PR TITLE
feat(core): framework-split 7 shared layouts via resolver shim

### DIFF
--- a/components/com_j2commerce/layouts/app_bootstrap5/fallback/missing_template.php
+++ b/components/com_j2commerce/layouts/app_bootstrap5/fallback/missing_template.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+\defined('_JEXEC') or die;
+
+use Joomla\CMS\Language\Text;
+
+$filename    = $displayData['filename'] ?? 'unknown';
+$subtemplate = $displayData['subtemplate'] ?? 'unknown';
+?>
+<div class="alert alert-warning j2commerce-missing-template" role="alert">
+    <strong><?php echo Text::_('COM_J2COMMERCE'); ?>:</strong>
+    <?php echo Text::sprintf(
+        'COM_J2COMMERCE_ERR_TEMPLATE_FILE_NOT_FOUND',
+        htmlspecialchars($filename, ENT_QUOTES, 'UTF-8'),
+        htmlspecialchars($subtemplate, ENT_QUOTES, 'UTF-8')
+    ); ?>
+</div>

--- a/components/com_j2commerce/layouts/app_bootstrap5/form/coupon.php
+++ b/components/com_j2commerce/layouts/app_bootstrap5/form/coupon.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\Language\Text;
+
+$couponCode   = $displayData['couponCode'] ?? '';
+$formId       = $displayData['formId'] ?? 'j2c-coupon';
+$variant      = $displayData['variant'] ?? 'inline';
+$accordionId  = $displayData['accordionId'] ?? '';
+$expanded     = !empty($displayData['expanded']);
+$discountLabel = $displayData['discountLabel'] ?? '';
+$hasCoupon    = !empty($couponCode);
+
+?>
+<?php if ($variant === 'accordion') : ?>
+<div class="accordion-item">
+    <h2 class="accordion-header">
+        <button class="accordion-button <?php echo $expanded ? '' : 'collapsed'; ?>"
+                type="button"
+                data-bs-toggle="collapse"
+                data-bs-target="#<?php echo $formId; ?>-collapse"
+                aria-expanded="<?php echo $expanded ? 'true' : 'false'; ?>"
+                aria-controls="<?php echo $formId; ?>-collapse">
+            <?php echo Text::_('COM_J2COMMERCE_COUPON_CODE'); ?>
+            <?php if ($hasCoupon) : ?>
+                <span class="badge bg-success ms-2 j2c-coupon-badge"><?php echo htmlspecialchars($couponCode, ENT_QUOTES, 'UTF-8'); ?></span>
+                <?php if ($discountLabel) : ?>
+                    <small class="text-body-tertiary ms-1"><?php echo htmlspecialchars($discountLabel, ENT_QUOTES, 'UTF-8'); ?></small>
+                <?php endif; ?>
+            <?php endif; ?>
+        </button>
+    </h2>
+    <div id="<?php echo $formId; ?>-collapse"
+         class="accordion-collapse collapse <?php echo $expanded ? 'show' : ''; ?>"
+         <?php if ($accordionId) : ?>data-bs-parent="#<?php echo $accordionId; ?>"<?php endif; ?>>
+        <div class="accordion-body">
+<?php endif; ?>
+
+<div class="j2c-coupon-form" id="<?php echo $formId; ?>" data-type="coupon">
+    <?php if ($hasCoupon) : ?>
+        <div class="d-flex align-items-center justify-content-between py-1">
+            <span>
+                <span class="badge bg-success">
+                    <span class="icon-tag me-1" aria-hidden="true"></span><?php echo htmlspecialchars($couponCode, ENT_QUOTES, 'UTF-8'); ?>
+                </span>
+                <?php if ($discountLabel) : ?>
+                    <small class="text-body-tertiary ms-1"><?php echo htmlspecialchars($discountLabel, ENT_QUOTES, 'UTF-8'); ?></small>
+                <?php endif; ?>
+            </span>
+            <button type="button" class="btn btn-sm btn-link text-danger p-0 j2c-remove-coupon"
+                    title="<?php echo Text::_('COM_J2COMMERCE_REMOVE_COUPON'); ?>">
+                <span class="icon-times" aria-hidden="true"></span>
+                <?php echo Text::_('COM_J2COMMERCE_REMOVE'); ?>
+            </button>
+        </div>
+    <?php else : ?>
+        <div class="j2c-coupon-input-wrap">
+            <div class="input-group">
+                <div class="input-group_inner">
+                    <input type="text" name="coupon" class="form-control" placeholder="<?php echo Text::_('COM_J2COMMERCE_ENTER_COUPON_CODE'); ?>" aria-label="<?php echo Text::_('COM_J2COMMERCE_COUPON_CODE'); ?>" />
+                </div>
+                <button type="button" class="btn btn-outline-secondary j2c-apply-coupon">
+                    <?php echo Text::_('COM_J2COMMERCE_APPLY_COUPON'); ?>
+                </button>
+            </div>
+        </div>
+    <?php endif; ?>
+</div>
+
+<?php if ($variant === 'accordion') : ?>
+        </div>
+    </div>
+</div>
+<?php endif; ?>

--- a/components/com_j2commerce/layouts/app_bootstrap5/form/voucher.php
+++ b/components/com_j2commerce/layouts/app_bootstrap5/form/voucher.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\Language\Text;
+
+$voucherCode  = $displayData['voucherCode'] ?? '';
+$formId       = $displayData['formId'] ?? 'j2c-voucher';
+$variant      = $displayData['variant'] ?? 'inline';
+$accordionId  = $displayData['accordionId'] ?? '';
+$expanded     = !empty($displayData['expanded']);
+$discountLabel = $displayData['discountLabel'] ?? '';
+$hasVoucher   = !empty($voucherCode);
+
+?>
+<?php if ($variant === 'accordion') : ?>
+<div class="accordion-item">
+    <h2 class="accordion-header">
+        <button class="accordion-button <?php echo $expanded ? '' : 'collapsed'; ?>"
+                type="button"
+                data-bs-toggle="collapse"
+                data-bs-target="#<?php echo $formId; ?>-collapse"
+                aria-expanded="<?php echo $expanded ? 'true' : 'false'; ?>"
+                aria-controls="<?php echo $formId; ?>-collapse">
+            <?php echo Text::_('COM_J2COMMERCE_VOUCHER_CODE'); ?>
+            <?php if ($hasVoucher) : ?>
+                <span class="badge bg-success ms-2 j2c-voucher-badge"><?php echo htmlspecialchars($voucherCode, ENT_QUOTES, 'UTF-8'); ?></span>
+                <?php if ($discountLabel) : ?>
+                    <small class="text-body-tertiary ms-1"><?php echo htmlspecialchars($discountLabel, ENT_QUOTES, 'UTF-8'); ?></small>
+                <?php endif; ?>
+            <?php endif; ?>
+        </button>
+    </h2>
+    <div id="<?php echo $formId; ?>-collapse"
+         class="accordion-collapse collapse <?php echo $expanded ? 'show' : ''; ?>"
+         <?php if ($accordionId) : ?>data-bs-parent="#<?php echo $accordionId; ?>"<?php endif; ?>>
+        <div class="accordion-body">
+<?php endif; ?>
+
+<div class="j2c-voucher-form" id="<?php echo $formId; ?>" data-type="voucher">
+    <?php if ($hasVoucher) : ?>
+        <div class="d-flex align-items-center justify-content-between py-1">
+            <span>
+                <span class="badge bg-success">
+                    <span class="icon-tag me-1" aria-hidden="true"></span><?php echo htmlspecialchars($voucherCode, ENT_QUOTES, 'UTF-8'); ?>
+                </span>
+                <?php if ($discountLabel) : ?>
+                    <small class="text-body-tertiary ms-1"><?php echo htmlspecialchars($discountLabel, ENT_QUOTES, 'UTF-8'); ?></small>
+                <?php endif; ?>
+            </span>
+            <button type="button" class="btn btn-sm btn-link text-danger p-0 j2c-remove-voucher"
+                    title="<?php echo Text::_('COM_J2COMMERCE_REMOVE_VOUCHER'); ?>">
+                <span class="icon-times" aria-hidden="true"></span>
+                <?php echo Text::_('COM_J2COMMERCE_REMOVE'); ?>
+            </button>
+        </div>
+    <?php else : ?>
+        <div class="j2c-voucher-input-wrap">
+            <div class="input-group">
+                <div class="input-group_inner">
+                    <input type="text" name="voucher" class="form-control" placeholder="<?php echo Text::_('COM_J2COMMERCE_ENTER_VOUCHER_CODE'); ?>" aria-label="<?php echo Text::_('COM_J2COMMERCE_VOUCHER_CODE'); ?>" />
+                </div>
+                <button type="button" class="btn btn-outline-secondary j2c-apply-voucher">
+                    <?php echo Text::_('COM_J2COMMERCE_APPLY_VOUCHER'); ?>
+                </button>
+            </div>
+        </div>
+    <?php endif; ?>
+</div>
+
+<?php if ($variant === 'accordion') : ?>
+        </div>
+    </div>
+</div>
+<?php endif; ?>

--- a/components/com_j2commerce/layouts/app_bootstrap5/orderitem/attributes.php
+++ b/components/com_j2commerce/layouts/app_bootstrap5/orderitem/attributes.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+\defined('_JEXEC') or die;
+
+use Joomla\CMS\Language\Text;
+
+$grouped         = $displayData['grouped'] ?? [];
+$typeRenderers   = $displayData['typeRenderers'] ?? [];
+$isAdminContext  = $displayData['isAdminContext'] ?? false;
+$buildDownloadUrl = $displayData['buildDownloadUrl'] ?? static fn(string $m): string => '';
+$variant         = $displayData['variant'] ?? 'full';
+
+$mutedClass      = 'text-body-secondary d-block text-truncate';
+$attachmentIcon  = static function (string $type) use ($variant): string {
+    if ($variant === 'inline') {
+        return '';
+    }
+    $faIcon = $type === 'image' ? 'fa-image' : 'fa-paperclip';
+    return '<span class="fa-solid ' . $faIcon . ' me-1" aria-hidden="true"></span>';
+};
+
+// --- Inline variant (emails) — no paperclip icon, plain filename text ---
+if ($variant === 'inline') {
+    $parts = [];
+    foreach ($grouped as $group) {
+        $groupType = $group['type'] ?? '';
+        if (!empty($typeRenderers[$groupType])) {
+            $parts[] = $typeRenderers[$groupType];
+            continue;
+        }
+        foreach ($group['items'] as $gItem) {
+            if ($groupType === 'product_children') {
+                $qty = (int) ($gItem['qty'] ?? 1);
+                $label = $qty > 1
+                    ? '(' . $qty . ') ' . htmlspecialchars($gItem['name'], ENT_QUOTES, 'UTF-8')
+                    : htmlspecialchars($gItem['name'], ENT_QUOTES, 'UTF-8');
+                $parts[] = $label;
+            } else {
+                $name  = htmlspecialchars($gItem['name'] ?? '', ENT_QUOTES, 'UTF-8');
+                $value = htmlspecialchars($gItem['value'] ?? '', ENT_QUOTES, 'UTF-8');
+                $parts[] = $value !== '' ? $name . ': ' . $value : $name;
+            }
+        }
+    }
+    echo implode('<br>', $parts);
+    return;
+}
+
+// --- Compact variant (sidecart, checkout, confirmation, myprofile, drawer, cart_module) ---
+if ($variant === 'compact') {
+    foreach ($grouped as $group) {
+        $groupType = $group['type'] ?? '';
+        if (!empty($typeRenderers[$groupType])) {
+            echo $typeRenderers[$groupType];
+            continue;
+        }
+        foreach ($group['items'] as $gItem) {
+            if ($groupType === 'product_children') {
+                $qty = (int) ($gItem['qty'] ?? 1);
+                $label = $qty > 1
+                    ? '(' . $qty . ') ' . htmlspecialchars(Text::_($gItem['name']), ENT_QUOTES, 'UTF-8')
+                    : htmlspecialchars(Text::_($gItem['name']), ENT_QUOTES, 'UTF-8');
+                ?>
+                <small class="<?php echo $mutedClass; ?>"><?php echo $label; ?></small>
+                <?php
+                continue;
+            }
+
+            $name      = htmlspecialchars(Text::_($gItem['name'] ?? ''), ENT_QUOTES, 'UTF-8');
+            $value     = htmlspecialchars(Text::_($gItem['value'] ?? ''), ENT_QUOTES, 'UTF-8');
+            $mangled   = (string) ($gItem['mangled_name'] ?? '');
+            $itemType  = (string) ($gItem['type'] ?? '');
+            ?>
+            <small class="<?php echo $mutedClass; ?>">
+                <?php echo $name; ?><?php if ($value !== ''): ?>:
+                    <?php if ($mangled !== ''): ?>
+                        <?php echo $attachmentIcon($itemType); ?><?php echo $value; ?>
+                    <?php else: ?>
+                        <?php echo $value; ?>
+                    <?php endif; ?>
+                <?php endif; ?>
+            </small>
+            <?php
+        }
+    }
+    return;
+}
+
+// --- Full variant (cart page, admin order, admin edit) ---
+?>
+<div class="cart-item-options">
+    <?php foreach ($grouped as $group):
+        $groupType = $group['type'] ?? '';
+        if (!empty($typeRenderers[$groupType])) {
+            echo $typeRenderers[$groupType];
+            continue;
+        }
+        foreach ($group['items'] as $gItem):
+            if ($groupType === 'product_children'):
+                $qty = (int) ($gItem['qty'] ?? 1);
+                $label = $qty > 1
+                    ? '(' . $qty . ') ' . htmlspecialchars(Text::_($gItem['name']), ENT_QUOTES, 'UTF-8')
+                    : htmlspecialchars(Text::_($gItem['name']), ENT_QUOTES, 'UTF-8');
+                ?>
+                <div class="small d-flex align-items-center">
+                    <div class="item-option item-option-name"><?php echo $label; ?></div>
+                </div>
+            <?php else:
+                $name      = htmlspecialchars(Text::_($gItem['name'] ?? ''), ENT_QUOTES, 'UTF-8');
+                $value     = htmlspecialchars(Text::_($gItem['value'] ?? ''), ENT_QUOTES, 'UTF-8');
+                $mangled   = (string) ($gItem['mangled_name'] ?? '');
+                $itemType  = (string) ($gItem['type'] ?? '');
+                $isFileUpload = $mangled !== '';
+                $isAdminLink  = $isFileUpload && $isAdminContext;
+                ?>
+                <div class="small d-flex align-items-center">
+                    <div class="item-option item-option-name"><?php echo $name; ?><?php if ($value !== ''): ?>:<?php endif; ?></div>
+                    <?php if ($isAdminLink):
+                        $href = $buildDownloadUrl($mangled);
+                        ?>
+                        <a href="<?php echo $href; ?>" class="item-option item-option-value fw-bold ms-1 text-decoration-none"
+                           title="<?php echo htmlspecialchars(Text::_('COM_J2COMMERCE_ORDER_DOWNLOAD_FILE'), ENT_QUOTES, 'UTF-8'); ?>">
+                            <?php echo $attachmentIcon($itemType); ?><?php echo $value; ?>
+                        </a>
+                    <?php elseif ($isFileUpload && $value !== ''): ?>
+                        <div class="item-option item-option-value fw-bold ms-1">
+                            <?php echo $attachmentIcon($itemType); ?><?php echo $value; ?>
+                        </div>
+                    <?php elseif ($value !== ''): ?>
+                        <div class="item-option item-option-value fw-bold ms-1"><?php echo $value; ?></div>
+                    <?php endif; ?>
+                </div>
+            <?php endif;
+        endforeach;
+    endforeach; ?>
+</div>

--- a/components/com_j2commerce/layouts/app_bootstrap5/product/quantity.php
+++ b/components/com_j2commerce/layouts/app_bootstrap5/product/quantity.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+\defined('_JEXEC') or die;
+
+use Joomla\CMS\Language\Text;
+
+// Shim pre-builds $inputHtml and passes it via $displayData
+$inputHtml         = (string) ($displayData['inputHtml'] ?? '');
+$decrementDisabled = (string) ($displayData['decrementDisabled'] ?? '');
+$incrementDisabled = (string) ($displayData['incrementDisabled'] ?? '');
+$iconMinus         = (string) ($displayData['iconMinus'] ?? '');
+$iconPlus          = (string) ($displayData['iconPlus'] ?? '');
+?>
+<div class="count-input flex-shrink-0">
+    <button type="button" class="btn btn-icon btn-lg" data-decrement aria-label="<?php echo htmlspecialchars(Text::_('COM_J2COMMERCE_DECREASE_QUANTITY'), ENT_QUOTES, 'UTF-8'); ?>"<?php echo $decrementDisabled; ?>>
+        <span class="<?php echo htmlspecialchars($iconMinus, ENT_QUOTES, 'UTF-8'); ?>" aria-hidden="true"></span>
+    </button>
+    <?php echo $inputHtml; ?>
+    <button type="button" class="btn btn-icon btn-lg" data-increment aria-label="<?php echo htmlspecialchars(Text::_('COM_J2COMMERCE_INCREASE_QUANTITY'), ENT_QUOTES, 'UTF-8'); ?>"<?php echo $incrementDisabled; ?>>
+        <span class="<?php echo htmlspecialchars($iconPlus, ENT_QUOTES, 'UTF-8'); ?>" aria-hidden="true"></span>
+    </button>
+</div>

--- a/components/com_j2commerce/layouts/app_bootstrap5/productoption/upload_file.php
+++ b/components/com_j2commerce/layouts/app_bootstrap5/productoption/upload_file.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+\defined('_JEXEC') or die;
+
+use Joomla\CMS\Language\Text;
+
+$optionId    = (int) ($displayData['productOptionId'] ?? 0);
+$required    = (bool) ($displayData['required'] ?? false);
+$optionName  = (string) ($displayData['optionName'] ?? '');
+$ajaxUrl     = (string) ($displayData['ajaxUrl'] ?? '');
+$maxSizeMB   = (float) ($displayData['maxSizeMB'] ?? 0);
+$allowedExts = (string) ($displayData['allowedExts'] ?? '');
+$inputId     = (string) ($displayData['inputId'] ?? 'j2c-upload-input-' . $optionId);
+$hiddenId    = (string) ($displayData['hiddenId'] ?? 'input-option' . $optionId);
+$hintText    = (string) ($displayData['hintText'] ?? '');
+$esc         = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+?>
+<div id="option-<?php echo $optionId; ?>" class="option mb-3">
+    <span class="form-label fw-bold d-block mb-2">
+        <?php echo $esc(Text::_($optionName)); ?><?php if ($required) : ?>
+            <span class="text-danger" aria-hidden="true">*</span>
+            <span class="visually-hidden"><?php echo Text::_('JFIELD_FIELD_REQUIRED_LABEL'); ?></span>
+        <?php endif; ?>
+    </span>
+    <label
+        class="j2c-dropzone"
+        for="<?php echo $inputId; ?>"
+        data-j2c-dropzone
+        data-ajax-url="<?php echo $esc($ajaxUrl); ?>"
+        data-hidden-id="<?php echo $esc($hiddenId); ?>"
+        data-maxsize-mb="<?php echo $esc((string) $maxSizeMB); ?>"
+        data-allowed-exts="<?php echo $esc($allowedExts); ?>">
+        <span class="dz-icon">
+            <span class="fa-solid fa-cloud-arrow-up" aria-hidden="true"></span>
+        </span>
+        <span class="dz-title">
+            <?php echo Text::_('COM_J2COMMERCE_UPLOAD_DROP_FILE_OR'); ?>
+            <span class="browse"><?php echo Text::_('COM_J2COMMERCE_UPLOAD_BROWSE'); ?></span>
+        </span>
+        <?php if ($hintText !== '') : ?>
+            <span class="dz-hint"><?php echo $esc($hintText); ?></span>
+        <?php endif; ?>
+        <input
+            id="<?php echo $inputId; ?>"
+            type="file"
+            class="j2c-upload-native"
+            <?php if ($allowedExts !== '') : ?>accept=".<?php echo $esc(str_replace(',', ',.', $allowedExts)); ?>"<?php endif; ?>
+            <?php if ($required) : ?>aria-required="true"<?php endif; ?> />
+    </label>
+    <input
+        type="hidden"
+        name="product_option[<?php echo $optionId; ?>]"
+        value=""
+        id="<?php echo $esc($hiddenId); ?>" />
+</div>

--- a/components/com_j2commerce/layouts/app_bootstrap5/productoption/upload_image.php
+++ b/components/com_j2commerce/layouts/app_bootstrap5/productoption/upload_image.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+\defined('_JEXEC') or die;
+
+use Joomla\CMS\Language\Text;
+
+$optionId    = (int) ($displayData['productOptionId'] ?? 0);
+$required    = (bool) ($displayData['required'] ?? false);
+$optionName  = (string) ($displayData['optionName'] ?? '');
+$ajaxUrl     = (string) ($displayData['ajaxUrl'] ?? '');
+$maxSizeMB   = (float) ($displayData['maxSizeMB'] ?? 0);
+$allowedExts = (string) ($displayData['allowedExts'] ?? '');
+$inputId     = (string) ($displayData['inputId'] ?? 'j2c-upload-input-' . $optionId);
+$hiddenId    = (string) ($displayData['hiddenId'] ?? 'input-option' . $optionId);
+$hintText    = (string) ($displayData['hintText'] ?? '');
+$esc         = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+?>
+<div id="option-<?php echo $optionId; ?>" class="option mb-3">
+    <span class="form-label fw-bold d-block mb-2">
+        <?php echo $esc(Text::_($optionName)); ?><?php if ($required) : ?>
+            <span class="text-danger" aria-hidden="true">*</span>
+            <span class="visually-hidden"><?php echo Text::_('JFIELD_FIELD_REQUIRED_LABEL'); ?></span>
+        <?php endif; ?>
+    </span>
+    <label
+        class="j2c-img-hero"
+        for="<?php echo $inputId; ?>"
+        data-j2c-image-hero
+        data-ajax-url="<?php echo $esc($ajaxUrl); ?>"
+        data-hidden-id="<?php echo $esc($hiddenId); ?>"
+        data-maxsize-mb="<?php echo $esc((string) $maxSizeMB); ?>"
+        data-allowed-exts="<?php echo $esc($allowedExts); ?>">
+        <span class="ih-thumb">
+            <span class="j2c-thumb-icon fa-solid fa-image" aria-hidden="true"></span>
+        </span>
+        <span class="ih-body">
+            <span class="ih-title"><?php echo Text::_('COM_J2COMMERCE_UPLOAD_ADD_PHOTO'); ?></span>
+            <span class="ih-hint"><?php echo $esc($hintText); ?></span>
+        </span>
+        <span class="ih-cta" data-icon-replace="fa-solid fa-arrows-rotate">
+            <span class="fa-solid fa-upload me-1" aria-hidden="true"></span>
+            <?php echo Text::_('COM_J2COMMERCE_PRODUCT_OPTION_CHOOSE_IMAGE'); ?>
+        </span>
+        <input
+            id="<?php echo $inputId; ?>"
+            type="file"
+            class="j2c-upload-native"
+            accept="image/*"
+            <?php if ($required) : ?>aria-required="true"<?php endif; ?> />
+    </label>
+    <input
+        type="hidden"
+        name="product_option[<?php echo $optionId; ?>]"
+        value=""
+        id="<?php echo $esc($hiddenId); ?>" />
+</div>

--- a/components/com_j2commerce/layouts/app_uikit/fallback/missing_template.php
+++ b/components/com_j2commerce/layouts/app_uikit/fallback/missing_template.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+\defined('_JEXEC') or die;
+
+use Joomla\CMS\Language\Text;
+
+$filename    = $displayData['filename'] ?? 'unknown';
+$subtemplate = $displayData['subtemplate'] ?? 'unknown';
+?>
+<div class="uk-alert uk-alert-warning j2commerce-missing-template" role="alert">
+    <strong><?php echo Text::_('COM_J2COMMERCE'); ?>:</strong>
+    <?php echo Text::sprintf(
+        'COM_J2COMMERCE_ERR_TEMPLATE_FILE_NOT_FOUND',
+        htmlspecialchars($filename, ENT_QUOTES, 'UTF-8'),
+        htmlspecialchars($subtemplate, ENT_QUOTES, 'UTF-8')
+    ); ?>
+</div>

--- a/components/com_j2commerce/layouts/app_uikit/form/coupon.php
+++ b/components/com_j2commerce/layouts/app_uikit/form/coupon.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\Language\Text;
+
+$couponCode   = $displayData['couponCode'] ?? '';
+$formId       = $displayData['formId'] ?? 'j2c-coupon';
+$variant      = $displayData['variant'] ?? 'inline';
+$expanded     = !empty($displayData['expanded']);
+$discountLabel = $displayData['discountLabel'] ?? '';
+$hasCoupon    = !empty($couponCode);
+
+?>
+<?php if ($variant === 'accordion') : ?>
+<li<?php echo $expanded ? ' class="uk-open"' : ''; ?>>
+    <a class="uk-accordion-title" href="#">
+        <?php echo Text::_('COM_J2COMMERCE_COUPON_CODE'); ?>
+        <?php if ($hasCoupon) : ?>
+            <span class="uk-label uk-label-success uk-margin-small-left j2c-coupon-badge"><?php echo htmlspecialchars($couponCode, ENT_QUOTES, 'UTF-8'); ?></span>
+            <?php if ($discountLabel) : ?>
+                <small class="uk-text-muted uk-margin-small-left"><?php echo htmlspecialchars($discountLabel, ENT_QUOTES, 'UTF-8'); ?></small>
+            <?php endif; ?>
+        <?php endif; ?>
+    </a>
+    <div class="uk-accordion-content">
+<?php endif; ?>
+
+<div class="j2c-coupon-form" id="<?php echo $formId; ?>" data-type="coupon">
+    <?php if ($hasCoupon) : ?>
+        <div class="uk-flex uk-flex-middle uk-flex-between uk-padding-small">
+            <span>
+                <span class="uk-label uk-label-success">
+                    <span class="icon-tag uk-margin-small-right" aria-hidden="true"></span><?php echo htmlspecialchars($couponCode, ENT_QUOTES, 'UTF-8'); ?>
+                </span>
+                <?php if ($discountLabel) : ?>
+                    <small class="uk-text-muted uk-margin-small-left"><?php echo htmlspecialchars($discountLabel, ENT_QUOTES, 'UTF-8'); ?></small>
+                <?php endif; ?>
+            </span>
+            <button type="button" class="uk-button uk-button-link uk-text-danger j2c-remove-coupon"
+                    title="<?php echo Text::_('COM_J2COMMERCE_REMOVE_COUPON'); ?>">
+                <span class="icon-times" aria-hidden="true"></span>
+                <?php echo Text::_('COM_J2COMMERCE_REMOVE'); ?>
+            </button>
+        </div>
+    <?php else : ?>
+        <div class="j2c-coupon-input-wrap">
+            <div class="uk-flex uk-flex-stretch">
+                <div class="uk-width-expand">
+                    <input type="text" name="coupon" class="uk-input" placeholder="<?php echo Text::_('COM_J2COMMERCE_ENTER_COUPON_CODE'); ?>" aria-label="<?php echo Text::_('COM_J2COMMERCE_COUPON_CODE'); ?>" />
+                </div>
+                <button type="button" class="uk-button uk-button-default j2c-apply-coupon">
+                    <?php echo Text::_('COM_J2COMMERCE_APPLY_COUPON'); ?>
+                </button>
+            </div>
+        </div>
+    <?php endif; ?>
+</div>
+
+<?php if ($variant === 'accordion') : ?>
+    </div>
+</li>
+<?php endif; ?>

--- a/components/com_j2commerce/layouts/app_uikit/form/voucher.php
+++ b/components/com_j2commerce/layouts/app_uikit/form/voucher.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\Language\Text;
+
+$voucherCode  = $displayData['voucherCode'] ?? '';
+$formId       = $displayData['formId'] ?? 'j2c-voucher';
+$variant      = $displayData['variant'] ?? 'inline';
+$expanded     = !empty($displayData['expanded']);
+$discountLabel = $displayData['discountLabel'] ?? '';
+$hasVoucher   = !empty($voucherCode);
+
+?>
+<?php if ($variant === 'accordion') : ?>
+<li<?php echo $expanded ? ' class="uk-open"' : ''; ?>>
+    <a class="uk-accordion-title" href="#">
+        <?php echo Text::_('COM_J2COMMERCE_VOUCHER_CODE'); ?>
+        <?php if ($hasVoucher) : ?>
+            <span class="uk-label uk-label-success uk-margin-small-left j2c-voucher-badge"><?php echo htmlspecialchars($voucherCode, ENT_QUOTES, 'UTF-8'); ?></span>
+            <?php if ($discountLabel) : ?>
+                <small class="uk-text-muted uk-margin-small-left"><?php echo htmlspecialchars($discountLabel, ENT_QUOTES, 'UTF-8'); ?></small>
+            <?php endif; ?>
+        <?php endif; ?>
+    </a>
+    <div class="uk-accordion-content">
+<?php endif; ?>
+
+<div class="j2c-voucher-form" id="<?php echo $formId; ?>" data-type="voucher">
+    <?php if ($hasVoucher) : ?>
+        <div class="uk-flex uk-flex-middle uk-flex-between uk-padding-small">
+            <span>
+                <span class="uk-label uk-label-success">
+                    <span class="icon-tag uk-margin-small-right" aria-hidden="true"></span><?php echo htmlspecialchars($voucherCode, ENT_QUOTES, 'UTF-8'); ?>
+                </span>
+                <?php if ($discountLabel) : ?>
+                    <small class="uk-text-muted uk-margin-small-left"><?php echo htmlspecialchars($discountLabel, ENT_QUOTES, 'UTF-8'); ?></small>
+                <?php endif; ?>
+            </span>
+            <button type="button" class="uk-button uk-button-link uk-text-danger j2c-remove-voucher"
+                    title="<?php echo Text::_('COM_J2COMMERCE_REMOVE_VOUCHER'); ?>">
+                <span class="icon-times" aria-hidden="true"></span>
+                <?php echo Text::_('COM_J2COMMERCE_REMOVE'); ?>
+            </button>
+        </div>
+    <?php else : ?>
+        <div class="j2c-voucher-input-wrap">
+            <div class="uk-flex uk-flex-stretch">
+                <div class="uk-width-expand">
+                    <input type="text" name="voucher" class="uk-input" placeholder="<?php echo Text::_('COM_J2COMMERCE_ENTER_VOUCHER_CODE'); ?>" aria-label="<?php echo Text::_('COM_J2COMMERCE_VOUCHER_CODE'); ?>" />
+                </div>
+                <button type="button" class="uk-button uk-button-default j2c-apply-voucher">
+                    <?php echo Text::_('COM_J2COMMERCE_APPLY_VOUCHER'); ?>
+                </button>
+            </div>
+        </div>
+    <?php endif; ?>
+</div>
+
+<?php if ($variant === 'accordion') : ?>
+    </div>
+</li>
+<?php endif; ?>

--- a/components/com_j2commerce/layouts/app_uikit/orderitem/attributes.php
+++ b/components/com_j2commerce/layouts/app_uikit/orderitem/attributes.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+\defined('_JEXEC') or die;
+
+use Joomla\CMS\Language\Text;
+
+$grouped         = $displayData['grouped'] ?? [];
+$typeRenderers   = $displayData['typeRenderers'] ?? [];
+$isAdminContext  = $displayData['isAdminContext'] ?? false;
+$buildDownloadUrl = $displayData['buildDownloadUrl'] ?? static fn(string $m): string => '';
+$variant         = $displayData['variant'] ?? 'full';
+
+$mutedClass      = 'uk-text-muted uk-display-block uk-text-truncate';
+$attachmentIcon  = static function (string $type) use ($variant): string {
+    if ($variant === 'inline') {
+        return '';
+    }
+    $ukIcon = $type === 'image' ? 'image' : 'file-text';
+    return '<span uk-icon="icon: ' . $ukIcon . '" class="uk-margin-small-right" aria-hidden="true"></span>';
+};
+
+// --- Inline variant (emails) — no icon, plain filename text ---
+if ($variant === 'inline') {
+    $parts = [];
+    foreach ($grouped as $group) {
+        $groupType = $group['type'] ?? '';
+        if (!empty($typeRenderers[$groupType])) {
+            $parts[] = $typeRenderers[$groupType];
+            continue;
+        }
+        foreach ($group['items'] as $gItem) {
+            if ($groupType === 'product_children') {
+                $qty = (int) ($gItem['qty'] ?? 1);
+                $label = $qty > 1
+                    ? '(' . $qty . ') ' . htmlspecialchars($gItem['name'], ENT_QUOTES, 'UTF-8')
+                    : htmlspecialchars($gItem['name'], ENT_QUOTES, 'UTF-8');
+                $parts[] = $label;
+            } else {
+                $name  = htmlspecialchars($gItem['name'] ?? '', ENT_QUOTES, 'UTF-8');
+                $value = htmlspecialchars($gItem['value'] ?? '', ENT_QUOTES, 'UTF-8');
+                $parts[] = $value !== '' ? $name . ': ' . $value : $name;
+            }
+        }
+    }
+    echo implode('<br>', $parts);
+    return;
+}
+
+// --- Compact variant (sidecart, checkout, confirmation, myprofile, drawer, cart_module) ---
+if ($variant === 'compact') {
+    foreach ($grouped as $group) {
+        $groupType = $group['type'] ?? '';
+        if (!empty($typeRenderers[$groupType])) {
+            echo $typeRenderers[$groupType];
+            continue;
+        }
+        foreach ($group['items'] as $gItem) {
+            if ($groupType === 'product_children') {
+                $qty = (int) ($gItem['qty'] ?? 1);
+                $label = $qty > 1
+                    ? '(' . $qty . ') ' . htmlspecialchars(Text::_($gItem['name']), ENT_QUOTES, 'UTF-8')
+                    : htmlspecialchars(Text::_($gItem['name']), ENT_QUOTES, 'UTF-8');
+                ?>
+                <small class="<?php echo $mutedClass; ?>"><?php echo $label; ?></small>
+                <?php
+                continue;
+            }
+
+            $name      = htmlspecialchars(Text::_($gItem['name'] ?? ''), ENT_QUOTES, 'UTF-8');
+            $value     = htmlspecialchars(Text::_($gItem['value'] ?? ''), ENT_QUOTES, 'UTF-8');
+            $mangled   = (string) ($gItem['mangled_name'] ?? '');
+            $itemType  = (string) ($gItem['type'] ?? '');
+            ?>
+            <small class="<?php echo $mutedClass; ?>">
+                <?php echo $name; ?><?php if ($value !== ''): ?>:
+                    <?php if ($mangled !== ''): ?>
+                        <?php echo $attachmentIcon($itemType); ?><?php echo $value; ?>
+                    <?php else: ?>
+                        <?php echo $value; ?>
+                    <?php endif; ?>
+                <?php endif; ?>
+            </small>
+            <?php
+        }
+    }
+    return;
+}
+
+// --- Full variant (cart page, admin order, admin edit) ---
+?>
+<div class="cart-item-options">
+    <?php foreach ($grouped as $group):
+        $groupType = $group['type'] ?? '';
+        if (!empty($typeRenderers[$groupType])) {
+            echo $typeRenderers[$groupType];
+            continue;
+        }
+        foreach ($group['items'] as $gItem):
+            if ($groupType === 'product_children'):
+                $qty = (int) ($gItem['qty'] ?? 1);
+                $label = $qty > 1
+                    ? '(' . $qty . ') ' . htmlspecialchars(Text::_($gItem['name']), ENT_QUOTES, 'UTF-8')
+                    : htmlspecialchars(Text::_($gItem['name']), ENT_QUOTES, 'UTF-8');
+                ?>
+                <div class="uk-text-small uk-flex uk-flex-middle">
+                    <div class="item-option item-option-name"><?php echo $label; ?></div>
+                </div>
+            <?php else:
+                $name      = htmlspecialchars(Text::_($gItem['name'] ?? ''), ENT_QUOTES, 'UTF-8');
+                $value     = htmlspecialchars(Text::_($gItem['value'] ?? ''), ENT_QUOTES, 'UTF-8');
+                $mangled   = (string) ($gItem['mangled_name'] ?? '');
+                $itemType  = (string) ($gItem['type'] ?? '');
+                $isFileUpload = $mangled !== '';
+                $isAdminLink  = $isFileUpload && $isAdminContext;
+                ?>
+                <div class="uk-text-small uk-flex uk-flex-middle">
+                    <div class="item-option item-option-name"><?php echo $name; ?><?php if ($value !== ''): ?>:<?php endif; ?></div>
+                    <?php if ($isAdminLink):
+                        $href = $buildDownloadUrl($mangled);
+                        ?>
+                        <a href="<?php echo $href; ?>" class="item-option item-option-value uk-text-bold uk-margin-small-left text-decoration-none"
+                           title="<?php echo htmlspecialchars(Text::_('COM_J2COMMERCE_ORDER_DOWNLOAD_FILE'), ENT_QUOTES, 'UTF-8'); ?>">
+                            <?php echo $attachmentIcon($itemType); ?><?php echo $value; ?>
+                        </a>
+                    <?php elseif ($isFileUpload && $value !== ''): ?>
+                        <div class="item-option item-option-value uk-text-bold uk-margin-small-left">
+                            <?php echo $attachmentIcon($itemType); ?><?php echo $value; ?>
+                        </div>
+                    <?php elseif ($value !== ''): ?>
+                        <div class="item-option item-option-value uk-text-bold uk-margin-small-left"><?php echo $value; ?></div>
+                    <?php endif; ?>
+                </div>
+            <?php endif;
+        endforeach;
+    endforeach; ?>
+</div>

--- a/components/com_j2commerce/layouts/app_uikit/product/quantity.php
+++ b/components/com_j2commerce/layouts/app_uikit/product/quantity.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+\defined('_JEXEC') or die;
+
+use Joomla\CMS\Language\Text;
+
+// Shim pre-builds $inputHtml and passes it via $displayData
+$inputHtml         = (string) ($displayData['inputHtml'] ?? '');
+$decrementDisabled = (string) ($displayData['decrementDisabled'] ?? '');
+$incrementDisabled = (string) ($displayData['incrementDisabled'] ?? '');
+?>
+<div class="count-input uk-flex-none">
+    <button type="button" class="uk-button uk-button-default" data-decrement aria-label="<?php echo htmlspecialchars(Text::_('COM_J2COMMERCE_DECREASE_QUANTITY'), ENT_QUOTES, 'UTF-8'); ?>"<?php echo $decrementDisabled; ?>>
+        <span uk-icon="icon: minus" aria-hidden="true"></span>
+    </button>
+    <?php echo $inputHtml; ?>
+    <button type="button" class="uk-button uk-button-default" data-increment aria-label="<?php echo htmlspecialchars(Text::_('COM_J2COMMERCE_INCREASE_QUANTITY'), ENT_QUOTES, 'UTF-8'); ?>"<?php echo $incrementDisabled; ?>>
+        <span uk-icon="icon: plus" aria-hidden="true"></span>
+    </button>
+</div>

--- a/components/com_j2commerce/layouts/app_uikit/productoption/upload_file.php
+++ b/components/com_j2commerce/layouts/app_uikit/productoption/upload_file.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+\defined('_JEXEC') or die;
+
+use Joomla\CMS\Language\Text;
+
+$optionId    = (int) ($displayData['productOptionId'] ?? 0);
+$required    = (bool) ($displayData['required'] ?? false);
+$optionName  = (string) ($displayData['optionName'] ?? '');
+$ajaxUrl     = (string) ($displayData['ajaxUrl'] ?? '');
+$maxSizeMB   = (float) ($displayData['maxSizeMB'] ?? 0);
+$allowedExts = (string) ($displayData['allowedExts'] ?? '');
+$inputId     = (string) ($displayData['inputId'] ?? 'j2c-upload-input-' . $optionId);
+$hiddenId    = (string) ($displayData['hiddenId'] ?? 'input-option' . $optionId);
+$hintText    = (string) ($displayData['hintText'] ?? '');
+$esc         = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+?>
+<div id="option-<?php echo $optionId; ?>" class="option uk-margin-small-bottom">
+    <span class="uk-form-label uk-text-bold uk-display-block uk-margin-small-bottom">
+        <?php echo $esc(Text::_($optionName)); ?><?php if ($required) : ?>
+            <span class="uk-text-danger" aria-hidden="true">*</span>
+            <span class="uk-hidden-visually"><?php echo Text::_('JFIELD_FIELD_REQUIRED_LABEL'); ?></span>
+        <?php endif; ?>
+    </span>
+    <label
+        class="uk-upl-dropzone"
+        for="<?php echo $inputId; ?>"
+        data-j2c-dropzone
+        data-ajax-url="<?php echo $esc($ajaxUrl); ?>"
+        data-hidden-id="<?php echo $esc($hiddenId); ?>"
+        data-maxsize-mb="<?php echo $esc((string) $maxSizeMB); ?>"
+        data-allowed-exts="<?php echo $esc($allowedExts); ?>">
+        <span class="dz-icon">
+            <span uk-icon="icon: cloud-upload" aria-hidden="true"></span>
+        </span>
+        <span class="dz-title">
+            <?php echo Text::_('COM_J2COMMERCE_UPLOAD_DROP_FILE_OR'); ?>
+            <span class="browse"><?php echo Text::_('COM_J2COMMERCE_UPLOAD_BROWSE'); ?></span>
+        </span>
+        <?php if ($hintText !== '') : ?>
+            <span class="dz-hint"><?php echo $esc($hintText); ?></span>
+        <?php endif; ?>
+        <input
+            id="<?php echo $inputId; ?>"
+            type="file"
+            class="j2c-upload-native"
+            <?php if ($allowedExts !== '') : ?>accept=".<?php echo $esc(str_replace(',', ',.', $allowedExts)); ?>"<?php endif; ?>
+            <?php if ($required) : ?>aria-required="true"<?php endif; ?> />
+    </label>
+    <input
+        type="hidden"
+        name="product_option[<?php echo $optionId; ?>]"
+        value=""
+        id="<?php echo $esc($hiddenId); ?>" />
+</div>

--- a/components/com_j2commerce/layouts/app_uikit/productoption/upload_image.php
+++ b/components/com_j2commerce/layouts/app_uikit/productoption/upload_image.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+\defined('_JEXEC') or die;
+
+use Joomla\CMS\Language\Text;
+
+$optionId    = (int) ($displayData['productOptionId'] ?? 0);
+$required    = (bool) ($displayData['required'] ?? false);
+$optionName  = (string) ($displayData['optionName'] ?? '');
+$ajaxUrl     = (string) ($displayData['ajaxUrl'] ?? '');
+$maxSizeMB   = (float) ($displayData['maxSizeMB'] ?? 0);
+$allowedExts = (string) ($displayData['allowedExts'] ?? '');
+$inputId     = (string) ($displayData['inputId'] ?? 'j2c-upload-input-' . $optionId);
+$hiddenId    = (string) ($displayData['hiddenId'] ?? 'input-option' . $optionId);
+$hintText    = (string) ($displayData['hintText'] ?? '');
+$esc         = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+?>
+<div id="option-<?php echo $optionId; ?>" class="option uk-margin-small-bottom">
+    <span class="uk-form-label uk-text-bold uk-display-block uk-margin-small-bottom">
+        <?php echo $esc(Text::_($optionName)); ?><?php if ($required) : ?>
+            <span class="uk-text-danger" aria-hidden="true">*</span>
+            <span class="uk-hidden-visually"><?php echo Text::_('JFIELD_FIELD_REQUIRED_LABEL'); ?></span>
+        <?php endif; ?>
+    </span>
+    <label
+        class="uk-img-hero"
+        for="<?php echo $inputId; ?>"
+        data-j2c-image-hero
+        data-ajax-url="<?php echo $esc($ajaxUrl); ?>"
+        data-hidden-id="<?php echo $esc($hiddenId); ?>"
+        data-maxsize-mb="<?php echo $esc((string) $maxSizeMB); ?>"
+        data-allowed-exts="<?php echo $esc($allowedExts); ?>">
+        <span class="ih-thumb">
+            <span class="j2c-thumb-icon" uk-icon="icon: image" aria-hidden="true"></span>
+        </span>
+        <span class="ih-body">
+            <span class="ih-title"><?php echo Text::_('COM_J2COMMERCE_UPLOAD_ADD_PHOTO'); ?></span>
+            <span class="ih-hint"><?php echo $esc($hintText); ?></span>
+        </span>
+        <span class="ih-cta" data-icon-replace="uk-icon-refresh">
+            <span uk-icon="icon: upload" class="uk-margin-small-right" aria-hidden="true"></span>
+            <?php echo Text::_('COM_J2COMMERCE_PRODUCT_OPTION_CHOOSE_IMAGE'); ?>
+        </span>
+        <input
+            id="<?php echo $inputId; ?>"
+            type="file"
+            class="j2c-upload-native"
+            accept="image/*"
+            <?php if ($required) : ?>aria-required="true"<?php endif; ?> />
+    </label>
+    <input
+        type="hidden"
+        name="product_option[<?php echo $optionId; ?>]"
+        value=""
+        id="<?php echo $esc($hiddenId); ?>" />
+</div>

--- a/components/com_j2commerce/layouts/fallback/missing_template.php
+++ b/components/com_j2commerce/layouts/fallback/missing_template.php
@@ -11,16 +11,14 @@ declare(strict_types=1);
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Language\Text;
+use J2Commerce\Component\J2commerce\Site\Service\ProductLayoutService;
 
-$filename    = $displayData['filename'] ?? 'unknown';
-$subtemplate = $displayData['subtemplate'] ?? 'unknown';
-?>
-<div class="alert alert-warning j2commerce-missing-template" role="alert">
-    <strong><?php echo Text::_('COM_J2COMMERCE'); ?>:</strong>
-    <?php echo Text::sprintf(
-        'COM_J2COMMERCE_ERR_TEMPLATE_FILE_NOT_FOUND',
-        htmlspecialchars($filename, ENT_QUOTES, 'UTF-8'),
-        htmlspecialchars($subtemplate, ENT_QUOTES, 'UTF-8')
-    ); ?>
-</div>
+$rawFramework = $displayData['framework'] ?? '';
+$framework = ($rawFramework === 'uikit3' || $rawFramework === 'uikit') ? 'uikit' : 'bootstrap5';
+
+ProductLayoutService::setSubtemplateOverride($framework);
+try {
+    echo ProductLayoutService::renderLayout('fallback.missing_template', $displayData);
+} finally {
+    ProductLayoutService::clearSubtemplateOverride();
+}

--- a/components/com_j2commerce/layouts/form/coupon.php
+++ b/components/com_j2commerce/layouts/form/coupon.php
@@ -12,6 +12,7 @@
 // phpcs:enable PSR1.Files.SideEffects
 
 use J2Commerce\Component\J2commerce\Administrator\Helper\CurrencyHelper;
+use J2Commerce\Component\J2commerce\Site\Service\ProductLayoutService;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
@@ -48,26 +49,14 @@ if (!$assetsRegistered) {
     $assetsRegistered = true;
 }
 
-$couponCode    = $displayData['couponCode'] ?? '';
-$formId        = $displayData['formId'] ?? 'j2c-coupon';
-$variant       = $displayData['variant'] ?? 'inline';
-$accordionId   = $displayData['accordionId'] ?? '';
-$expanded      = !empty($displayData['expanded']);
-$showDiscount  = !empty($displayData['showDiscount']);
-$framework     = $displayData['framework'] ?? 'bootstrap5';
-$isUikit       = ($framework === 'uikit3');
-$hasCoupon     = !empty($couponCode);
+// Normalize framework: caller passes 'framework' key from its own context
+$rawFramework = $displayData['framework'] ?? 'bootstrap5';
+$framework = ($rawFramework === 'uikit3' || $rawFramework === 'uikit') ? 'uikit' : 'bootstrap5';
 
-// Framework-conditional class strings
-$clsAppliedRow  = $isUikit ? 'uk-flex uk-flex-middle uk-flex-between uk-padding-small' : 'd-flex align-items-center justify-content-between py-1';
-$clsBadge       = $isUikit ? 'uk-label uk-label-success' : 'badge bg-success';
-$clsIconMargin  = $isUikit ? 'uk-margin-small-right' : 'me-1';
-$clsDiscountSm  = $isUikit ? 'uk-text-muted uk-margin-small-left' : 'text-body-tertiary ms-1';
-$clsRemoveBtn   = $isUikit ? 'uk-button uk-button-link uk-text-danger j2c-remove-coupon' : 'btn btn-sm btn-link text-danger p-0 j2c-remove-coupon';
-$clsInputWrap   = $isUikit ? 'uk-flex uk-flex-stretch' : 'input-group';
-$clsInputInner  = $isUikit ? 'uk-width-expand' : 'input-group_inner';
-$clsInput       = $isUikit ? 'uk-input' : 'form-control';
-$clsApplyBtn    = $isUikit ? 'uk-button uk-button-default j2c-apply-coupon' : 'btn btn-outline-secondary j2c-apply-coupon';
+// Compute discount label (framework-agnostic) — passed into framework files so they stay purely presentational
+$couponCode   = $displayData['couponCode'] ?? '';
+$showDiscount = !empty($displayData['showDiscount']);
+$hasCoupon    = !empty($couponCode);
 
 $discountLabel = '';
 if ($hasCoupon && $showDiscount) {
@@ -89,79 +78,11 @@ if ($hasCoupon && $showDiscount) {
     }
 }
 
-?>
-<?php if ($variant === 'accordion' && $isUikit) : ?>
-<li<?php echo $expanded ? ' class="uk-open"' : ''; ?>>
-    <a class="uk-accordion-title" href="#">
-        <?php echo Text::_('COM_J2COMMERCE_COUPON_CODE'); ?>
-        <?php if ($hasCoupon) : ?>
-            <span class="uk-label uk-label-success uk-margin-small-left j2c-coupon-badge"><?php echo htmlspecialchars($couponCode, ENT_QUOTES, 'UTF-8'); ?></span>
-            <?php if ($discountLabel) : ?>
-                <small class="uk-text-muted uk-margin-small-left"><?php echo htmlspecialchars($discountLabel, ENT_QUOTES, 'UTF-8'); ?></small>
-            <?php endif; ?>
-        <?php endif; ?>
-    </a>
-    <div class="uk-accordion-content">
-<?php elseif ($variant === 'accordion') : ?>
-<div class="accordion-item">
-    <h2 class="accordion-header">
-        <button class="accordion-button <?php echo $expanded ? '' : 'collapsed'; ?>"
-                type="button"
-                data-bs-toggle="collapse"
-                data-bs-target="#<?php echo $formId; ?>-collapse"
-                aria-expanded="<?php echo $expanded ? 'true' : 'false'; ?>"
-                aria-controls="<?php echo $formId; ?>-collapse">
-            <?php echo Text::_('COM_J2COMMERCE_COUPON_CODE'); ?>
-            <?php if ($hasCoupon) : ?>
-                <span class="badge bg-success ms-2 j2c-coupon-badge"><?php echo htmlspecialchars($couponCode, ENT_QUOTES, 'UTF-8'); ?></span>
-                <?php if ($discountLabel) : ?>
-                    <small class="text-body-tertiary ms-1"><?php echo htmlspecialchars($discountLabel, ENT_QUOTES, 'UTF-8'); ?></small>
-                <?php endif; ?>
-            <?php endif; ?>
-        </button>
-    </h2>
-    <div id="<?php echo $formId; ?>-collapse"
-         class="accordion-collapse collapse <?php echo $expanded ? 'show' : ''; ?>"
-         <?php if ($accordionId) : ?>data-bs-parent="#<?php echo $accordionId; ?>"<?php endif; ?>>
-        <div class="accordion-body">
-<?php endif; ?>
+$displayData['discountLabel'] = $discountLabel;
 
-<div class="j2c-coupon-form" id="<?php echo $formId; ?>" data-type="coupon">
-    <?php if ($hasCoupon) : ?>
-        <div class="<?php echo $clsAppliedRow; ?>">
-            <span>
-                <span class="<?php echo $clsBadge; ?>">
-                    <span class="icon-tag <?php echo $clsIconMargin; ?>" aria-hidden="true"></span><?php echo htmlspecialchars($couponCode, ENT_QUOTES, 'UTF-8'); ?>
-                </span>
-                <?php if ($discountLabel) : ?>
-                    <small class="<?php echo $clsDiscountSm; ?>"><?php echo htmlspecialchars($discountLabel, ENT_QUOTES, 'UTF-8'); ?></small>
-                <?php endif; ?>
-            </span>
-            <button type="button" class="<?php echo $clsRemoveBtn; ?>"
-                    title="<?php echo Text::_('COM_J2COMMERCE_REMOVE_COUPON'); ?>">
-                <span class="icon-times" aria-hidden="true"></span>
-                <?php echo Text::_('COM_J2COMMERCE_REMOVE'); ?>
-            </button>
-        </div>
-    <?php else : ?>
-        <div class="j2c-coupon-input-wrap">
-            <div class="<?php echo $clsInputWrap; ?>">
-                <div class="<?php echo $clsInputInner; ?>">
-                    <input type="text" name="coupon" class="<?php echo $clsInput; ?>" placeholder="<?php echo Text::_('COM_J2COMMERCE_ENTER_COUPON_CODE'); ?>" aria-label="<?php echo Text::_('COM_J2COMMERCE_COUPON_CODE'); ?>" />
-                </div>
-                <button type="button" class="<?php echo $clsApplyBtn; ?>">
-                    <?php echo Text::_('COM_J2COMMERCE_APPLY_COUPON'); ?>
-                </button>
-            </div>
-        </div>
-    <?php endif; ?>
-</div>
-
-<?php if ($variant === 'accordion' && $isUikit) : ?>
-    </div>
-</li>
-<?php elseif ($variant === 'accordion') : ?>
-        </div>
-    </div>
-</div>
-<?php endif; ?>
+ProductLayoutService::setSubtemplateOverride($framework);
+try {
+    echo ProductLayoutService::renderLayout('form.coupon', $displayData);
+} finally {
+    ProductLayoutService::clearSubtemplateOverride();
+}

--- a/components/com_j2commerce/layouts/form/voucher.php
+++ b/components/com_j2commerce/layouts/form/voucher.php
@@ -12,6 +12,7 @@
 // phpcs:enable PSR1.Files.SideEffects
 
 use J2Commerce\Component\J2commerce\Administrator\Helper\CurrencyHelper;
+use J2Commerce\Component\J2commerce\Site\Service\ProductLayoutService;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
@@ -48,26 +49,14 @@ if (!$assetsRegistered) {
     $assetsRegistered = true;
 }
 
-$voucherCode   = $displayData['voucherCode'] ?? '';
-$formId        = $displayData['formId'] ?? 'j2c-voucher';
-$variant       = $displayData['variant'] ?? 'inline';
-$accordionId   = $displayData['accordionId'] ?? '';
-$expanded      = !empty($displayData['expanded']);
-$showDiscount  = !empty($displayData['showDiscount']);
-$framework     = $displayData['framework'] ?? 'bootstrap5';
-$isUikit       = ($framework === 'uikit3');
-$hasVoucher    = !empty($voucherCode);
+// Normalize framework: caller passes 'framework' key from its own context
+$rawFramework = $displayData['framework'] ?? 'bootstrap5';
+$framework = ($rawFramework === 'uikit3' || $rawFramework === 'uikit') ? 'uikit' : 'bootstrap5';
 
-// Framework-conditional class strings
-$clsAppliedRow  = $isUikit ? 'uk-flex uk-flex-middle uk-flex-between uk-padding-small' : 'd-flex align-items-center justify-content-between py-1';
-$clsBadge       = $isUikit ? 'uk-label uk-label-success' : 'badge bg-success';
-$clsIconMargin  = $isUikit ? 'uk-margin-small-right' : 'me-1';
-$clsDiscountSm  = $isUikit ? 'uk-text-muted uk-margin-small-left' : 'text-body-tertiary ms-1';
-$clsRemoveBtn   = $isUikit ? 'uk-button uk-button-link uk-text-danger j2c-remove-voucher' : 'btn btn-sm btn-link text-danger p-0 j2c-remove-voucher';
-$clsInputWrap   = $isUikit ? 'uk-flex uk-flex-stretch' : 'input-group';
-$clsInputInner  = $isUikit ? 'uk-width-expand' : 'input-group_inner';
-$clsInput       = $isUikit ? 'uk-input' : 'form-control';
-$clsApplyBtn    = $isUikit ? 'uk-button uk-button-default j2c-apply-voucher' : 'btn btn-outline-secondary j2c-apply-voucher';
+// Compute discount label (framework-agnostic) — passed into framework files so they stay purely presentational
+$voucherCode  = $displayData['voucherCode'] ?? '';
+$showDiscount = !empty($displayData['showDiscount']);
+$hasVoucher   = !empty($voucherCode);
 
 $discountLabel = '';
 if ($hasVoucher && $showDiscount) {
@@ -86,78 +75,11 @@ if ($hasVoucher && $showDiscount) {
     }
 }
 
-?>
-<?php if ($variant === 'accordion' && $isUikit) : ?>
-<li<?php echo $expanded ? ' class="uk-open"' : ''; ?>>
-    <a class="uk-accordion-title" href="#">
-        <?php echo Text::_('COM_J2COMMERCE_VOUCHER_CODE'); ?>
-        <?php if ($hasVoucher) : ?>
-            <span class="uk-label uk-label-success uk-margin-small-left j2c-voucher-badge"><?php echo htmlspecialchars($voucherCode, ENT_QUOTES, 'UTF-8'); ?></span>
-            <?php if ($discountLabel) : ?>
-                <small class="uk-text-muted uk-margin-small-left"><?php echo htmlspecialchars($discountLabel, ENT_QUOTES, 'UTF-8'); ?></small>
-            <?php endif; ?>
-        <?php endif; ?>
-    </a>
-    <div class="uk-accordion-content">
-<?php elseif ($variant === 'accordion') : ?>
-<div class="accordion-item">
-    <h2 class="accordion-header">
-        <button class="accordion-button <?php echo $expanded ? '' : 'collapsed'; ?>"
-                type="button"
-                data-bs-toggle="collapse"
-                data-bs-target="#<?php echo $formId; ?>-collapse"
-                aria-expanded="<?php echo $expanded ? 'true' : 'false'; ?>"
-                aria-controls="<?php echo $formId; ?>-collapse">
-            <?php echo Text::_('COM_J2COMMERCE_VOUCHER_CODE'); ?>
-            <?php if ($hasVoucher) : ?>
-                <span class="badge bg-success ms-2 j2c-voucher-badge"><?php echo htmlspecialchars($voucherCode, ENT_QUOTES, 'UTF-8'); ?></span>
-                <?php if ($discountLabel) : ?>
-                    <small class="text-body-tertiary ms-1"><?php echo htmlspecialchars($discountLabel, ENT_QUOTES, 'UTF-8'); ?></small>
-                <?php endif; ?>
-            <?php endif; ?>
-        </button>
-    </h2>
-    <div id="<?php echo $formId; ?>-collapse"
-         class="accordion-collapse collapse <?php echo $expanded ? 'show' : ''; ?>"
-         <?php if ($accordionId) : ?>data-bs-parent="#<?php echo $accordionId; ?>"<?php endif; ?>>
-        <div class="accordion-body">
-<?php endif; ?>
+$displayData['discountLabel'] = $discountLabel;
 
-<div class="j2c-voucher-form" id="<?php echo $formId; ?>" data-type="voucher">
-    <?php if ($hasVoucher) : ?>
-        <div class="<?php echo $clsAppliedRow; ?>">
-            <span>
-                <span class="<?php echo $clsBadge; ?>">
-                    <span class="icon-tag <?php echo $clsIconMargin; ?>" aria-hidden="true"></span><?php echo htmlspecialchars($voucherCode, ENT_QUOTES, 'UTF-8'); ?>
-                </span>
-                <?php if ($discountLabel) : ?>
-                    <small class="<?php echo $clsDiscountSm; ?>"><?php echo htmlspecialchars($discountLabel, ENT_QUOTES, 'UTF-8'); ?></small>
-                <?php endif; ?>
-            </span>
-            <button type="button" class="<?php echo $clsRemoveBtn; ?>" title="<?php echo Text::_('COM_J2COMMERCE_REMOVE_VOUCHER'); ?>">
-                <span class="icon-times" aria-hidden="true"></span>
-                <?php echo Text::_('COM_J2COMMERCE_REMOVE'); ?>
-            </button>
-        </div>
-    <?php else : ?>
-        <div class="j2c-voucher-input-wrap">
-            <div class="<?php echo $clsInputWrap; ?>">
-                <div class="<?php echo $clsInputInner; ?>">
-                    <input type="text" name="voucher" class="<?php echo $clsInput; ?>" placeholder="<?php echo Text::_('COM_J2COMMERCE_ENTER_VOUCHER_CODE'); ?>" aria-label="<?php echo Text::_('COM_J2COMMERCE_VOUCHER_CODE'); ?>" />
-                </div>
-                <button type="button" class="<?php echo $clsApplyBtn; ?>">
-                    <?php echo Text::_('COM_J2COMMERCE_APPLY_VOUCHER'); ?>
-                </button>
-            </div>
-        </div>
-    <?php endif; ?>
-</div>
-
-<?php if ($variant === 'accordion' && $isUikit) : ?>
-    </div>
-</li>
-<?php elseif ($variant === 'accordion') : ?>
-        </div>
-    </div>
-</div>
-<?php endif; ?>
+ProductLayoutService::setSubtemplateOverride($framework);
+try {
+    echo ProductLayoutService::renderLayout('form.voucher', $displayData);
+} finally {
+    ProductLayoutService::clearSubtemplateOverride();
+}

--- a/components/com_j2commerce/layouts/orderitem/attributes.php
+++ b/components/com_j2commerce/layouts/orderitem/attributes.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 use J2Commerce\Component\J2commerce\Administrator\Helper\OrderItemAttributeHelper;
-use Joomla\CMS\Language\Text;
+use J2Commerce\Component\J2commerce\Site\Service\ProductLayoutService;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 
@@ -30,7 +30,8 @@ $attributes = $displayData['attributes'] ?? [];
 $item       = $displayData['item'] ?? null;
 $context    = $displayData['context'] ?? 'cart';
 $variant    = $displayData['variant'] ?? 'full';
-$framework  = ($displayData['framework'] ?? 'bootstrap5') === 'uikit3' ? 'uikit3' : 'bootstrap5';
+$rawFramework = ($displayData['framework'] ?? 'bootstrap5');
+$framework  = $rawFramework === 'uikit3' ? 'uikit3' : 'bootstrap5';
 
 if (empty($attributes)) {
     return;
@@ -50,19 +51,6 @@ $event = J2CommerceHelper::plugin()->event('RenderOrderItemAttributes', [
 $typeRenderers = $event->getArgument('typeRenderers', []);
 
 $isAdminContext = ($context === 'admin_order' || $context === 'admin_edit');
-$isEmailVariant = ($variant === 'inline');
-
-$attachmentIcon = static function (string $type) use ($framework, $isEmailVariant): string {
-    if ($isEmailVariant) {
-        return '';
-    }
-    if ($framework === 'uikit3') {
-        $ukIcon = $type === 'image' ? 'image' : 'file-text';
-        return '<span uk-icon="icon: ' . $ukIcon . '" class="uk-margin-small-right" aria-hidden="true"></span>';
-    }
-    $faIcon = $type === 'image' ? 'fa-image' : 'fa-paperclip';
-    return '<span class="fa-solid ' . $faIcon . ' me-1" aria-hidden="true"></span>';
-};
 
 $buildDownloadUrl = static function (string $mangled): string {
     return Route::_('index.php?option=com_j2commerce&task=orderfile.download'
@@ -70,120 +58,19 @@ $buildDownloadUrl = static function (string $mangled): string {
         . '&' . Session::getFormToken() . '=1');
 };
 
-$mutedClass = $framework === 'uikit3' ? 'uk-text-muted uk-display-block uk-text-truncate' : 'text-body-secondary d-block text-truncate';
+// Pass computed values into $displayData so framework files stay purely presentational
+$displayData['grouped']         = $grouped;
+$displayData['typeRenderers']   = $typeRenderers;
+$displayData['isAdminContext']  = $isAdminContext;
+$displayData['buildDownloadUrl'] = $buildDownloadUrl;
+$displayData['framework']       = $framework;
 
-// --- Inline variant (emails) — no paperclip icon, plain filename text ---
-if ($variant === 'inline') {
-    $parts = [];
-    foreach ($grouped as $group) {
-        $groupType = $group['type'] ?? '';
-        if (!empty($typeRenderers[$groupType])) {
-            $parts[] = $typeRenderers[$groupType];
-            continue;
-        }
-        foreach ($group['items'] as $gItem) {
-            if ($groupType === 'product_children') {
-                $qty = (int) ($gItem['qty'] ?? 1);
-                $label = $qty > 1
-                    ? '(' . $qty . ') ' . htmlspecialchars($gItem['name'], ENT_QUOTES, 'UTF-8')
-                    : htmlspecialchars($gItem['name'], ENT_QUOTES, 'UTF-8');
-                $parts[] = $label;
-            } else {
-                $name  = htmlspecialchars($gItem['name'] ?? '', ENT_QUOTES, 'UTF-8');
-                $value = htmlspecialchars($gItem['value'] ?? '', ENT_QUOTES, 'UTF-8');
-                $parts[] = $value !== '' ? $name . ': ' . $value : $name;
-            }
-        }
-    }
-    echo implode('<br>', $parts);
-    return;
+// Normalize override key
+$override = ($framework === 'uikit3') ? 'uikit' : 'bootstrap5';
+
+ProductLayoutService::setSubtemplateOverride($override);
+try {
+    echo ProductLayoutService::renderLayout('orderitem.attributes', $displayData);
+} finally {
+    ProductLayoutService::clearSubtemplateOverride();
 }
-
-// --- Compact variant (sidecart, checkout, confirmation, myprofile, drawer, cart_module) ---
-if ($variant === 'compact') {
-    foreach ($grouped as $group) {
-        $groupType = $group['type'] ?? '';
-        if (!empty($typeRenderers[$groupType])) {
-            echo $typeRenderers[$groupType];
-            continue;
-        }
-        foreach ($group['items'] as $gItem) {
-            if ($groupType === 'product_children') {
-                $qty = (int) ($gItem['qty'] ?? 1);
-                $label = $qty > 1
-                    ? '(' . $qty . ') ' . htmlspecialchars(Text::_($gItem['name']), ENT_QUOTES, 'UTF-8')
-                    : htmlspecialchars(Text::_($gItem['name']), ENT_QUOTES, 'UTF-8');
-                ?>
-                <small class="<?php echo $mutedClass; ?>"><?php echo $label; ?></small>
-                <?php
-                continue;
-            }
-
-            $name      = htmlspecialchars(Text::_($gItem['name'] ?? ''), ENT_QUOTES, 'UTF-8');
-            $value     = htmlspecialchars(Text::_($gItem['value'] ?? ''), ENT_QUOTES, 'UTF-8');
-            $mangled   = (string) ($gItem['mangled_name'] ?? '');
-            $itemType  = (string) ($gItem['type'] ?? '');
-            ?>
-            <small class="<?php echo $mutedClass; ?>">
-                <?php echo $name; ?><?php if ($value !== ''): ?>:
-                    <?php if ($mangled !== ''): ?>
-                        <?php echo $attachmentIcon($itemType); ?><?php echo $value; ?>
-                    <?php else: ?>
-                        <?php echo $value; ?>
-                    <?php endif; ?>
-                <?php endif; ?>
-            </small>
-            <?php
-        }
-    }
-    return;
-}
-
-// --- Full variant (cart page, admin order, admin edit) ---
-?>
-<div class="cart-item-options">
-    <?php foreach ($grouped as $group):
-        $groupType = $group['type'] ?? '';
-        if (!empty($typeRenderers[$groupType])) {
-            echo $typeRenderers[$groupType];
-            continue;
-        }
-        foreach ($group['items'] as $gItem):
-            if ($groupType === 'product_children'):
-                $qty = (int) ($gItem['qty'] ?? 1);
-                $label = $qty > 1
-                    ? '(' . $qty . ') ' . htmlspecialchars(Text::_($gItem['name']), ENT_QUOTES, 'UTF-8')
-                    : htmlspecialchars(Text::_($gItem['name']), ENT_QUOTES, 'UTF-8');
-                ?>
-                <div class="small d-flex align-items-center">
-                    <div class="item-option item-option-name"><?php echo $label; ?></div>
-                </div>
-            <?php else:
-                $name      = htmlspecialchars(Text::_($gItem['name'] ?? ''), ENT_QUOTES, 'UTF-8');
-                $value     = htmlspecialchars(Text::_($gItem['value'] ?? ''), ENT_QUOTES, 'UTF-8');
-                $mangled   = (string) ($gItem['mangled_name'] ?? '');
-                $itemType  = (string) ($gItem['type'] ?? '');
-                $isFileUpload = $mangled !== '';
-                $isAdminLink  = $isFileUpload && $isAdminContext;
-                ?>
-                <div class="small d-flex align-items-center">
-                    <div class="item-option item-option-name"><?php echo $name; ?><?php if ($value !== ''): ?>:<?php endif; ?></div>
-                    <?php if ($isAdminLink):
-                        $href = $buildDownloadUrl($mangled);
-                        ?>
-                        <a href="<?php echo $href; ?>" class="item-option item-option-value fw-bold ms-1 text-decoration-none"
-                           title="<?php echo htmlspecialchars(Text::_('COM_J2COMMERCE_ORDER_DOWNLOAD_FILE'), ENT_QUOTES, 'UTF-8'); ?>">
-                            <?php echo $attachmentIcon($itemType); ?><?php echo $value; ?>
-                        </a>
-                    <?php elseif ($isFileUpload && $value !== ''): ?>
-                        <div class="item-option item-option-value fw-bold ms-1">
-                            <?php echo $attachmentIcon($itemType); ?><?php echo $value; ?>
-                        </div>
-                    <?php elseif ($value !== ''): ?>
-                        <div class="item-option item-option-value fw-bold ms-1"><?php echo $value; ?></div>
-                    <?php endif; ?>
-                </div>
-            <?php endif;
-        endforeach;
-    endforeach; ?>
-</div>

--- a/components/com_j2commerce/layouts/product/quantity.php
+++ b/components/com_j2commerce/layouts/product/quantity.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * @package     J2Commerce
  * @subpackage  com_j2commerce
@@ -12,6 +11,7 @@ declare(strict_types=1);
 
 \defined('_JEXEC') or die;
 
+use J2Commerce\Component\J2commerce\Site\Service\ProductLayoutService;
 use Joomla\CMS\Language\Text;
 
 /**
@@ -36,7 +36,7 @@ use Joomla\CMS\Language\Text;
 
 extract($displayData, EXTR_SKIP);
 
-// Plain input (cart context or buttons suppressed)
+// Plain input (cart context or buttons suppressed) — framework-agnostic
 if ($isCart || !$showButtons) {
     $html  = '<input type="' . htmlspecialchars($inputType, ENT_QUOTES, 'UTF-8') . '"';
     $html .= ' name="' . htmlspecialchars($inputName, ENT_QUOTES, 'UTF-8') . '"';
@@ -46,9 +46,6 @@ if ($isCart || !$showButtons) {
         $html .= ' max="' . (int) $maxQty . '"';
     }
     $html .= ' step="1"';
-    if ($inputType === 'number') {
-        // nothing extra
-    }
     $html .= ' class="' . htmlspecialchars($inputClass, ENT_QUOTES, 'UTF-8') . '"';
     $html .= ' aria-label="' . htmlspecialchars(Text::_('COM_J2COMMERCE_QUANTITY'), ENT_QUOTES, 'UTF-8') . '"';
     $html .= ' />';
@@ -56,7 +53,7 @@ if ($isCart || !$showButtons) {
     return;
 }
 
-// Full quantity control with +/- buttons
+// Full quantity control with +/- buttons — delegate to framework file
 $inputHtml  = '<input type="' . htmlspecialchars($inputType, ENT_QUOTES, 'UTF-8') . '"';
 $inputHtml .= ' name="' . htmlspecialchars($inputName, ENT_QUOTES, 'UTF-8') . '"';
 $inputHtml .= ' value="' . (int) $defaultQty . '"';
@@ -73,21 +70,13 @@ $inputHtml .= ' readonly';
 $inputHtml .= ' class="' . htmlspecialchars($inputClass, ENT_QUOTES, 'UTF-8') . '"';
 $inputHtml .= ' aria-label="' . htmlspecialchars(Text::_('COM_J2COMMERCE_QUANTITY'), ENT_QUOTES, 'UTF-8') . '"';
 $inputHtml .= ' />';
-?>
-<div class="count-input flex-shrink-0">
-    <button type="button" class="btn btn-icon btn-lg" data-decrement aria-label="<?php echo htmlspecialchars(Text::_('COM_J2COMMERCE_DECREASE_QUANTITY'), ENT_QUOTES, 'UTF-8'); ?>"<?php echo $decrementDisabled; ?>>
-        <?php if ($iconSet === 'uikit') : ?>
-            <span uk-icon="icon: minus" aria-hidden="true"></span>
-        <?php else : ?>
-            <span class="<?php echo htmlspecialchars($iconMinus, ENT_QUOTES, 'UTF-8'); ?>" aria-hidden="true"></span>
-        <?php endif; ?>
-    </button>
-    <?php echo $inputHtml; ?>
-    <button type="button" class="btn btn-icon btn-lg" data-increment aria-label="<?php echo htmlspecialchars(Text::_('COM_J2COMMERCE_INCREASE_QUANTITY'), ENT_QUOTES, 'UTF-8'); ?>"<?php echo $incrementDisabled; ?>>
-        <?php if ($iconSet === 'uikit') : ?>
-            <span uk-icon="icon: plus" aria-hidden="true"></span>
-        <?php else : ?>
-            <span class="<?php echo htmlspecialchars($iconPlus, ENT_QUOTES, 'UTF-8'); ?>" aria-hidden="true"></span>
-        <?php endif; ?>
-    </button>
-</div>
+
+$displayData['inputHtml'] = $inputHtml;
+
+$framework = ($iconSet === 'uikit') ? 'uikit' : 'bootstrap5';
+ProductLayoutService::setSubtemplateOverride($framework);
+try {
+    echo ProductLayoutService::renderLayout('product.quantity', $displayData);
+} finally {
+    ProductLayoutService::clearSubtemplateOverride();
+}

--- a/components/com_j2commerce/layouts/productoption/upload_file.php
+++ b/components/com_j2commerce/layouts/productoption/upload_file.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 \defined('_JEXEC') or die;
 
+use J2Commerce\Component\J2commerce\Site\Service\ProductLayoutService;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
@@ -38,17 +39,9 @@ if ($isGuest && (int) ComponentHelper::getParams('com_j2commerce')->get('allow_g
 }
 
 $optionId    = (int) ($displayData['productOptionId'] ?? 0);
-$productId   = (int) ($displayData['productId'] ?? 0);
-$required    = (bool) ($displayData['required'] ?? false);
-$optionName  = (string) ($displayData['optionName'] ?? '');
-$ajaxUrl     = (string) ($displayData['ajaxUrl'] ?? '');
 $maxSizeMB   = (float) ($displayData['maxSizeMB'] ?? 0);
 $allowedExts = (string) ($displayData['allowedExts'] ?? '');
-$framework   = ($displayData['framework'] ?? 'bs5') === 'uikit' ? 'uikit' : 'bs5';
-
-$inputId  = 'j2c-upload-input-' . $optionId;
-$hiddenId = 'input-option' . $optionId;
-$esc      = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+$framework   = ($displayData['framework'] ?? 'bs5') === 'uikit' ? 'uikit' : 'bootstrap5';
 
 $hintParts = [];
 if ($allowedExts !== '') {
@@ -59,46 +52,13 @@ if ($maxSizeMB > 0) {
 }
 $hintText = implode(' · ', $hintParts);
 
-$dropzoneClass = $framework === 'uikit' ? 'uk-upl-dropzone' : 'j2c-dropzone';
-$labelClass    = $framework === 'uikit' ? 'uk-form-label uk-text-bold d-block mb-2' : 'form-label fw-bold d-block mb-2';
-$requiredClass = $framework === 'uikit' ? 'uk-text-danger' : 'text-danger';
-$wrapperClass  = $framework === 'uikit' ? 'option uk-margin-small-bottom' : 'option mb-3';
-?>
-<div id="option-<?php echo $optionId; ?>" class="<?php echo $wrapperClass; ?>">
-    <span class="<?php echo $labelClass; ?>">
-        <?php echo $esc(Text::_($optionName)); ?><?php if ($required) : ?>
-            <span class="<?php echo $requiredClass; ?>" aria-hidden="true">*</span>
-            <span class="visually-hidden"><?php echo Text::_('JFIELD_FIELD_REQUIRED_LABEL'); ?></span>
-        <?php endif; ?>
-    </span>
-    <label
-        class="<?php echo $dropzoneClass; ?>"
-        for="<?php echo $inputId; ?>"
-        data-j2c-dropzone
-        data-ajax-url="<?php echo $esc($ajaxUrl); ?>"
-        data-hidden-id="<?php echo $esc($hiddenId); ?>"
-        data-maxsize-mb="<?php echo $esc((string) $maxSizeMB); ?>"
-        data-allowed-exts="<?php echo $esc($allowedExts); ?>">
-        <span class="dz-icon">
-            <span class="fa-solid fa-cloud-arrow-up" aria-hidden="true"></span>
-        </span>
-        <span class="dz-title">
-            <?php echo Text::_('COM_J2COMMERCE_UPLOAD_DROP_FILE_OR'); ?>
-            <span class="browse"><?php echo Text::_('COM_J2COMMERCE_UPLOAD_BROWSE'); ?></span>
-        </span>
-        <?php if ($hintText !== '') : ?>
-            <span class="dz-hint"><?php echo $esc($hintText); ?></span>
-        <?php endif; ?>
-        <input
-            id="<?php echo $inputId; ?>"
-            type="file"
-            class="j2c-upload-native"
-            <?php if ($allowedExts !== '') : ?>accept=".<?php echo $esc(str_replace(',', ',.', $allowedExts)); ?>"<?php endif; ?>
-            <?php if ($required) : ?>aria-required="true"<?php endif; ?> />
-    </label>
-    <input
-        type="hidden"
-        name="product_option[<?php echo $optionId; ?>]"
-        value=""
-        id="<?php echo $esc($hiddenId); ?>" />
-</div>
+$displayData['inputId']  = 'j2c-upload-input-' . $optionId;
+$displayData['hiddenId'] = 'input-option' . $optionId;
+$displayData['hintText'] = $hintText;
+
+ProductLayoutService::setSubtemplateOverride($framework);
+try {
+    echo ProductLayoutService::renderLayout('productoption.upload_file', $displayData);
+} finally {
+    ProductLayoutService::clearSubtemplateOverride();
+}

--- a/components/com_j2commerce/layouts/productoption/upload_image.php
+++ b/components/com_j2commerce/layouts/productoption/upload_image.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 \defined('_JEXEC') or die;
 
+use J2Commerce\Component\J2commerce\Site\Service\ProductLayoutService;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
@@ -38,17 +39,9 @@ if ($isGuest && (int) ComponentHelper::getParams('com_j2commerce')->get('allow_g
 }
 
 $optionId    = (int) ($displayData['productOptionId'] ?? 0);
-$productId   = (int) ($displayData['productId'] ?? 0);
-$required    = (bool) ($displayData['required'] ?? false);
-$optionName  = (string) ($displayData['optionName'] ?? '');
-$ajaxUrl     = (string) ($displayData['ajaxUrl'] ?? '');
 $maxSizeMB   = (float) ($displayData['maxSizeMB'] ?? 0);
 $allowedExts = (string) ($displayData['allowedExts'] ?? '');
-$framework   = ($displayData['framework'] ?? 'bs5') === 'uikit' ? 'uikit' : 'bs5';
-
-$inputId  = 'j2c-upload-input-' . $optionId;
-$hiddenId = 'input-option' . $optionId;
-$esc      = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+$framework   = ($displayData['framework'] ?? 'bs5') === 'uikit' ? 'uikit' : 'bootstrap5';
 
 $hintParts = [];
 if ($allowedExts !== '') {
@@ -61,47 +54,13 @@ $hintText = $hintParts !== []
     ? Text::sprintf('COM_J2COMMERCE_UPLOAD_HINT_IMAGE', implode(' · ', $hintParts))
     : Text::_('COM_J2COMMERCE_UPLOAD_HINT_IMAGE_GENERIC');
 
-$heroClass     = $framework === 'uikit' ? 'uk-img-hero' : 'j2c-img-hero';
-$labelClass    = $framework === 'uikit' ? 'uk-form-label uk-text-bold d-block mb-2' : 'form-label fw-bold d-block mb-2';
-$requiredClass = $framework === 'uikit' ? 'uk-text-danger' : 'text-danger';
-$wrapperClass  = $framework === 'uikit' ? 'option uk-margin-small-bottom' : 'option mb-3';
-?>
-<div id="option-<?php echo $optionId; ?>" class="<?php echo $wrapperClass; ?>">
-    <span class="<?php echo $labelClass; ?>">
-        <?php echo $esc(Text::_($optionName)); ?><?php if ($required) : ?>
-            <span class="<?php echo $requiredClass; ?>" aria-hidden="true">*</span>
-            <span class="visually-hidden"><?php echo Text::_('JFIELD_FIELD_REQUIRED_LABEL'); ?></span>
-        <?php endif; ?>
-    </span>
-    <label
-        class="<?php echo $heroClass; ?>"
-        for="<?php echo $inputId; ?>"
-        data-j2c-image-hero
-        data-ajax-url="<?php echo $esc($ajaxUrl); ?>"
-        data-hidden-id="<?php echo $esc($hiddenId); ?>"
-        data-maxsize-mb="<?php echo $esc((string) $maxSizeMB); ?>"
-        data-allowed-exts="<?php echo $esc($allowedExts); ?>">
-        <span class="ih-thumb">
-            <span class="j2c-thumb-icon fa-solid fa-image" aria-hidden="true"></span>
-        </span>
-        <span class="ih-body">
-            <span class="ih-title"><?php echo Text::_('COM_J2COMMERCE_UPLOAD_ADD_PHOTO'); ?></span>
-            <span class="ih-hint"><?php echo $esc($hintText); ?></span>
-        </span>
-        <span class="ih-cta" data-icon-replace="fa-solid fa-arrows-rotate">
-            <span class="fa-solid fa-upload me-1" aria-hidden="true"></span>
-            <?php echo Text::_('COM_J2COMMERCE_PRODUCT_OPTION_CHOOSE_IMAGE'); ?>
-        </span>
-        <input
-            id="<?php echo $inputId; ?>"
-            type="file"
-            class="j2c-upload-native"
-            accept="image/*"
-            <?php if ($required) : ?>aria-required="true"<?php endif; ?> />
-    </label>
-    <input
-        type="hidden"
-        name="product_option[<?php echo $optionId; ?>]"
-        value=""
-        id="<?php echo $esc($hiddenId); ?>" />
-</div>
+$displayData['inputId']  = 'j2c-upload-input-' . $optionId;
+$displayData['hiddenId'] = 'input-option' . $optionId;
+$displayData['hintText'] = $hintText;
+
+ProductLayoutService::setSubtemplateOverride($framework);
+try {
+    echo ProductLayoutService::renderLayout('productoption.upload_image', $displayData);
+} finally {
+    ProductLayoutService::clearSubtemplateOverride();
+}


### PR DESCRIPTION
## Core Update

Converts 7 shared component layouts from inline framework-branching to the `app_bootstrap5/` + `app_uikit/` subfolder + delegation-shim pattern established by `checkout.payment_icons`, so UIkit sites render proper UIkit markup.

### Changes
- **7 shims** (modified): `form/coupon`, `form/voucher`, `orderitem/attributes`, `productoption/upload_file`, `productoption/upload_image`, `product/quantity`, `fallback/missing_template`
- **14 framework files** (new): `app_bootstrap5/` + `app_uikit/` versions of each
- Each shim normalizes the caller-passed framework (`uikit3`/`uikit`→uikit, `bs5`/`bootstrap5`/empty→bootstrap5), sets a subtemplate override, delegates to `ProductLayoutService::renderLayout()`, and clears the override in a `finally`. Framework-agnostic work (asset registration, coupon/voucher DB lookups, guest gates, attribute grouping + events, plain-qty early-return) stays in the shim once; framework files are purely presentational.
- Fixes latent UIkit fidelity bugs (old inline branch leaked Bootstrap utilities); sr-only text uses `uk-hidden-visually`.

### Files Modified
| Type | Count |
|------|-------|
| PHP layout files | 21 (7 modified shims, 14 new framework files) |

### Pre-Flight
- [x] PHP syntax check passed (all 21 files)
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only (non-core .gitignore + build/* excluded)
- [x] joomla6-code-reviewer PASS (0 critical, 0 high)

### Follow-up (not in this PR)
Shared JS (`coupon-voucher.js`, `option-upload-fields.js`) still emits Bootstrap markup/classes on AJAX — framework-neutral JS is the next step.