### PR TITLE
fix(product): match configurable child option layouts to parent markup

### DIFF
--- a/components/com_j2commerce/layouts/app_bootstrap5/product/configurablechildoptions.php
+++ b/components/com_j2commerce/layouts/app_bootstrap5/product/configurablechildoptions.php
@@ -16,158 +16,177 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Uri\Uri;
 
 // Layout for rendering child configurable options via AJAX.
-// Injected into #ChildOptions{poId} when a parent option is selected.
+// Injected into #child-ChildOptions{poId} when a parent option is selected.
+// Markup mirrors tmpl/bootstrap5/view_configurableoptions.php so children look
+// identical to their parents. Injected nodes keep inline onchange + the
+// initConfigCheckboxes data-* hooks because DOMContentLoaded delegation in
+// j2commerce.js cannot bind elements added after page load.
 
-$product = $displayData['product'];
-$params  = $displayData['params'];
-$options = $displayData['options'] ?? [];
-
+$product        = $displayData['product'];
+$params         = $displayData['params'];
+$options        = $displayData['options'] ?? [];
 $product_helper = J2CommerceHelper::product();
-$platform = J2CommerceHelper::platform();
-$product_id = (int) $product->j2commerce_product_id;
+$platform       = J2CommerceHelper::platform();
+$product_id     = (int) $product->j2commerce_product_id;
+$esc            = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
 ?>
 <?php if (!empty($options)) : ?>
     <?php foreach ($options as $option) : ?>
         <?php $optionId = (int) $option['productoption_id']; ?>
 
         <?php if ($option['type'] === 'select' && !empty($option['optionvalue'])) : ?>
-        <?php $selectInputId = 'child-product-option-' . $product_id . '-' . $optionId; ?>
-        <div id="child-option-<?php echo $optionId; ?>" class="option mb-3">
-            <?php if ($option['required']) : ?>
-            <span class="required">*</span>
-            <?php endif; ?>
-            <label class="form-label" for="<?php echo $selectInputId; ?>"><?php echo htmlspecialchars(Text::_($option['option_name']), ENT_QUOTES, 'UTF-8'); ?>:</label>
-            <select id="<?php echo $selectInputId; ?>" name="product_option[<?php echo $optionId; ?>]"
-                class="form-select"
-                onchange="doAjaxFilter(this.options[this.selectedIndex].value, <?php echo $product_id; ?>, <?php echo $optionId; ?>, '#child-option-<?php echo $optionId; ?>');">
-                <option value=""><?php echo Text::_('COM_J2COMMERCE_ADDTOCART_SELECT'); ?></option>
-                <?php foreach ($option['optionvalue'] as $option_value) : ?>
-                    <?php $checked = !empty($option_value['product_optionvalue_default']) ? 'selected="selected"' : ''; ?>
-                    <option <?php echo $checked; ?> value="<?php echo (int) $option_value['product_optionvalue_id']; ?>">
-                        <?php echo htmlspecialchars(Text::_($option_value['optionvalue_name']), ENT_QUOTES, 'UTF-8'); ?>
-                        <?php if ($option_value['product_optionvalue_price'] > 0 && $params->get('product_option_price', 1)) : ?>
-                        (<?php if ($params->get('product_option_price_prefix', 1)) : ?><?php echo htmlspecialchars($option_value['product_optionvalue_prefix'], ENT_QUOTES, 'UTF-8'); ?><?php endif; ?><?php echo $product_helper->displayPrice($option_value['product_optionvalue_price'], $product, $params, 'products.view.option'); ?>)
-                        <?php endif; ?>
-                    </option>
-                <?php endforeach; ?>
-            </select>
-        </div>
+            <div id="child-option-<?php echo $optionId; ?>" class="option mb-3">
+                <label class="form-label fw-semibold pb-1 mb-2">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>
+                    <?php if ($option['required']) : ?>
+                        <span class="text-danger">*</span>
+                    <?php endif; ?>
+                </label>
+                <select name="product_option[<?php echo $optionId; ?>]" class="j2commerce-option-filter" data-product-id="<?php echo $product_id; ?>" data-option-id="<?php echo $optionId; ?>"
+                    onchange="doAjaxFilter(this.options[this.selectedIndex].value, <?php echo $product_id; ?>, <?php echo $optionId; ?>, '#child-option-<?php echo $optionId; ?>');">
+                    <option value=""><?php echo Text::_('COM_J2COMMERCE_CHOOSE'); ?></option>
+                    <?php foreach ($option['optionvalue'] as $option_value) : ?>
+                        <?php $checked = $option_value['product_optionvalue_default'] ? 'selected="selected"' : ''; ?>
+                        <?php $optionValueId = (int) $option_value['product_optionvalue_id']; ?>
+                        <option <?php echo $checked; ?> value="<?php echo $optionValueId; ?>">
+                            <?php echo $esc(Text::_($option_value['optionvalue_name'])); ?>
+                            <?php if ($option_value['product_optionvalue_price'] > 0 && $params->get('product_option_price', 1)) : ?>
+                                (
+                                <?php if ($params->get('product_option_price_prefix', 1)) : ?>
+                                    <?php echo $esc($option_value['product_optionvalue_prefix']); ?>
+                                <?php endif; ?>
+                                <?php echo $product_helper->displayPrice($option_value['product_optionvalue_price'], $product, $params, 'products.view.option'); ?>
+                                )
+                            <?php endif; ?>
+                        </option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
         <?php endif; ?>
 
         <?php if ($option['type'] === 'radio' && !empty($option['optionvalue'])) : ?>
-        <div id="child-option-<?php echo $optionId; ?>" class="option mb-3">
-            <?php if ($option['required']) : ?>
-            <span class="required">*</span>
-            <?php endif; ?>
-            <b><?php echo htmlspecialchars(Text::_($option['option_name']), ENT_QUOTES, 'UTF-8'); ?>:</b><br>
-            <?php foreach ($option['optionvalue'] as $option_value) : ?>
-                <?php $childOptionValueInputId = 'child-option-value-' . $product_id . '-' . $optionId . '-' . (int) $option_value['product_optionvalue_id']; ?>
-                <?php $checked = !empty($option_value['product_optionvalue_default']) ? 'checked="checked"' : ''; ?>
-                <input <?php echo $checked; ?> type="radio"
-                    name="product_option[<?php echo $optionId; ?>]"
-                    value="<?php echo (int) $option_value['product_optionvalue_id']; ?>"
-                    id="<?php echo $childOptionValueInputId; ?>"
-                    onchange="doAjaxFilter(this.value, <?php echo $product_id; ?>, <?php echo $optionId; ?>, '#child-option-<?php echo $optionId; ?>');" />
-                <?php if ($params->get('image_for_product_options', 0) && !empty($option_value['optionvalue_image'])) : ?>
-                    <img class="optionvalue-image-<?php echo (int) $option_value['product_optionvalue_id']; ?>"
-                         src="<?php echo Uri::root(true) . '/' . htmlspecialchars($option_value['optionvalue_image'], ENT_QUOTES, 'UTF-8'); ?>"
-                         alt="<?php echo htmlspecialchars(Text::_($option_value['optionvalue_name']), ENT_QUOTES, 'UTF-8'); ?>" />
-                <?php endif; ?>
-                <label for="<?php echo $childOptionValueInputId; ?>">
-                    <?php echo htmlspecialchars(Text::_($option_value['optionvalue_name']), ENT_QUOTES, 'UTF-8'); ?>
-                    <?php if ($option_value['product_optionvalue_price'] > 0 && $params->get('product_option_price', 1)) : ?>
-                        (<?php if ($params->get('product_option_price_prefix', 1)) : ?><?php echo htmlspecialchars($option_value['product_optionvalue_prefix'], ENT_QUOTES, 'UTF-8'); ?><?php endif; ?><?php echo $product_helper->displayPrice($option_value['product_optionvalue_price'], $product, $params, 'products.view.option'); ?>)
+            <div id="child-option-<?php echo $optionId; ?>" class="option mb-3">
+                <label class="form-label fw-semibold pb-1 mb-2">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>:
+                    <?php if ($option['required']) : ?>
+                        <span class="text-danger">*</span>
                     <?php endif; ?>
+                    <span class="fw-normal fs-sm ms-1" id="child-radioOption<?php echo $optionId; ?>"></span>
                 </label>
-                <br>
-            <?php endforeach; ?>
-        </div>
-        <?php endif; ?>
+                <div class="j2commerce-radio-options d-flex flex-wrap gap-2" data-binded-label="#child-radioOption<?php echo $optionId; ?>">
+                    <?php foreach ($option['optionvalue'] as $option_value) : ?>
+                        <?php $checked = !empty($option_value['product_optionvalue_default']) ? 'checked="checked"' : ''; ?>
+                        <?php $optionValueId = (int) $option_value['product_optionvalue_id']; ?>
+                        <?php $childOptionValueInputId = 'child-option-value-' . $product_id . '-' . $optionId . '-' . $optionValueId; ?>
+                        <input <?php echo $checked; ?> type="radio" name="product_option[<?php echo $optionId; ?>]" value="<?php echo $optionValueId; ?>" id="<?php echo $childOptionValueInputId; ?>" class="btn-check" autocomplete="off"
+                            onchange="doAjaxFilter(this.value, <?php echo $product_id; ?>, <?php echo $optionId; ?>, '#child-option-<?php echo $optionId; ?>');" />
 
