### PR TITLE
fix(product): enable drag-to-reorder for config option values modal

### DIFF
--- a/administrator/components/com_j2commerce/tmpl/product/form_ajax_optionvalues.php
+++ b/administrator/components/com_j2commerce/tmpl/product/form_ajax_optionvalues.php
@@ -48,7 +48,10 @@ foreach ($parentOptionValues as $parentOpvalue) {
 $conSpan = 0;
 
 
-$style = '.j2commerce-ajax-optionvalues{};';
+$style = '.j2commerce-ajax-optionvalues{}'
+    . '.j2commerce-ov-drag-handle{cursor:grab;}'
+    . '.j2commerce-ov-drag-handle:active{cursor:grabbing;}'
+    . '#j2commerce-optionvalues-tbody tr.j2commerce-ov-dragging{opacity:.5;background:var(--template-bg-dark-5,#f0f0f0);}';
 $wa->addInlineStyle($style, [], []);
 ?>
 <div class="j2commerce-ajax-optionvalues" data-product-id="<?php echo $productId; ?>" data-productoption-id="<?php echo $productOptionId; ?>">
@@ -197,7 +200,7 @@ $wa->addInlineStyle($style, [], []);
                         <?php foreach ($productOptionValues as $key => $poptionvalue): ?>
                             <tr class="row<?php echo $k; ?>" data-pov-id="<?php echo $poptionvalue->j2commerce_product_optionvalue_id; ?>">
                                 <td>
-                                    <span class="icon-menu text-muted" title="<?php echo Text::_('JGRID_HEADING_ORDERING'); ?>"></span>
+                                    <span class="icon-menu j2commerce-ov-drag-handle text-body-tertiary" role="button" aria-label="<?php echo Text::_('JGRID_HEADING_ORDERING'); ?>" title="<?php echo Text::_('JGRID_HEADING_ORDERING'); ?>"></span>
                                     <input type="hidden" name="<?php echo $prefix . '[' . $poptionvalue->j2commerce_product_optionvalue_id . '][productoption_id]'; ?>" value="<?php echo $productOptionId; ?>">
                                     <input type="hidden" name="<?php echo $prefix . '[' . $poptionvalue->j2commerce_product_optionvalue_id . '][j2commerce_product_optionvalue_id]'; ?>" value="<?php echo $poptionvalue->j2commerce_product_optionvalue_id; ?>">
                                 </td>

--- a/administrator/components/com_j2commerce/tmpl/product/form_configoptions.php
+++ b/administrator/components/com_j2commerce/tmpl/product/form_configoptions.php
@@ -331,6 +331,8 @@ document.addEventListener('DOMContentLoaded', () => {
         const productId = container.dataset.productId;
         const productOptionId = container.dataset.productoptionId;
 
+        initOptionValuesSortable();
+
         const createBtn = document.getElementById('j2commerce-create-optionvalue-btn');
         if (createBtn) {
             createBtn.addEventListener('click', async () => {
@@ -574,6 +576,68 @@ document.addEventListener('DOMContentLoaded', () => {
 
                 btn.disabled = false;
             });
+        });
+    }
+
+    // Drag-to-reorder for the current option values table. Native HTML5 DnD,
+    // restricted to the .j2commerce-ov-drag-handle. On drop the visible
+    // [ordering] inputs are renumbered so "Save Changes" persists the new order.
+    function initOptionValuesSortable() {
+        const tbody = document.getElementById('j2commerce-optionvalues-tbody');
+        if (!tbody) return;
+
+        let dragRow = null;
+
+        tbody.addEventListener('pointerdown', (e) => {
+            const handle = e.target.closest('.j2commerce-ov-drag-handle');
+            const row = e.target.closest('tr[data-pov-id]');
+            if (handle && row) {
+                row.setAttribute('draggable', 'true');
+            }
+        });
+
+        tbody.addEventListener('dragstart', (e) => {
+            const row = e.target.closest('tr[data-pov-id]');
+            if (!row || row.getAttribute('draggable') !== 'true') {
+                e.preventDefault();
+                return;
+            }
+            dragRow = row;
+            row.classList.add('j2commerce-ov-dragging');
+            e.dataTransfer.effectAllowed = 'move';
+            e.dataTransfer.setData('text/plain', row.dataset.povId || '');
+        });
+
+        tbody.addEventListener('dragover', (e) => {
+            if (!dragRow) return;
+            e.preventDefault();
+            e.dataTransfer.dropEffect = 'move';
+            const target = e.target.closest('tr[data-pov-id]');
+            if (!target || target === dragRow) return;
+            const rect = target.getBoundingClientRect();
+            const after = (e.clientY - rect.top) > rect.height / 2;
+            tbody.insertBefore(dragRow, after ? target.nextSibling : target);
+        });
+
+        tbody.addEventListener('drop', (e) => {
+            if (dragRow) e.preventDefault();
+        });
+
+        tbody.addEventListener('dragend', () => {
+            if (!dragRow) return;
+            dragRow.classList.remove('j2commerce-ov-dragging');
+            dragRow.removeAttribute('draggable');
+            dragRow = null;
+            renumberOptionValueOrdering();
+        });
+    }
+
+    function renumberOptionValueOrdering() {
+        const tbody = document.getElementById('j2commerce-optionvalues-tbody');
+        if (!tbody) return;
+        tbody.querySelectorAll('tr[data-pov-id]').forEach((row, idx) => {
+            const orderingInput = row.querySelector('input[name$="[ordering]"]');
+            if (orderingInput) orderingInput.value = idx + 1;
         });
     }
 


### PR DESCRIPTION
## Core Update

The ordering handle in the config option-values modal (`#j2commerceConfigOptionValuesModal`) was a **static decorative `icon-menu` span** with no drag wiring — it appeared greyed out and could not reorder rows. Reordering was only possible via the numeric Ordering inputs.

### Changes
- **Vanilla HTML5 drag-and-drop** on `#j2commerce-optionvalues-tbody`, restricted to the `.j2commerce-ov-drag-handle`. No new JS library; no jQuery, no `innerHTML`.
- On drop, each row's visible `[ordering]` input is renumbered (1-based) so the existing **Save Changes** AJAX (`products.saveProductOptionValueAjax`) persists the new order — no backend change.
- Listeners are **delegated on the tbody**, so they survive Create / Add-All re-renders (which fully re-run `initOptionValuesHandlers()`).
- Handle gets a `cursor: grab` affordance + dragging-row highlight; replaced banned `text-muted` with `text-body-tertiary`.

### Files Modified
| File | |
|------|------|
| `tmpl/product/form_ajax_optionvalues.php` | handle markup + inline styles |
| `tmpl/product/form_configoptions.php` | sortable init + ordering renumber JS |

### Notes
- Native HTML5 DnD is mouse/pointer only (same limitation as Joomla core list views); the numeric Ordering field remains for touch.

### Pre-Flight
- [x] PHP syntax check passed (both)
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only (unrelated working-tree files excluded)
- [x] Branched off upstream/main