### PR TITLE
fix(product): resolve option-type label from registered map, not hardcoded key

### DIFF
--- a/administrator/components/com_j2commerce/src/Helper/J2CommerceHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/J2CommerceHelper.php
@@ -98,6 +98,23 @@ class J2CommerceHelper extends ContentHelper
 
         return $layout->render($data);
     }
+
+    /** Resolves an option-type label from the merged core+plugin map (OptionModel::getOptionTypes), cached per request. */
+    public static function getOptionTypeLabel(string $type): string
+    {
+        static $types = null;
+
+        if ($types === null) {
+            $model = Factory::getApplication()
+                ->bootComponent('com_j2commerce')
+                ->getMVCFactory()
+                ->createModel('Option', 'Administrator', ['ignore_request' => true]);
+
+            $types = $model ? $model->getOptionTypes() : [];
+        }
+
+        return $types[$type] ?? Text::_('COM_J2COMMERCE_' . strtoupper($type));
+    }
     /**
      * Gets a list of the actions that can be performed.
      *

--- a/administrator/components/com_j2commerce/tmpl/product/form_configoptions.php
+++ b/administrator/components/com_j2commerce/tmpl/product/form_configoptions.php
@@ -82,7 +82,7 @@ $csrfToken = \Joomla\CMS\Session\Session::getFormToken();
                                         <?php endif; ?>
                                     </div>
                                     <div>
-                                        <small><?php echo Text::_('COM_J2COMMERCE_OPTION_TYPE'); ?> <?php echo Text::_('COM_J2COMMERCE_' . strtoupper($poption->type)); ?></small>
+                                        <small><?php echo Text::_('COM_J2COMMERCE_OPTION_TYPE'); ?> <?php echo $this->escape(J2CommerceHelper::getOptionTypeLabel($poption->type)); ?></small>
                                     </div>
                                 </td>
                                 <td>

--- a/administrator/components/com_j2commerce/tmpl/product/form_options.php
+++ b/administrator/components/com_j2commerce/tmpl/product/form_options.php
@@ -66,7 +66,7 @@ $csrfToken = \Joomla\CMS\Session\Session::getFormToken();
                                     <input type="hidden" name="<?php echo $formPrefix.'[item_options]['.$poption->j2commerce_productoption_id .'][option_id]';?>" value="<?php echo $poption->option_id;?>">
 
                                     <small>(<?php echo $this->escape($poption->option_unique_name);?>)</small>
-                                    <small><?php echo Text::_('COM_J2COMMERCE_OPTION_TYPE');?> <?php echo Text::_('COM_J2COMMERCE_'.strtoupper($poption->type))?></small>
+                                    <small><?php echo Text::_('COM_J2COMMERCE_OPTION_TYPE');?> <?php echo $this->escape(J2CommerceHelper::getOptionTypeLabel($poption->type));?></small>
                                     <?php if(isset($poption->type) && ($poption->type =='select' || $poption->type =='radio' || $poption->type =='checkbox' || $poption->type =='color')):?>
                                         <button type="button" class="small ms-2 btn btn-outline-primary btn-sm j2commerce-option-values-link"
                                            data-product-id="<?php echo $item->j2commerce_product_id; ?>"


### PR DESCRIPTION
## Summary
Fixes #1123

Three product-edit option panels rendered each type's label by string-building a core language key: `Text::_('COM_J2COMMERCE_' . strtoupper($poption->type))`. Plugin-registered option types (added via the #1113 `onJ2CommerceGetOptionTypes` event) have no matching core key, so the screen showed the raw, untranslated key — e.g. a `donation` type rendered **`COM_J2COMMERCE_DONATION`**.

Same class of drift as #1120: a second spot hardcoding the option-type list instead of consulting `OptionModel::getOptionTypes()`.

## Changes
- **`J2CommerceHelper::getOptionTypeLabel(string $type): string`** — new. Resolves the label from `OptionModel::getOptionTypes()` (the merged core+plugin map already used by the picker / `OptionTypeField`), cached per request via a static. Falls back to the legacy `COM_J2COMMERCE_<TYPE>` key for safety.
- **`tmpl/product/form_options.php`** — label now `$this->escape(J2CommerceHelper::getOptionTypeLabel(...))`
- **`tmpl/product/form_configoptions.php`** — same

Picker and label now share one source of truth and can no longer drift.

## Testing
1. Enable a plugin that registers an option type via `onJ2CommerceGetOptionTypes` (e.g. `plg_j2commerce_app_donation` → `donation`)
2. Create an Option of that type, attach it to a product
3. Edit the product → Options panel shows the registered label ("Donation"), not `COM_J2COMMERCE_DONATION`
4. Built-in types (text/select/radio/…) still render their labels
5. Verify on a configurable product (`form_configoptions`)

## Files Changed
- `administrator/components/com_j2commerce/src/Helper/J2CommerceHelper.php` — new cached label resolver
- `administrator/components/com_j2commerce/tmpl/product/form_options.php` — use resolver
- `administrator/components/com_j2commerce/tmpl/product/form_configoptions.php` — use resolver

## Note
The issue also listed `tmpl/product/form_variablesubscriptionproduct_options.php`. That file is a **non-core plugin override** (owned by `plg_j2commerce_app_subscriptionproduct`, gitignored in this repo) — its identical fix will be submitted to the extensions repo separately, not in this core PR.

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Code style (php-cs-fixer) passed
- [x] Core files only (non-core varsub override excluded)