-        <?php if ($option['type'] === 'checkbox' && !empty($option['optionvalue'])) : ?>
-        <div id="child-option-<?php echo $optionId; ?>" class="option mb-3" data-config-checkbox="1" data-product-id="<?php echo $product_id; ?>" data-po-id="<?php echo $optionId; ?>">
-            <?php if ($option['required']) : ?>
-            <span class="required">*</span>
-            <?php endif; ?>
-            <b><?php echo htmlspecialchars(Text::_($option['option_name']), ENT_QUOTES, 'UTF-8'); ?>:</b><br>
-            <?php foreach ($option['optionvalue'] as $option_value) : ?>
-                <?php $childOptionValueInputId = 'child-option-value-' . $product_id . '-' . $optionId . '-' . (int) $option_value['product_optionvalue_id']; ?>
-                <input type="checkbox"
-                    name="product_option[<?php echo $optionId; ?>][]"
-                    value="<?php echo (int) $option_value['product_optionvalue_id']; ?>"
-                    id="<?php echo $childOptionValueInputId; ?>" />
-                <?php if ($params->get('image_for_product_options', 0) && !empty($option_value['optionvalue_image'])) : ?>
-                    <img class="optionvalue-image-<?php echo (int) $option_value['product_optionvalue_id']; ?>"
-                         src="<?php echo Uri::root(true) . '/' . htmlspecialchars($option_value['optionvalue_image'], ENT_QUOTES, 'UTF-8'); ?>"
-                         alt="<?php echo htmlspecialchars(Text::_($option_value['optionvalue_name']), ENT_QUOTES, 'UTF-8'); ?>" />
-                <?php endif; ?>
-                <label for="<?php echo $childOptionValueInputId; ?>">
-                    <?php echo htmlspecialchars(Text::_($option_value['optionvalue_name']), ENT_QUOTES, 'UTF-8'); ?>
-                    <?php if ($option_value['product_optionvalue_price'] > 0 && $params->get('product_option_price', 1)) : ?>
-                        (<?php if ($params->get('product_option_price_prefix', 1)) : ?><?php echo htmlspecialchars($option_value['product_optionvalue_prefix'], ENT_QUOTES, 'UTF-8'); ?><?php endif; ?><?php echo $product_helper->displayPrice($option_value['product_optionvalue_price'], $product, $params, 'products.view.option'); ?>)
-                    <?php endif; ?>
-                </label>
-                <br>
-            <?php endforeach; ?>
-        </div>
+                        <?php if ($params->get('image_for_product_options', 0) && !empty($option_value['optionvalue_image'])) : ?>
+                            <label class="btn btn-image p-0 form-check-label border-2" for="<?php echo $childOptionValueInputId; ?>" data-label="<?php echo $esc(Text::_($option_value['optionvalue_name'])); ?>">
+                                <img class="optionvalue-image me-1" src="<?php echo Uri::root(true) . '/' . $esc($option_value['optionvalue_image']); ?>" alt="<?php echo $esc(Text::_($option_value['optionvalue_name'])); ?>" width="56" style="width:56px;" />
+                                <span class="visually-hidden"><?php echo $esc(Text::_($option_value['optionvalue_name'])); ?></span>
+                            </label>
+                        <?php else : ?>
+                            <label class="btn btn-sm btn-outline-secondary form-check-label border-2" for="<?php echo $childOptionValueInputId; ?>" data-label="<?php echo $esc(Text::_($option_value['optionvalue_name'])); ?>">
+                                <?php echo $esc(Text::_($option_value['optionvalue_name'])); ?>
+                                <?php if ($option_value['product_optionvalue_price'] > 0 && $params->get('product_option_price', 1)) : ?>
+                                    <?php if ($params->get('product_option_price_prefix', 1)) : ?>
+                                        <?php echo $esc($option_value['product_optionvalue_prefix']); ?>
+                                    <?php endif; ?>
+                                    <?php echo $product_helper->displayPrice($option_value['product_optionvalue_price'], $product, $params, 'products.view.option'); ?>
+                                <?php endif; ?>
+                            </label>
+                        <?php endif; ?>
+                    <?php endforeach; ?>
+                </div>
+            </div>
         <?php endif; ?>
 
         <?php if ($option['type'] === 'color' && !empty($option['optionvalue'])) : ?>
-            <div id="option-<?php echo $optionId; ?>" class="option mb-3">
-                <div class="form-label fw-semibold pb-1 mb-2">
-                    <?php echo htmlspecialchars(Text::_($option['option_name']), ENT_QUOTES, 'UTF-8'); ?>:
+            <div id="child-option-<?php echo $optionId; ?>" class="option mb-3">
+                <label class="form-label fw-semibold pb-1 mb-2">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>:
                     <?php if ($option['required']) : ?>
                         <span class="text-danger">*</span>
                     <?php endif; ?>
                     <span class="fw-normal fs-sm ms-1" id="child-colorOption<?php echo $optionId; ?>"></span>
-                </div>
+                </label>
                 <div class="j2commerce-color-options d-flex flex-wrap gap-2" data-binded-label="#child-colorOption<?php echo $optionId; ?>">
                     <?php foreach ($option['optionvalue'] as $option_value) : ?>
-                        <?php $childOptionValueInputId = 'child-option-value-' . $product_id . '-' . $optionId . '-' . (int) $option_value['product_optionvalue_id']; ?>
                         <?php $checked = !empty($option_value['product_optionvalue_default']) ? 'checked="checked"' : ''; ?>
-                        <input <?php echo $checked; ?> type="radio"
-                            name="product_option[<?php echo $optionId; ?>]"
-                            value="<?php echo (int) $option_value['product_optionvalue_id']; ?>"
-                            id="<?php echo $childOptionValueInputId; ?>"
-                            class="btn-check"
+                        <?php $colorValueId = (int) $option_value['product_optionvalue_id']; ?>
+                        <?php $childOptionValueInputId = 'child-option-value-' . $product_id . '-' . $optionId . '-' . $colorValueId; ?>
+                        <input <?php echo $checked; ?> type="radio" name="product_option[<?php echo $optionId; ?>]" value="<?php echo $colorValueId; ?>" id="<?php echo $childOptionValueInputId; ?>" class="btn-check"
                             onchange="doAjaxFilter(this.value, <?php echo $product_id; ?>, <?php echo $optionId; ?>, '#child-option-<?php echo $optionId; ?>');" />
-
-                        <label for="<?php echo $childOptionValueInputId; ?>" class="btn btn-color fs-xl" title="<?php echo htmlspecialchars(Text::_($option_value['optionvalue_name']), ENT_QUOTES, 'UTF-8'); ?>" data-label="<?php echo htmlspecialchars(Text::_($option_value['optionvalue_name']), ENT_QUOTES, 'UTF-8'); ?>" style="color:<?php echo htmlspecialchars($option_value['optionvalue_image'], ENT_QUOTES, 'UTF-8'); ?>;">
-                            <span class="visually-hidden"><?php echo htmlspecialchars(Text::_($option_value['optionvalue_name']), ENT_QUOTES, 'UTF-8'); ?></span>
+                        <label for="<?php echo $childOptionValueInputId; ?>" class="btn btn-color fs-xl" title="<?php echo $esc(Text::_($option_value['optionvalue_name'])); ?>" data-label="<?php echo $esc(Text::_($option_value['optionvalue_name'])); ?>" style="color:<?php echo $esc($option_value['optionvalue_image']); ?>;">
+                            <span class="visually-hidden"><?php echo $esc(Text::_($option_value['optionvalue_name'])); ?></span>
                         </label>
                     <?php endforeach; ?>
                 </div>
             </div>
         <?php endif; ?>
+
+        <?php if ($option['type'] === 'checkbox' && !empty($option['optionvalue'])) : ?>
+            <div id="child-option-<?php echo $optionId; ?>" class="option" data-config-checkbox="1" data-product-id="<?php echo $product_id; ?>" data-po-id="<?php echo $optionId; ?>">
+                <?php if ($option['required']) : ?>
+                    <span class="required">*</span>
+                <?php endif; ?>
+                <b><?php echo $esc(Text::_($option['option_name'])); ?>:</b><br>
+                <?php foreach ($option['optionvalue'] as $option_value) : ?>
+                    <?php $checkboxValueId = (int) $option_value['product_optionvalue_id']; ?>
+                    <?php $childOptionValueInputId = 'child-option-value-' . $product_id . '-' . $optionId . '-' . $checkboxValueId; ?>
+                    <input type="checkbox"
+                        name="product_option[<?php echo $optionId; ?>][]"
+                        value="<?php echo $checkboxValueId; ?>"
+                        id="<?php echo $childOptionValueInputId; ?>" />
+                    <?php if ($params->get('image_for_product_options', 0) && !empty($option_value['optionvalue_image'])) : ?>
+                        <img class="optionvalue-image-<?php echo $checkboxValueId; ?>"
+                             src="<?php echo Uri::root(true) . '/' . $esc($option_value['optionvalue_image']); ?>" />
+                    <?php endif; ?>
+                    <label for="<?php echo $childOptionValueInputId; ?>">
+                        <?php echo $esc(Text::_($option_value['optionvalue_name'])); ?>
+                        <?php if ($option_value['product_optionvalue_price'] > 0 && $params->get('product_option_price', 1)) : ?>
+                            (
+                            <?php if ($params->get('product_option_price_prefix', 1)) : ?>
+                                <?php echo $esc($option_value['product_optionvalue_prefix']); ?>
+                            <?php endif; ?>
+                            <?php echo $product_helper->displayPrice($option_value['product_optionvalue_price'], $product, $params, 'products.view.option'); ?>
+                            )
+                        <?php endif; ?>
+                    </label>
+                <?php endforeach; ?>
+            </div>
+        <?php endif; ?>
+
         <?php if ($option['type'] === 'text') : ?>
             <?php $text_option_params = $platform->getRegistry($option['option_params'] ?? '{}'); ?>
             <?php $textInputId = 'child-product-option-text-' . $product_id . '-' . $optionId; ?>
             <div id="child-option-<?php echo $optionId; ?>" class="option mb-3">
-                <label class="form-label fw-semibold pb-1 mb-1" for="<?php echo $textInputId; ?>">
-                    <?php echo htmlspecialchars(Text::_($option['option_name']), ENT_QUOTES, 'UTF-8'); ?>
+                <label class="form-label fw-semibold pb-1 mb-2" for="<?php echo $textInputId; ?>">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>
                     <?php if ($option['required']) : ?>
                         <span class="text-danger">*</span>
                     <?php endif; ?>
                 </label>
                 <input id="<?php echo $textInputId; ?>" type="text" class="form-control"
                     name="product_option[<?php echo $optionId; ?>]"
-                    value="<?php echo htmlspecialchars($option['optionvalue'] ?? '', ENT_QUOTES, 'UTF-8'); ?>"
-                    placeholder="<?php echo htmlspecialchars($text_option_params->get('place_holder', ''), ENT_QUOTES, 'UTF-8'); ?>" />
+                    value="<?php echo $esc($option['optionvalue'] ?? ''); ?>"
+                    placeholder="<?php echo $esc($text_option_params->get('place_holder', '')); ?>" />
             </div>
         <?php endif; ?>
 
         <?php if ($option['type'] === 'textarea') : ?>
             <?php $textareaInputId = 'child-product-option-textarea-' . $product_id . '-' . $optionId; ?>
             <div id="child-option-<?php echo $optionId; ?>" class="option mb-3">
-                <label class="form-label fw-semibold pb-1 mb-1" for="<?php echo $textareaInputId; ?>">
-                    <?php echo htmlspecialchars(Text::_($option['option_name']), ENT_QUOTES, 'UTF-8'); ?>
+                <label class="form-label fw-semibold pb-1 mb-2" for="<?php echo $textareaInputId; ?>">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>
                     <?php if ($option['required']) : ?>
                         <span class="text-danger">*</span>
                     <?php endif; ?>
                 </label>
                 <textarea id="<?php echo $textareaInputId; ?>" class="form-control"
                     name="product_option[<?php echo $optionId; ?>]"
