### PR TITLE
fix(core): GeoZone field defaults to All (empty) not first geozone

### DIFF
--- a/administrator/components/com_j2commerce/src/Field/GeozoneField.php
+++ b/administrator/components/com_j2commerce/src/Field/GeozoneField.php
@@ -33,6 +33,10 @@ class GeozoneField extends ListField
     {
         $options = parent::getOptions();
 
+        // Empty value = no geozone restriction (available everywhere). Listed first
+        // so a freshly saved form defaults to "All" instead of the first geozone.
+        array_unshift($options, HTMLHelper::_('select.option', '', Text::_('JALL')));
+
         try {
             $db = Factory::getContainer()->get(DatabaseInterface::class);
 


### PR DESCRIPTION
## Core Update

### Changes
The `GeoZone` custom form field (`administrator/components/com_j2commerce/src/Field/GeozoneField.php`) had no leading empty option. With `default=""` on the XML field but no matching `value=""` option in the dropdown, the browser auto-selected the **first geozone** in the list. Saving a payment/shipping plugin then silently restricted it to that zone — there was no way to keep a method available everywhere.

**Fix:** prepend an empty-value option labelled **"All"** (core `JALL` string, always loaded on the com_plugins edit page):

```php
array_unshift($options, HTMLHelper::_('select.option', '', Text::_('JALL')));
```

Empty value casts to `geozone_id` `0`, which `CheckoutController` already treats as *"available everywhere"* (`CheckoutController.php:1118-1123`). Applies to every `type="GeoZone"` field (payment/shipping plugins + tax rates) — single core fix, no per-extension change.

### Files Modified
| Type | Count |
|------|-------|
| PHP files | 1 |
| JS/CSS assets | 0 |
| Language files | 0 |
| XML/Config | 0 |

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Code style (php-cs-fixer) passed
- [x] Core files only (non-core excluded)