### PR TITLE
feat(options): plugin extension points for custom option types (fixes #1113)

### DIFF
--- a/administrator/components/com_j2commerce/forms/option.xml
+++ b/administrator/components/com_j2commerce/forms/option.xml
@@ -29,27 +29,14 @@
 
         <field
             name="type"
-            type="list"
+            type="optiontype"
+            addfieldprefix="J2Commerce\Component\J2commerce\Administrator\Field"
             label="COM_J2COMMERCE_OPTION_TYPE"
             description="COM_J2COMMERCE_OPTION_TYPE_DESCRIPTION"
             required="true"
             class="form-select"
             >
             <option value="">COM_J2COMMERCE_OPTION_SELECT_TYPE</option>
-            <option value="text">COM_J2COMMERCE_OPTION_TYPE_TEXT</option>
-            <option value="textarea">COM_J2COMMERCE_OPTION_TYPE_TEXTAREA</option>
-            <option value="select">COM_J2COMMERCE_OPTION_TYPE_SELECT</option>
-            <option value="radio">COM_J2COMMERCE_OPTION_TYPE_RADIO</option>
-            <option value="checkbox">COM_J2COMMERCE_OPTION_TYPE_CHECKBOX</option>
-            <option value="date">COM_J2COMMERCE_OPTION_TYPE_DATE</option>
-            <option value="datetime">COM_J2COMMERCE_OPTION_TYPE_DATETIME</option>
-            <option value="time">COM_J2COMMERCE_OPTION_TYPE_TIME</option>
-            <option value="file">COM_J2COMMERCE_OPTION_TYPE_FILE</option>
-            <option value="image">COM_J2COMMERCE_OPTION_TYPE_IMAGE</option>
-            <option value="color">COM_J2COMMERCE_OPTION_TYPE_COLOR</option>
-            <option value="number">COM_J2COMMERCE_OPTION_TYPE_NUMBER</option>
-            <option value="email">COM_J2COMMERCE_OPTION_TYPE_EMAIL</option>
-            <option value="url">COM_J2COMMERCE_OPTION_TYPE_URL</option>
         </field>
 
         <field

--- a/administrator/components/com_j2commerce/src/Field/OptionTypeField.php
+++ b/administrator/components/com_j2commerce/src/Field/OptionTypeField.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Administrator\Field;
+
+\defined('_JEXEC') or die;
+
+use Joomla\CMS\Factory;
+use Joomla\CMS\Form\Field\ListField;
+use Joomla\CMS\HTML\HTMLHelper;
+
+/**
+ * OptionType field - dropdown of product option types.
+ *
+ * Sources the list from OptionModel::getOptionTypes(), so any type a plugin
+ * registers via the onJ2CommerceGetOptionTypes event appears automatically.
+ *
+ * @since  6.0.7
+ */
+class OptionTypeField extends ListField
+{
+    protected $type = 'OptionType';
+
+    protected static ?array $cachedTypes = null;
+
+    public function getOptions(): array
+    {
+        $options = parent::getOptions();
+
+        foreach ($this->getOptionTypes() as $value => $label) {
+            $options[] = HTMLHelper::_('select.option', $value, $label);
+        }
+
+        return $options;
+    }
+
+    protected function getOptionTypes(): array
+    {
+        if (self::$cachedTypes !== null) {
+            return self::$cachedTypes;
+        }
+
+        $model = Factory::getApplication()
+            ->bootComponent('com_j2commerce')
+            ->getMVCFactory()
+            ->createModel('Option', 'Administrator', ['ignore_request' => true]);
+
+        self::$cachedTypes = $model ? $model->getOptionTypes() : [];
+
+        return self::$cachedTypes;
+    }
+}

--- a/administrator/components/com_j2commerce/src/Helper/ProductHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/ProductHelper.php
@@ -2124,6 +2124,27 @@ class ProductHelper
                     'weight'                 => '',
                     'weight_prefix'          => '',
                 ];
+            } else {
+                // Unknown / plugin-registered option type — let a plugin price it.
+                // Handlers addResult(['option_price' => float, 'option_weight' => float, 'option_data' => array]).
+                $event = J2CommerceHelper::plugin()->event('GetCustomOptionPrice', [
+                    'productOption' => $productOption,
+                    'optionValue'   => $optionValue,
+                    'productId'     => $productId,
+                ]);
+
+                foreach ((array) $event->getEventResult() as $row) {
+                    if (!\is_array($row)) {
+                        continue;
+                    }
+
+                    $optionPrice += (float) ($row['option_price'] ?? 0);
+                    $optionWeight += (float) ($row['option_weight'] ?? 0);
+
+                    foreach ((array) ($row['option_data'] ?? []) as $dataRow) {
+                        $optionData[] = $dataRow;
+                    }
+                }
             }
         }
 