-                    cols="20" rows="5"><?php echo htmlspecialchars($option['optionvalue'] ?? '', ENT_QUOTES, 'UTF-8'); ?></textarea>
+                    cols="20" rows="5"><?php echo $esc($option['optionvalue'] ?? ''); ?></textarea>
             </div>
         <?php endif; ?>
 

--- a/components/com_j2commerce/layouts/app_uikit/product/configurablechildoptions.php
+++ b/components/com_j2commerce/layouts/app_uikit/product/configurablechildoptions.php
@@ -16,138 +16,151 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Uri\Uri;
 
 // Layout for rendering child configurable options via AJAX.
-// Injected into #ChildOptions{poId} when a parent option is selected.
+// Injected into #child-ChildOptions{poId} when a parent option is selected.
+// Markup mirrors tmpl/uikit/view_configurableoptions.php so children look
+// identical to their parents. Injected nodes keep inline onchange + the
+// initConfigCheckboxes data-* hooks: innerHTML never executes the parent's
+// per-option <script> blocks, so checkbox binding relies on initConfigCheckboxes
+// in j2commerce.js, and select/radio/color filtering relies on inline onchange.
 
-$product = $displayData['product'];
-$params  = $displayData['params'];
-$options = $displayData['options'] ?? [];
-
+$product        = $displayData['product'];
+$params         = $displayData['params'];
+$options        = $displayData['options'] ?? [];
 $product_helper = J2CommerceHelper::product();
-$platform = J2CommerceHelper::platform();
-$product_id = $product->j2commerce_product_id;
-$esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+$platform       = J2CommerceHelper::platform();
+$product_id     = (int) $product->j2commerce_product_id;
+$esc            = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
 ?>
 <?php if (!empty($options)) : ?>
     <?php foreach ($options as $option) : ?>
         <?php $optionId = (int) $option['productoption_id']; ?>
 
         <?php if ($option['type'] === 'select' && !empty($option['optionvalue'])) : ?>
-        <?php $selectInputId = 'child-product-option-' . (int) $product_id . '-' . $optionId; ?>
-        <div id="child-option-<?php echo $optionId; ?>" class="option uk-margin-small-bottom">
-            <?php if ($option['required']) : ?>
-            <span class="required">*</span>
-            <?php endif; ?>
-            <label class="uk-form-label" for="<?php echo $selectInputId; ?>"><?php echo $esc(Text::_($option['option_name'])); ?>:</label>
-            <select id="<?php echo $selectInputId; ?>" name="product_option[<?php echo $optionId; ?>]"
-                class="uk-select"
-                onchange="doAjaxFilter(this.options[this.selectedIndex].value, <?php echo (int) $product_id; ?>, <?php echo $optionId; ?>, '#child-option-<?php echo $optionId; ?>');">
-                <option value=""><?php echo Text::_('COM_J2COMMERCE_ADDTOCART_SELECT'); ?></option>
-                <?php foreach ($option['optionvalue'] as $option_value) : ?>
-                    <?php $checked = !empty($option_value['product_optionvalue_default']) ? 'selected="selected"' : ''; ?>
-                    <option <?php echo $checked; ?> value="<?php echo (int) $option_value['product_optionvalue_id']; ?>">
-                        <?php echo $esc(Text::_($option_value['optionvalue_name'])); ?>
-                        <?php if ($option_value['product_optionvalue_price'] > 0 && $params->get('product_option_price', 1)) : ?>
-                        (<?php if ($params->get('product_option_price_prefix', 1)) : ?><?php echo $esc($option_value['product_optionvalue_prefix']); ?><?php endif; ?><?php echo $product_helper->displayPrice($option_value['product_optionvalue_price'], $product, $params, 'products.view.option'); ?>)
-                        <?php endif; ?>
-                    </option>
-                <?php endforeach; ?>
-            </select>
-        </div>
+            <div id="child-option-<?php echo $optionId; ?>" class="option uk-margin-small-bottom">
+                <label class="uk-form-label uk-text-bold uk-display-block">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>
+                    <?php if ($option['required']) : ?>
+                        <span class="uk-text-danger">*</span>
+                    <?php endif; ?>
+                </label>
+                <select class="uk-select" name="product_option[<?php echo $optionId; ?>]" onchange="doAjaxFilter(this.options[this.selectedIndex].value, <?php echo $product_id; ?>, <?php echo $optionId; ?>, '#child-option-<?php echo $optionId; ?>');">
+                    <option value=""><?php echo Text::_('COM_J2COMMERCE_CHOOSE'); ?></option>
+                    <?php foreach ($option['optionvalue'] as $option_value) : ?>
+                        <?php $checked = !empty($option_value['product_optionvalue_default']) ? 'selected="selected"' : ''; ?>
+                        <option <?php echo $checked; ?> value="<?php echo (int) $option_value['product_optionvalue_id']; ?>">
+                            <?php echo $esc(Text::_($option_value['optionvalue_name'])); ?>
+                            <?php if ($option_value['product_optionvalue_price'] > 0 && $params->get('product_option_price', 1)) : ?>
+                                (
+                                <?php if ($params->get('product_option_price_prefix', 1)) : ?>
+                                    <?php echo $esc($option_value['product_optionvalue_prefix']); ?>
+                                <?php endif; ?>
+                                <?php echo $product_helper->displayPrice($option_value['product_optionvalue_price'], $product, $params, 'products.view.option'); ?>
+                                )
+                            <?php endif; ?>
+                        </option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
         <?php endif; ?>
 
         <?php if ($option['type'] === 'radio' && !empty($option['optionvalue'])) : ?>
-        <div id="child-option-<?php echo $optionId; ?>" class="option uk-margin-small-bottom">
-            <?php if ($option['required']) : ?>
-            <span class="required">*</span>
-            <?php endif; ?>
-            <b><?php echo $esc(Text::_($option['option_name'])); ?>:</b><br>
-            <?php foreach ($option['optionvalue'] as $option_value) : ?>
-                <?php $childOptionValueInputId = 'child-option-value-' . (int) $product_id . '-' . $optionId . '-' . (int) $option_value['product_optionvalue_id']; ?>
-                <?php $checked = !empty($option_value['product_optionvalue_default']) ? 'checked="checked"' : ''; ?>
-                <input <?php echo $checked; ?> type="radio"
-                    name="product_option[<?php echo $optionId; ?>]"
-                    value="<?php echo (int) $option_value['product_optionvalue_id']; ?>"
-                    id="<?php echo $childOptionValueInputId; ?>"
-                    class="uk-radio"
-                    onchange="doAjaxFilter(this.value, <?php echo (int) $product_id; ?>, <?php echo $optionId; ?>, '#child-option-<?php echo $optionId; ?>');" />
-                <?php if ($params->get('image_for_product_options', 0) && !empty($option_value['optionvalue_image'])) : ?>
-                    <img class="optionvalue-image-<?php echo (int) $option_value['product_optionvalue_id']; ?>"
-                         src="<?php echo Uri::root(true) . '/' . $esc($option_value['optionvalue_image']); ?>"
-                         alt="<?php echo $esc(Text::_($option_value['optionvalue_name'])); ?>" />
-                <?php endif; ?>
-                <label for="<?php echo $childOptionValueInputId; ?>">
-                    <?php echo $esc(Text::_($option_value['optionvalue_name'])); ?>
-                    <?php if ($option_value['product_optionvalue_price'] > 0 && $params->get('product_option_price', 1)) : ?>
-                        (<?php if ($params->get('product_option_price_prefix', 1)) : ?><?php echo $esc($option_value['product_optionvalue_prefix']); ?><?php endif; ?><?php echo $product_helper->displayPrice($option_value['product_optionvalue_price'], $product, $params, 'products.view.option'); ?>)
-                    <?php endif; ?>
-                </label>
-                <br>
-            <?php endforeach; ?>
-        </div>
-        <?php endif; ?>
-
-        <?php if ($option['type'] === 'checkbox' && !empty($option['optionvalue'])) : ?>
-        <div id="child-option-<?php echo $optionId; ?>" class="option uk-margin-small-bottom" data-config-checkbox="1" data-product-id="<?php echo (int) $product_id; ?>" data-po-id="<?php echo $optionId; ?>">
-            <?php if ($option['required']) : ?>
-            <span class="required">*</span>
-            <?php endif; ?>
-            <b><?php echo $esc(Text::_($option['option_name'])); ?>:</b><br>
-            <?php foreach ($option['optionvalue'] as $option_value) : ?>
-                <?php $childOptionValueInputId = 'child-option-value-' . (int) $product_id . '-' . $optionId . '-' . (int) $option_value['product_optionvalue_id']; ?>
-                <input type="checkbox"
-                    class="uk-checkbox"
-                    name="product_option[<?php echo $optionId; ?>][]"
-                    value="<?php echo (int) $option_value['product_optionvalue_id']; ?>"
-                    id="<?php echo $childOptionValueInputId; ?>" />
-                <?php if ($params->get('image_for_product_options', 0) && !empty($option_value['optionvalue_image'])) : ?>
-                    <img class="optionvalue-image-<?php echo (int) $option_value['product_optionvalue_id']; ?>"
-                         src="<?php echo Uri::root(true) . '/' . $esc($option_value['optionvalue_image']); ?>"
-                         alt="<?php echo $esc(Text::_($option_value['optionvalue_name'])); ?>" />
-                <?php endif; ?>
-                <label for="<?php echo $childOptionValueInputId; ?>">
-                    <?php echo $esc(Text::_($option_value['optionvalue_name'])); ?>
-                    <?php if ($option_value['product_optionvalue_price'] > 0 && $params->get('product_option_price', 1)) : ?>
-                        (<?php if ($params->get('product_option_price_prefix', 1)) : ?><?php echo $esc($option_value['product_optionvalue_prefix']); ?><?php endif; ?><?php echo $product_helper->displayPrice($option_value['product_optionvalue_price'], $product, $params, 'products.view.option'); ?>)
-                    <?php endif; ?>
-                </label>
-                <br>
-            <?php endforeach; ?>
-        </div>
-        <?php endif; ?>
-
-        <?php if ($option['type'] === 'color' && !empty($option['optionvalue'])) : ?>
             <div id="child-option-<?php echo $optionId; ?>" class="option uk-margin-small-bottom">
-                <div class="uk-form-label uk-text-bold">
+                <label class="uk-form-label uk-text-bold uk-display-block">
                     <?php echo $esc(Text::_($option['option_name'])); ?>:
                     <?php if ($option['required']) : ?>
                         <span class="uk-text-danger">*</span>
                     <?php endif; ?>
