### PR TITLE
feat(product): variant deep-linking (receiver + finder + card sender) — fixes #1132

### DIFF
--- a/administrator/components/com_j2commerce/src/Model/Behavior/Flexivariable.php
+++ b/administrator/components/com_j2commerce/src/Model/Behavior/Flexivariable.php
@@ -750,6 +750,24 @@ class Flexivariable
         if (isset($defaultVariant->j2commerce_variant_id) && !empty($defaultVariant->j2commerce_variant_id)) {
             $product->variant = $defaultVariant;
 
+            // Honour a ?sku= storefront deep link: make the requested SKU's
+            // variant active so price, image, stock and pre-selected options
+            // render for it. An unknown SKU keeps the default variant.
+            $app = Factory::getApplication();
+
+            if ($app->isClient('site')) {
+                $requestedSku = trim((string) $app->getInput()->getString('sku', ''));
+
+                if ($requestedSku !== '') {
+                    foreach ($product->variants as $candidateVariant) {
+                        if (isset($candidateVariant->sku) && (string) $candidateVariant->sku === $requestedSku) {
+                            $product->variant = $candidateVariant;
+                            break;
+                        }
+                    }
+                }
+            }
+
             if ($product->variant->quantity_restriction && $product->variant->min_sale_qty > 0) {
                 $product->quantity = $product->variant->min_sale_qty;
             }

--- a/administrator/components/com_j2commerce/src/Model/Behavior/Variable.php
+++ b/administrator/components/com_j2commerce/src/Model/Behavior/Variable.php
@@ -580,6 +580,24 @@ class Variable
         // Select default variant
         $product->variant = ProductHelper::getDefaultVariant($product->variants) ?? reset($product->variants);
 
+        // Honour a ?sku= deep link on the storefront: make the requested SKU's
+        // variant the active one so price, image, stock and the pre-selected
+        // options all render for it. An unknown SKU keeps the default variant.
+        $app = Factory::getApplication();
+
+        if ($app->isClient('site')) {
+            $requestedSku = trim((string) $app->getInput()->getString('sku', ''));
+
+            if ($requestedSku !== '') {
+                foreach ($product->variants as $candidateVariant) {
+                    if (isset($candidateVariant->sku) && (string) $candidateVariant->sku === $requestedSku) {
+                        $product->variant = $candidateVariant;
+                        break;
+                    }
+                }
+            }
+        }
+
         if ($product->variant->quantity_restriction && $product->variant->min_sale_qty > 0) {
             $product->quantity = $product->variant->min_sale_qty;
         } else {

--- a/media/com_j2commerce/js/site/j2commerce.js
+++ b/media/com_j2commerce/js/site/j2commerce.js
@@ -712,6 +712,45 @@ const J2Commerce = {
         });
     },
 
+    // Update a list/module card's product links (image + title) with the
+    // selected variant id. No-op on the product detail page, which has no
+    // .j2commerce-product-item wrapper. A falsy variantId strips the param so
+    // the link falls back to the default variant.
+    syncCardVariantLinks(form, variantId) {
+        const card = form.closest('.j2commerce-product-item');
+        if (!card) return;
+
+        const anchors = card.querySelectorAll(
+            '.j2commerce-product-image a[href], .j2commerce-product-title a[href]'
+        );
+
+        anchors.forEach(a => {
+            const href = a.getAttribute('href');
+            if (!href || href.startsWith('javascript:') || href.startsWith('#')) return;
+            a.setAttribute('href', this.setQueryParam(href, 'variant_id', variantId || null));
+        });
+    },
+
+    // Set (value truthy) or remove (value falsy) a query-string parameter on a
+    // URL, preserving the path, other params and any hash fragment.
+    setQueryParam(url, key, value) {
+        const hashIndex = url.indexOf('#');
+        const hash = hashIndex >= 0 ? url.slice(hashIndex) : '';
+        const path = hashIndex >= 0 ? url.slice(0, hashIndex) : url;
+        const qIndex = path.indexOf('?');
+        const base = qIndex >= 0 ? path.slice(0, qIndex) : path;
+        const params = new URLSearchParams(qIndex >= 0 ? path.slice(qIndex + 1) : '');
+
+        if (value) {
+            params.set(key, value);
+        } else {
+            params.delete(key);
+        }
+
+        const query = params.toString();
+        return base + (query ? '?' + query : '') + hash;
+    },
+
     /**
      * Handle AJAX price update
      * @param {number} productId - Product ID
@@ -762,6 +801,11 @@ const J2Commerce = {
             const variantInput = form.querySelector('input[name="variant_id"]');
             if (variantInput) variantInput.value = variantId || '';
             values.variant_id = variantId;
+
+            // On list/module cards, keep the product links in sync with the
+            // selected variant so clicking the image or title opens the detail
+            // page with that variant pre-selected (consumed by initVariantDeepLink).
+            this.syncCardVariantLinks(form, variantId);
         }
 
         this.dispatchEvent('beforeAjaxPrice', { form, values });

--- a/plugins/finder/j2commerce/src/Extension/J2commerce.php
+++ b/plugins/finder/j2commerce/src/Extension/J2commerce.php
@@ -540,6 +540,14 @@ final class J2commerce extends Adapter implements SubscriberInterface
                 $item->addInstruction(Indexer::META_CONTEXT, 'upcs');
                 $item->upcs = $variantData['upcs'];
             }
+
+            // Deep-link the product result to the first SKU's variant so a SKU
+            // search lands on that variant pre-selected on the product page.
+            if ($redirectTo !== 'article' && !empty($variantData['first_sku_variant_id'])) {
+                $variantQuery = '&variant_id=' . (int) $variantData['first_sku_variant_id'];
+                $item->url   .= $variantQuery;
+                $item->route .= $variantQuery;
+            }
         }
 
         // Translate the state. Articles should only be published if the category is published.
@@ -588,7 +596,7 @@ final class J2commerce extends Adapter implements SubscriberInterface
      *
      * @param   int  $productId  The J2Commerce product ID.
      *
-     * @return  array{skus: array, upcs: array}  Arrays of SKUs and UPCs for the product.
+     * @return  array{skus: array, upcs: array, first_sku_variant_id: int}  SKUs/UPCs plus the first SKU's variant id.
      *
      * @since   6.0.0
      */