--- a/administrator/components/com_j2commerce/src/Model/OptionModel.php
+++ b/administrator/components/com_j2commerce/src/Model/OptionModel.php
@@ -12,6 +12,7 @@ namespace J2Commerce\Component\J2commerce\Administrator\Model;
 
 \defined('_JEXEC') or die;
 
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
@@ -482,7 +483,7 @@ class OptionModel extends AdminModel
     public function getOptionTypes()
     {
         // Common option types for ecommerce
-        return [
+        $types = [
             'text'     => Text::_('COM_J2COMMERCE_OPTION_TYPE_TEXT'),
             'textarea' => Text::_('COM_J2COMMERCE_OPTION_TYPE_TEXTAREA'),
             'select'   => Text::_('COM_J2COMMERCE_OPTION_TYPE_SELECT'),
@@ -498,6 +499,20 @@ class OptionModel extends AdminModel
             'email'    => Text::_('COM_J2COMMERCE_OPTION_TYPE_EMAIL'),
             'url'      => Text::_('COM_J2COMMERCE_OPTION_TYPE_URL'),
         ];
+
+        // Allow plugins to register additional option types via addResult([key => label]).
+        $event   = J2CommerceHelper::plugin()->event('GetOptionTypes', ['types' => $types]);
+        $results = $event->getEventResult();
+
+        if (!empty($results) && \is_array($results)) {
+            $validResults = array_filter($results, 'is_array');
+
+            if (!empty($validResults)) {
+                $types = array_merge($types, ...$validResults);
+            }
+        }
+
+        return $types;
     }
 
     /**


### PR DESCRIPTION
## Summary
Fixes #1113

Restores J2Store-style extensibility so non-core plugins can register **new product option types** and price them — entirely through events. Unblocks `app_donation` (and any future custom-option-type app) without core hacks.

> Part 4 of the issue (the non-iterable `BeforeAddToCart` loop) is **already fixed** by merged #1115, so it is intentionally **not** included here.

## Changes
- **`OptionModel::getOptionTypes()`** — fires `onJ2CommerceGetOptionTypes`; plugins register types via `addResult(['mytype' => $label])`, merged into the list.
- **New `Field\OptionTypeField`** — sources the admin *Options → type* picker from `getOptionTypes()`, so registered types appear automatically.
- **`forms/option.xml`** — `type` field is now data-driven (`type="optiontype"`); 14 hardcoded `<option>` removed, empty placeholder kept.
- **`ProductHelper::getOptionPrice()`** — adds an `else` branch firing `onJ2CommerceGetCustomOptionPrice` for unknown types; sums `option_price`/`option_weight`/`option_data` from plugin results.

### Design note
`PluginEvent` extends `AbstractImmutableEvent` — only `result`/`forms`/`html` args are mutable. So the contract uses `addResult()` / `getEventResult()` (mirrors `getPricingCalculators()`), **not** `setArgument('types', …)` which would throw. Plugin handlers call `$event->addResult([...])`.

### New events
| Event | Args | Plugin returns |
|-------|------|----------------|
| `onJ2CommerceGetOptionTypes` | `['types' => array]` | `addResult(['mytype' => $label])` |
| `onJ2CommerceGetCustomOptionPrice` | `['productOption','optionValue','productId']` | `addResult(['option_price'=>float,'option_weight'=>float,'option_data'=>array])` |

## Backward compatibility
Additive. All 14 built-in types and existing pricing/weight paths unchanged; events only augment.

## Testing
1. Admin → Products → Options → New: all 14 built-in types still listed (placeholder first, original order).
2. Configure a built-in option on a product, add to cart: price/data unchanged.
3. With a plugin subscribing both events: its type appears in the picker, and entering a value adds the correct price to line item / cart / order via `getOptionPrice()`.

## Files Changed
- `administrator/components/com_j2commerce/src/Model/OptionModel.php` — event hook
- `administrator/components/com_j2commerce/src/Field/OptionTypeField.php` — NEW data-driven list field
- `administrator/components/com_j2commerce/forms/option.xml` — data-driven `type` field
- `administrator/components/com_j2commerce/src/Helper/ProductHelper.php` — custom-type pricing event

## Pre-Flight
- [x] PHP syntax check passed
- [x] php-cs-fixer passed
- [x] No secrets / FOF remnants
- [x] Core files only; no language strings added (reuses existing keys)