### PR TITLE
feat(core): decouple coupon/voucher + upload JS from Bootstrap

### DIFF
--- a/build/build_package.php
+++ b/build/build_package.php
@@ -34,20 +34,20 @@ $baseVersion = $matches[1];
 $baseVersionDashed = str_replace('.', '-', $baseVersion);
 $buildNum = 1;
 
-// Check both old com_ and new pkg_ patterns
+// Match legacy `_beta_{N}` and current `-{N}` filename formats so the build
+// number keeps climbing across the naming switch.
 foreach (['com_j2commerce_', 'pkg_j2commerce_'] as $prefix) {
-    $existingFiles = glob($outputDir . '/' . $prefix . $baseVersionDashed . '_beta_*.zip');
-    if ($existingFiles) {
-        foreach ($existingFiles as $f) {
-            if (preg_match('/_beta_(\d+)\.zip$/', $f, $m)) {
-                $buildNum = max($buildNum, (int) $m[1] + 1);
-            }
+    $base = $outputDir . '/' . $prefix . $baseVersionDashed;
+    foreach (array_merge(glob($base . '_beta_*.zip') ?: [], glob($base . '-*.zip') ?: []) as $f) {
+        if (preg_match('/(?:_beta_|-)(\d+)\.zip$/', $f, $m)) {
+            $buildNum = max($buildNum, (int) $m[1] + 1);
         }
     }
 }
 
-// Version used in manifests — NO build number (per PRD)
-$version = $baseVersion;
+// Version used in manifests — base version + build number (e.g. 6.3.2.3) so
+// 3rd-party extensions can identify the exact non-official build.
+$version = $baseVersion . '.' . $buildNum;
 
 $excludePatterns = [
     '.git', '.gitignore', '.github', '.claude',
@@ -601,7 +601,7 @@ if (!empty($conflictFiles)) {
 
 echo "Conflict marker check OK\n";
 
-$finalZipName = "pkg_j2commerce_{$baseVersionDashed}_beta_{$buildNum}.zip";
+$finalZipName = "pkg_j2commerce_{$baseVersionDashed}-{$buildNum}.zip";
 $finalZipPath = $outputDir . '/' . $finalZipName;
 echo "\nBuilding: {$finalZipName}\n\n";
 

--- a/components/com_j2commerce/layouts/app_bootstrap5/productoption/upload_image.php
+++ b/components/com_j2commerce/layouts/app_bootstrap5/productoption/upload_image.php
@@ -46,7 +46,7 @@ $esc         = static fn(string $value): string => htmlspecialchars($value, ENT_
             <span class="ih-title"><?php echo Text::_('COM_J2COMMERCE_UPLOAD_ADD_PHOTO'); ?></span>
             <span class="ih-hint"><?php echo $esc($hintText); ?></span>
         </span>
-        <span class="ih-cta" data-icon-replace="fa-solid fa-arrows-rotate">
+        <span class="ih-cta" data-icon-replace="fa-solid fa-arrows-rotate me-1">
             <span class="fa-solid fa-upload me-1" aria-hidden="true"></span>
             <?php echo Text::_('COM_J2COMMERCE_PRODUCT_OPTION_CHOOSE_IMAGE'); ?>
         </span>

--- a/components/com_j2commerce/layouts/app_uikit/productoption/upload_image.php
+++ b/components/com_j2commerce/layouts/app_uikit/productoption/upload_image.php
@@ -46,7 +46,7 @@ $esc         = static fn(string $value): string => htmlspecialchars($value, ENT_
             <span class="ih-title"><?php echo Text::_('COM_J2COMMERCE_UPLOAD_ADD_PHOTO'); ?></span>
             <span class="ih-hint"><?php echo $esc($hintText); ?></span>
         </span>
-        <span class="ih-cta" data-icon-replace="uk-icon-refresh">
+        <span class="ih-cta" data-icon-replace="" data-icon-replace-uk="refresh" data-icon-replace-class="uk-margin-small-right">
             <span uk-icon="icon: upload" class="uk-margin-small-right" aria-hidden="true"></span>
             <?php echo Text::_('COM_J2COMMERCE_PRODUCT_OPTION_CHOOSE_IMAGE'); ?>
         </span>

--- a/components/com_j2commerce/layouts/form/coupon.php
+++ b/components/com_j2commerce/layouts/form/coupon.php
@@ -23,6 +23,12 @@ $lang = Factory::getApplication()->getLanguage();
 $lang->load('com_j2commerce', JPATH_SITE)
     || $lang->load('com_j2commerce', JPATH_SITE . '/components/com_j2commerce');
 
+// Normalize framework (caller passes 'framework' from its own context) — needed by the
+// asset block below, so it MUST be computed before addScriptOptions reads $isUk.
+$rawFramework = $displayData['framework'] ?? 'bootstrap5';
+$framework    = ($rawFramework === 'uikit3' || $rawFramework === 'uikit') ? 'uikit' : 'bootstrap5';
+$isUk         = ($framework === 'uikit');
+
 // Self-register assets (once per request, no matter how many instances)
 static $assetsRegistered = false;
 if (!$assetsRegistered) {
@@ -44,14 +50,37 @@ if (!$assetsRegistered) {
             'removeVoucher'=> Text::_('COM_J2COMMERCE_REMOVE_VOUCHER'),
             'remove'       => Text::_('COM_J2COMMERCE_REMOVE'),
         ],
+        'framework' => $isUk ? 'uikit' : 'bootstrap5',
+        'classes'   => $isUk ? [
+            'appliedRow'     => 'uk-flex uk-flex-middle uk-flex-between uk-padding-small',
+            'badge'          => 'uk-label uk-label-success',
+            'iconTag'        => 'icon-tag uk-margin-small-right',
+            'removeBtnBase'  => 'uk-button uk-button-link uk-text-danger',
+            'input'          => 'uk-input',
+            'inputWrap'      => 'uk-flex uk-flex-stretch',
+            'inputInner'     => 'uk-width-expand',
+            'applyBtnBase'   => 'uk-button uk-button-default',
+            'fieldError'     => 'j2c-field-error uk-text-danger uk-text-small uk-margin-small-top',
+            'accordionBadge' => 'uk-label uk-label-success uk-margin-small-left',
+        ] : [
+            'appliedRow'     => 'd-flex align-items-center justify-content-between py-1',
+            'badge'          => 'badge bg-success',
+            'iconTag'        => 'icon-tag me-1',
+            'removeBtnBase'  => 'btn btn-sm btn-link text-danger p-0',
+            'input'          => 'form-control',
+            'inputWrap'      => 'input-group',
+            'inputInner'     => 'input-group_inner',
+            'applyBtnBase'   => 'btn btn-outline-secondary',
+            'fieldError'     => 'j2c-field-error text-danger small mt-1',
+            'accordionBadge' => 'badge bg-success ms-2',
+        ],
+        'accordion' => $isUk
+            ? ['itemSelector' => 'li', 'headerSelector' => '.uk-accordion-title']
+            : ['itemSelector' => '.accordion-item', 'headerSelector' => '.accordion-button'],
     ]);
     Text::script('COM_J2COMMERCE_LOADING');
     $assetsRegistered = true;
 }
-
-// Normalize framework: caller passes 'framework' key from its own context
-$rawFramework = $displayData['framework'] ?? 'bootstrap5';
-$framework = ($rawFramework === 'uikit3' || $rawFramework === 'uikit') ? 'uikit' : 'bootstrap5';
 
 // Compute discount label (framework-agnostic) — passed into framework files so they stay purely presentational
 $couponCode   = $displayData['couponCode'] ?? '';

--- a/components/com_j2commerce/layouts/form/voucher.php
+++ b/components/com_j2commerce/layouts/form/voucher.php
@@ -23,6 +23,12 @@ $lang = Factory::getApplication()->getLanguage();
 $lang->load('com_j2commerce', JPATH_SITE)
     || $lang->load('com_j2commerce', JPATH_SITE . '/components/com_j2commerce');
 
+// Normalize framework (caller passes 'framework' from its own context) — needed by the
+// asset block below, so it MUST be computed before addScriptOptions reads $isUk.
+$rawFramework = $displayData['framework'] ?? 'bootstrap5';
+$framework    = ($rawFramework === 'uikit3' || $rawFramework === 'uikit') ? 'uikit' : 'bootstrap5';
+$isUk         = ($framework === 'uikit');
+
 // Self-register assets (once per request, no matter how many instances)
 static $assetsRegistered = false;
 if (!$assetsRegistered) {
@@ -44,14 +50,37 @@ if (!$assetsRegistered) {
             'removeVoucher'=> Text::_('COM_J2COMMERCE_REMOVE_VOUCHER'),
             'remove'       => Text::_('COM_J2COMMERCE_REMOVE'),
         ],
+        'framework' => $isUk ? 'uikit' : 'bootstrap5',
+        'classes'   => $isUk ? [
+            'appliedRow'     => 'uk-flex uk-flex-middle uk-flex-between uk-padding-small',
+            'badge'          => 'uk-label uk-label-success',
+            'iconTag'        => 'icon-tag uk-margin-small-right',
+            'removeBtnBase'  => 'uk-button uk-button-link uk-text-danger',
+            'input'          => 'uk-input',
+            'inputWrap'      => 'uk-flex uk-flex-stretch',
+            'inputInner'     => 'uk-width-expand',
+            'applyBtnBase'   => 'uk-button uk-button-default',
+            'fieldError'     => 'j2c-field-error uk-text-danger uk-text-small uk-margin-small-top',
+            'accordionBadge' => 'uk-label uk-label-success uk-margin-small-left',
+        ] : [
+            'appliedRow'     => 'd-flex align-items-center justify-content-between py-1',
+            'badge'          => 'badge bg-success',
+            'iconTag'        => 'icon-tag me-1',
+            'removeBtnBase'  => 'btn btn-sm btn-link text-danger p-0',
+            'input'          => 'form-control',
+            'inputWrap'      => 'input-group',
+            'inputInner'     => 'input-group_inner',
+            'applyBtnBase'   => 'btn btn-outline-secondary',
+            'fieldError'     => 'j2c-field-error text-danger small mt-1',
+            'accordionBadge' => 'badge bg-success ms-2',
+        ],
+        'accordion' => $isUk
+            ? ['itemSelector' => 'li', 'headerSelector' => '.uk-accordion-title']
+            : ['itemSelector' => '.accordion-item', 'headerSelector' => '.accordion-button'],
     ]);
     Text::script('COM_J2COMMERCE_LOADING');
     $assetsRegistered = true;
 }
-
-// Normalize framework: caller passes 'framework' key from its own context
-$rawFramework = $displayData['framework'] ?? 'bootstrap5';
-$framework = ($rawFramework === 'uikit3' || $rawFramework === 'uikit') ? 'uikit' : 'bootstrap5';
 
 // Compute discount label (framework-agnostic) — passed into framework files so they stay purely presentational
 $voucherCode  = $displayData['voucherCode'] ?? '';

--- a/media/com_j2commerce/js/site/coupon-voucher.js
+++ b/media/com_j2commerce/js/site/coupon-voucher.js
@@ -16,7 +16,8 @@
  * After AJAX success, switches the form DOM between input/applied states and
  * dispatches custom DOM events so consuming pages can react (refresh totals, etc.).
  *
- * Required: Joomla.getOptions('j2commerce.couponVoucher') with {baseUrl, csrfToken, strings}
+ * Required: Joomla.getOptions('j2commerce.couponVoucher') with
+ *   {baseUrl, csrfToken, strings, framework, classes, accordion}
  */
 (function () {
 
@@ -24,24 +25,47 @@
     const baseUrl = options.baseUrl || 'index.php';
     const token   = options.csrfToken || '';
     const strings = options.strings || {};
+    const fw      = options.framework || 'bootstrap5';
+    const acc     = options.accordion || { itemSelector: '.accordion-item', headerSelector: '.accordion-button' };
+
+    // Bootstrap 5 fallback defaults (used when options.classes is absent)
+    const DEFAULTS = {
+        appliedRow:     'd-flex align-items-center justify-content-between py-1',
+        badge:          'badge bg-success',
+        iconTag:        'icon-tag me-1',
+        removeBtnBase:  'btn btn-sm btn-link text-danger p-0',
+        input:          'form-control',
+        inputWrap:      'input-group',
+        inputInner:     'input-group_inner',
+        applyBtnBase:   'btn btn-outline-secondary',
+        fieldError:     'j2c-field-error text-danger small mt-1',
+        accordionBadge: 'badge bg-success ms-2',
+    };
+
+    const classes = options.classes || {};
+
+    /** Return the framework class for key, falling back to Bootstrap 5 default. */
+    function cls(key) {
+        return classes[key] || DEFAULTS[key] || '';
+    }
 
     // --- Inline error display ---
 
     function showInputError(input, message) {
         clearInputError(input);
-        const inner = input.closest('.input-group_inner');
+        const inner = input.closest('.input-group_inner, .uk-width-expand');
         if (!inner) return;
 
         input.style.borderColor = '#dc3545';
 
         const xBtn = document.createElement('span');
         xBtn.className = 'j2c-input-clear';
-        xBtn.innerHTML = '&times;';
+        xBtn.textContent = '×';
         inner.appendChild(xBtn);
 
-        const group = inner.closest('.input-group');
+        const group = inner.parentElement;
         const errDiv = document.createElement('div');
-        errDiv.className = 'j2c-field-error text-danger small mt-1';
+        errDiv.className = cls('fieldError');
         errDiv.textContent = message;
         (group || inner).parentElement.appendChild(errDiv);
 
@@ -53,78 +77,130 @@
     }
 
     function clearInputError(input) {
-        const inner = input.closest('.input-group_inner');
+        const inner = input.closest('.input-group_inner, .uk-width-expand');
         if (!inner) return;
         const xBtn = inner.querySelector('.j2c-input-clear');
         if (xBtn) xBtn.remove();
         input.style.borderColor = '';
-        const group = inner.closest('.input-group');
+        const group = inner.parentElement;
         const errDiv = (group || inner).parentElement?.querySelector('.j2c-field-error');
         if (errDiv) errDiv.remove();
+    }
+
+    // --- Spinner ---
+
+    function buildSpinner() {
+        if (fw === 'uikit') {
+            const s = document.createElement('span');
+            s.setAttribute('uk-spinner', '');
+            return s;
+        }
+        const s = document.createElement('span');
+        s.className = 'spinner-border spinner-border-sm';
+        s.setAttribute('role', 'status');
+        const vh = document.createElement('span');
+        vh.className = 'visually-hidden';
+        vh.textContent = Joomla.Text._('COM_J2COMMERCE_LOADING');
+        s.appendChild(vh);
+        return s;
     }
 
     // --- Form state switching ---
 
     function showAppliedState(form, code, type) {
-        var removeClass = type === 'coupon' ? 'j2c-remove-coupon' : 'j2c-remove-voucher';
-        var removeTitle = type === 'coupon' ? (strings.removeCoupon || 'Remove Coupon') : (strings.removeVoucher || 'Remove Voucher');
-        var removeText  = strings.remove || 'Remove';
-        var escaped = code.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+        const removeClass  = type === 'coupon' ? 'j2c-remove-coupon' : 'j2c-remove-voucher';
+        const removeTitle  = type === 'coupon' ? (strings.removeCoupon || 'Remove Coupon') : (strings.removeVoucher || 'Remove Voucher');
+        const removeText   = strings.remove || 'Remove';
 
-        form.innerHTML =
-            '<div class="d-flex align-items-center justify-content-between py-1">' +
-                '<span class="badge bg-success">' +
-                    '<span class="icon-tag me-1" aria-hidden="true"></span>' + escaped +
-                '</span>' +
-                '<button type="button" class="btn btn-sm btn-link text-danger p-0 ' + removeClass + '"' +
-                    ' title="' + removeTitle + '">' +
-                    '<span class="icon-times" aria-hidden="true"></span> ' + removeText +
-                '</button>' +
-            '</div>';
+        // Badge: <span class="badge ..."><span class="icon-tag ..." aria-hidden></span> CODE</span>
+        const iconSpan = document.createElement('span');
+        iconSpan.className = cls('iconTag');
+        iconSpan.setAttribute('aria-hidden', 'true');
 
-        // Update accordion header badge if inside an accordion
-        var accordionItem = form.closest('.accordion-item');
-        if (accordionItem) {
-            var header = accordionItem.querySelector('.accordion-button');
+        const badge = document.createElement('span');
+        badge.className = cls('badge');
+        badge.appendChild(iconSpan);
+        badge.appendChild(document.createTextNode(code));
+
+        // Remove button: <button class="removeBtnBase removeClass" ...>
+        const timesSpan = document.createElement('span');
+        timesSpan.className = 'icon-times';
+        timesSpan.setAttribute('aria-hidden', 'true');
+
+        const removeBtn = document.createElement('button');
+        removeBtn.type = 'button';
+        removeBtn.className = cls('removeBtnBase') + ' ' + removeClass;
+        removeBtn.title = removeTitle;
+        removeBtn.appendChild(timesSpan);
+        removeBtn.appendChild(document.createTextNode(' ' + removeText));
+
+        // Row wrapper
+        const row = document.createElement('div');
+        row.className = cls('appliedRow');
+        row.appendChild(badge);
+        row.appendChild(removeBtn);
+
+        form.replaceChildren(row);
+
+        // Update accordion header badge
+        const item = form.closest(acc.itemSelector);
+        if (item) {
+            const header = item.querySelector(acc.headerSelector);
             if (header) {
-                var existingBadge = header.querySelector('.j2c-' + type + '-badge');
+                let existingBadge = header.querySelector('.j2c-' + type + '-badge');
                 if (!existingBadge) {
-                    var badge = document.createElement('span');
-                    badge.className = 'badge bg-success ms-2 j2c-' + type + '-badge';
-                    badge.textContent = code;
-                    header.appendChild(badge);
-                } else {
-                    existingBadge.textContent = code;
+                    existingBadge = document.createElement('span');
+                    existingBadge.className = cls('accordionBadge') + ' j2c-' + type + '-badge';
+                    header.appendChild(existingBadge);
                 }
+                existingBadge.textContent = code;
             }
         }
     }
 
     function showInputState(form, type) {
-        var inputName   = type === 'coupon' ? 'coupon' : 'voucher';
-        var applyClass  = type === 'coupon' ? 'j2c-apply-coupon' : 'j2c-apply-voucher';
-        var placeholder = type === 'coupon' ? (strings.enterCoupon || 'Enter coupon code') : (strings.enterVoucher || 'Enter voucher code');
-        var ariaLabel   = type === 'coupon' ? (strings.couponCode || 'Coupon Code') : (strings.voucherCode || 'Voucher Code');
-        var btnText     = type === 'coupon' ? (strings.applyCoupon || 'Apply Coupon') : (strings.applyVoucher || 'Apply Voucher');
+        const inputName   = type === 'coupon' ? 'coupon' : 'voucher';
+        const applyClass  = type === 'coupon' ? 'j2c-apply-coupon' : 'j2c-apply-voucher';
+        const placeholder = type === 'coupon' ? (strings.enterCoupon || 'Enter coupon code') : (strings.enterVoucher || 'Enter voucher code');
+        const ariaLabel   = type === 'coupon' ? (strings.couponCode || 'Coupon Code') : (strings.voucherCode || 'Voucher Code');
+        const btnText     = type === 'coupon' ? (strings.applyCoupon || 'Apply Coupon') : (strings.applyVoucher || 'Apply Voucher');
 
-        form.innerHTML =
-            '<div class="j2c-' + type + '-input-wrap">' +
-                '<div class="input-group">' +
-                    '<div class="input-group_inner">' +
-                        '<input type="text" name="' + inputName + '" class="form-control"' +
-                            ' placeholder="' + placeholder + '"' +
-                            ' aria-label="' + ariaLabel + '">' +
-                    '</div>' +
-                    '<button type="button" class="btn btn-outline-secondary ' + applyClass + '">' +
-                        btnText +
-                    '</button>' +
-                '</div>' +
-            '</div>';
+        // Input element
+        const input = document.createElement('input');
+        input.type = 'text';
+        input.name = inputName;
+        input.className = cls('input');
+        input.placeholder = placeholder;
+        input.setAttribute('aria-label', ariaLabel);
 
-        // Remove accordion header badge if inside an accordion
-        var accordionItem = form.closest('.accordion-item');
-        if (accordionItem) {
-            var badge = accordionItem.querySelector('.j2c-' + type + '-badge');
+        // Inner wrap
+        const inner = document.createElement('div');
+        inner.className = cls('inputInner');
+        inner.appendChild(input);
+
+        // Apply button
+        const applyBtn = document.createElement('button');
+        applyBtn.type = 'button';
+        applyBtn.className = cls('applyBtnBase') + ' ' + applyClass;
+        applyBtn.textContent = btnText;
+
+        // Outer wrap
+        const wrap = document.createElement('div');
+        wrap.className = cls('inputWrap');
+        wrap.appendChild(inner);
+        wrap.appendChild(applyBtn);
+
+        // Container
+        const container = document.createElement('div');
+        container.className = 'j2c-' + type + '-input-wrap';
+        container.appendChild(wrap);
+
+        form.replaceChildren(container);
+
+        // Remove accordion header badge
+        const item = form.closest(acc.itemSelector);
+        if (item) {
+            const badge = item.querySelector('.j2c-' + type + '-badge');
             if (badge) badge.remove();
         }
     }
@@ -171,9 +247,9 @@
 
         clearInputError(input);
         const code = input.value.trim();
-        const origHTML = btn.innerHTML;
+        const orig = Array.from(btn.childNodes).map(function (n) { return n.cloneNode(true); });
         btn.disabled = true;
-        btn.innerHTML = '<span class="spinner-border spinner-border-sm" role="status"><span class="visually-hidden">' + Joomla.Text._("COM_J2COMMERCE_LOADING") + '</span></span>';
+        btn.replaceChildren(buildSpinner());
 
         postAction('carts.applyCouponAjax', { coupon: code })
             .then(function (data) {
@@ -185,7 +261,7 @@
                 } else {
                     showInputError(input, data.message || 'Invalid coupon code.');
                     btn.disabled = false;
-                    btn.innerHTML = origHTML;
+                    btn.replaceChildren(...orig);
                     dispatchEvent(form, 'j2commerce:coupon:error', {
                         message: data.message || '', formId: form.id
                     });
@@ -194,7 +270,7 @@
             .catch(function () {
                 showInputError(input, 'An error occurred.');
                 btn.disabled = false;
-                btn.innerHTML = origHTML;
+                btn.replaceChildren(...orig);
             });
     });
 
@@ -236,9 +312,9 @@
 
         clearInputError(input);
         const code = input.value.trim();
-        const origHTML = btn.innerHTML;
+        const orig = Array.from(btn.childNodes).map(function (n) { return n.cloneNode(true); });
         btn.disabled = true;
-        btn.innerHTML = '<span class="spinner-border spinner-border-sm" role="status"><span class="visually-hidden">' + Joomla.Text._("COM_J2COMMERCE_LOADING") + '</span></span>';
+        btn.replaceChildren(buildSpinner());
 
         postAction('carts.applyVoucherAjax', { voucher: code })
             .then(function (data) {
@@ -250,7 +326,7 @@
                 } else {
                     showInputError(input, data.message || 'Invalid voucher code.');
                     btn.disabled = false;
-                    btn.innerHTML = origHTML;
+                    btn.replaceChildren(...orig);
                     dispatchEvent(form, 'j2commerce:voucher:error', {
                         message: data.message || '', formId: form.id
                     });
@@ -259,7 +335,7 @@
             .catch(function () {
                 showInputError(input, 'An error occurred.');
                 btn.disabled = false;
-                btn.innerHTML = origHTML;
+                btn.replaceChildren(...orig);
             });
     });
 

--- a/media/com_j2commerce/js/site/option-upload-fields.js
+++ b/media/com_j2commerce/js/site/option-upload-fields.js
@@ -110,7 +110,7 @@
         // submit handler intercepts label clicks. We open the picker explicitly.
         zone.removeAttribute('for');
 
-        const originalTitleHTML = title ? title.innerHTML : '';
+        const originalTitleNodes = title ? Array.from(title.childNodes).map(n => n.cloneNode(true)) : [];
 
         zone.addEventListener('click', e => {
             if (e.target === input) return;
@@ -125,7 +125,7 @@
             if (err) {
                 setStatus(zone, err, 'error');
                 zone.classList.remove('has-file');
-                if (title) title.innerHTML = originalTitleHTML;
+                if (title) title.replaceChildren(...originalTitleNodes.map(n => n.cloneNode(true)));
                 return;
             }
             zone.classList.add('has-file');
@@ -173,9 +173,9 @@
         // submit handler intercepts label clicks. We open the picker explicitly.
         hero.removeAttribute('for');
 
-        const originalTitle = title ? title.textContent : '';
-        const originalHint  = hint ? hint.textContent : '';
-        const originalCta   = cta ? cta.innerHTML : '';
+        const originalTitle    = title ? title.textContent : '';
+        const originalHint     = hint ? hint.textContent : '';
+        const originalCtaNodes = cta ? Array.from(cta.childNodes).map(n => n.cloneNode(true)) : [];
 
         hero.addEventListener('click', e => {
             if (e.target === input) return;
@@ -193,7 +193,7 @@
                 setStatus(hero, err, 'error');
                 if (title) title.textContent = originalTitle;
                 if (hint)  hint.textContent  = originalHint;
-                if (cta)   cta.innerHTML     = originalCta;
+                if (cta)   cta.replaceChildren(...originalCtaNodes.map(n => n.cloneNode(true)));
                 return;
             }
 
@@ -213,13 +213,17 @@
             if (hint)  hint.textContent  = bytesToMB(file.size) + ' MB · ' + t('COM_J2COMMERCE_UPLOAD_READY', 'ready to upload');
 
             if (cta) {
-                // Build the "Change Image" CTA with a refresh icon
-                cta.innerHTML = '';
                 const i = document.createElement('span');
-                i.className = (cta.dataset.iconReplace || 'fa-solid fa-arrows-rotate') + ' me-1';
+                if (cta.dataset.iconReplaceUk) {
+                    i.setAttribute('uk-icon', 'icon: ' + cta.dataset.iconReplaceUk);
+                    if (cta.dataset.iconReplaceClass) {
+                        i.className = cta.dataset.iconReplaceClass;
+                    }
+                } else {
+                    i.className = cta.dataset.iconReplace || 'fa-solid fa-arrows-rotate';
+                }
                 i.setAttribute('aria-hidden', 'true');
-                cta.appendChild(i);
-                cta.appendChild(document.createTextNode(' ' + t('COM_J2COMMERCE_PRODUCT_OPTION_CHANGE_IMAGE', 'Change Image')));
+                cta.replaceChildren(i, document.createTextNode(' ' + t('COM_J2COMMERCE_PRODUCT_OPTION_CHANGE_IMAGE', 'Change Image')));
             }
 
             uploadFile(file, hero);


### PR DESCRIPTION
## Core Update

Makes the shared checkout JS framework-neutral so UIkit sites stop receiving Bootstrap markup. Follow-up to the layout framework-split (#1087).

### Changes
- **`coupon-voucher.js`** — removed all banned `innerHTML`; applied/input form states now built via `createElement`/`replaceChildren`/`textContent`. Reads a framework class-map + framework flag + accordion selectors from `Joomla.getOptions('j2commerce.couponVoucher')`, with Bootstrap fallback defaults. Spinner built per framework (`uk-spinner` vs `spinner-border`).
- **`form/coupon.php` + `form/voucher.php` shims** — pass `framework`/`classes`/`accordion` into the existing `addScriptOptions`. Framework normalized **before** the asset block (avoids feeding UIkit the Bootstrap map).
- **`option-upload-fields.js`** — dropped hardcoded Bootstrap `me-1`; icon built from `data-icon-replace` (FA, verbatim) or `data-icon-replace-uk` + `data-icon-replace-class` (UIkit `uk-icon`); clone-node save/restore replaces `innerHTML`.
- **`app_bootstrap5|app_uikit/productoption/upload_image.php`** — icon-replace data attributes per framework.

### Files Modified
| Type | Count |
|------|-------|
| JS assets | 2 |
| PHP layouts | 4 |

### Pre-Flight
- [x] PHP syntax (php -l) + JS syntax (node --check) passed
- [x] No secrets / no FOF remnants
- [x] Zero innerHTML/insertAdjacentHTML; XSS-safe (code via textContent)
- [x] joomla6-code-reviewer: CRITICAL ($isUk-before-assignment) found and FIXED; re-verified
- [x] Core files only (.gitignore + build/* excluded)

### Known follow-ups (not in this PR)
- H-1: 3 hardcoded English error fallbacks in coupon-voucher.js (lines ~262/271/327/336) need new `COM_J2COMMERCE_*` lang keys — kept separate.
- `app_uikit/form/{coupon,voucher}.php` still use `uk-text-muted` (UIkit's own class).