### PR TITLE
fix(product): option price stops updating when product shown twice (fixes #1133)

### DIFF
--- a/media/com_j2commerce/js/site/j2commerce.js
+++ b/media/com_j2commerce/js/site/j2commerce.js
@@ -24,6 +24,7 @@ const J2Commerce = {
         this.initRadioOptionLabels();
         this.initShippingSameAsBilling();
         this.initConfigurableDefaults();
+        this.initVariantDeepLink();
         this.equalizeHeights();
         let _eqTimer;
         window.addEventListener('resize', () => {
@@ -359,6 +360,21 @@ const J2Commerce = {
         return undefined;
     },
 
+    // Resolve the element that triggered an inline onchange/onclick handler.
+    // Prefer the live event target so duplicate IDs — which occur when the same
+    // product is rendered twice on a page (detail/list view + a products module)
+    // — resolve to the instance the user actually interacted with, not the first
+    // match in the document. Falls back to ID lookup for programmatic callers.
+    resolveTriggerElement(elementId) {
+        if (elementId instanceof Element) return elementId;
+
+        const evt = window.event;
+        if (evt && evt.target instanceof Element) return evt.target;
+
+        const cleanId = String(elementId).replace(/^#/, '');
+        return document.getElementById(cleanId) || document.querySelector(`[id="${cleanId}"]`);
+    },
+
     /**
      * Handle AJAX filter for product options
      * @param {string} povId - Product option value ID
@@ -367,9 +383,7 @@ const J2Commerce = {
      * @param {string} elementId - Triggering element ID
      */
     async doAjaxFilter(povId, productId, poId, elementId) {
-        // Strip leading # — templates pass CSS selectors but getElementById expects bare IDs
-        const cleanId = elementId.startsWith('#') ? elementId.slice(1) : elementId;
-        const element = document.getElementById(cleanId) || document.querySelector(`[id="${cleanId}"]`);
+        const element = this.resolveTriggerElement(elementId);
         if (!element) return;
 
         const form = element.closest('form');
@@ -377,7 +391,11 @@ const J2Commerce = {
 
         // Resolve the child-options container. Keep the current set visible (dimmed,
         // height reserved) while the new set loads — no eager wipe, so no layout collapse.
-        const childContainer = document.getElementById(`ChildOptions${poId}`)
+        // Scope to the triggering form first so the correct instance is updated when
+        // the same product is rendered twice on a page (duplicate IDs).
+        const childContainer = form.querySelector(`[id="ChildOptions${poId}"]`)
+            || form.querySelector(`[id="child-ChildOptions${poId}"]`)
+            || document.getElementById(`ChildOptions${poId}`)
             || document.getElementById(`child-ChildOptions${poId}`);
         if (childContainer) {
             this.setChildLoading(childContainer, true);
@@ -643,13 +661,64 @@ const J2Commerce = {
         });
     },
 
+    // On page load, honour a ?variant_id=N deep link on the product detail page
+    // by pre-selecting the options that make up that variant. When the param is
+    // absent or does not belong to the product, the server-rendered default
+    // selection is left untouched.
+    initVariantDeepLink() {
+        const requestedVariant = new URLSearchParams(window.location.search).get('variant_id');
+        if (!requestedVariant || !/^\d+$/.test(requestedVariant)) return;
+
+        document.querySelectorAll('form[data-product_variants]').forEach(form => {
+            let variants;
+            try {
+                variants = JSON.parse(form.dataset.product_variants || '{}');
+            } catch (e) {
+                return;
+            }
+
+            // The variant map is keyed by variant id; the value is the
+            // comma-separated option-value combination for that variant.
+            const combination = variants[requestedVariant];
+            if (combination === undefined) return;
+
+            const productId = form.dataset.product_id ?? form.dataset.productId;
+            const povIds = String(combination).split(',').filter(Boolean);
+
+            povIds.forEach(pov => {
+                const choice = form.querySelector('#option-value-' + CSS.escape(pov));
+                if (choice && (choice.type === 'radio' || choice.type === 'checkbox')) {
+                    choice.checked = true;
+                    return;
+                }
+
+                const select = Array.from(form.querySelectorAll('select'))
+                    .find(s => s.querySelector('option[value="' + CSS.escape(pov) + '"]'));
+                if (select) select.value = pov;
+            });
+
+            const variantInput = form.querySelector('input[name="variant_id"]');
+            if (variantInput) variantInput.value = requestedVariant;
+
+            // Re-sync price, SKU, image and stock for the deep-linked variant via
+            // the existing update path (recomputes the variant from the inputs).
+            const firstOption = form.querySelector('[id^="option-"]');
+            if (firstOption && productId) {
+                this.doAjaxPrice(productId, firstOption.id);
+            }
+
+            this.initRadioOptionLabels();
+            this.initColorOptionLabels();
+        });
+    },
+
     /**
      * Handle AJAX price update
      * @param {number} productId - Product ID
      * @param {string} elementId - Triggering element ID
      */
     async doAjaxPrice(productId, elementId) {
-        const element = document.getElementById(elementId) || document.querySelector(`[id="${elementId}"]`);
+        const element = this.resolveTriggerElement(elementId);
         if (!element) return;
 
         const form = element.closest('form');
@@ -731,7 +800,13 @@ const J2Commerce = {
      * @param {HTMLFormElement} form - The product form
      */
     updateProductDisplay(productId, response, form) {
-        const product = document.querySelector(`.j2commerce-product-${productId}`) || document.querySelector(`.product-${productId}`);
+        // Resolve the container from the triggering form first so the correct
+        // instance updates when the same product appears twice on a page (e.g.
+        // detail/list view + a products module). Fall back to the global lookup
+        // for callers with no form context.
+        const product = (form && (form.closest(`.j2commerce-product-${productId}`) || form.closest(`.product-${productId}`)))
+            || document.querySelector(`.j2commerce-product-${productId}`)
+            || document.querySelector(`.product-${productId}`);
         if (!product || response.error) return;
 
         // SKU — detail uses .sku, list uses .sku-value
@@ -806,7 +881,7 @@ const J2Commerce = {
         // Main image — skip legacy swap if variant gallery handled by Swiper
         if (response.main_image && !response.variant_gallery?.length) {
             const mainImages = [
-                document.querySelector(`.j2commerce-product-main-image-${productId}`),
+                product.querySelector(`.j2commerce-product-main-image-${productId}`),
                 product.querySelector('.j2commerce-mainimage .j2commerce-img-responsive'),
                 product.querySelector('.j2commerce-product-additional-images .additional-mainimage')
             ];


### PR DESCRIPTION
## Summary
Fixes #1133

When the same variable product is rendered twice on one page (its detail/list view **and** a `mod_j2commerce_products` instance showing the same product), selecting options no longer updated the price for that product — in either copy. The other copy's Add-to-Cart button also flickered. No console error.

## Root cause
Duplicate DOM. Two copies of the same product produce duplicate element IDs and duplicate `.j2commerce-product-{id}` containers. The option-change JS resolved everything globally by ID/class:
- Inline handlers pass a non-instance-unique id string (`doAjaxPrice(5, 'option-12')`).
- `doAjaxPrice`/`doAjaxFilter` did `getElementById(elementId)` → first match → read the **wrong instance's form** → recomputed an unchanged variant.
- `updateProductDisplay` did `document.querySelector('.j2commerce-product-{id}')` → wrote to the first instance only.

Net: the instance the user touched never updated; the *other* instance's submit button toggled disabled→enabled (the flicker).

## Changes
- New `resolveTriggerElement()` — prefers the live `event.target` (the element the user actually interacted with) so duplicate IDs resolve to the correct instance; falls back to ID lookup for programmatic callers.
- `doAjaxFilter` / `doAjaxPrice` — resolve the element via the helper, so `element.closest('form')` is the correct instance form.
- `doAjaxFilter` child-options container — scoped to the triggering form first, global fallback.
- `updateProductDisplay` — container resolved from the triggering form first (`form.closest('.j2commerce-product-{id}')`), global fallback; main-image swap scoped to that container.

Single-file JS fix; no template churn. Fallbacks preserve existing behavior wherever no event context exists.

## Testing
1. Admin → create a `mod_j2commerce_products` instance showing variable products with option selection enabled; assign to a page.
2. **Detail + module:** open product A's detail page where the module also shows A. Change options in detail → detail price updates; change in module → module price updates. Neither flickers the other's Add-to-Cart.
3. **List + module:** open a category/list page that also shows A in the module. Change options in the list item and in the module → each updates its own price independently.

## Files Changed
- `media/com_j2commerce/js/site/j2commerce.js` — instance-scoped option/price AJAX resolution