### PR TITLE
fix(shipping): apply weight-based shipping rules at checkout

### DIFF
--- a/administrator/components/com_j2commerce/src/Model/CartItemsModel.php
+++ b/administrator/components/com_j2commerce/src/Model/CartItemsModel.php
@@ -147,7 +147,7 @@ class CartItemsModel extends ListModel
             );
 
         // Join with variants table to get variant information (shipping needed for isShippingEnabled check)
-        $query->select('v.sku, v.price as variant_price, v.shipping')
+        $query->select('v.sku, v.price as variant_price, v.shipping, v.weight')
             ->join('LEFT', $db->quoteName('#__j2commerce_variants', 'v') . ' ON (' . $db->quoteName('v.j2commerce_variant_id') . ' = ' . $db->quoteName('a.variant_id') . ')');
 
         // Filter by cart ID (required)


### PR DESCRIPTION
## Summary
Fixes #1100

Weight-based standard shipping rules (Per Order Weight = type 5, Per Item Weight = type 4) never applied a charge at checkout, while flat-rate rules worked.

## Root Cause
`CartItemsModel` joins `#__j2commerce_variants` but selected only `v.sku, v.price, v.shipping` — **not `v.weight`**. So cart items always reported weight `0`:

- `CartItemsModel.php:150` — variant weight column missing from SELECT
- `CartDefault.php:299` — `$baseWeight = (float)($item->weight ?? 0)` → `0`
- `CartDefault.php:302` — `weight_total = 0`
- `ShippingStandard.php:615` — `if ($totalWeight <= 0) return null;` → no rate produced

Flat-rate (type 0) was unaffected because `getRate()` skips the weight range filter when weight is `0`.

## Changes
- Add `v.weight` to the variants SELECT in `CartItemsModel::getListQuery()`.

## Testing
1. Product with a defined weight, within a Per Order Weight rate range.
2. Checkout with a matching geozone shipping address.
3. Shipping charge now appears (previously absent).
4. Regression: flat-rate methods still display.

## Files Changed
- `administrator/components/com_j2commerce/src/Model/CartItemsModel.php` — select variant weight so cart items carry weight into shipping calculation.