### PR TITLE
feat(checkout): emit display events at billing + shipping/payment steps

### DIFF
--- a/components/com_j2commerce/tmpl/checkout/bootstrap5/default_billing.php
+++ b/components/com_j2commerce/tmpl/checkout/bootstrap5/default_billing.php
@@ -12,6 +12,7 @@
 // phpcs:enable PSR1.Files.SideEffects
 
 use J2Commerce\Component\J2commerce\Administrator\Helper\CustomFieldHelper;
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 use Joomla\CMS\Language\Text;
 
 /** @var \J2Commerce\Component\J2commerce\Site\View\Checkout\HtmlView $this */
@@ -95,6 +96,8 @@ $hasAddresses = !empty($addresses);
         </div>
     </div>
     <?php endif; ?>
+
+    <?php echo J2CommerceHelper::plugin()->eventWithHtml('CheckoutBilling', [$this]); ?>
 
     <div class="mt-3">
         <button type="button" id="button-billing-address" class="btn btn-primary btn-checkout-step">

--- a/components/com_j2commerce/tmpl/checkout/bootstrap5/default_shipping_payment.php
+++ b/components/com_j2commerce/tmpl/checkout/bootstrap5/default_shipping_payment.php
@@ -107,6 +107,8 @@ $currency = J2CommerceHelper::currency();
         </div>
     <?php endif; ?>
 
+    <?php echo J2CommerceHelper::plugin()->eventWithHtml('AfterDisplayShippingPayment', [$this->order]); ?>
+
     <div class="mt-3">
         <button type="button" id="button-payment-method" class="btn btn-primary btn-checkout-step">
             <?php echo Text::_('COM_J2COMMERCE_CHECKOUT_CONTINUE'); ?>

--- a/components/com_j2commerce/tmpl/checkout/uikit3/default_billing.php
+++ b/components/com_j2commerce/tmpl/checkout/uikit3/default_billing.php
@@ -12,6 +12,7 @@
 // phpcs:enable PSR1.Files.SideEffects
 
 use J2Commerce\Component\J2commerce\Administrator\Helper\CustomFieldHelper;
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 use Joomla\CMS\Language\Text;
 
 /** @var \J2Commerce\Component\J2commerce\Site\View\Checkout\HtmlView $this */
@@ -99,6 +100,8 @@ $hasAddresses = !empty($addresses);
         </label>
     </div>
     <?php endif; ?>
+
+    <?php echo J2CommerceHelper::plugin()->eventWithHtml('CheckoutBilling', [$this]); ?>
 
     <div class="uk-margin-top">
         <button type="button" id="button-billing-address" class="uk-button uk-button-primary btn-checkout-step">

--- a/components/com_j2commerce/tmpl/checkout/uikit3/default_shipping_payment.php
+++ b/components/com_j2commerce/tmpl/checkout/uikit3/default_shipping_payment.php
@@ -107,6 +107,8 @@ $currency = J2CommerceHelper::currency();
         </div>
     <?php endif; ?>
 
+    <?php echo J2CommerceHelper::plugin()->eventWithHtml('AfterDisplayShippingPayment', [$this->order]); ?>
+
     <div class="uk-margin-top">
         <button type="button" id="button-payment-method" class="uk-button uk-button-primary btn-checkout-step">
             <?php echo Text::_('COM_J2COMMERCE_CHECKOUT_CONTINUE'); ?>


### PR DESCRIPTION
## Core Update

Adds the checkout display-event emits that j2commerce **app plugins** rely on to render content at checkout, but which were missing from the native `com_j2commerce` templates.

### Problem
- `default_billing.php` never emitted any plugin display event, so for **logged-in** users (who skip the guest/register templates) plugins like `app_gdpr` could not render their terms checkbox at the billing step — yet validation still fired, blocking checkout with no checkbox to accept (j2commerce6extensions #259).
- `onJ2CommerceAfterDisplayShippingPayment` existed only in legacy `com_j2store` and was never emitted in `com_j2commerce`, silently breaking the payment-step display for `app_gdpr`, `app_additionalterms`, `app_acymailing`, `app_subscriptionproduct`.

### Changes
- `default_billing.php` (bootstrap5 + uikit3): emit new `onJ2CommerceCheckoutBilling` (`eventWithHtml('CheckoutBilling', [$this])`) before the Continue button.
- `default_shipping_payment.php` (bootstrap5 + uikit3): emit `onJ2CommerceAfterDisplayShippingPayment` (`eventWithHtml('AfterDisplayShippingPayment', [$this->order])`) before the Continue button.

Both are placed inside the step so any rendered field posts with that step's form.

### Files Modified
| Type | Count |
|------|-------|
| PHP templates | 4 |

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants / JFactory
- [x] Core files only (4 checkout templates)