-                    <span class="uk-text-muted uk-text-small" id="child-colorOption<?php echo $optionId; ?>"></span>
-                </div>
-                <div class="j2commerce-color-options uk-flex uk-flex-wrap" style="gap: 0.5rem;" data-binded-label="#child-colorOption<?php echo $optionId; ?>">
+                    <span class="uk-text-normal" id="child-radioOption<?php echo $optionId; ?>"></span>
+                </label>
+                <div class="j2commerce-radio-options uk-flex uk-flex-wrap" style="gap:.5rem;" data-binded-label="#child-radioOption<?php echo $optionId; ?>">
                     <?php foreach ($option['optionvalue'] as $option_value) : ?>
-                        <?php $childOptionValueInputId = 'child-option-value-' . (int) $product_id . '-' . $optionId . '-' . (int) $option_value['product_optionvalue_id']; ?>
                         <?php $checked = !empty($option_value['product_optionvalue_default']) ? 'checked="checked"' : ''; ?>
-                        <input <?php echo $checked; ?> type="radio"
-                            name="product_option[<?php echo $optionId; ?>]"
-                            value="<?php echo (int) $option_value['product_optionvalue_id']; ?>"
-                            id="<?php echo $childOptionValueInputId; ?>"
-                            class="uk-hidden"
-                            onchange="doAjaxFilter(this.value, <?php echo (int) $product_id; ?>, <?php echo $optionId; ?>, '#child-option-<?php echo $optionId; ?>');" />
+                        <?php $optionValueId = (int) $option_value['product_optionvalue_id']; ?>
+                        <?php $childOptionValueInputId = 'child-option-value-' . $product_id . '-' . $optionId . '-' . $optionValueId; ?>
+                        <input <?php echo $checked; ?> type="radio" name="product_option[<?php echo $optionId; ?>]" value="<?php echo $optionValueId; ?>" id="<?php echo $childOptionValueInputId; ?>" class="uk-radio uk-hidden" onchange="doAjaxFilter(this.value, <?php echo $product_id; ?>, <?php echo $optionId; ?>, '#child-option-<?php echo $optionId; ?>');" autocomplete="off" />
 
+                        <?php if ($params->get('image_for_product_options', 0) && !empty($option_value['optionvalue_image'])) : ?>
+                            <label class="btn-image" for="<?php echo $childOptionValueInputId; ?>" data-label="<?php echo $esc(Text::_($option_value['optionvalue_name'])); ?>">
+                                <img class="optionvalue-image" src="<?php echo Uri::root(true) . '/' . $esc($option_value['optionvalue_image']); ?>" alt="<?php echo $esc(Text::_($option_value['optionvalue_name'])); ?>" width="56" style="width:56px;" />
+                                <span class="uk-invisible"><?php echo $esc(Text::_($option_value['optionvalue_name'])); ?></span>
+                            </label>
+                        <?php else : ?>
+                            <label class="uk-button uk-button-small uk-button-default" for="<?php echo $childOptionValueInputId; ?>" data-label="<?php echo $esc(Text::_($option_value['optionvalue_name'])); ?>">
+                                <?php echo $esc(Text::_($option_value['optionvalue_name'])); ?>
+                                <?php if ($option_value['product_optionvalue_price'] > 0 && $params->get('product_option_price', 1)) : ?>
+                                    <?php if ($params->get('product_option_price_prefix', 1)) : ?>
+                                        <?php echo $esc($option_value['product_optionvalue_prefix']); ?>
+                                    <?php endif; ?>
+                                    <?php echo $product_helper->displayPrice($option_value['product_optionvalue_price'], $product, $params, 'products.view.option'); ?>
+                                <?php endif; ?>
+                            </label>
+                        <?php endif; ?>
+                    <?php endforeach; ?>
+                </div>
+            </div>
+        <?php endif; ?>
+
+        <?php if ($option['type'] === 'color' && !empty($option['optionvalue'])) : ?>
+            <div id="child-option-<?php echo $optionId; ?>" class="option uk-margin-small-bottom">
+                <label class="uk-form-label uk-text-bold uk-display-block">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>:
+                    <?php if ($option['required']) : ?>
+                        <span class="uk-text-danger">*</span>
+                    <?php endif; ?>
+                    <span class="uk-text-normal" id="child-colorOption<?php echo $optionId; ?>"></span>
+                </label>
+                <div class="j2commerce-color-options uk-flex uk-flex-wrap" style="gap:.5rem;" data-binded-label="#child-colorOption<?php echo $optionId; ?>">
+                    <?php foreach ($option['optionvalue'] as $option_value) : ?>
+                        <?php $checked = !empty($option_value['product_optionvalue_default']) ? 'checked="checked"' : ''; ?>
+                        <?php $colorValueId = (int) $option_value['product_optionvalue_id']; ?>
+                        <?php $childOptionValueInputId = 'child-option-value-' . $product_id . '-' . $optionId . '-' . $colorValueId; ?>
+                        <input <?php echo $checked; ?> type="radio" name="product_option[<?php echo $optionId; ?>]" value="<?php echo $colorValueId; ?>" id="<?php echo $childOptionValueInputId; ?>" class="uk-radio uk-hidden" onchange="doAjaxFilter(this.value, <?php echo $product_id; ?>, <?php echo $optionId; ?>, '#child-option-<?php echo $optionId; ?>');" />
                         <label for="<?php echo $childOptionValueInputId; ?>" class="btn-color" title="<?php echo $esc(Text::_($option_value['optionvalue_name'])); ?>" data-label="<?php echo $esc(Text::_($option_value['optionvalue_name'])); ?>" style="color:<?php echo $esc($option_value['optionvalue_image']); ?>;">
-                            <span class="uk-hidden"><?php echo $esc(Text::_($option_value['optionvalue_name'])); ?></span>
+                            <span class="uk-invisible"><?php echo $esc(Text::_($option_value['optionvalue_name'])); ?></span>
                         </label>
                     <?php endforeach; ?>
                 </div>
             </div>
         <?php endif; ?>
 
+        <?php if ($option['type'] === 'checkbox' && !empty($option['optionvalue'])) : ?>
+            <div id="child-option-<?php echo $optionId; ?>" class="option uk-margin-small-bottom" data-config-checkbox="1" data-product-id="<?php echo $product_id; ?>" data-po-id="<?php echo $optionId; ?>">
+                <?php if ($option['required']) : ?>
+                    <span class="uk-text-danger">*</span>
+                <?php endif; ?>
+                <b><?php echo $esc(Text::_($option['option_name'])); ?>:</b><br>
+                <?php foreach ($option['optionvalue'] as $option_value) : ?>
+                    <?php $checkboxValueId = (int) $option_value['product_optionvalue_id']; ?>
+                    <?php $childOptionValueInputId = 'child-option-value-' . $product_id . '-' . $optionId . '-' . $checkboxValueId; ?>
+                    <label class="uk-flex uk-flex-middle" style="gap:.5rem;">
+                        <input type="checkbox"
+                            class="uk-checkbox"
+                            name="product_option[<?php echo $optionId; ?>][]"
+                            value="<?php echo $checkboxValueId; ?>"
+                            id="<?php echo $childOptionValueInputId; ?>" />
+                        <?php if ($params->get('image_for_product_options', 0) && !empty($option_value['optionvalue_image'])) : ?>
+                            <img class="optionvalue-image-<?php echo $checkboxValueId; ?>"
+                                 src="<?php echo Uri::root(true) . '/' . $esc($option_value['optionvalue_image']); ?>" />
+                        <?php endif; ?>
+                        <?php echo $esc(Text::_($option_value['optionvalue_name'])); ?>
+                        <?php if ($option_value['product_optionvalue_price'] > 0 && $params->get('product_option_price', 1)) : ?>
+                            (
+                            <?php if ($params->get('product_option_price_prefix', 1)) : ?>
+                                <?php echo $esc($option_value['product_optionvalue_prefix']); ?>
+                            <?php endif; ?>
+                            <?php echo $product_helper->displayPrice($option_value['product_optionvalue_price'], $product, $params, 'products.view.option'); ?>
+                            )
+                        <?php endif; ?>
+                    </label>
+                <?php endforeach; ?>
+            </div>
+        <?php endif; ?>
+
         <?php if ($option['type'] === 'text') : ?>
             <?php $text_option_params = $platform->getRegistry($option['option_params'] ?? '{}'); ?>
-            <?php $textInputId = 'child-product-option-text-' . (int) $product_id . '-' . $optionId; ?>
+            <?php $textInputId = 'child-product-option-text-' . $product_id . '-' . $optionId; ?>
             <div id="child-option-<?php echo $optionId; ?>" class="option uk-margin-small-bottom">
-                <label class="uk-form-label" for="<?php echo $textInputId; ?>">
+                <label class="uk-form-label uk-text-bold uk-display-block" for="<?php echo $textInputId; ?>">
                     <?php echo $esc(Text::_($option['option_name'])); ?>
                     <?php if ($option['required']) : ?>
                         <span class="uk-text-danger">*</span>
@@ -161,9 +174,9 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
         <?php endif; ?>
 
         <?php if ($option['type'] === 'textarea') : ?>
-            <?php $textareaInputId = 'child-product-option-textarea-' . (int) $product_id . '-' . $optionId; ?>
+            <?php $textareaInputId = 'child-product-option-textarea-' . $product_id . '-' . $optionId; ?>
             <div id="child-option-<?php echo $optionId; ?>" class="option uk-margin-small-bottom">
-                <label class="uk-form-label" for="<?php echo $textareaInputId; ?>">
+                <label class="uk-form-label uk-text-bold uk-display-block" for="<?php echo $textareaInputId; ?>">
                     <?php echo $esc(Text::_($option['option_name'])); ?>
                     <?php if ($option['required']) : ?>
                         <span class="uk-text-danger">*</span>

--- a/plugins/j2commerce/app_bootstrap5/layouts/product/configurablechildoptions.php
+++ b/plugins/j2commerce/app_bootstrap5/layouts/product/configurablechildoptions.php
@@ -16,158 +16,177 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Uri\Uri;
 
 // Layout for rendering child configurable options via AJAX.
-// Injected into #ChildOptions{poId} when a parent option is selected.
+// Injected into #child-ChildOptions{poId} when a parent option is selected.
+// Markup mirrors tmpl/bootstrap5/view_configurableoptions.php so children look
+// identical to their parents. Injected nodes keep inline onchange + the
+// initConfigCheckboxes data-* hooks because DOMContentLoaded delegation in
+// j2commerce.js cannot bind elements added after page load.
 
