### PR TITLE
Multiple tax rates are not applied to local sales

### DIFF
--- a/administrator/components/com_j2commerce/src/Helper/TaxHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/TaxHelper.php
@@ -132,14 +132,34 @@ final class TaxHelper
     /**
      * Load the matching `#__j2commerce_taxrates` row for a profile + geozone set.
      *
+     * Returns the first matching row only. Use getAllTaxRatesForGeozone() when
+     * multiple rates may apply (e.g. state + local tax stacking).
+     *
      * @return  \stdClass|null  Raw row or null when nothing matches.
      *
      * @since   6.3.0
      */
     public static function getTaxRateForGeozone(int $taxprofileId, array $geozoneIds): ?\stdClass
     {
+        $rows = self::getAllTaxRatesForGeozone($taxprofileId, $geozoneIds);
+
+        return $rows[0] ?? null;
+    }
+
+    /**
+     * Load ALL matching `#__j2commerce_taxrates` rows for a profile + geozone set.
+     *
+     * Unlike getTaxRateForGeozone() this returns every rule that matches so that
+     * compound-rate scenarios (e.g. state 6.25% + local 2%) are all included.
+     *
+     * @return  \stdClass[]  Array of raw rows (may be empty).
+     *
+     * @since   6.3.0
+     */
+    public static function getAllTaxRatesForGeozone(int $taxprofileId, array $geozoneIds): array
+    {
         if ($taxprofileId <= 0 || empty($geozoneIds)) {
-            return null;
+            return [];
         }
 
         $db    = Factory::getContainer()->get(DatabaseInterface::class);
@@ -167,9 +187,9 @@ final class TaxHelper
             ->bind(':profileId', $taxprofileId, ParameterType::INTEGER)
             ->order($db->quoteName('tr.ordering') . ' ASC');
 
-        $db->setQuery($query, 0, 1);
+        $db->setQuery($query);
 
-        return $db->loadObject() ?: null;
+        return $db->loadObjectList() ?: [];
     }
 
     /**
@@ -191,17 +211,15 @@ final class TaxHelper
         $address ??= self::getCustomerAddress();
         $ratesets = [];
 
-        $taxInfo = self::getTaxRateForGeozone($taxprofileId, $geozoneIds);
-
-        if ($taxInfo !== null) {
-            $rate                         = new \stdClass();
-            $rate->j2commerce_taxrate_id  = (int) ($taxInfo->j2commerce_taxrate_id ?? 0);
-            $rate->name                   = (string) ($taxInfo->taxrate_name ?? '');
-            $rate->taxrate_name           = $rate->name;
-            $rate->rate                   = (float) ($taxInfo->tax_percent ?? 0);
-            $rate->tax_percent            = $rate->rate;
-            $rate->taxprofile_name        = (string) ($taxInfo->taxprofile_name ?? '');
-            $ratesets[]                   = $rate;
+        foreach (self::getAllTaxRatesForGeozone($taxprofileId, $geozoneIds) as $taxInfo) {
+            $rate                        = new \stdClass();
+            $rate->j2commerce_taxrate_id = (int) ($taxInfo->j2commerce_taxrate_id ?? 0);
+            $rate->name                  = (string) ($taxInfo->taxrate_name ?? '');
+            $rate->taxrate_name          = $rate->name;
+            $rate->rate                  = (float) ($taxInfo->tax_percent ?? 0);
+            $rate->tax_percent           = $rate->rate;
+            $rate->taxprofile_name       = (string) ($taxInfo->taxprofile_name ?? '');
+            $ratesets[]                  = $rate;
         }
 
         $event = J2CommerceHelper::plugin()->event('AfterGetTaxRateItems', [


### PR DESCRIPTION
Root Cause                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                               
  TaxHelper::getTaxRateForGeozone() used $db->setQuery($query, 0, 1) (LIMIT 1), so it returned only one tax rate — the first one ordered by tr.ordering. When a local customer's address matches two geozones (e.g., a state geozone → 6.25% and a city geozone → 2%), only the state rate was 
  ever returned. The local rate was silently dropped.                                                                                                                                                                                                                                        

  What was changed — TaxHelper.php:

  1. New getAllTaxRatesForGeozone() — same query as before but with no LIMIT, returns \stdClass[] (all matching rows).
  2. getTaxRateForGeozone() refactored — now delegates to getAllTaxRatesForGeozone() and returns $rows[0] ?? null, preserving its existing ?stdClass signature so callers like getTaxProfileInfo() (shipping tax display) are unaffected.
  3. getTaxRatesForProfile() fixed — now iterates all rows from getAllTaxRatesForGeozone() instead of processing a single result, so both state (6.25%) and local (2%) rates are added to $ratesets and flow through to calculateTotals().

  No other files needed changes — CartOrder::calculateTotals() already iterates the full $ratesets array and tracks each rate individually, so it works correctly once the rate-resolution layer returns both rates.