### PR TITLE
fix(confirmation): register j2commerce.css on uikit3 order confirmation

### DIFF
--- a/components/com_j2commerce/tmpl/confirmation/uikit3/default.php
+++ b/components/com_j2commerce/tmpl/confirmation/uikit3/default.php
@@ -15,12 +15,16 @@ use J2Commerce\Component\J2commerce\Administrator\Helper\CurrencyHelper;
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2htmlHelper;
 use J2Commerce\Plugin\System\J2Commerce\Helper\LeafletMapHelper;
+use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
 /** @var \J2Commerce\Component\J2commerce\Site\View\Confirmation\HtmlView $this */
+
+$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
+$wa->registerAndUseStyle('com_j2commerce.site', 'media/com_j2commerce/css/site/j2commerce.css');
 
 $order     = $this->order;
 $paction   = $this->paction;


### PR DESCRIPTION
## Core Update

### Problem

The UIkit3 order confirmation template (`components/com_j2commerce/tmpl/confirmation/uikit3/default.php`) was missing the `j2commerce.css` asset registration, so two confirmation-specific rules never reached the page:

- `.j2commerce-confirmation .j2c-order-item-img { width:64px; height:64px; object-fit:cover }` (line 844 of `media/com_j2commerce/css/site/j2commerce.css`)
- `#j2c-confirmation-map { height:250px }` (line 751)

Result on a UIkit3-framework site:

- Product thumbnails in the Order Summary sidebar rendered at their **natural size (1000×1000px)** — broke the layout completely
- The Leaflet shipping-address map collapsed to **2px tall** (invisible)

### Why this slipped through

The Bootstrap 5 confirmation path works because `app_bootstrap5.AppBootstrap5::onAfterAddCSS` globally registers `j2commerce_bs5.css` on every site request, AND the BS5 product-list wrapper template (`tmpl/bootstrap5/default.php`) registers `j2commerce.css` via the canonical `com_j2commerce.site` asset name.

The UIkit3 confirmation view does not dispatch through the `app_uikit/tmpl/uikit/default.php` wrapper, so neither registration reached it.

### Fix

Self-register `j2commerce.css` at the top of the UIkit3 confirmation template using the canonical asset name `com_j2commerce.site` (matches BS5 + UIkit3 wrappers, so dedupe works on any page that already has it):

```php
$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
$wa->registerAndUseStyle('com_j2commerce.site', 'media/com_j2commerce/css/site/j2commerce.css');
```

### Verification

Tested live on `https://localhost/waltherj6/order-confirmation` (UIkit3 framework):

| Element | Before fix | After fix |
|---------|-----------|-----------|
| `.j2c-order-item-img` computed width | 1000px | 64px |
| `.j2c-order-item-img` computed height | 1000px | 64px |
| `#j2c-confirmation-map` offsetHeight | 2px | 252px |
| Loaded stylesheets | `j2commerce_bs5.css` only | `j2commerce.css` + `j2commerce_bs5.css` |

Visual screenshot confirmed: product image renders as a small 64px thumbnail in the sidebar, Leaflet map renders below the Thank You banner with the shipping marker visible.

### Files Modified

| Type | Count |
|------|-------|
| PHP files | 1 |
| Total lines added | 4 |
| Total lines removed | 0 |

### Pre-Flight

- [x] PHP syntax check passed (`php -l`)
- [x] No secrets detected
- [x] No FOF / `JFactory::` remnants
- [x] Core files only (no non-core / no `.gitignore` / no dev-tooling)
- [x] Manual browser verification on a real order confirmation page

### Audit follow-up (not in this PR)

Other UIkit3 tmpl views that use `.j2c-*` or `.j2commerce-*` classes from `j2commerce.css` may have the same dependency gap. Worth auditing: cart, checkout step views, product detail tabs, account dashboard. Each can use the same one-line `registerAndUseStyle` pattern if it ships broken.