-$product = $displayData['product'];
-$params  = $displayData['params'];
-$options = $displayData['options'] ?? [];
-
+$product        = $displayData['product'];
+$params         = $displayData['params'];
+$options        = $displayData['options'] ?? [];
 $product_helper = J2CommerceHelper::product();
-$platform = J2CommerceHelper::platform();
-$product_id = (int) $product->j2commerce_product_id;
+$platform       = J2CommerceHelper::platform();
+$product_id     = (int) $product->j2commerce_product_id;
+$esc            = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
 ?>
 <?php if (!empty($options)) : ?>
     <?php foreach ($options as $option) : ?>
         <?php $optionId = (int) $option['productoption_id']; ?>
 
         <?php if ($option['type'] === 'select' && !empty($option['optionvalue'])) : ?>
-        <?php $selectInputId = 'child-product-option-' . $product_id . '-' . $optionId; ?>
-        <div id="child-option-<?php echo $optionId; ?>" class="option mb-3">
-            <?php if ($option['required']) : ?>
-            <span class="required">*</span>
-            <?php endif; ?>
-            <label class="form-label" for="<?php echo $selectInputId; ?>"><?php echo htmlspecialchars(Text::_($option['option_name']), ENT_QUOTES, 'UTF-8'); ?>:</label>
-            <select id="<?php echo $selectInputId; ?>" name="product_option[<?php echo $optionId; ?>]"
-                class="form-select"
-                onchange="doAjaxFilter(this.options[this.selectedIndex].value, <?php echo $product_id; ?>, <?php echo $optionId; ?>, '#child-option-<?php echo $optionId; ?>');">
-                <option value=""><?php echo Text::_('COM_J2COMMERCE_ADDTOCART_SELECT'); ?></option>
-                <?php foreach ($option['optionvalue'] as $option_value) : ?>
-                    <?php $checked = !empty($option_value['product_optionvalue_default']) ? 'selected="selected"' : ''; ?>
-                    <option <?php echo $checked; ?> value="<?php echo (int) $option_value['product_optionvalue_id']; ?>">
-                        <?php echo htmlspecialchars(Text::_($option_value['optionvalue_name']), ENT_QUOTES, 'UTF-8'); ?>
-                        <?php if ($option_value['product_optionvalue_price'] > 0 && $params->get('product_option_price', 1)) : ?>
-                        (<?php if ($params->get('product_option_price_prefix', 1)) : ?><?php echo htmlspecialchars($option_value['product_optionvalue_prefix'], ENT_QUOTES, 'UTF-8'); ?><?php endif; ?><?php echo $product_helper->displayPrice($option_value['product_optionvalue_price'], $product, $params, 'products.view.option'); ?>)
-                        <?php endif; ?>
-                    </option>
-                <?php endforeach; ?>
-            </select>
-        </div>
+            <div id="child-option-<?php echo $optionId; ?>" class="option mb-3">
+                <label class="form-label fw-semibold pb-1 mb-2">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>
+                    <?php if ($option['required']) : ?>
+                        <span class="text-danger">*</span>
+                    <?php endif; ?>
+                </label>
+                <select name="product_option[<?php echo $optionId; ?>]" class="j2commerce-option-filter" data-product-id="<?php echo $product_id; ?>" data-option-id="<?php echo $optionId; ?>"
+                    onchange="doAjaxFilter(this.options[this.selectedIndex].value, <?php echo $product_id; ?>, <?php echo $optionId; ?>, '#child-option-<?php echo $optionId; ?>');">
+                    <option value=""><?php echo Text::_('COM_J2COMMERCE_CHOOSE'); ?></option>
+                    <?php foreach ($option['optionvalue'] as $option_value) : ?>
+                        <?php $checked = $option_value['product_optionvalue_default'] ? 'selected="selected"' : ''; ?>
+                        <?php $optionValueId = (int) $option_value['product_optionvalue_id']; ?>
+                        <option <?php echo $checked; ?> value="<?php echo $optionValueId; ?>">
+                            <?php echo $esc(Text::_($option_value['optionvalue_name'])); ?>
+                            <?php if ($option_value['product_optionvalue_price'] > 0 && $params->get('product_option_price', 1)) : ?>
+                                (
+                                <?php if ($params->get('product_option_price_prefix', 1)) : ?>
+                                    <?php echo $esc($option_value['product_optionvalue_prefix']); ?>
+                                <?php endif; ?>
+                                <?php echo $product_helper->displayPrice($option_value['product_optionvalue_price'], $product, $params, 'products.view.option'); ?>
+                                )
+                            <?php endif; ?>
+                        </option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
         <?php endif; ?>
 
         <?php if ($option['type'] === 'radio' && !empty($option['optionvalue'])) : ?>
-        <div id="child-option-<?php echo $optionId; ?>" class="option mb-3">
-            <?php if ($option['required']) : ?>
-            <span class="required">*</span>
-            <?php endif; ?>
-            <b><?php echo htmlspecialchars(Text::_($option['option_name']), ENT_QUOTES, 'UTF-8'); ?>:</b><br>
-            <?php foreach ($option['optionvalue'] as $option_value) : ?>
-                <?php $childOptionValueInputId = 'child-option-value-' . $product_id . '-' . $optionId . '-' . (int) $option_value['product_optionvalue_id']; ?>
-                <?php $checked = !empty($option_value['product_optionvalue_default']) ? 'checked="checked"' : ''; ?>
-                <input <?php echo $checked; ?> type="radio"
-                    name="product_option[<?php echo $optionId; ?>]"
-                    value="<?php echo (int) $option_value['product_optionvalue_id']; ?>"
-                    id="<?php echo $childOptionValueInputId; ?>"
-                    onchange="doAjaxFilter(this.value, <?php echo $product_id; ?>, <?php echo $optionId; ?>, '#child-option-<?php echo $optionId; ?>');" />
-                <?php if ($params->get('image_for_product_options', 0) && !empty($option_value['optionvalue_image'])) : ?>
-                    <img class="optionvalue-image-<?php echo (int) $option_value['product_optionvalue_id']; ?>"
-                         src="<?php echo Uri::root(true) . '/' . htmlspecialchars($option_value['optionvalue_image'], ENT_QUOTES, 'UTF-8'); ?>"
-                         alt="<?php echo htmlspecialchars(Text::_($option_value['optionvalue_name']), ENT_QUOTES, 'UTF-8'); ?>" />
-                <?php endif; ?>
-                <label for="<?php echo $childOptionValueInputId; ?>">
-                    <?php echo htmlspecialchars(Text::_($option_value['optionvalue_name']), ENT_QUOTES, 'UTF-8'); ?>
-                    <?php if ($option_value['product_optionvalue_price'] > 0 && $params->get('product_option_price', 1)) : ?>
-                        (<?php if ($params->get('product_option_price_prefix', 1)) : ?><?php echo htmlspecialchars($option_value['product_optionvalue_prefix'], ENT_QUOTES, 'UTF-8'); ?><?php endif; ?><?php echo $product_helper->displayPrice($option_value['product_optionvalue_price'], $product, $params, 'products.view.option'); ?>)
+            <div id="child-option-<?php echo $optionId; ?>" class="option mb-3">
+                <label class="form-label fw-semibold pb-1 mb-2">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>:
+                    <?php if ($option['required']) : ?>
+                        <span class="text-danger">*</span>
                     <?php endif; ?>
+                    <span class="fw-normal fs-sm ms-1" id="child-radioOption<?php echo $optionId; ?>"></span>
                 </label>
-                <br>
-            <?php endforeach; ?>
-        </div>
-        <?php endif; ?>
+                <div class="j2commerce-radio-options d-flex flex-wrap gap-2" data-binded-label="#child-radioOption<?php echo $optionId; ?>">
+                    <?php foreach ($option['optionvalue'] as $option_value) : ?>
+                        <?php $checked = !empty($option_value['product_optionvalue_default']) ? 'checked="checked"' : ''; ?>
+                        <?php $optionValueId = (int) $option_value['product_optionvalue_id']; ?>
+                        <?php $childOptionValueInputId = 'child-option-value-' . $product_id . '-' . $optionId . '-' . $optionValueId; ?>
+                        <input <?php echo $checked; ?> type="radio" name="product_option[<?php echo $optionId; ?>]" value="<?php echo $optionValueId; ?>" id="<?php echo $childOptionValueInputId; ?>" class="btn-check" autocomplete="off"
+                            onchange="doAjaxFilter(this.value, <?php echo $product_id; ?>, <?php echo $optionId; ?>, '#child-option-<?php echo $optionId; ?>');" />
 
