### PR TITLE
fix(checkout): enforce payment geozone + subtotal limits in core

### DIFF
--- a/administrator/components/com_j2commerce/stubs/payment/Extension.php.stub
+++ b/administrator/components/com_j2commerce/stubs/payment/Extension.php.stub
@@ -23,7 +23,6 @@ use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Router\Route;
 use Joomla\Database\DatabaseAwareTrait;
 use Joomla\Database\DatabaseInterface;
-use Joomla\Database\ParameterType;
 use Joomla\Event\DispatcherInterface;
 use Joomla\Event\Event;
 use Joomla\Event\EventInterface;
@@ -102,7 +101,6 @@ final class {{Type}}{{Name}} extends CMSPlugin implements SubscriberInterface
     {
         return [
             'onJ2CommerceCalculateFees'     => 'onCalculateFees',
-            'onJ2CommerceGetPaymentOptions' => 'onGetPaymentOptions',
             'onJ2CommerceGetPaymentPlugins' => 'onGetPaymentPlugins',
             'onJ2CommercePrePayment'        => 'onPrePayment',
             'onJ2CommercePostPayment'       => 'onPostPayment',
@@ -164,41 +162,6 @@ final class {{Type}}{{Name}} extends CMSPlugin implements SubscriberInterface
             }
         }
 {{/if}}
