### PR TITLE
fix(option): allow option value name of "0" to save

### DIFF
--- a/administrator/components/com_j2commerce/src/Model/OptionModel.php
+++ b/administrator/components/com_j2commerce/src/Model/OptionModel.php
@@ -630,12 +630,13 @@ class OptionModel extends AdminModel
             $ordering = 1;
 
             foreach ($valuesData as $valueData) {
-                if (empty($valueData['optionvalue_name'])) {
+                // Use a strict empty-string check, not empty(), so a value named "0" is kept
+                $valueName = trim((string) ($valueData['optionvalue_name'] ?? ''));
+                if ($valueName === '') {
                     continue;
                 }
 
                 $existingId = (int) ($valueData['j2commerce_optionvalue_id'] ?? 0);
-                $valueName  = $valueData['optionvalue_name'];
                 $valueImage = $valueData['optionvalue_image'] ?? '';
 
                 if ($existingId > 0) {
@@ -728,12 +729,13 @@ class OptionModel extends AdminModel
             $ordering = 1;
 
             foreach ($valuesData as $valueData) {
-                if (empty($valueData['optionvalue_name'])) {
+                // Use a strict empty-string check, not empty(), so a value named "0" is kept
+                $valueName = trim((string) ($valueData['optionvalue_name'] ?? ''));
+                if ($valueName === '') {
                     continue;
                 }
 
                 $existingId = (int) ($valueData['j2commerce_optionvalue_id'] ?? 0);
-                $valueName  = $valueData['optionvalue_name'];
                 $colorValue = $valueData['optionvalue_color'] ?? '#000000';
 
                 if ($existingId > 0) {


### PR DESCRIPTION
## Core Update

Entering an option value of `0` on the Option edit screen (`view=option`) did not persist.

### Root cause
`OptionModel::saveOptionValues()` and `saveOptionColorValues()` skipped each subform row with `empty($valueData['optionvalue_name'])`. In PHP `empty("0")` is `true`, so an option value named exactly `0` was silently dropped — every other value saved fine.

### Fix
Replace the falsy check with a strict empty-string check:
```php
$valueName = trim((string) ($valueData['optionvalue_name'] ?? ''));
if ($valueName === '') {
    continue;
}
```
- Keeps `"0"` (and all other real values)
- Still skips genuinely blank / whitespace-only rows
- Removed the now-redundant duplicate `$valueName` assignment

### Files Modified
| File | |
|------|------|
| `src/Model/OptionModel.php` | strict name check in both save methods |

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core file only
- [x] Branched off upstream/main