-        <?php if ($option['type'] === 'checkbox' && !empty($option['optionvalue'])) : ?>
-        <div id="child-option-<?php echo $optionId; ?>" class="option mb-3" data-config-checkbox="1" data-product-id="<?php echo $product_id; ?>" data-po-id="<?php echo $optionId; ?>">
-            <?php if ($option['required']) : ?>
-            <span class="required">*</span>
-            <?php endif; ?>
-            <b><?php echo htmlspecialchars(Text::_($option['option_name']), ENT_QUOTES, 'UTF-8'); ?>:</b><br>
-            <?php foreach ($option['optionvalue'] as $option_value) : ?>
-                <?php $childOptionValueInputId = 'child-option-value-' . $product_id . '-' . $optionId . '-' . (int) $option_value['product_optionvalue_id']; ?>
-                <input type="checkbox"
-                    name="product_option[<?php echo $optionId; ?>][]"
-                    value="<?php echo (int) $option_value['product_optionvalue_id']; ?>"
-                    id="<?php echo $childOptionValueInputId; ?>" />
-                <?php if ($params->get('image_for_product_options', 0) && !empty($option_value['optionvalue_image'])) : ?>
-                    <img class="optionvalue-image-<?php echo (int) $option_value['product_optionvalue_id']; ?>"
-                         src="<?php echo Uri::root(true) . '/' . htmlspecialchars($option_value['optionvalue_image'], ENT_QUOTES, 'UTF-8'); ?>"
-                         alt="<?php echo htmlspecialchars(Text::_($option_value['optionvalue_name']), ENT_QUOTES, 'UTF-8'); ?>" />
-                <?php endif; ?>
-                <label for="<?php echo $childOptionValueInputId; ?>">
-                    <?php echo htmlspecialchars(Text::_($option_value['optionvalue_name']), ENT_QUOTES, 'UTF-8'); ?>
-                    <?php if ($option_value['product_optionvalue_price'] > 0 && $params->get('product_option_price', 1)) : ?>
-                        (<?php if ($params->get('product_option_price_prefix', 1)) : ?><?php echo htmlspecialchars($option_value['product_optionvalue_prefix'], ENT_QUOTES, 'UTF-8'); ?><?php endif; ?><?php echo $product_helper->displayPrice($option_value['product_optionvalue_price'], $product, $params, 'products.view.option'); ?>)
-                    <?php endif; ?>
-                </label>
-                <br>
-            <?php endforeach; ?>
-        </div>
+                        <?php if ($params->get('image_for_product_options', 0) && !empty($option_value['optionvalue_image'])) : ?>
+                            <label class="btn btn-image p-0 form-check-label border-2" for="<?php echo $childOptionValueInputId; ?>" data-label="<?php echo $esc(Text::_($option_value['optionvalue_name'])); ?>">
+                                <img class="optionvalue-image me-1" src="<?php echo Uri::root(true) . '/' . $esc($option_value['optionvalue_image']); ?>" alt="<?php echo $esc(Text::_($option_value['optionvalue_name'])); ?>" width="56" style="width:56px;" />
+                                <span class="visually-hidden"><?php echo $esc(Text::_($option_value['optionvalue_name'])); ?></span>
+                            </label>
+                        <?php else : ?>
+                            <label class="btn btn-sm btn-outline-secondary form-check-label border-2" for="<?php echo $childOptionValueInputId; ?>" data-label="<?php echo $esc(Text::_($option_value['optionvalue_name'])); ?>">
+                                <?php echo $esc(Text::_($option_value['optionvalue_name'])); ?>
+                                <?php if ($option_value['product_optionvalue_price'] > 0 && $params->get('product_option_price', 1)) : ?>
+                                    <?php if ($params->get('product_option_price_prefix', 1)) : ?>
+                                        <?php echo $esc($option_value['product_optionvalue_prefix']); ?>
+                                    <?php endif; ?>
+                                    <?php echo $product_helper->displayPrice($option_value['product_optionvalue_price'], $product, $params, 'products.view.option'); ?>
+                                <?php endif; ?>
+                            </label>
+                        <?php endif; ?>
+                    <?php endforeach; ?>
+                </div>
+            </div>
         <?php endif; ?>
 
         <?php if ($option['type'] === 'color' && !empty($option['optionvalue'])) : ?>
-            <div id="option-<?php echo $optionId; ?>" class="option mb-3">
-                <div class="form-label fw-semibold pb-1 mb-2">
-                    <?php echo htmlspecialchars(Text::_($option['option_name']), ENT_QUOTES, 'UTF-8'); ?>:
+            <div id="child-option-<?php echo $optionId; ?>" class="option mb-3">
+                <label class="form-label fw-semibold pb-1 mb-2">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>:
                     <?php if ($option['required']) : ?>
                         <span class="text-danger">*</span>
                     <?php endif; ?>
                     <span class="fw-normal fs-sm ms-1" id="child-colorOption<?php echo $optionId; ?>"></span>
-                </div>
+                </label>
                 <div class="j2commerce-color-options d-flex flex-wrap gap-2" data-binded-label="#child-colorOption<?php echo $optionId; ?>">
                     <?php foreach ($option['optionvalue'] as $option_value) : ?>
-                        <?php $childOptionValueInputId = 'child-option-value-' . $product_id . '-' . $optionId . '-' . (int) $option_value['product_optionvalue_id']; ?>
                         <?php $checked = !empty($option_value['product_optionvalue_default']) ? 'checked="checked"' : ''; ?>
-                        <input <?php echo $checked; ?> type="radio"
-                            name="product_option[<?php echo $optionId; ?>]"
-                            value="<?php echo (int) $option_value['product_optionvalue_id']; ?>"
-                            id="<?php echo $childOptionValueInputId; ?>"
-                            class="btn-check"
+                        <?php $colorValueId = (int) $option_value['product_optionvalue_id']; ?>
+                        <?php $childOptionValueInputId = 'child-option-value-' . $product_id . '-' . $optionId . '-' . $colorValueId; ?>
+                        <input <?php echo $checked; ?> type="radio" name="product_option[<?php echo $optionId; ?>]" value="<?php echo $colorValueId; ?>" id="<?php echo $childOptionValueInputId; ?>" class="btn-check"
                             onchange="doAjaxFilter(this.value, <?php echo $product_id; ?>, <?php echo $optionId; ?>, '#child-option-<?php echo $optionId; ?>');" />
-
-                        <label for="<?php echo $childOptionValueInputId; ?>" class="btn btn-color fs-xl" title="<?php echo htmlspecialchars(Text::_($option_value['optionvalue_name']), ENT_QUOTES, 'UTF-8'); ?>" data-label="<?php echo htmlspecialchars(Text::_($option_value['optionvalue_name']), ENT_QUOTES, 'UTF-8'); ?>" style="color:<?php echo htmlspecialchars($option_value['optionvalue_image'], ENT_QUOTES, 'UTF-8'); ?>;">
-                            <span class="visually-hidden"><?php echo htmlspecialchars(Text::_($option_value['optionvalue_name']), ENT_QUOTES, 'UTF-8'); ?></span>
+                        <label for="<?php echo $childOptionValueInputId; ?>" class="btn btn-color fs-xl" title="<?php echo $esc(Text::_($option_value['optionvalue_name'])); ?>" data-label="<?php echo $esc(Text::_($option_value['optionvalue_name'])); ?>" style="color:<?php echo $esc($option_value['optionvalue_image']); ?>;">
+                            <span class="visually-hidden"><?php echo $esc(Text::_($option_value['optionvalue_name'])); ?></span>
                         </label>
                     <?php endforeach; ?>
                 </div>
             </div>
         <?php endif; ?>
+
+        <?php if ($option['type'] === 'checkbox' && !empty($option['optionvalue'])) : ?>
+            <div id="child-option-<?php echo $optionId; ?>" class="option" data-config-checkbox="1" data-product-id="<?php echo $product_id; ?>" data-po-id="<?php echo $optionId; ?>">
+                <?php if ($option['required']) : ?>
+                    <span class="required">*</span>
+                <?php endif; ?>
+                <b><?php echo $esc(Text::_($option['option_name'])); ?>:</b><br>
+                <?php foreach ($option['optionvalue'] as $option_value) : ?>
+                    <?php $checkboxValueId = (int) $option_value['product_optionvalue_id']; ?>
+                    <?php $childOptionValueInputId = 'child-option-value-' . $product_id . '-' . $optionId . '-' . $checkboxValueId; ?>
+                    <input type="checkbox"
+                        name="product_option[<?php echo $optionId; ?>][]"
+                        value="<?php echo $checkboxValueId; ?>"
+                        id="<?php echo $childOptionValueInputId; ?>" />
+                    <?php if ($params->get('image_for_product_options', 0) && !empty($option_value['optionvalue_image'])) : ?>
+                        <img class="optionvalue-image-<?php echo $checkboxValueId; ?>"
+                             src="<?php echo Uri::root(true) . '/' . $esc($option_value['optionvalue_image']); ?>" />
+                    <?php endif; ?>
+                    <label for="<?php echo $childOptionValueInputId; ?>">
+                        <?php echo $esc(Text::_($option_value['optionvalue_name'])); ?>
+                        <?php if ($option_value['product_optionvalue_price'] > 0 && $params->get('product_option_price', 1)) : ?>
+                            (
+                            <?php if ($params->get('product_option_price_prefix', 1)) : ?>
+                                <?php echo $esc($option_value['product_optionvalue_prefix']); ?>
+                            <?php endif; ?>
+                            <?php echo $product_helper->displayPrice($option_value['product_optionvalue_price'], $product, $params, 'products.view.option'); ?>
+                            )
+                        <?php endif; ?>
+                    </label>
+                <?php endforeach; ?>
+            </div>
+        <?php endif; ?>
+
         <?php if ($option['type'] === 'text') : ?>
             <?php $text_option_params = $platform->getRegistry($option['option_params'] ?? '{}'); ?>
             <?php $textInputId = 'child-product-option-text-' . $product_id . '-' . $optionId; ?>
             <div id="child-option-<?php echo $optionId; ?>" class="option mb-3">
-                <label class="form-label fw-semibold pb-1 mb-1" for="<?php echo $textInputId; ?>">
-                    <?php echo htmlspecialchars(Text::_($option['option_name']), ENT_QUOTES, 'UTF-8'); ?>
+                <label class="form-label fw-semibold pb-1 mb-2" for="<?php echo $textInputId; ?>">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>
                     <?php if ($option['required']) : ?>
                         <span class="text-danger">*</span>
                     <?php endif; ?>
                 </label>
                 <input id="<?php echo $textInputId; ?>" type="text" class="form-control"
                     name="product_option[<?php echo $optionId; ?>]"
-                    value="<?php echo htmlspecialchars($option['optionvalue'] ?? '', ENT_QUOTES, 'UTF-8'); ?>"
-                    placeholder="<?php echo htmlspecialchars($text_option_params->get('place_holder', ''), ENT_QUOTES, 'UTF-8'); ?>" />
+                    value="<?php echo $esc($option['optionvalue'] ?? ''); ?>"
+                    placeholder="<?php echo $esc($text_option_params->get('place_holder', '')); ?>" />
             </div>
         <?php endif; ?>
 
         <?php if ($option['type'] === 'textarea') : ?>
             <?php $textareaInputId = 'child-product-option-textarea-' . $product_id . '-' . $optionId; ?>
             <div id="child-option-<?php echo $optionId; ?>" class="option mb-3">
-                <label class="form-label fw-semibold pb-1 mb-1" for="<?php echo $textareaInputId; ?>">
-                    <?php echo htmlspecialchars(Text::_($option['option_name']), ENT_QUOTES, 'UTF-8'); ?>
+                <label class="form-label fw-semibold pb-1 mb-2" for="<?php echo $textareaInputId; ?>">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>
                     <?php if ($option['required']) : ?>
                         <span class="text-danger">*</span>
                     <?php endif; ?>
                 </label>
                 <textarea id="<?php echo $textareaInputId; ?>" class="form-control"
                     name="product_option[<?php echo $optionId; ?>]"
-                    cols="20" rows="5"><?php echo htmlspecialchars($option['optionvalue'] ?? '', ENT_QUOTES, 'UTF-8'); ?></textarea>
+                    cols="20" rows="5"><?php echo $esc($option['optionvalue'] ?? ''); ?></textarea>
             </div>
         <?php endif; ?>
 

--- a/plugins/j2commerce/app_uikit/layouts/product/configurablechildoptions.php
+++ b/plugins/j2commerce/app_uikit/layouts/product/configurablechildoptions.php
@@ -16,138 +16,151 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Uri\Uri;
 
 // Layout for rendering child configurable options via AJAX.
