### PR TITLE
fix(core): Geozone field type case so dropdown (incl. "All") loads on Linux

### DIFF
--- a/administrator/components/com_j2commerce/forms/taxrate.xml
+++ b/administrator/components/com_j2commerce/forms/taxrate.xml
@@ -31,7 +31,7 @@
 
         <field
             name="geozone_id"
-            type="GeoZone"
+            type="Geozone"
             label="COM_J2COMMERCE_FIELD_GEOZONE"
             description="COM_J2COMMERCE_FIELD_GEOZONE_DESC"
             required="true"

--- a/administrator/components/com_j2commerce/src/Field/GeozoneField.php
+++ b/administrator/components/com_j2commerce/src/Field/GeozoneField.php
@@ -27,7 +27,7 @@ use Joomla\Database\DatabaseInterface;
  */
 class GeozoneField extends ListField
 {
-    protected $type = 'GeoZone';
+    protected $type = 'Geozone';
 
     public function getOptions(): array
     {

--- a/plugins/j2commerce/payment_banktransfer/payment_banktransfer.xml
+++ b/plugins/j2commerce/payment_banktransfer/payment_banktransfer.xml
@@ -157,7 +157,7 @@
 
                 <field
                     name="geozone_id"
-                    type="GeoZone"
+                    type="Geozone"
                     default=""
                     label="COM_J2COMMERCE_GEOZONE_RESTRICTION"
                     description="COM_J2COMMERCE_GEOZONE_RESTRICTION_DESC"

--- a/plugins/j2commerce/payment_cash/payment_cash.xml
+++ b/plugins/j2commerce/payment_cash/payment_cash.xml
@@ -156,7 +156,7 @@
 
                 <field
                     name="geozone_id"
-                    type="GeoZone"
+                    type="Geozone"
                     default=""
                     label="COM_J2COMMERCE_GEOZONE_RESTRICTION"
                     description="COM_J2COMMERCE_GEOZONE_RESTRICTION_DESC"

--- a/plugins/j2commerce/payment_moneyorder/payment_moneyorder.xml
+++ b/plugins/j2commerce/payment_moneyorder/payment_moneyorder.xml
@@ -159,7 +159,7 @@
 
                 <field
                     name="geozone_id"
-                    type="GeoZone"
+                    type="Geozone"
                     default=""
                     label="COM_J2COMMERCE_GEOZONE_RESTRICTION"
                     description="COM_J2COMMERCE_GEOZONE_RESTRICTION_DESC"

--- a/plugins/j2commerce/payment_paypal/payment_paypal.xml
+++ b/plugins/j2commerce/payment_paypal/payment_paypal.xml
@@ -268,7 +268,7 @@
 
                 <field
                     name="geozone_id"
-                    type="GeoZone"
+                    type="Geozone"
                     default=""
                     label="COM_J2COMMERCE_GEOZONE_RESTRICTION"
                     description="COM_J2COMMERCE_GEOZONE_RESTRICTION_DESC"

--- a/plugins/j2commerce/shipping_free/shipping_free.xml
+++ b/plugins/j2commerce/shipping_free/shipping_free.xml
@@ -74,7 +74,7 @@
 
                 <field
                     name="geozones"
-                    type="GeoZone"
+                    type="Geozone"
                     multiple="true"
                     label="COM_J2COMMERCE_GEOZONE_RESTRICTION"
                     description="COM_J2COMMERCE_GEOZONE_RESTRICTION_DESC"


### PR DESCRIPTION
## Problem
On Linux (case-sensitive filesystem) the **Geozone** dropdown either fails to load or renders the geozone list **without the \"All\" (no restriction) option**. Windows/macOS are unaffected.

## Root cause
The field class/file is `GeozoneField` / `GeozoneField.php` (lowercase **z**), but the form XMLs declare `type="GeoZone"` (capital **Z**). Joomla (`FormHelper::loadClass`) turns `type="GeoZone"` into class `GeoZoneField` → file `GeoZoneField.php`, which **does not exist** on a case-sensitive filesystem, so the namespaced field class never loads.

The field was previously named `GeoZoneField` (capital Z) and had **no** \"All\" option; it was later renamed to `GeozoneField` and gained `array_unshift(... Text::_('JALL'))`. On an install **updated** from the older release, the stale `GeoZoneField.php` lingers next to the new `GeozoneField.php` on Linux (two distinct filenames), and `type="GeoZone"` loads the **old** file → geozones render, \"All\" missing. On Windows/macOS the update overwrote the old file (same name, case-insensitive) so only the new field exists and \"All\" shows — which is why it only reproduces on Linux.

## Fix
Standardise every **core** reference to `type="Geozone"`, which resolves to the real `GeozoneField` class/file on every OS, and update the field's `$type` property to match.

## Files changed (7)
- `administrator/components/com_j2commerce/forms/taxrate.xml`
- `administrator/components/com_j2commerce/src/Field/GeozoneField.php` (`$type`)
- `plugins/j2commerce/payment_cash/payment_cash.xml`
- `plugins/j2commerce/payment_moneyorder/payment_moneyorder.xml`
- `plugins/j2commerce/payment_banktransfer/payment_banktransfer.xml`
- `plugins/j2commerce/payment_paypal/payment_paypal.xml`
- `plugins/j2commerce/shipping_free/shipping_free.xml`

## Testing
1. On a Linux site, open **J2Commerce → Tax → a Tax Rate** (and a core payment/shipping method's Geozone Restriction).
2. Verify the Geozone dropdown lists geozones **and** shows **\"All\"** first.

## Notes
- Verified XML well-formed + `php -l` clean on all 7 files.
- Non-core extensions (payment_adyen, payment_stripe, etc.) carry the same `type="GeoZone"` and need the same change in the extensions repo — tracked separately in j2commerce/j2commerce6extensions.
- Recommended follow-up: have the component update script delete a stale `administrator/components/com_j2commerce/src/Field/GeoZoneField.php` if present, so the dead old class can't be picked up by a case-insensitive `class_exists()` collision when a not-yet-fixed `type="GeoZone"` field renders on the same page.