### PR TITLE
fix(checkout): enforce CSRF token on POST when orderpayment_type is set

### DIFF
--- a/components/com_j2commerce/src/Controller/CheckoutController.php
+++ b/components/com_j2commerce/src/Controller/CheckoutController.php
@@ -1381,6 +1381,12 @@ class CheckoutController extends BaseController
 
         if (empty($orderpaymentType)) {
             Session::checkToken('get') or $this->app->redirect($this->getCheckoutUrl());
+        } elseif ($this->input->getMethod() === 'POST') {
+            // On-site card-collecting plugins POST orderpayment_type alongside
+            // raw PAN/CVV. Enforce CSRF on every browser POST here. Offsite
+            // gateway returns arrive as GET redirects (no token) and are
+            // finalized via order-state guards instead.
+            Session::checkToken('post') or $this->app->redirect($this->getCheckoutUrl());
         }
 
         $session        = $this->app->getSession();


### PR DESCRIPTION
## Summary

Fixes #1114

`CheckoutController::confirmPayment()` only ran `Session::checkToken()` on the **empty-`orderpayment_type`** branch. Any browser POST that set `orderpayment_type` — including an on-site card form carrying raw PAN/CVV — bypassed the core CSRF check entirely. Exposed pattern: `payment_interpay`, and any plugin rendering its own card form that posts `orderpayment_type=...` (`payment_authorizenet`, `payment_paytrace`, etc.).

## Changes

- `CheckoutController.php` (~L1382) — add an additive `elseif`: when `orderpayment_type` is present **and** the request method is `POST`, enforce `Session::checkToken('post')` or redirect to checkout.

The check is method-gated so legitimate flows are untouched:
- On-site card + offline (cash / bank transfer / money order) forms already render `HTMLHelper::_('form.token')` → pass.
- Offsite gateway returns arrive as **GET** redirects (e.g. `payment_paypal/tmpl/notify.php`) with no token → method is not POST → exempt, finalized via order-state guards.

Renders the per-plugin `Session::checkToken('post')` band-aids (e.g. in `payment_interpay`) redundant.

## Testing

1. Frontend checkout → Cash / Bank Transfer / Money Order → Place Order → completes.
2. PayPal (offsite) → redirect out and return → order finalizes (GET return path).
3. Negative: hand-craft a POST to `task=checkout.confirmPayment` with `orderpayment_type` set and **no** token → bounced to checkout (before: processed).
4. On-site card plugin StartSession POST → still works.

## Files Changed

- `components/com_j2commerce/src/Controller/CheckoutController.php` — 6 insertions

## Pre-Flight

- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Code style (php-cs-fixer) passed
- [x] Core file only