-// Injected into #ChildOptions{poId} when a parent option is selected.
+// Injected into #child-ChildOptions{poId} when a parent option is selected.
+// Markup mirrors tmpl/uikit/view_configurableoptions.php so children look
+// identical to their parents. Injected nodes keep inline onchange + the
+// initConfigCheckboxes data-* hooks: innerHTML never executes the parent's
+// per-option <script> blocks, so checkbox binding relies on initConfigCheckboxes
+// in j2commerce.js, and select/radio/color filtering relies on inline onchange.
 
-$product = $displayData['product'];
-$params  = $displayData['params'];
-$options = $displayData['options'] ?? [];
-
+$product        = $displayData['product'];
+$params         = $displayData['params'];
+$options        = $displayData['options'] ?? [];
 $product_helper = J2CommerceHelper::product();
-$platform = J2CommerceHelper::platform();
-$product_id = $product->j2commerce_product_id;
-$esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+$platform       = J2CommerceHelper::platform();
+$product_id     = (int) $product->j2commerce_product_id;
+$esc            = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
 ?>
 <?php if (!empty($options)) : ?>
     <?php foreach ($options as $option) : ?>
         <?php $optionId = (int) $option['productoption_id']; ?>
 
         <?php if ($option['type'] === 'select' && !empty($option['optionvalue'])) : ?>
-        <?php $selectInputId = 'child-product-option-' . (int) $product_id . '-' . $optionId; ?>
-        <div id="child-option-<?php echo $optionId; ?>" class="option uk-margin-small-bottom">
-            <?php if ($option['required']) : ?>
-            <span class="required">*</span>
-            <?php endif; ?>
-            <label class="uk-form-label" for="<?php echo $selectInputId; ?>"><?php echo $esc(Text::_($option['option_name'])); ?>:</label>
-            <select id="<?php echo $selectInputId; ?>" name="product_option[<?php echo $optionId; ?>]"
-                class="uk-select"
-                onchange="doAjaxFilter(this.options[this.selectedIndex].value, <?php echo (int) $product_id; ?>, <?php echo $optionId; ?>, '#child-option-<?php echo $optionId; ?>');">
-                <option value=""><?php echo Text::_('COM_J2COMMERCE_ADDTOCART_SELECT'); ?></option>
-                <?php foreach ($option['optionvalue'] as $option_value) : ?>
-                    <?php $checked = !empty($option_value['product_optionvalue_default']) ? 'selected="selected"' : ''; ?>
-                    <option <?php echo $checked; ?> value="<?php echo (int) $option_value['product_optionvalue_id']; ?>">
-                        <?php echo $esc(Text::_($option_value['optionvalue_name'])); ?>
-                        <?php if ($option_value['product_optionvalue_price'] > 0 && $params->get('product_option_price', 1)) : ?>
-                        (<?php if ($params->get('product_option_price_prefix', 1)) : ?><?php echo $esc($option_value['product_optionvalue_prefix']); ?><?php endif; ?><?php echo $product_helper->displayPrice($option_value['product_optionvalue_price'], $product, $params, 'products.view.option'); ?>)
-                        <?php endif; ?>
-                    </option>
-                <?php endforeach; ?>
-            </select>
-        </div>
+            <div id="child-option-<?php echo $optionId; ?>" class="option uk-margin-small-bottom">
+                <label class="uk-form-label uk-text-bold uk-display-block">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>
+                    <?php if ($option['required']) : ?>
+                        <span class="uk-text-danger">*</span>
+                    <?php endif; ?>
+                </label>
+                <select class="uk-select" name="product_option[<?php echo $optionId; ?>]" onchange="doAjaxFilter(this.options[this.selectedIndex].value, <?php echo $product_id; ?>, <?php echo $optionId; ?>, '#child-option-<?php echo $optionId; ?>');">
+                    <option value=""><?php echo Text::_('COM_J2COMMERCE_CHOOSE'); ?></option>
+                    <?php foreach ($option['optionvalue'] as $option_value) : ?>
+                        <?php $checked = !empty($option_value['product_optionvalue_default']) ? 'selected="selected"' : ''; ?>
+                        <option <?php echo $checked; ?> value="<?php echo (int) $option_value['product_optionvalue_id']; ?>">
+                            <?php echo $esc(Text::_($option_value['optionvalue_name'])); ?>
+                            <?php if ($option_value['product_optionvalue_price'] > 0 && $params->get('product_option_price', 1)) : ?>
+                                (
+                                <?php if ($params->get('product_option_price_prefix', 1)) : ?>
+                                    <?php echo $esc($option_value['product_optionvalue_prefix']); ?>
+                                <?php endif; ?>
+                                <?php echo $product_helper->displayPrice($option_value['product_optionvalue_price'], $product, $params, 'products.view.option'); ?>
+                                )
+                            <?php endif; ?>
+                        </option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
         <?php endif; ?>
 
         <?php if ($option['type'] === 'radio' && !empty($option['optionvalue'])) : ?>
-        <div id="child-option-<?php echo $optionId; ?>" class="option uk-margin-small-bottom">
-            <?php if ($option['required']) : ?>
-            <span class="required">*</span>
-            <?php endif; ?>
-            <b><?php echo $esc(Text::_($option['option_name'])); ?>:</b><br>
-            <?php foreach ($option['optionvalue'] as $option_value) : ?>
-                <?php $childOptionValueInputId = 'child-option-value-' . (int) $product_id . '-' . $optionId . '-' . (int) $option_value['product_optionvalue_id']; ?>
-                <?php $checked = !empty($option_value['product_optionvalue_default']) ? 'checked="checked"' : ''; ?>
-                <input <?php echo $checked; ?> type="radio"
-                    name="product_option[<?php echo $optionId; ?>]"
-                    value="<?php echo (int) $option_value['product_optionvalue_id']; ?>"
-                    id="<?php echo $childOptionValueInputId; ?>"
-                    class="uk-radio"
-                    onchange="doAjaxFilter(this.value, <?php echo (int) $product_id; ?>, <?php echo $optionId; ?>, '#child-option-<?php echo $optionId; ?>');" />
-                <?php if ($params->get('image_for_product_options', 0) && !empty($option_value['optionvalue_image'])) : ?>
-                    <img class="optionvalue-image-<?php echo (int) $option_value['product_optionvalue_id']; ?>"
-                         src="<?php echo Uri::root(true) . '/' . $esc($option_value['optionvalue_image']); ?>"
-                         alt="<?php echo $esc(Text::_($option_value['optionvalue_name'])); ?>" />
-                <?php endif; ?>
-                <label for="<?php echo $childOptionValueInputId; ?>">
-                    <?php echo $esc(Text::_($option_value['optionvalue_name'])); ?>
-                    <?php if ($option_value['product_optionvalue_price'] > 0 && $params->get('product_option_price', 1)) : ?>
-                        (<?php if ($params->get('product_option_price_prefix', 1)) : ?><?php echo $esc($option_value['product_optionvalue_prefix']); ?><?php endif; ?><?php echo $product_helper->displayPrice($option_value['product_optionvalue_price'], $product, $params, 'products.view.option'); ?>)
-                    <?php endif; ?>
-                </label>
-                <br>
-            <?php endforeach; ?>
-        </div>
-        <?php endif; ?>
-
-        <?php if ($option['type'] === 'checkbox' && !empty($option['optionvalue'])) : ?>
-        <div id="child-option-<?php echo $optionId; ?>" class="option uk-margin-small-bottom" data-config-checkbox="1" data-product-id="<?php echo (int) $product_id; ?>" data-po-id="<?php echo $optionId; ?>">
-            <?php if ($option['required']) : ?>
-            <span class="required">*</span>
-            <?php endif; ?>
-            <b><?php echo $esc(Text::_($option['option_name'])); ?>:</b><br>
-            <?php foreach ($option['optionvalue'] as $option_value) : ?>
-                <?php $childOptionValueInputId = 'child-option-value-' . (int) $product_id . '-' . $optionId . '-' . (int) $option_value['product_optionvalue_id']; ?>
-                <input type="checkbox"
-                    class="uk-checkbox"
-                    name="product_option[<?php echo $optionId; ?>][]"
-                    value="<?php echo (int) $option_value['product_optionvalue_id']; ?>"
-                    id="<?php echo $childOptionValueInputId; ?>" />
-                <?php if ($params->get('image_for_product_options', 0) && !empty($option_value['optionvalue_image'])) : ?>
-                    <img class="optionvalue-image-<?php echo (int) $option_value['product_optionvalue_id']; ?>"
-                         src="<?php echo Uri::root(true) . '/' . $esc($option_value['optionvalue_image']); ?>"
-                         alt="<?php echo $esc(Text::_($option_value['optionvalue_name'])); ?>" />
-                <?php endif; ?>
-                <label for="<?php echo $childOptionValueInputId; ?>">
-                    <?php echo $esc(Text::_($option_value['optionvalue_name'])); ?>
-                    <?php if ($option_value['product_optionvalue_price'] > 0 && $params->get('product_option_price', 1)) : ?>
-                        (<?php if ($params->get('product_option_price_prefix', 1)) : ?><?php echo $esc($option_value['product_optionvalue_prefix']); ?><?php endif; ?><?php echo $product_helper->displayPrice($option_value['product_optionvalue_price'], $product, $params, 'products.view.option'); ?>)
-                    <?php endif; ?>
-                </label>
-                <br>
-            <?php endforeach; ?>
-        </div>
-        <?php endif; ?>
-
-        <?php if ($option['type'] === 'color' && !empty($option['optionvalue'])) : ?>
             <div id="child-option-<?php echo $optionId; ?>" class="option uk-margin-small-bottom">
-                <div class="uk-form-label uk-text-bold">
+                <label class="uk-form-label uk-text-bold uk-display-block">
                     <?php echo $esc(Text::_($option['option_name'])); ?>:
                     <?php if ($option['required']) : ?>
                         <span class="uk-text-danger">*</span>
                     <?php endif; ?>
-                    <span class="uk-text-muted uk-text-small" id="child-colorOption<?php echo $optionId; ?>"></span>
-                </div>
-                <div class="j2commerce-color-options uk-flex uk-flex-wrap" style="gap: 0.5rem;" data-binded-label="#child-colorOption<?php echo $optionId; ?>">
+                    <span class="uk-text-normal" id="child-radioOption<?php echo $optionId; ?>"></span>
+                </label>
+                <div class="j2commerce-radio-options uk-flex uk-flex-wrap" style="gap:.5rem;" data-binded-label="#child-radioOption<?php echo $optionId; ?>">
                     <?php foreach ($option['optionvalue'] as $option_value) : ?>
