### PR TITLE
fix(inventory): Stock Status reflects actual shopper-facing status

### DIFF
--- a/administrator/components/com_j2commerce/src/Model/InventoryModel.php
+++ b/administrator/components/com_j2commerce/src/Model/InventoryModel.php
@@ -124,6 +124,7 @@ class InventoryModel extends ListModel
                 'pq.sold, ' .
                 'v.manage_stock, ' .
                 'v.availability, ' .
+                'v.allow_backorder, ' .
                 'v.j2commerce_variant_id, ' .
                 'v.sku, ' .
                 'pq.variant_id'
@@ -225,8 +226,13 @@ class InventoryModel extends ListModel
                 // Set default values for null fields
                 $item->quantity     = $item->quantity ?? 0;
                 $item->manage_stock = $item->manage_stock ?? 0;
-                $item->availability = $item->availability ?? 1;
                 $item->has_options  = $item->has_options ?? 0;
+
+                // Reflect the shopper-facing stock status, not the raw column.
+                // Storefront rule (ProductHelper::validateVariableProduct): when stock
+                // is not managed the item is always sellable; when managed it is in
+                // stock only if availability is set or backorders are allowed.
+                $item->availability = $this->resolveStockStatus($item);
 
                 // Add SKU field to item if not present
                 if (!isset($item->sku)) {
@@ -244,6 +250,31 @@ class InventoryModel extends ListModel
         }
 
         return $items;
+    }
+
+    /**
+     * Resolve the shopper-facing stock status for the inventory select.
+     *
+     * Mirrors the storefront rule (ProductHelper::validateVariableProduct):
+     * unmanaged stock is always in stock; managed stock is in stock only when
+     * availability is set or backorders are allowed.
+     *
+     * @param   object  $row  Product/variant row with manage_stock, availability, allow_backorder.
+     *
+     * @return  int  1 = in stock, 0 = out of stock.
+     *
+     * @since   6.0.0
+     */
+    private function resolveStockStatus(object $row): int
+    {
+        if ((int) ($row->manage_stock ?? 0) !== 1) {
+            return 1;
+        }
+
+        $available = !empty($row->availability);
+        $backorder = (int) ($row->allow_backorder ?? 0) >= 1;
+
+        return ($available || $backorder) ? 1 : 0;
     }
 
     /**
@@ -598,6 +629,7 @@ class InventoryModel extends ListModel
                 'v.sku',
                 'v.manage_stock',
                 'v.availability',
+                'v.allow_backorder',
                 'v.is_master',
                 'pq.quantity',
                 'pq.on_hold',
@@ -620,9 +652,9 @@ class InventoryModel extends ListModel
                 foreach ($variants as $variant) {
                     $variant->quantity     = $variant->quantity ?? 0;
                     $variant->manage_stock = $variant->manage_stock ?? 0;
-                    $variant->availability = $variant->availability ?? 1;
                     $variant->on_hold      = $variant->on_hold ?? 0;
                     $variant->sold         = $variant->sold ?? 0;
+                    $variant->availability = $this->resolveStockStatus($variant);
                 }
             }
 


### PR DESCRIPTION
## Summary
Fixes #1147

The admin Inventory view's **Stock Status** select did not reflect a product/variant's real stock state — it almost always showed **In Stock**, so the client never realised many products were out of stock on the storefront.

## Root cause
`InventoryModel::getItems()` (and `getProductVariants()`) coerced the `availability` value with `?? 1`. The `availability` column has **no DB default**, so every product whose availability was never explicitly set is `NULL` — and `NULL ?? 1` rendered it as **In Stock**. Meanwhile the storefront treats empty/`NULL` availability (for managed stock) as **out of stock**, producing the mismatch.

## Changes
- Removed the `availability ?? 1` fabrication in `getItems()` and `getProductVariants()`.
- Added `resolveStockStatus()` which derives the displayed status the same way the storefront does (`ProductHelper::validateVariableProduct`):
  - **not managing stock** → always In Stock
  - **managing stock** → In Stock only if `availability` is set **or** backorders are allowed, else Out of Stock
- Added `v.allow_backorder` to the list + variant queries so the backorder case is evaluated correctly.

No template or language changes.

## Testing
1. Admin → `index.php?option=com_j2commerce&view=inventory`.
2. Managed-stock product with unset/0 availability → now shows **Out of Stock** (was In Stock), matching the storefront.
3. **Manage Stock = No** product → still **In Stock** (storefront always sells it).
4. Managed product with **Backorder allowed** + availability 0 → **In Stock**.
5. Variant rows follow the same logic; changing a select + Save persists correctly.

## Files Changed
- `administrator/components/com_j2commerce/src/Model/InventoryModel.php`

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Code style (php-cs-fixer) passed
- [x] Core file only