### PR TITLE
fix(lib): repair clear-selection button in multiselect modals

### DIFF
--- a/libraries/j2commerce/layouts/com_contact/contacts/modal_multiselect.php
+++ b/libraries/j2commerce/layouts/com_contact/contacts/modal_multiselect.php
@@ -75,8 +75,8 @@ $wa->registerAndUseScript(
                             id="clear-selection-btn"
                             class="btn btn-outline-danger ms-2"
                             style="display: none;"
-                            title="<?php echo Text::_('LIB_J2COMMERCE_CONTACT_SELECT_MODAL_CLEAR_ALL_CONTACTS_LABEL'); ?>">
-                        <span class="icon-trash" aria-hidden="true"></i> <?php echo Text::_('LIB_J2COMMERCE_ITEM_SELECT_MODAL_SELECTION_CLEAR_LABEL'); ?>
+                            title="<?php echo Text::_('LIB_J2COMMERCE_ITEM_SELECT_MODAL_SELECTION_CLEAR_LABEL'); ?>">
+                        <span class="icon-trash" aria-hidden="true"></span> <?php echo Text::_('LIB_J2COMMERCE_ITEM_SELECT_MODAL_SELECTION_CLEAR_LABEL'); ?>
                     </button>
                     <button type="button"
                             id="done-btn"

--- a/libraries/j2commerce/layouts/com_content/articles/modal_multiselect.php
+++ b/libraries/j2commerce/layouts/com_content/articles/modal_multiselect.php
@@ -76,8 +76,8 @@ $wa->registerAndUseScript(
                             id="clear-selection-btn"
                             class="btn btn-outline-danger ms-2"
                             style="display: none;"
-                            title="<?php echo Text::_('LIB_J2COMMERCE_ARTICLE_SELECT_MODAL_CLEAR_ALL_ARTICLES_LABEL'); ?>">
-                        <span class="icon-trash" aria-hidden="true"></i> <?php echo Text::_('LIB_J2COMMERCE_ITEM_SELECT_MODAL_SELECTION_CLEAR_LABEL'); ?>
+                            title="<?php echo Text::_('LIB_J2COMMERCE_ITEM_SELECT_MODAL_SELECTION_CLEAR_LABEL'); ?>">
+                        <span class="icon-trash" aria-hidden="true"></span> <?php echo Text::_('LIB_J2COMMERCE_ITEM_SELECT_MODAL_SELECTION_CLEAR_LABEL'); ?>
                     </button>
                     <button type="button"
                             id="done-btn"

--- a/libraries/j2commerce/layouts/com_users/users/modal_multiselect.php
+++ b/libraries/j2commerce/layouts/com_users/users/modal_multiselect.php
@@ -77,8 +77,8 @@ $wa->registerAndUseScript(
                             id="clear-selection-btn"
                             class="btn btn-outline-danger ms-2"
                             style="display: none;"
-                            title="<?php echo Text::_('LIB_J2COMMERCE_USER_SELECT_MODAL_CLEAR_ALL_USERS_LABEL'); ?>">
-                        <span class="icon-trash" aria-hidden="true"></i> <?php echo Text::_('LIB_J2COMMERCE_ITEM_SELECT_MODAL_SELECTION_CLEAR_LABEL'); ?>
+                            title="<?php echo Text::_('LIB_J2COMMERCE_ITEM_SELECT_MODAL_SELECTION_CLEAR_LABEL'); ?>">
+                        <span class="icon-trash" aria-hidden="true"></span> <?php echo Text::_('LIB_J2COMMERCE_ITEM_SELECT_MODAL_SELECTION_CLEAR_LABEL'); ?>
                     </button>
                     <button type="button"
                             id="done-btn"


### PR DESCRIPTION
## Core Update

### Changes
Fixes the clear-selection button in the J2Commerce multiselect picker modals (users, contacts, articles).

- **Malformed tag**: `<span class="icon-trash" aria-hidden="true"></i>` closed with `</i>` instead of `</span>`, causing the browser to absorb the visible "Clear Selection" label into the aria-hidden span (hidden from screen readers).
- **Undefined title key**: button `title` pointed at `LIB_J2COMMERCE_{USER,CONTACT,ARTICLE}_SELECT_MODAL_CLEAR_ALL_*_LABEL` which are not defined in any .ini, rendering as raw tokens. Now reuses the defined `LIB_J2COMMERCE_ITEM_SELECT_MODAL_SELECTION_CLEAR_LABEL` (present in all locales).

### Files Modified
| Type | Count |
|------|-------|
| PHP layout files | 3 |

- libraries/j2commerce/layouts/com_users/users/modal_multiselect.php
- libraries/j2commerce/layouts/com_contact/contacts/modal_multiselect.php
- libraries/j2commerce/layouts/com_content/articles/modal_multiselect.php

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] No new language strings (reuses existing defined key)
- [x] Core files only (non-core excluded)