-                        <?php $childOptionValueInputId = 'child-option-value-' . (int) $product_id . '-' . $optionId . '-' . (int) $option_value['product_optionvalue_id']; ?>
                         <?php $checked = !empty($option_value['product_optionvalue_default']) ? 'checked="checked"' : ''; ?>
-                        <input <?php echo $checked; ?> type="radio"
-                            name="product_option[<?php echo $optionId; ?>]"
-                            value="<?php echo (int) $option_value['product_optionvalue_id']; ?>"
-                            id="<?php echo $childOptionValueInputId; ?>"
-                            class="uk-hidden"
-                            onchange="doAjaxFilter(this.value, <?php echo (int) $product_id; ?>, <?php echo $optionId; ?>, '#child-option-<?php echo $optionId; ?>');" />
+                        <?php $optionValueId = (int) $option_value['product_optionvalue_id']; ?>
+                        <?php $childOptionValueInputId = 'child-option-value-' . $product_id . '-' . $optionId . '-' . $optionValueId; ?>
+                        <input <?php echo $checked; ?> type="radio" name="product_option[<?php echo $optionId; ?>]" value="<?php echo $optionValueId; ?>" id="<?php echo $childOptionValueInputId; ?>" class="uk-radio uk-hidden" onchange="doAjaxFilter(this.value, <?php echo $product_id; ?>, <?php echo $optionId; ?>, '#child-option-<?php echo $optionId; ?>');" autocomplete="off" />
 
+                        <?php if ($params->get('image_for_product_options', 0) && !empty($option_value['optionvalue_image'])) : ?>
+                            <label class="btn-image" for="<?php echo $childOptionValueInputId; ?>" data-label="<?php echo $esc(Text::_($option_value['optionvalue_name'])); ?>">
+                                <img class="optionvalue-image" src="<?php echo Uri::root(true) . '/' . $esc($option_value['optionvalue_image']); ?>" alt="<?php echo $esc(Text::_($option_value['optionvalue_name'])); ?>" width="56" style="width:56px;" />
+                                <span class="uk-invisible"><?php echo $esc(Text::_($option_value['optionvalue_name'])); ?></span>
+                            </label>
+                        <?php else : ?>
+                            <label class="uk-button uk-button-small uk-button-default" for="<?php echo $childOptionValueInputId; ?>" data-label="<?php echo $esc(Text::_($option_value['optionvalue_name'])); ?>">
+                                <?php echo $esc(Text::_($option_value['optionvalue_name'])); ?>
+                                <?php if ($option_value['product_optionvalue_price'] > 0 && $params->get('product_option_price', 1)) : ?>
+                                    <?php if ($params->get('product_option_price_prefix', 1)) : ?>
+                                        <?php echo $esc($option_value['product_optionvalue_prefix']); ?>
+                                    <?php endif; ?>
+                                    <?php echo $product_helper->displayPrice($option_value['product_optionvalue_price'], $product, $params, 'products.view.option'); ?>
+                                <?php endif; ?>
+                            </label>
+                        <?php endif; ?>
+                    <?php endforeach; ?>
+                </div>
+            </div>
+        <?php endif; ?>
+
+        <?php if ($option['type'] === 'color' && !empty($option['optionvalue'])) : ?>
+            <div id="child-option-<?php echo $optionId; ?>" class="option uk-margin-small-bottom">
+                <label class="uk-form-label uk-text-bold uk-display-block">
+                    <?php echo $esc(Text::_($option['option_name'])); ?>:
+                    <?php if ($option['required']) : ?>
+                        <span class="uk-text-danger">*</span>
+                    <?php endif; ?>
+                    <span class="uk-text-normal" id="child-colorOption<?php echo $optionId; ?>"></span>
+                </label>
+                <div class="j2commerce-color-options uk-flex uk-flex-wrap" style="gap:.5rem;" data-binded-label="#child-colorOption<?php echo $optionId; ?>">
+                    <?php foreach ($option['optionvalue'] as $option_value) : ?>
+                        <?php $checked = !empty($option_value['product_optionvalue_default']) ? 'checked="checked"' : ''; ?>
+                        <?php $colorValueId = (int) $option_value['product_optionvalue_id']; ?>
+                        <?php $childOptionValueInputId = 'child-option-value-' . $product_id . '-' . $optionId . '-' . $colorValueId; ?>
+                        <input <?php echo $checked; ?> type="radio" name="product_option[<?php echo $optionId; ?>]" value="<?php echo $colorValueId; ?>" id="<?php echo $childOptionValueInputId; ?>" class="uk-radio uk-hidden" onchange="doAjaxFilter(this.value, <?php echo $product_id; ?>, <?php echo $optionId; ?>, '#child-option-<?php echo $optionId; ?>');" />
                         <label for="<?php echo $childOptionValueInputId; ?>" class="btn-color" title="<?php echo $esc(Text::_($option_value['optionvalue_name'])); ?>" data-label="<?php echo $esc(Text::_($option_value['optionvalue_name'])); ?>" style="color:<?php echo $esc($option_value['optionvalue_image']); ?>;">
-                            <span class="uk-hidden"><?php echo $esc(Text::_($option_value['optionvalue_name'])); ?></span>
+                            <span class="uk-invisible"><?php echo $esc(Text::_($option_value['optionvalue_name'])); ?></span>
                         </label>
                     <?php endforeach; ?>
                 </div>
             </div>
         <?php endif; ?>
 
+        <?php if ($option['type'] === 'checkbox' && !empty($option['optionvalue'])) : ?>
+            <div id="child-option-<?php echo $optionId; ?>" class="option uk-margin-small-bottom" data-config-checkbox="1" data-product-id="<?php echo $product_id; ?>" data-po-id="<?php echo $optionId; ?>">
+                <?php if ($option['required']) : ?>
+                    <span class="uk-text-danger">*</span>
+                <?php endif; ?>
+                <b><?php echo $esc(Text::_($option['option_name'])); ?>:</b><br>
+                <?php foreach ($option['optionvalue'] as $option_value) : ?>
+                    <?php $checkboxValueId = (int) $option_value['product_optionvalue_id']; ?>
+                    <?php $childOptionValueInputId = 'child-option-value-' . $product_id . '-' . $optionId . '-' . $checkboxValueId; ?>
+                    <label class="uk-flex uk-flex-middle" style="gap:.5rem;">
+                        <input type="checkbox"
+                            class="uk-checkbox"
+                            name="product_option[<?php echo $optionId; ?>][]"
+                            value="<?php echo $checkboxValueId; ?>"
+                            id="<?php echo $childOptionValueInputId; ?>" />
+                        <?php if ($params->get('image_for_product_options', 0) && !empty($option_value['optionvalue_image'])) : ?>
+                            <img class="optionvalue-image-<?php echo $checkboxValueId; ?>"
+                                 src="<?php echo Uri::root(true) . '/' . $esc($option_value['optionvalue_image']); ?>" />
+                        <?php endif; ?>
+                        <?php echo $esc(Text::_($option_value['optionvalue_name'])); ?>
+                        <?php if ($option_value['product_optionvalue_price'] > 0 && $params->get('product_option_price', 1)) : ?>
+                            (
+                            <?php if ($params->get('product_option_price_prefix', 1)) : ?>
+                                <?php echo $esc($option_value['product_optionvalue_prefix']); ?>
+                            <?php endif; ?>
+                            <?php echo $product_helper->displayPrice($option_value['product_optionvalue_price'], $product, $params, 'products.view.option'); ?>
+                            )
+                        <?php endif; ?>
+                    </label>
+                <?php endforeach; ?>
+            </div>
+        <?php endif; ?>
+
         <?php if ($option['type'] === 'text') : ?>
             <?php $text_option_params = $platform->getRegistry($option['option_params'] ?? '{}'); ?>
-            <?php $textInputId = 'child-product-option-text-' . (int) $product_id . '-' . $optionId; ?>
+            <?php $textInputId = 'child-product-option-text-' . $product_id . '-' . $optionId; ?>
             <div id="child-option-<?php echo $optionId; ?>" class="option uk-margin-small-bottom">
-                <label class="uk-form-label" for="<?php echo $textInputId; ?>">
+                <label class="uk-form-label uk-text-bold uk-display-block" for="<?php echo $textInputId; ?>">
                     <?php echo $esc(Text::_($option['option_name'])); ?>
                     <?php if ($option['required']) : ?>
                         <span class="uk-text-danger">*</span>
@@ -161,9 +174,9 @@ $esc = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES, 
         <?php endif; ?>
 
         <?php if ($option['type'] === 'textarea') : ?>
-            <?php $textareaInputId = 'child-product-option-textarea-' . (int) $product_id . '-' . $optionId; ?>
+            <?php $textareaInputId = 'child-product-option-textarea-' . $product_id . '-' . $optionId; ?>
             <div id="child-option-<?php echo $optionId; ?>" class="option uk-margin-small-bottom">
-                <label class="uk-form-label" for="<?php echo $textareaInputId; ?>">
+                <label class="uk-form-label uk-text-bold uk-display-block" for="<?php echo $textareaInputId; ?>">
                     <?php echo $esc(Text::_($option['option_name'])); ?>
                     <?php if ($option['required']) : ?>
                         <span class="uk-text-danger">*</span>


### PR DESCRIPTION
## Core Update

Rewrite the `app_bootstrap5` and `app_uikit` `configurablechildoptions` layouts (plugin source + component runtime mirror) so AJAX-injected configurable child options render with the **same HTML structure as their parent options** (`view_configurableoptions`). Children now look identical to parents.

### Changes
- BS5 child select/radio/color/checkbox/text/textarea markup aligned to parent (`fw-semibold` labels, `btn-check` button radios, color swatches, parens-spaced prices, `text-danger` required marks)
- UIkit child markup aligned to parent (`uk-form-label uk-text-bold uk-display-block`, `uk-button`/`btn-image` radios, `btn-color`, flex checkbox rows); replaced `uk-text-muted` with `uk-text-normal`
- Preserved child-only functional hooks (required because innerHTML-injected nodes never get DOMContentLoaded delegation or inline `<script>` binding):
  - inline `onchange=doAjaxFilter(...)` for select/radio/color filtering
  - `data-config-checkbox=1` + `data-product-id` + `data-po-id` for `initConfigCheckboxes()` rebinding
- child-prefixed element ids avoid duplicate-id clashes with the hidden standalone `#option-{id}`; fixes a latent un-prefixed color-block id

### Files Modified
| Type | Count |
|------|-------|
| PHP layout files | 4 |

### Pre-Flight
- [x] PHP syntax check passed (all 4)
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only (43 unrelated working-tree files excluded)
- [x] Rebased on upstream/main