### PR TITLE
fix(router): route category listings through products view (no phantom category view)

### DIFF
--- a/components/com_j2commerce/src/Helper/RouteHelper.php
+++ b/components/com_j2commerce/src/Helper/RouteHelper.php
@@ -154,16 +154,8 @@ abstract class RouteHelper
             $menuView = $activeMenu->query['view'] ?? null;
 
             if ($menuView === 'categories') {
-                // We're in a categories menu - generate URL within this hierarchy
-                // Use category view which routes through the categories menu
-                $link = 'index.php?option=com_j2commerce&view=category&id=' . $catid;
-
-                // Include the parent from menu for proper path building
-                $menuParentId = isset($activeMenu->query['id']) ? (int) $activeMenu->query['id'] : 1;
-                if ($menuParentId > 1) {
-                    // The router needs this to know where to start the category path
-                    $link .= '&catid=' . $menuParentId;
-                }
+                // We're in a categories menu - stay within this hierarchy via products view
+                $link = 'index.php?option=com_j2commerce&view=products&catid=' . $catid;
 
                 if (!empty($language) && $language !== '*' && Multilanguage::isEnabled()) {
                     $link .= '&lang=' . $language;
@@ -185,10 +177,11 @@ abstract class RouteHelper
      *
      * Priority for category URLs:
      * 1. Single category menu (products view with catid matching this category)
-     * 2. Categories menu (categories view with ancestor hierarchy)
+     * 2. Products view for this category (the nestable products route builds the path)
      *
      * @param   int          $catid      The category ID (required)
-     * @param   int|null     $parentId   The parent category ID (optional, looked up if not provided)
+     * @param   int|null     $parentId   Ignored — retained for backward compatibility; the
+     *                                    nestable products view now derives the path itself
      * @param   string|null  $language   The language code
      *
      * @return  string  The category route URL
@@ -230,59 +223,14 @@ abstract class RouteHelper
             }
         }
 
-        // PRIORITY 2: No single category menu found - use category view with hierarchy
-        $link = 'index.php?option=com_j2commerce&view=category&id=' . $catid;
-
-        // Include parent category ID for proper hierarchy building
-        // This allows RouterView's StandardRules to build the path correctly
-        if ($parentId === null) {
-            // Look up the parent category ID
-            $parentId = self::getCategoryParentId($catid);
-        }
-
-        if ($parentId && $parentId > 1) {
-            $link .= '&catid=' . $parentId;
-        }
+        // PRIORITY 2: no dedicated menu — the nestable products view builds the path.
+        $link = 'index.php?option=com_j2commerce&view=products&catid=' . $catid;
 
         if (!empty($language) && $language !== '*' && Multilanguage::isEnabled()) {
             $link .= '&lang=' . $language;
         }
 
         return $link;
