### PR TITLE
fix(checkout): remove duplicate label on floating-style phone field

### DIFF
--- a/administrator/components/com_j2commerce/src/Helper/CustomFieldHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/CustomFieldHelper.php
@@ -1093,15 +1093,14 @@ class CustomFieldHelper
 
         // UIkit has no form-floating; stacked-label fallback.
         if ($isFloating && !$isUikit) {
-            return '<div class="form-normal">'
-                . '<label for="' . $id . '" class="form-label">' . $labelHtml . '</label>'
-                . '<div class="' . $cls . '"' . $groupAttrs . '>'
+            // Floating style: only the inner form-floating label, no standalone top
+            // label, to match the other field types (text/email/number/etc.).
+            return '<div class="' . $cls . '"' . $groupAttrs . '>'
                 . $hiddenInput
                 . ($isSingleCountry ? $countryStatic : $countryBtn)
                 . '<div class="form-floating flex-grow-1">'
                 . $nationalInput
                 . '<label>' . $labelHtml . '</label>'
-                . '</div>'
                 . '</div>'
                 . '</div>';
         }


### PR DESCRIPTION
## Summary
Fixes #1135

Under the **Floating Label** checkout field style, the telephone custom field rendered an extra standalone label above the input, so the phone field stood out compared to the other fields (which show only their floating label).

## Root Cause
`CustomFieldHelper::renderTelephoneField()`'s Bootstrap floating branch wrapped the field in a `form-normal` div and emitted a standalone `<label class="form-label">` in addition to the inner `.form-floating` label. Every other field type's floating branch emits only the `.form-floating` label.

## Changes
- Drop the `form-normal` wrapper and the redundant top `<label>` from the telephone floating branch, leaving just the input-group with the inner `.form-floating` (national input + its floating label) — matching the text/email/number floating output.
- UIkit branch, `none`-mode branch, and normal-style branch unchanged.

## Testing
1. Admin → J2Commerce config → Checkout Field Style = Floating Label.
2. Address has a Phone (telephone) custom field.
3. Frontend checkout (Bootstrap 5 template) → phone field shows only the floating label, no extra static label above it.
4. Switch style back to Normal → phone label renders normally (regression check).
5. Phone "none" mode and single-country layouts still render correctly.

## Files Changed
- `administrator/components/com_j2commerce/src/Helper/CustomFieldHelper.php` — telephone floating-label branch markup.