### PR TITLE
fix(products): load own variant in onUpdateProduct price recalc

### DIFF
--- a/administrator/components/com_j2commerce/src/Model/Behavior/Downloadable.php
+++ b/administrator/components/com_j2commerce/src/Model/Behavior/Downloadable.php
@@ -607,7 +607,7 @@ class Downloadable
 
         // Get variant
         /** @var VariantsModel $variantModel */
-        $variantModel = $this->mvcFactory->createModel('Variants', 'Administrator');
+        $variantModel = $this->mvcFactory->createModel('Variants', 'Administrator', ['ignore_request' => true]);
         $variantModel->setState('filter.product_id', $product->j2commerce_product_id);
         $variantModel->setState('filter.is_master', 1);
         $variants          = $variantModel->getItems();

--- a/administrator/components/com_j2commerce/src/Model/Behavior/Simple.php
+++ b/administrator/components/com_j2commerce/src/Model/Behavior/Simple.php
@@ -493,7 +493,7 @@ class Simple
         }
 
         /** @var VariantsModel $variantModel */
-        $variantModel = $this->mvcFactory->createModel('Variants', 'Administrator');
+        $variantModel = $this->mvcFactory->createModel('Variants', 'Administrator', ['ignore_request' => true]);
         $variantModel->setState('filter.product_id', $product->j2commerce_product_id);
         $variantModel->setState('filter.is_master', 1);
         $variants          = $variantModel->getItems();


### PR DESCRIPTION
## Summary
Fixes #1126

`Simple::onUpdateProduct()` and `Downloadable::onUpdateProduct()` created `VariantsModel` without `['ignore_request' => true]`. Because `getItems()` lazily runs `populateState()` **after** the manual `setState('filter.product_id', ...)`, `populateState()` overwrote `filter.product_id` back to `0` (request default). With no product filter, the query returned the first global `is_master` variant — another product's master — so `product.update` reported the wrong product's price on the live recalc.

The same two files already use the correct pattern in their display path (`Simple.php:404`, `Downloadable.php:506`); only the AJAX recalc path was missed.

## Changes
- `Simple.php` (`onUpdateProduct`) — add `['ignore_request' => true]` to the `VariantsModel` creation
- `Downloadable.php` (`onUpdateProduct`) — same

## Testing
1. Frontend product page of a simple product with a price-affecting option (e.g. a $0-base donation product).
2. Change the option / quantity to trigger the `product.update` recalc.
3. Verify the displayed price reflects the **product's own** variant price (e.g. donation 500 → 500, not 509.95) and matches what the cart charges.
4. Verify variable/configurable products are unaffected.

Verified locally: `product.update` for the test product now returns `base 0 / price 0` with no option and `base 500 / price 500` with a 500 donation (previously `13.50 / 9.95` from an unrelated variant).

## Files Changed
- `administrator/components/com_j2commerce/src/Model/Behavior/Simple.php`
- `administrator/components/com_j2commerce/src/Model/Behavior/Downloadable.php`