### PR TITLE
fix(cart): consume plugin event result instead of iterating event object

### DIFF
--- a/administrator/components/com_j2commerce/src/Model/Behavior/CartDefault.php
+++ b/administrator/components/com_j2commerce/src/Model/Behavior/CartDefault.php
@@ -163,7 +163,7 @@ class CartDefault
             $pluginHelper = J2CommerceHelper::plugin();
             $results      = $pluginHelper->event('AfterCreateItemForAddToCart', [$item, $values]);
 
-            foreach ($results as $result) {
+            foreach ($results->getArgument('result', []) as $result) {
                 if (\is_array($result)) {
                     foreach ($result as $key => $value) {
                         $item->set($key, $value);
@@ -179,8 +179,8 @@ class CartDefault
                 $product->product_options ?? [],
             ]);
 
-            foreach ($validationResults as $result) {
-                if (!empty($result['error'])) {
+            foreach ($validationResults->getArgument('result', []) as $result) {
+                if (\is_array($result) && !empty($result['error'])) {
                     $errors['error']['general'] = $result['error'];
                 }
             }


### PR DESCRIPTION
## Summary

Fixes #1112

`CartDefault` collected results from `onJ2CommerceBeforeAddToCart` and `onJ2CommerceAfterCreateItemForAddToCart` by iterating the returned `PluginEvent` object directly with `foreach`. `PluginEvent` is not `Traversable` and exposes no public properties, so from `CartDefault` scope both loops ran **zero iterations with no exception** — silently ignoring add-to-cart validation blocking and item modifications.

## Changes

- `CartDefault.php` L166 — iterate `$results->getArgument('result', [])` instead of the event object (item modification).
- `CartDefault.php` L182 — iterate `$validationResults->getArgument('result', [])` instead of the event object (validation blocking), plus an `is_array()` guard on each result entry.

Matches the canonical consumption pattern already used in `CartOrder.php:745-747`. Plugin handlers contribute via `$event->addResult(...)`, which appends to the `result` argument that `getArgument('result')` reads back.

## Testing

1. Enable a J2Commerce plugin subscribing to `onJ2CommerceBeforeAddToCart` that calls `$event->addResult(['error' => 'blocked'])`.
2. Add that product to the cart on the frontend.
3. Verify the add is **blocked** and the error surfaces (before this fix it was silently added).
4. Regression: a normal product with no blocking plugin still adds correctly.
5. A plugin doing `addResult([['field' => 'val']])` on `onJ2CommerceAfterCreateItemForAddToCart` now modifies the cart item.

## Files Changed

- `administrator/components/com_j2commerce/src/Model/Behavior/CartDefault.php` — 3 insertions, 3 deletions

## Pre-Flight

- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Code style (php-cs-fixer) passed
- [x] Core file only