-    }
-
-    /**
-     * Get the parent category ID for a category.
-     *
-     * @param   int  $catid  The category ID
-     *
-     * @return  int|null  The parent category ID or null
-     *
-     * @since   6.0.0
-     */
-    private static function getCategoryParentId(int $catid): ?int
-    {
-        static $cache = [];
-
-        if (isset($cache[$catid])) {
-            return $cache[$catid];
-        }
-
-        $db    = \Joomla\CMS\Factory::getContainer()->get(\Joomla\Database\DatabaseInterface::class);
-        $query = $db->getQuery(true);
-
-        $query->select($db->quoteName('parent_id'))
-            ->from($db->quoteName('#__categories'))
-            ->where($db->quoteName('id') . ' = :catid')
-            ->where($db->quoteName('extension') . ' = ' . $db->quote('com_content'))
-            ->bind(':catid', $catid, \Joomla\Database\ParameterType::INTEGER);
-
-        $db->setQuery($query);
-        $result = $db->loadResult();
-
-        $cache[$catid] = $result ? (int) $result : null;
-
-        return $cache[$catid];
     }
 
     /**

--- a/components/com_j2commerce/src/Service/Router.php
+++ b/components/com_j2commerce/src/Service/Router.php
@@ -96,31 +96,23 @@ class Router extends RouterView
 
         $this->noIDs = true;
 
-        // Register view hierarchy for canonical URL generation
-        // Following com_content pattern: categories -> category (nestable) -> product
-
-        // Categories view - shows list of product categories (top-level for categories menu)
         $categories = new RouterViewConfiguration('categories');
         $categories->setKey('id');
         $this->registerView($categories);
 
-        // Category view - nestable, parent is categories
-        // Key is 'id' because getCategoryRoute uses id= not catid=
-        // This enables: /categories/chocolate and /categories/chocolate/subcategory
+        // Not nestable: kept only for back-compat segment lineage, never a dispatch target.
         $category = new RouterViewConfiguration('category');
-        $category->setKey('id')->setParent($categories, 'catid')->setNestable();
+        $category->setKey('id')->setParent($categories, 'catid');
         $this->registerView($category);
 
-        // Single product view - parent is category, linked via 'catid'
-        // This enables: /categories/chocolate/product-alias
-        $product = new RouterViewConfiguration('product');
-        $product->setKey('id')->setParent($category, 'catid');
-        $this->registerView($product);
-
-        // Products list view (alternative root for products menu)
-        // Note: Products menu uses catid filter, not category hierarchy in URL
+        // The authoritative category-listing view; nestable so it builds /parent/child paths.
         $products = new RouterViewConfiguration('products');
+        $products->setKey('catid')->setParent($categories, 'catid')->setNestable();
         $this->registerView($products);
+
+        $product = new RouterViewConfiguration('product');
+        $product->setKey('id')->setParent($products, 'catid');
+        $this->registerView($product);
 
         // Other views without category hierarchy
         $this->registerView(new RouterViewConfiguration('producttags'));
@@ -221,40 +213,18 @@ class Router extends RouterView
             }
         }
 
-        // For category view, find matching menu
-        if (isset($query['view']) && $query['view'] === 'category' && isset($query['id'])) {
-            $catid = (int) $query['id'];
-
-            $result         = $this->findCategoriesMenuForCategory($catid);
-            $categoriesMenu = $result ? $result['menu'] : null;
-
-            if ($categoriesMenu) {
-                $query['Itemid'] = $categoriesMenu->id;
-            } else {
-                $productsMenu = $this->findProductsMenuByCatid($catid);
-
-                if ($productsMenu) {
-                    $query['Itemid'] = $productsMenu->id;
-                }
-            }
-        }
-
-        // For categoryalias view, rewrite to category view with correct Itemid
+        // For categoryalias view, rewrite to products view with correct Itemid
         if (($query['view'] ?? '') === 'categoryalias' && !empty($query['id'])) {
-            $catid          = (int) $query['id'];
-            $result         = $this->findCategoriesMenuForCategory($catid);
-            $categoriesMenu = $result ? $result['menu'] : null;
+            $catid    = (int) $query['id'];
+            $result   = $this->findCategoriesMenuForCategory($catid);
+            $menuItem = $result ? $result['menu'] : $this->findProductsMenuByCatid($catid);
 
-            if ($categoriesMenu) {
-                $query['view']   = 'category';
-                $query['Itemid'] = $categoriesMenu->id;
-            } else {
-                $query['view'] = 'category';
-                $menuItem      = $this->findProductsMenuByCatid($catid);
+            $query['view']  = 'products';
+            $query['catid'] = $catid;
+            unset($query['id']);
 
-                if ($menuItem) {
-                    $query['Itemid'] = $menuItem->id;
-                }
+            if ($menuItem) {
+                $query['Itemid'] = $menuItem->id;
             }
         }
 
@@ -316,22 +286,32 @@ class Router extends RouterView
             }
         }
 
-        // CASE 1: Products view with catid - find matching menu item
+        // CASE 1: Products view with catid
         if (isset($query['view']) && $query['view'] === 'products' && isset($query['catid'])) {
             $catid = (int) $query['catid'];
 
-            // Try to find a menu item that matches this products view + catid
+            // PRIORITY 1: an exact products menu for this catid → clean menu alias URL
             $menuItem = $this->findProductsMenuByCatid($catid);
 
             if ($menuItem) {
-                // Set the Itemid to the found menu
                 $query['Itemid'] = $menuItem->id;
-
-                // Remove view and catid from query as they're implicit in the menu item
                 unset($query['view'], $query['catid']);
 
-                // Return empty segments - the menu alias will be the URL
                 return [];
+            }
+
+            // PRIORITY 2: build the category path here when a categories menu roots this
+            // catid. Bypasses StandardRules, which reads the menu's catid key — a categories
+            // menu carries 'id', not 'catid', and would emit an "Undefined array key catid".
+            $categoriesMenu = $this->findCategoriesMenuForCategory($catid);
+
+            if ($categoriesMenu) {
+                $query['Itemid'] = $categoriesMenu['menu']->id;
+
+                unset($query['view'], $query['catid']);
+
+                // Empty path (catid IS the menu's own category) → bare menu alias.
+                return $categoriesMenu['path'];
             }
         }
 
@@ -987,6 +967,17 @@ class Router extends RouterView
         return $id ?: (int) $segment;
     }
 
+    // getProducts*() are resolved by StandardRules via reflection for the nestable products view.
+    public function getProductsSegment($id, $query): array
+    {
+        return $this->getCategorySegment($id, $query);
+    }
+
+    public function getProductsId($segment, $query): int
+    {
+        return $this->getCategoryId($segment, $query);
+    }
+
     /**
      * Get URL segments for categories view
      *
@@ -1383,7 +1374,19 @@ class Router extends RouterView
         }
 
         // Let parent handle other cases
-        return parent::parse($segments);
+        $vars = parent::parse($segments);
+
+        // Back-compat: stale view=category URLs redirect to products
+        if (($vars['view'] ?? '') === 'category') {
+            $vars['view'] = 'products';
+
+            if (isset($vars['id'])) {
+                $vars['catid'] = $vars['id'];
+                unset($vars['id']);
+            }
+        }
+
+        return $vars;
     }
 
     /**


### PR DESCRIPTION
## Summary
Fixes #1153
Fixes #1154

Sub-category links 404'd with `View not found: category` and, when worked around, rendered the wrong category's products. **Root cause:** the router registered a nestable `category` (singular) view that has **no View class** (phantom → 404 on dispatch), while the real category-listing renderer — the **products** view (`view=products&catid`, which reads the request catid) — was registered **non-nestable**, so it couldn't build clean `/parent/child` paths and fell back to a mismatched menu.

In J2Commerce the category-listing view **is** `view=products`; this change finishes the com_content nestable pattern by pointing it at the existing products view instead of a non-existent category view.

## Changes
- **Router view registration:** `products` is now the nestable category-path view (`setKey('catid')->setParent(categories,'catid')->setNestable()`); `product` reparented under `products`; the leftover `category` view de-nestabled (kept only as non-dispatch segment lineage).
- Added `getProductsSegment()` / `getProductsId()` (delegate to the existing category helpers; resolved by StandardRules via reflection).
- **RouteHelper:** `getCategoryRoute()` and `getCategoryRouteInContext()` now emit `view=products&catid` everywhere — `view=category` is no longer emitted; removed dead `getCategoryParentId()`.
- **preprocess:** `categoryalias` rewrite now targets `view=products`.
- **parse():** back-compat — any stale `view=category` result is rewritten to `view=products` (`id→catid`) so old bookmarks/SEF links never 404.
- **build() CASE 1:** when a categories menu roots the catid, build the category path here and return before `parent::build()` — this avoids the core `StandardRules.php:265` `Undefined array key "catid"` notice (a categories menu carries `id`, not `catid`).

## Not changed
- **Product-detail URLs are unchanged** (verified). The product view self-derives `catid` from its content article.

## Testing (browser-verified)
1. `/test-category` → "Test Child 1" → clean URL `/test-category/test-child-1`, renders the correct category, no 404.
2. `/shop-categories/others` → 14 products, **no "Undefined array key catid" notice**; sibling chips resolve (`/shop-categories`, `/j2commerce-chocolate`).
3. `/j2commerce-chocolate` + product URLs (`/j2commerce-chocolate/pitch-dark-bastard`) unchanged and render.
4. Old `index.php?option=com_j2commerce&view=category&id=X` resolves (back-compat), no 404.

## Files Changed
- `components/com_j2commerce/src/Service/Router.php`
- `components/com_j2commerce/src/Helper/RouteHelper.php`

## Pre-Flight
- [x] php -l clean
- [x] php-cs-fixer clean
- [x] zero `view=category` emitters (grep)
- [x] joomla6-code-reviewer: PASS (0 critical / 0 high)
- [x] Core files only