### PR TITLE
fix(schema): widen paymentprofiles.payment_token to varchar(255)

### DIFF
--- a/administrator/components/com_j2commerce/sql/install.mysql.utf8.sql
+++ b/administrator/components/com_j2commerce/sql/install.mysql.utf8.sql
@@ -940,7 +940,7 @@ CREATE TABLE IF NOT EXISTS `#__j2commerce_paymentprofiles` (
   `user_id` int NOT NULL,
   `provider` varchar(50) NOT NULL DEFAULT 'authorizenet',
   `customer_profile_id` varchar(50) NOT NULL,
-  `payment_token` varchar(100) NOT NULL DEFAULT '',
+  `payment_token` varchar(255) NOT NULL DEFAULT '',
   `token_label` varchar(100) NOT NULL DEFAULT '',
   `is_renewal_default` tinyint unsigned NOT NULL DEFAULT 0,
   `environment` varchar(10) NOT NULL DEFAULT 'production',

--- a/administrator/components/com_j2commerce/sql/updates/mysql/6.3.2-2026-05-27.sql
+++ b/administrator/components/com_j2commerce/sql/updates/mysql/6.3.2-2026-05-27.sql
@@ -1,0 +1,3 @@
+-- Widen paymentprofiles.payment_token for gateway token hrefs that exceed 100 chars (e.g. Worldpay verified-token URLs ~117 chars). See issue #1103.
+ALTER TABLE `#__j2commerce_paymentprofiles`
+    MODIFY COLUMN `payment_token` varchar(255) NOT NULL DEFAULT '';


### PR DESCRIPTION
## Summary
Fixes #1103

Widen `#__j2commerce_paymentprofiles.payment_token` from `varchar(100)` to `varchar(255)`. The column stores the gateway token reference for the shared saved-card vault. Some gateways store a full token URL/href that exceeds 100 chars (Worldpay verified-token hrefs run ~117), causing silent truncation that breaks saved-card charges and MIT subscription renewals.

## Changes
- `install.mysql.utf8.sql` — `payment_token` column widened to `varchar(255)` for clean installs (single-line change)
- `sql/updates/mysql/6.3.2-2026-05-27.sql` (new) — `ALTER TABLE ... MODIFY COLUMN payment_token varchar(255)` for existing installs

## Index note
Composite `uq_user_provider_env_token (user_id, provider, environment, payment_token)` at varchar(255) utf8mb4 is ~1264 bytes — within the InnoDB 3072-byte limit. No index changes required.

## Follow-up
The temporary stopgap `ALTER` in **plg_j2commerce_payment_worldpay** update SQL (`sql/updates/mysql/6.0.2.sql`) can be removed once this ships — schema ownership returns to core.

## Testing
1. On an install still at `varchar(100)`, run admin → System → Database fix/update.
2. `DESCRIBE j6_j2commerce_paymentprofiles` → `payment_token` = `varchar(255)`.
3. Save a Worldpay card (~117-char href) → token stored whole; saved-card charge + MIT renewal succeed.

## Files Changed
- `administrator/components/com_j2commerce/sql/install.mysql.utf8.sql` — column width
- `administrator/components/com_j2commerce/sql/updates/mysql/6.3.2-2026-05-27.sql` — new update migration