### PR TITLE
fix(customfield): correct save2copy task match + unique namekey on copy

### DIFF
--- a/administrator/components/com_j2commerce/src/Model/CustomfieldModel.php
+++ b/administrator/components/com_j2commerce/src/Model/CustomfieldModel.php
@@ -292,9 +292,13 @@ class CustomfieldModel extends AdminModel
         // For save2copy: generate a unique field_namekey to avoid UNIQUE constraint violation
         $task = Factory::getApplication()->getInput()->get('task', '', 'cmd');
 
-        if ($task === 'customfield.save2copy' && !empty($data['field_namekey'])) {
+        if ($task === 'save2copy' && !empty($data['field_namekey'])) {
             $data['j2commerce_customfield_id'] = 0;
-            $data['field_namekey']             = $this->generateUniqueNamekey($data['field_namekey']);
+
+            $avoidAddressColumn = ($data['field_table'] ?? '') === 'address'
+                && !\in_array($data['field_type'] ?? '', ['customtext', 'multiuploader'], true);
+
+            $data['field_namekey'] = $this->generateUniqueNamekey($data['field_namekey'], $avoidAddressColumn);
         }
 
         // Consolidate zone dropdown values into field_default
@@ -385,7 +389,13 @@ class CustomfieldModel extends AdminModel
             isset($data['field_type']) && $data['field_type'] !== 'customtext' && $data['field_type'] !== 'multiuploader' &&
             !empty($data['field_namekey'])) {
 
-            $this->addAddressColumn($data['field_namekey']);
+            try {
+                $this->addAddressColumn($data['field_namekey']);
+            } catch (\RuntimeException $e) {
+                $this->setError($e->getMessage());
+
+                return false;
+            }
         }
 
         // Sync plugin area toggles into field_display JSON before saving
@@ -506,11 +516,15 @@ class CustomfieldModel extends AdminModel
         }
     }
 
-    protected function generateUniqueNamekey(string $baseKey): string
+    protected function generateUniqueNamekey(string $baseKey, bool $avoidAddressColumn = false): string
     {
         $db        = $this->getDatabase();
         $candidate = $baseKey . '_copy';
         $i         = 1;
+
+        // Orphaned columns can linger after a field is deleted, so address-field copies
+        // must also skip any namekey that already exists as an addresses column.
+        $addressColumns = $avoidAddressColumn ? $db->getTableColumns('#__j2commerce_addresses') : [];
 
         while (true) {
             $query = $db->getQuery(true)
@@ -520,7 +534,7 @@ class CustomfieldModel extends AdminModel
                 ->bind(':namekey', $candidate);
             $db->setQuery($query);
 
-            if ((int) $db->loadResult() === 0) {
+            if ((int) $db->loadResult() === 0 && !isset($addressColumns[$candidate])) {
                 return $candidate;
             }
 


### PR DESCRIPTION
## Summary
Fixes #1136

Save-as-copy on a custom field threw a PHP fatal ("A column with this name already exists in the addresses table") and, on plain fields, a duplicate-key error ("Duplicate entry '…' for key 'field_namekey'").

## Root Cause
`CustomfieldModel::save()` gated its unique-namekey regeneration on `$task === 'customfield.save2copy'`. The dispatched input task carries **no controller prefix** — it is bare `save2copy` (matching the proven pattern already used in `CouponModel`/`VoucherModel`). The condition never matched, so the original `field_namekey` was kept on copy:
- plain fields → UNIQUE-index violation on `field_namekey`
- address fields → `addAddressColumn()` hit an existing column and threw an **uncaught** `RuntimeException` (fatal error page)

## Changes
- Fix the task match: `'customfield.save2copy'` → `'save2copy'` (the core fix).
- `generateUniqueNamekey()` now also skips namekeys that already exist as orphaned columns in `#__j2commerce_addresses` (columns are not dropped when a field is deleted, so they drift out of sync with the customfields table). Gated by a new `$avoidAddressColumn` flag passed only for address-table field types.
- Wrap the `addAddressColumn()` call in `try/catch` → `setError()` + `return false`, so any residual collision surfaces a clean enqueued message instead of a fatal page.

Copies advance through `_copy`, `_copy2`, … (column names are `[a-z0-9_]` only, so the `_copyN` scheme is used rather than Joomla's `-2` alias dash).

## Testing
1. Admin → J2Commerce → Custom Fields.
2. Edit a plain field (e.g. `annual_revenue`, no `field_table`) → Save as Copy → saves as `annual_revenue_copy`, no duplicate error.
3. Save as Copy again → `annual_revenue_copy2`.
4. Repeat on an address-table field → `…_copy`, new column added, no fatal.
5. Normal Save / Save & New unaffected.

## Files Changed
- `administrator/components/com_j2commerce/src/Model/CustomfieldModel.php` — save2copy task match, address-column-aware unique namekey, fatal-to-clean-error guard.