### PR TITLE
fix(products): wire menu ordering params + assign article ordering

### DIFF
--- a/components/com_j2commerce/src/Model/ProductsModel.php
+++ b/components/com_j2commerce/src/Model/ProductsModel.php
@@ -134,7 +134,10 @@ class ProductsModel extends ListModel
 
         // Ordering from menu item params
         $orderBy        = $params->get('orderby_sec', 'order');
-        $orderDirection = $params->get('list_order_direction', 'ASC');
+        // 'cat_order' has its own direction field in the menu item; everything else uses list_order_direction.
+        $orderDirection = $orderBy === 'cat_order'
+            ? $params->get('category_order_direction', 'ASC')
+            : $params->get('list_order_direction', 'ASC');
         $orderDate      = match ($params->get('order_date', 'created')) {
             'published' => 'publish_up',
             default     => $params->get('order_date', 'created'),
@@ -267,6 +270,8 @@ class ProductsModel extends ListModel
         $id .= ':' . serialize($this->getState('filter.productfilter_ids', []));
         $id .= ':' . $this->getState('filter.price_from', 0);
         $id .= ':' . $this->getState('filter.price_to', 0);
+        $id .= ':' . $this->getState('list.ordering');
+        $id .= ':' . $this->getState('list.direction');
 
         return parent::getStoreId($id);
     }
@@ -462,6 +467,12 @@ class ProductsModel extends ListModel
         }
 
         $query->order($db->escape($orderCol) . ' ' . $db->escape($orderDir));
+
+        // Deterministic tie-breaker so rows that share an order value (e.g. products
+        // whose article ordering is still 0) keep a stable, predictable sequence.
+        if ($orderCol !== 'a.id') {
+            $query->order($db->quoteName('a.id') . ' ' . $db->escape($orderDir));
+        }
 
         return $query;
     }

--- a/components/com_j2commerce/tmpl/products/default.xml
+++ b/components/com_j2commerce/tmpl/products/default.xml
@@ -44,7 +44,7 @@
 				type="list"
 				label="COM_J2COMMERCE_PRODUCT_LIST_ORDERING"
 				description="COM_J2COMMERCE_PRODUCT_LIST_ORDERING_DESC"
-				useglobal="true"
+				default="order"
 				validate="options"
 			>
 				<option value="featured">COM_J2COMMERCE_PRODUCT_LIST_ORDERING_FEATURED</option>
@@ -64,6 +64,7 @@
 				label="COM_J2COMMERCE_PRODUCT_LIST_DIRECTION"
 				description="COM_J2COMMERCE_PRODUCT_LIST_DIRECTION_DESC"
 				default="ASC"
+				showon="orderby_sec!:cat_order"
 			>
 				<option value="ASC">JGLOBAL_ORDER_ASCENDING</option>
 				<option value="DESC">JGLOBAL_ORDER_DESCENDING</option>
@@ -86,7 +87,7 @@
 				type="list"
 				label="JGLOBAL_ORDERING_DATE_LABEL"
 				description="JGLOBAL_ORDERING_DATE_DESC"
-				useglobal="true"
+				default="created"
 				validate="options"
 				showon="orderby_sec:date"
 			>

--- a/plugins/content/j2commerce/src/Extension/J2Commerce.php
+++ b/plugins/content/j2commerce/src/Extension/J2Commerce.php
@@ -33,7 +33,6 @@ use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Router\Route;
-use Joomla\CMS\Session\Session;
 use Joomla\Database\DatabaseAwareTrait;
 use Joomla\Database\ParameterType;
 use Joomla\Event\SubscriberInterface;
@@ -530,8 +529,61 @@ final class J2Commerce extends CMSPlugin implements SubscriberInterface
         // Save product using native MVC
         $this->saveProduct($j2data);
 
+        // Newly created product: give its article a real per-category ordering value.
+        // Joomla leaves a new article's ordering at 0, which makes the frontend product
+        // list "Ordering" sort meaningless (every new product ties at 0).
+        if (!$existingProduct) {
+            $this->assignArticleOrderingIfUnset($articleId, (int) ($data->catid ?? 0));
+        }
+
         // Clear the static article cache to ensure fresh data on next load
         $this->clearArticleCache($articleId);
+    }
+
+    /**
+     * Set #__content.ordering to (max in category + 1) for a product article whose
+     * ordering is still 0, so the frontend "Ordering" sort produces a stable result.
+     */
+    private function assignArticleOrderingIfUnset(int $articleId, int $catid): void
+    {
+        if ($articleId <= 0 || $catid <= 0) {
+            return;
+        }
+
+        $db = $this->getDatabase();
+
+        $current = (int) $db->setQuery(
+            $db->getQuery(true)
+                ->select($db->quoteName('ordering'))
+                ->from($db->quoteName('#__content'))
+                ->where($db->quoteName('id') . ' = :id')
+                ->bind(':id', $articleId, ParameterType::INTEGER)
+        )->loadResult();
+
+        if ($current > 0) {
+            return;
+        }
+
+        // MAX is taken across the whole category (all articles, not just products) by
+        // design, so products share the same Joomla per-category ordering space.
+        $max = (int) $db->setQuery(
+            $db->getQuery(true)
+                ->select('MAX(' . $db->quoteName('ordering') . ')')
+                ->from($db->quoteName('#__content'))
+                ->where($db->quoteName('catid') . ' = :catid')
+                ->bind(':catid', $catid, ParameterType::INTEGER)
+        )->loadResult();
+
+        $newOrdering = $max + 1;
+
+        $db->setQuery(
+            $db->getQuery(true)
+                ->update($db->quoteName('#__content'))
+                ->set($db->quoteName('ordering') . ' = :ordering')
+                ->where($db->quoteName('id') . ' = :aid')
+                ->bind(':ordering', $newOrdering, ParameterType::INTEGER)
+                ->bind(':aid', $articleId, ParameterType::INTEGER)
+        )->execute();
     }
 
     /**
@@ -970,7 +1022,7 @@ final class J2Commerce extends CMSPlugin implements SubscriberInterface
                 }
 
                 $displayData = $this->buildDisplayData($product, $option, $options);
-                $html       .= ProductLayoutService::renderLayout($layoutId, $displayData);
+                $html .= ProductLayoutService::renderLayout($layoutId, $displayData);
             }
 
             $html .= '</div>';


### PR DESCRIPTION
## Core Update

Fixes the frontend Category Products list (`view=products&catid=`) "Ordering" + direction menu settings, which were silently ignored.

### Changes
- **`components/com_j2commerce/tmpl/products/default.xml`**: `orderby_sec` and `order_date` used `useglobal="true"` with no backing component config field, so Joomla saved an empty string and the menu selection never took effect. Removed `useglobal`, added real defaults (`order` / `created`). Added `showon="orderby_sec!:cat_order"` to `list_order_direction` so the dedicated category direction field shows in its place.
- **`components/com_j2commerce/src/Model/ProductsModel.php`**: read `category_order_direction` when ordering by `cat_order`; include `list.ordering` + `list.direction` in `getStoreId()` (cache previously ignored order changes); add a deterministic `a.id` tie-breaker so rows sharing an order value stay stable.
- **`plugins/content/j2commerce/src/Extension/J2Commerce.php`**: assign `#__content.ordering = MAX(category)+1` for newly created product articles (Joomla leaves new-article ordering at 0, which made the "Ordering" sort meaningless).

### Files Modified
| Type | Count |
|------|-------|
| PHP files | 2 |
| XML/Config | 1 |

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Code style (php-cs-fixer) passed
- [x] Core files only (non-core excluded)
- [x] CRLF normalized to LF on default.xml