### PR TITLE
fix(checkout): remove double parens on optional field indicator

### DIFF
--- a/administrator/components/com_j2commerce/src/Helper/CustomFieldHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/CustomFieldHelper.php
@@ -370,9 +370,9 @@ class CustomFieldHelper
             }
         } elseif (!$required && $requiredIndicator === 'optional') {
             if ($isUikit) {
-                $labelHtml .= ' <small class="uk-text-muted">(' . Text::_('COM_J2COMMERCE_OPTIONAL') . ')</small>';
+                $labelHtml .= ' <small class="uk-text-muted">' . Text::_('COM_J2COMMERCE_OPTIONAL') . '</small>';
             } else {
-                $labelHtml .= ' <small class="text-body-secondary">(' . Text::_('COM_J2COMMERCE_OPTIONAL') . ')</small>';
+                $labelHtml .= ' <small class="text-body-secondary">' . Text::_('COM_J2COMMERCE_OPTIONAL') . '</small>';
             }
         }
 


### PR DESCRIPTION
## Summary
Fixes #1138

Non-required checkout custom fields showed `((optional))` instead of `(optional)` — double parentheses.

## Root Cause
`CustomFieldHelper::renderField()` wrapped `Text::_('COM_J2COMMERCE_OPTIONAL')` in a literal `(...)`, but the frontend language value already includes its own parentheses (`(optional)`, `(facultatif)`, `（任意）`, …). The two stacked, producing `((optional))` — and double brackets on CJK locales.

## Changes
- Remove the literal `(` `)` around the OPTIONAL string in both the UIkit and Bootstrap branches, letting the language string own the parentheses. Fixes every locale at once; no `.ini` files changed.

## Testing
1. Admin → J2Commerce config → checkout required indicator = "Optional".
2. Frontend checkout (Bootstrap 5) with a non-required custom field → label shows `Field (optional)`, single parens.
3. UIkit template → same single-parens result.
4. Non-English locale → single parens, no double brackets.

## Files Changed
- `administrator/components/com_j2commerce/src/Helper/CustomFieldHelper.php` — drop code-side parens on the optional indicator.