### PR TITLE
fix(options): validate option type against registered types (fixes #1120)

### DIFF
--- a/administrator/components/com_j2commerce/src/Table/OptionTable.php
+++ b/administrator/components/com_j2commerce/src/Table/OptionTable.php
@@ -116,9 +116,14 @@ class OptionTable extends Table
             throw new \Exception(Text::_('COM_J2COMMERCE_OPTION_ERROR_UNIQUE_NAME_EXISTS'));
         }
 
-        // Validate type is one of the allowed types
-        $allowedTypes = ['text', 'textarea', 'select', 'radio', 'checkbox', 'date', 'datetime', 'time', 'file', 'image', 'color', 'number', 'email', 'url'];
-        if (!\in_array($this->type, $allowedTypes)) {
+        // Validate type against the registered option types (core + plugin-provided via onJ2CommerceGetOptionTypes).
+        $optionModel  = Factory::getApplication()
+            ->bootComponent('com_j2commerce')
+            ->getMVCFactory()
+            ->createModel('Option', 'Administrator', ['ignore_request' => true]);
+        $allowedTypes = $optionModel ? array_keys($optionModel->getOptionTypes()) : [];
+
+        if (!\in_array($this->type, $allowedTypes, true)) {
             throw new \Exception(Text::_('COM_J2COMMERCE_OPTION_ERROR_INVALID_TYPE'));
         }
 


### PR DESCRIPTION
## Summary

Fixes #1120

`OptionTable::check()` validated the option `type` against a hardcoded 14-element array. #1113 made the option-type **picker** extensible (`onJ2CommerceGetOptionTypes` + `OptionModel::getOptionTypes()`), but this save-time validator was missed — so a plugin-registered type (e.g. `app_donation`'s `donation`) shows in the dropdown yet fails to save with **"Invalid option type"**.

## Changes

- `OptionTable::check()` now sources the allowlist from `OptionModel::getOptionTypes()` — the same method the picker uses, which already merges plugin-registered types via the `onJ2CommerceGetOptionTypes` event.
- Picker and validator now share **one source of truth** and cannot drift again.
- `in_array(..., true)` strict comparison.
- `Factory` already imported; `getOptionTypes()` is a plugin event + array build (no DB), so cost in `check()` is negligible.

## Testing

1. Enable a plugin that registers an option type via `onJ2CommerceGetOptionTypes` (e.g. `plg_j2commerce_app_donation` → `donation`).
2. Admin → J2Commerce → Options → New.
3. Set name + Type = Donation → **Save** → saves OK (previously failed "Invalid option type").
4. Built-in types (text/select/etc.) still save — no regression.
5. A genuinely unknown/garbage type still fails with `COM_J2COMMERCE_OPTION_ERROR_INVALID_TYPE`.

## Files Changed

- `administrator/components/com_j2commerce/src/Table/OptionTable.php` — replace hardcoded type array with `array_keys($optionModel->getOptionTypes())`.

## Related

- #1113 (added picker event + price event; this validator was the missed spot)