-    }
-
-    public function onGetPaymentOptions(Event $event): void
-    {
-        if (!($event instanceof EventInterface)) {
-            return;
-        }
-
-        $args = $event->getArguments();
-        $element = $args[0] ?? null;
-        $order = $args[1] ?? null;
-
-        if ($element !== $this->_name || $order === null) {
-            return;
-        }
-
-        $found = true;
-
-{{#if geozone}}
-        $geozoneId = (int) $this->params->get('geozone_id', 0);
-
-        if ($geozoneId > 0) {
-            $order->setAddress();
-            $address = $order->getBillingAddress();
-            $found = $this->checkGeozone($geozoneId, $address);
-        }
-{{/if}}
-
-{{#if minmax_subtotal}}
-        if ($found) {
-            $found = $this->checkSubtotalLimits($order->order_subtotal);
-        }
-{{/if}}
-
-        $event->setArgument('result', $found);
     }
 
     public function onGetPaymentPlugins(Event $event): void
@@ -330,53 +293,6 @@ final class {{Type}}{{Name}} extends CMSPlugin implements SubscriberInterface
 
         return $html;
     }
-
-{{#if geozone}}
-    private function checkGeozone(int $geozoneId, array $address): bool
-    {
-        $db = $this->getDatabase();
-        $query = $db->getQuery(true);
-
-        $countryId = (int) ($address['country_id'] ?? 0);
-        $zoneId = (int) ($address['zone_id'] ?? 0);
-
-        $query->select($db->quoteName('gz.j2commerce_geozone_id'))
-            ->from($db->quoteName('#__j2commerce_geozones', 'gz'))
-            ->innerJoin(
-                $db->quoteName('#__j2commerce_geozonerules', 'gzr')
-                . ' ON ' . $db->quoteName('gzr.geozone_id') . ' = ' . $db->quoteName('gz.j2commerce_geozone_id')
-            )
-            ->where($db->quoteName('gz.j2commerce_geozone_id') . ' = :geozoneId')
-            ->where($db->quoteName('gzr.country_id') . ' = :countryId')
-            ->where('(' . $db->quoteName('gzr.zone_id') . ' = 0 OR ' . $db->quoteName('gzr.zone_id') . ' = :zoneId)')
-            ->bind(':geozoneId', $geozoneId, ParameterType::INTEGER)
-            ->bind(':countryId', $countryId, ParameterType::INTEGER)
-            ->bind(':zoneId', $zoneId, ParameterType::INTEGER);
-
-        $db->setQuery($query);
-        $result = $db->loadResult();
-
-        return !empty($result);
-    }
-{{/if}}
-
-{{#if minmax_subtotal}}
-    private function checkSubtotalLimits(float $subtotal): bool
-    {
-        $minSubtotal = (float) $this->params->get('min_subtotal', 0);
-        $maxSubtotal = (float) $this->params->get('max_subtotal', -1);
-
-        if ($minSubtotal > 0 && $subtotal < $minSubtotal) {
-            return false;
-        }
-
-        if ($maxSubtotal >= 0 && $subtotal > $maxSubtotal) {
-            return false;
-        }
-
-        return true;
-    }
-{{/if}}
 
     protected function _getLayout(string $layout, ?\stdClass $vars = null): string
     {

--- a/components/com_j2commerce/src/Controller/CheckoutController.php
+++ b/components/com_j2commerce/src/Controller/CheckoutController.php
@@ -32,7 +32,10 @@ use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 use Joomla\CMS\User\UserFactoryInterface;
+use Joomla\Database\DatabaseInterface;
+use Joomla\Database\ParameterType;
 use Joomla\Event\DispatcherInterface;
+use Joomla\Registry\Registry;
 
 class CheckoutController extends BaseController
 {
@@ -1050,6 +1053,8 @@ class CheckoutController extends BaseController
             }
         }
 
+        $paymentMethods = $this->filterUnavailablePaymentMethods($paymentMethods, $order);
+
         $defaultPaymentMethod = J2CommerceHelper::config()->get('default_payment_method', '');
         $selectedPayment      = $session->get('payment_method', $defaultPaymentMethod, 'j2commerce');
 
@@ -1072,6 +1077,123 @@ class CheckoutController extends BaseController
             'showTerms'           => (int) J2CommerceHelper::config()->get('show_terms', 0),
             'termsDisplayType'    => J2CommerceHelper::config()->get('terms_display_type', 'link'),
         ]);
+    }
+
+    /**
+     * Drop payment methods whose plugin restricts them out of range.
+     *
+     * Applies the geozone (billing address) and subtotal-range restrictions
+     * advertised by each payment plugin's params. Centralized here because the
+     * per-plugin onJ2CommerceGetPaymentOptions hook is never dispatched.
+     *
+     * @param   array<int, array<string, mixed>>  $methods
+     *
+     * @return  array<int, array<string, mixed>>
+     */
+    private function filterUnavailablePaymentMethods(array $methods, ?object $order): array
+    {
+        if (empty($methods)) {
+            return $methods;
+        }
+
+        // null = billing address not resolvable yet → do not restrict by geozone.
+        $billingGeozones = $this->getBillingGeozones();
+        $subtotal        = (float) ($order->order_subtotal ?? 0);
+
+        $filtered = array_filter($methods, function (array $method) use ($billingGeozones, $subtotal): bool {
+            $element = (string) ($method['element'] ?? '');
+
+            if ($element === '') {
+                return true;
+            }
+
+            $plugin = PluginHelper::getPlugin('j2commerce', $element);
+
+            if (!$plugin) {
+                return true;
+            }
+
+            $params = new Registry($plugin->params ?? '');
+
+            $geozoneId = (int) $params->get('geozone_id', 0);
+
+            // geozone_id 0 = available everywhere. Otherwise it must match the
+            // buyer's billing geozone(s); an empty set means "outside all zones".
+            if ($geozoneId > 0 && $billingGeozones !== null && !\in_array($geozoneId, $billingGeozones, true)) {
+                return false;
+            }
+
+            $minSubtotal = (float) $params->get('min_subtotal', 0);
+            $maxSubtotal = (float) $params->get('max_subtotal', -1);
+
+            if ($minSubtotal > 0 && $subtotal < $minSubtotal) {
+                return false;
+            }
+
+            if ($maxSubtotal >= 0 && $subtotal > $maxSubtotal) {
+                return false;
+            }
+
+            return true;
+        });
+
+        return array_values($filtered);
+    }
+
+    /**
+     * Resolve the geozone IDs matching the buyer's billing address.
+     *
+     * @return  int[]|null  Matching geozone IDs, or null when no billing
+     *                      address is available (caller skips geozone filtering).
+     */
+    private function getBillingGeozones(): ?array
+    {
+        $session   = $this->app->getSession();
+        $countryId = 0;
+        $zoneId    = 0;
+
+        $addressId = (int) $session->get('billing_address_id', 0, 'j2commerce');
+
+        if ($addressId > 0) {
+            $db    = Factory::getContainer()->get(DatabaseInterface::class);
+            $query = $db->getQuery(true);
+
+            $query->select([$db->quoteName('country_id'), $db->quoteName('zone_id')])
+                ->from($db->quoteName('#__j2commerce_addresses'))
+                ->where($db->quoteName('j2commerce_address_id') . ' = :addrId')
+                ->bind(':addrId', $addressId, ParameterType::INTEGER);
+
+            $db->setQuery($query);
+            $address = $db->loadObject();
+
+            if ($address) {
+                $countryId = (int) $address->country_id;
+                $zoneId    = (int) $address->zone_id;
+            }
+        }
+
+        if ($countryId === 0) {
+            $countryId = (int) $session->get('billing_country_id', 0, 'j2commerce');
+            $zoneId    = (int) $session->get('billing_zone_id', 0, 'j2commerce');
+        }
+
+        if ($countryId === 0) {
+            return null;
+        }
+
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
+        $query = $db->getQuery(true);
+
+        $query->select('DISTINCT ' . $db->quoteName('geozone_id'))
+            ->from($db->quoteName('#__j2commerce_geozonerules'))
+            ->where($db->quoteName('country_id') . ' = :countryId')
+            ->where('(' . $db->quoteName('zone_id') . ' = 0 OR ' . $db->quoteName('zone_id') . ' = :zoneId)')
+            ->bind(':countryId', $countryId, ParameterType::INTEGER)
+            ->bind(':zoneId', $zoneId, ParameterType::INTEGER);
+
+        $db->setQuery($query);
+
+        return array_map('intval', $db->loadColumn() ?: []);
     }
 
     public function shippingPaymentMethodValidate(): void


### PR DESCRIPTION
## Summary

Fixes #1116

The payment **geozone** restriction (and the min/max **subtotal** restriction) was non-functional in every payment plugin. `onJ2CommerceGetPaymentOptions` is **never dispatched** anywhere in the component or library, and the canonical stub handler called `$order->setAddress()` / `$order->getBillingAddress()` — methods that don't exist (would fatal if the event ever fired). Payment methods are gathered only via `onJ2CommerceGetPaymentPlugins` with no filtering, so `geozone_id` / `min_subtotal` / `max_subtotal` config silently did nothing across ~30 plugins, incl. core `payment_cash` / `payment_moneyorder` / `payment_paypal`.

## Changes

**Core — `components/com_j2commerce/src/Controller/CheckoutController.php`**
- After payment methods are gathered in `shippingPaymentMethod()`, run new `filterUnavailablePaymentMethods()`:
  - Resolve the buyer's **billing** geozones from the session (`billing_address_id` → `#__j2commerce_addresses`, else `billing_country_id` / `billing_zone_id`), mirroring the proven `shipping_standard` pattern. `null` = no billing address yet → no geozone restriction; an empty match-set hides geozone-restricted methods.
  - Read each candidate plugin's params via `PluginHelper::getPlugin('j2commerce', element)` and drop methods whose `geozone_id` is set and unmatched, or whose `min_subtotal` / `max_subtotal` range excludes the order subtotal (exact `payment_cash` semantics).
- Schema verified against `#__j2commerce_geozonerules` and `#__j2commerce_addresses`.

**Stub — `administrator/components/com_j2commerce/stubs/payment/Extension.php.stub`**
- Remove the never-dispatched `onGetPaymentOptions` handler (and its fatal `setAddress()` / `getBillingAddress()` calls), its event subscription, the orphaned `checkGeozone` / `checkSubtotalLimits` helpers, and the now-unused `ParameterType` import. Newly scaffolded plugins inherit the working pattern (core-enforced). The `geozone_id` / `min_subtotal` / `max_subtotal` config fields remain — core reads them.

Fixes every payment plugin at one point with no per-plugin churn. Existing deployed plugins keep their (harmless, never-dispatched) handlers.

## Testing

1. Admin → set `payment_cash` Geozone to a zone covering only Country A.
2. Frontend logged-in, billing in Country A → Cash shown; billing in Country B → Cash hidden; `geozone_id=0` methods always shown. No fatal.
3. Guest checkout, billing A vs B → same.
4. `payment_cash` `min_subtotal=1000` with a small cart → hidden; `max_subtotal=5` with a larger cart → hidden; defaults (0 / -1) → always shown.
5. Scaffold a new payment plugin from the stub → no `onGetPaymentOptions` / `setAddress` remnant; geozone + subtotal limits still enforced by core.

## Files Changed

- `components/com_j2commerce/src/Controller/CheckoutController.php` — +1 filter call, +2 private methods, +3 imports
- `administrator/components/com_j2commerce/stubs/payment/Extension.php.stub` — remove dead/broken handler + helpers + orphaned import

## Pre-Flight

- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Code style (php-cs-fixer) passed
- [x] DB schema verified (geozonerules, addresses)
- [x] Core files only