### PR TITLE
fix(core): RouterModalCategory field type loads on Linux (case-sensitive FS)

### DIFF
--- a/components/com_j2commerce/tmpl/categories/default.xml
+++ b/components/com_j2commerce/tmpl/categories/default.xml
@@ -13,11 +13,11 @@
 			addfieldprefix="J2Commerce\Component\J2commerce\Administrator\Field">
 			<field
 				name="id"
-				type="RouterModalCategory"
+				type="Routermodalcategory"
 				extension="com_content"
 				label="JGLOBAL_CHOOSE_CATEGORY_LABEL"
 				description="COM_J2COMMERCE_CATEGORIES_PARENT_DESC"
-				default="1"
+				default=""
 			/>
 		</fieldset>
 	</fields>

--- a/components/com_j2commerce/tmpl/categoryalias/default.xml
+++ b/components/com_j2commerce/tmpl/categoryalias/default.xml
@@ -13,7 +13,7 @@
 			addfieldprefix="J2Commerce\Component\J2commerce\Administrator\Field">
 			<field
 				name="id"
-				type="RouterModalCategory"
+				type="Routermodalcategory"
 				extension="com_content"
 				label="JGLOBAL_CHOOSE_CATEGORY_LABEL"
 				description="COM_J2COMMERCE_CATEGORYALIAS_CATEGORY_DESC"

--- a/components/com_j2commerce/tmpl/products/default.xml
+++ b/components/com_j2commerce/tmpl/products/default.xml
@@ -13,7 +13,7 @@
 
 			<field
 				name="catid"
-				type="RouterModalCategory"
+				type="Routermodalcategory"
 				label="JGLOBAL_CHOOSE_CATEGORY_LABEL"
 				description="COM_J2COMMERCE_MENU_CATEGORY_DESC"
 				required="true"


### PR DESCRIPTION
## Core Update

Fixes the category-picker field failing to load on **Linux** in three menu-item layout param files. Same class of bug as the geozone field (#1151).

### Root cause
The layouts declared `type="RouterModalCategory"`. Joomla `FormHelper` resolves that to class `RouterModalCategoryField` → file `RouterModalCategoryField.php`. The real field class/file is **`RoutermodalcategoryField`** (`administrator/components/com_j2commerce/src/Field/RoutermodalcategoryField.php`). On a case-sensitive filesystem the file is not found → `class_exists()` false → the field silently falls back to a plain text input. Windows (case-insensitive FS) hid it.

### Fix
`type="RouterModalCategory"` → `type="Routermodalcategory"` in:
- `components/com_j2commerce/tmpl/categories/default.xml`
- `components/com_j2commerce/tmpl/categoryalias/default.xml`
- `components/com_j2commerce/tmpl/products/default.xml`

`Routermodalcategory` passes through `toSpaceSeparated`/`ucwords` unchanged → resolves to the real `RoutermodalcategoryField` on every OS.

Also: in `categories/default.xml` the `id` request param now defaults to empty instead of `1` (no longer preselects category 1).

### Files Modified
| Type | Count |
|------|-------|
| PHP files | 0 |
| JS/CSS assets | 0 |
| Language files | 0 |
| XML/Config | 3 |

### Pre-Flight
- [x] PHP syntax check passed (N/A — XML only)
- [x] No secrets detected
- [x] No FOF remnants (N/A — XML only)
- [x] Code style (php-cs-fixer) N/A — XML only
- [x] Core files only (non-core excluded)
- [x] Line endings normalized to upstream (LF) — diff is the 4 real lines, no EOL noise