### PR TITLE
fix(router): sub-category links 404 in Product Category List View

### DIFF
--- a/components/com_j2commerce/src/Helper/RouteHelper.php
+++ b/components/com_j2commerce/src/Helper/RouteHelper.php
@@ -185,10 +185,10 @@ abstract class RouteHelper
      *
      * Priority for category URLs:
      * 1. Single category menu (products view with catid matching this category)
-     * 2. Categories menu (categories view with ancestor hierarchy)
+     * 2. Products view for this category (the "Product Category List View")
      *
      * @param   int          $catid      The category ID (required)
-     * @param   int|null     $parentId   The parent category ID (optional, looked up if not provided)
+     * @param   int|null     $parentId   Deprecated/ignored — retained for backward compatibility
      * @param   string|null  $language   The language code
      *
      * @return  string  The category route URL
@@ -230,59 +230,18 @@ abstract class RouteHelper
             }
         }
 
-        // PRIORITY 2: No single category menu found - use category view with hierarchy
-        $link = 'index.php?option=com_j2commerce&view=category&id=' . $catid;
-
-        // Include parent category ID for proper hierarchy building
-        // This allows RouterView's StandardRules to build the path correctly
-        if ($parentId === null) {
-            // Look up the parent category ID
-            $parentId = self::getCategoryParentId($catid);
-        }
-
-        if ($parentId && $parentId > 1) {
-            $link .= '&catid=' . $parentId;
-        }
+        // PRIORITY 2: No single category menu found - route to the products view
+        // for this category. There is no standalone 'category' view in the frontend
+        // component; the products view ("Product Category List View") renders a
+        // category's product list (and its subcategories) from the catid, and the
+        // router resolves the best Itemid + SEF path for view=products&catid=X.
+        $link = 'index.php?option=com_j2commerce&view=products&catid=' . $catid;
 
         if (!empty($language) && $language !== '*' && Multilanguage::isEnabled()) {
             $link .= '&lang=' . $language;
         }
 
         return $link;
-    }
-
-    /**
-     * Get the parent category ID for a category.
-     *
-     * @param   int  $catid  The category ID
-     *
-     * @return  int|null  The parent category ID or null
-     *
-     * @since   6.0.0
-     */
-    private static function getCategoryParentId(int $catid): ?int
-    {
-        static $cache = [];
-
-        if (isset($cache[$catid])) {
-            return $cache[$catid];
-        }
-
-        $db    = \Joomla\CMS\Factory::getContainer()->get(\Joomla\Database\DatabaseInterface::class);
-        $query = $db->getQuery(true);
-
-        $query->select($db->quoteName('parent_id'))
-            ->from($db->quoteName('#__categories'))
-            ->where($db->quoteName('id') . ' = :catid')
-            ->where($db->quoteName('extension') . ' = ' . $db->quote('com_content'))
-            ->bind(':catid', $catid, \Joomla\Database\ParameterType::INTEGER);
-
-        $db->setQuery($query);
-        $result = $db->loadResult();
-
-        $cache[$catid] = $result ? (int) $result : null;
-
-        return $cache[$catid];
     }
 
     /**


### PR DESCRIPTION
## Summary
Fixes #1153

Sub-category links in the Product Category List View generated 404 errors. `RouteHelper::getCategoryRoute()` PRIORITY 2 built links to `view=category` (singular), which has **no view class or tmpl** in the frontend component (only `products`, `categories`, `categoryalias`, `product` exist; `DisplayController` default_view is `products` with no `category` mapping). Dispatching `view=category` → non-existent `...\View\Category\HtmlView` → 404, e.g. `/component/j2commerce/category/electronics?catid=44`.

The renderable "Product Category List View" is the **products** view, which lists a category's products from `catid`. The fix routes sub-category links there.

## Changes
- `getCategoryRoute()` PRIORITY 2: emit `index.php?option=com_j2commerce&view=products&catid=X` instead of `view=category&id=X&catid=<parent>`. The router (build CASE 1 + parse) already supports `view=products&catid=X` — attaches an Itemid when a matching products menu exists, otherwise the products view still renders from the input catid (no 404).
- PRIORITY 1 (exact products-menu catid match) unchanged.
- Removed the now-unused private `getCategoryParentId()` helper and parent-id plumbing. `$parentId` param retained for backward compatibility (callers still pass it) but ignored; docblock updated.

## Testing
1. Open a Product Category List View menu (e.g. "Shop", catid 44) that has sub-categories **without** their own menu items (e.g. Electronics 45).
2. Click a sub-category chip in the sub-category nav.
3. Verify: lands on the sub-category's product list — **no 404**.
4. Regressions: sub-category **with** its own menu item still uses that menu's URL; category with a matching products-menu still clean-routes; breadcrumbs (getCategoryRouteInContext fallback) still work.

## Files Changed
- `components/com_j2commerce/src/Helper/RouteHelper.php` — getCategoryRoute() PRIORITY 2 → products view; removed dead getCategoryParentId() (1 file, +8 / -49)

## Follow-up
- #1154 — the same dead `view=category` is still emitted by `getCategoryRouteInContext()` (categories-menu branch) and the router `categoryalias` rewrite. Separate menu context, not reproduced here — tracked separately.

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets
- [x] No FOF remnants
- [x] php-cs-fixer passed
- [x] joomla6-code-reviewer: PASS (0 critical / 0 warnings)
- [x] Core file only