### PR TITLE
fix(product): pass Registry to displayPrice in Simple/Downloadable behaviors

### DIFF
--- a/administrator/components/com_j2commerce/src/Model/Behavior/Downloadable.php
+++ b/administrator/components/com_j2commerce/src/Model/Behavior/Downloadable.php
@@ -596,7 +596,7 @@ class Downloadable
 
         $app           = Factory::getApplication();
         $input         = $app->getInput();
-        $config        = J2CommerceHelper::config();
+        $config        = J2CommerceHelper::config()->getParams();
         $productHelper = new ProductHelper();
         $pluginHelper  = J2CommerceHelper::plugin();
 

--- a/administrator/components/com_j2commerce/src/Model/Behavior/Simple.php
+++ b/administrator/components/com_j2commerce/src/Model/Behavior/Simple.php
@@ -483,7 +483,7 @@ class Simple
         }
 
         $app           = Factory::getApplication();
-        $config        = J2CommerceHelper::config();
+        $config        = J2CommerceHelper::config()->getParams();
         $productHelper = new ProductHelper();
         $pluginHelper  = J2CommerceHelper::plugin();
 


### PR DESCRIPTION
## Summary
Fixes #1122

`Simple::onUpdateProduct()` and `Downloadable::onUpdateProduct()` built `$config` from `J2CommerceHelper::config()` (a `ConfigHelper`) and passed it to `ProductHelper::displayPrice()`, whose third parameter is type-hinted `?\Joomla\Registry\Registry`. PHP threw a `TypeError`, returning **HTTP 500** for every `product.update` AJAX price recalc on simple and downloadable products.

This aligns both behaviors with the canonical `Configurable::onUpdateProduct()` pattern, which calls `->getParams()` to yield a `Registry`.

## Changes
- `Simple.php:486` — `J2CommerceHelper::config()` → `J2CommerceHelper::config()->getParams()`
- `Downloadable.php:599` — same

The returned `Registry` also satisfies the `BeforeUpdateProductReturn` event (passed by-ref), matching Configurable's usage.

## Testing
1. Frontend page of any simple product with a price-affecting option
2. Change quantity / option → fires `J2Commerce.doAjaxPrice` (`task=product.update`)
3. Verify AJAX returns HTTP 200 JSON and the displayed price updates (no 500)
4. Repeat with a downloadable product
5. Confirm variable/configurable products still recalc correctly

## Files Changed
- `administrator/components/com_j2commerce/src/Model/Behavior/Simple.php` — pass Registry to displayPrice()
- `administrator/components/com_j2commerce/src/Model/Behavior/Downloadable.php` — pass Registry to displayPrice()

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Code style (php-cs-fixer) passed
- [x] Core files only (2 files, no non-core)