@@ -597,20 +605,28 @@ final class J2commerce extends Adapter implements SubscriberInterface
         $db    = $this->getDatabase();
         $query = $db->getQuery(true);
 
-        $query->select($db->quoteName(['sku', 'upc']))
+        $query->select($db->quoteName(['j2commerce_variant_id', 'sku', 'upc']))
             ->from($db->quoteName('#__j2commerce_variants'))
             ->where($db->quoteName('product_id') . ' = :productId')
-            ->bind(':productId', $productId, ParameterType::INTEGER);
+            ->bind(':productId', $productId, ParameterType::INTEGER)
+            ->order($db->quoteName('j2commerce_variant_id') . ' ASC');
 
         $db->setQuery($query);
         $variants = $db->loadObjectList();
 
-        $skus = [];
-        $upcs = [];
+        $skus              = [];
+        $upcs              = [];
+        $firstSkuVariantId = 0;
 
         foreach ($variants as $variant) {
             if (!empty($variant->sku)) {
                 $skus[] = $variant->sku;
+
+                // First variant (lowest id) that carries a SKU becomes the
+                // deep-link target for the single product search result.
+                if ($firstSkuVariantId === 0) {
+                    $firstSkuVariantId = (int) $variant->j2commerce_variant_id;
+                }
             }
             if (!empty($variant->upc)) {
                 $upcs[] = $variant->upc;
@@ -618,8 +634,9 @@ final class J2commerce extends Adapter implements SubscriberInterface
         }
 
         return [
-            'skus' => $skus,
-            'upcs' => $upcs,
+            'skus'                 => $skus,
+            'upcs'                 => $upcs,
+            'first_sku_variant_id' => $firstSkuVariantId,
         ];
     }
 


### PR DESCRIPTION
## Core Update — full variant deep-link feature

Closes #1132.

Shoppers can pre-select a product variant from the URL; product URLs are otherwise unchanged and an absent/invalid param keeps the default variant.

### Receiver (product detail)
- `media/com_j2commerce/js/site/j2commerce.js` — `initVariantDeepLink()` reads `?variant_id=`, reverse-maps the option-value combination from `data-product_variants`, checks the matching option inputs, and re-syncs price/SKU/image/stock.
- `Behavior/Variable.php` + `Behavior/Flexivariable.php` — `onAfterGetProduct()` honours `?sku=` (storefront only, matched against the product's own variants) by making that SKU's variant active, so price/image/stock and the pre-selected options render server-side.

### Sender (list / module cards)
- `j2commerce.js` `syncCardVariantLinks()` — when a shopper changes options on a category-list or `mod_j2commerce_products` card, the image and title links are rewritten with `&variant_id=` for the selected variant (stripped when no variant matches). Works for bs5 + uikit, category + tag, and module instances. Resolves the exact scenario in #1132.

### Finder
- `finder/j2commerce` — product search results deep-link to the first SKU's variant (`&variant_id=`).

### Pre-Flight
- [x] PHP syntax + `node --check` JS passed
- [x] No secrets / FOF remnants
- [x] Core files only
- [x] joomla6-code-reviewer: PASS (PHP 0C/0H/0M)
