### PR TITLE
fix(inventory): admin availability column shows the saved value, not derived stock status

### DIFF
--- a/administrator/components/com_j2commerce/src/Model/InventoryModel.php
+++ b/administrator/components/com_j2commerce/src/Model/InventoryModel.php
@@ -228,11 +228,11 @@ class InventoryModel extends ListModel
                 $item->manage_stock = $item->manage_stock ?? 0;
                 $item->has_options  = $item->has_options ?? 0;
 
-                // Reflect the shopper-facing stock status, not the raw column.
-                // Storefront rule (ProductHelper::validateVariableProduct): when stock
-                // is not managed the item is always sellable; when managed it is in
-                // stock only if availability is set or backorders are allowed.
-                $item->availability = $this->resolveStockStatus($item);
+                // Show the raw saved availability — the editable column must mirror
+                // v.availability, not the derived shopper-facing status. A backorderable
+                // item is sellable on the storefront, but the admin field still reflects
+                // the saved Out of Stock / In Stock value the merchant set.
+                $item->availability = $item->availability ?? 1;
 
                 // Add SKU field to item if not present
                 if (!isset($item->sku)) {
@@ -250,31 +250,6 @@ class InventoryModel extends ListModel
         }
 
         return $items;
-    }
-
-    /**
-     * Resolve the shopper-facing stock status for the inventory select.
-     *
-     * Mirrors the storefront rule (ProductHelper::validateVariableProduct):
-     * unmanaged stock is always in stock; managed stock is in stock only when
-     * availability is set or backorders are allowed.
-     *
-     * @param   object  $row  Product/variant row with manage_stock, availability, allow_backorder.
-     *
-     * @return  int  1 = in stock, 0 = out of stock.
-     *
-     * @since   6.0.0
-     */
-    private function resolveStockStatus(object $row): int
-    {
-        if ((int) ($row->manage_stock ?? 0) !== 1) {
-            return 1;
-        }
-
-        $available = !empty($row->availability);
-        $backorder = (int) ($row->allow_backorder ?? 0) >= 1;
-
-        return ($available || $backorder) ? 1 : 0;
     }
 
     /**
@@ -774,7 +749,7 @@ class InventoryModel extends ListModel
                     $variant->manage_stock = $variant->manage_stock ?? 0;
                     $variant->on_hold      = $variant->on_hold ?? 0;
                     $variant->sold         = $variant->sold ?? 0;
-                    $variant->availability = $this->resolveStockStatus($variant);
+                    $variant->availability = $variant->availability ?? 1;
                 }
             }
 


### PR DESCRIPTION
## Summary
Fixes #1157

The admin **Inventory** list (`view=inventory`) renders the **Stock Status / Availability** column as an editable `<select>` bound to `$item->availability`. PR #1149 (for #1147) overwrote that property with `resolveStockStatus()` — the derived *shopper-facing* sellable status — in both the product list and the variant expansion. Because a backorderable item is "sellable", a product with `allow_backorder >= 1` always rendered **In Stock** even after the merchant saved **Out of Stock** (`v.availability = 0`).

An editable control must reflect the value it writes, not a derived value.

## Changes
- `InventoryModel::getItems()` — show the raw `v.availability` (null → 1, explicit 0 preserved) instead of `resolveStockStatus($item)`.
- `InventoryModel::getProductVariants()` — same for the variant rows.
- Removed the now-unused `resolveStockStatus()` private method.

Storefront sellability is unaffected — it is computed separately in `ProductHelper::validateVariableProduct`, not in this admin model.

## Testing
1. Components → J2Commerce → Inventory.
2. Product ID 1 (managed stock, `allow_backorder = 2`): set Stock Status to **Out of Stock**, reload — column now stays **Out of Stock** (previously reverted to In Stock).
3. Set **In Stock**, reload — stays In Stock.
4. Expand a variable product — each variant's Stock Status mirrors its saved value.

## Files Changed
- `administrator/components/com_j2commerce/src/Model/InventoryModel.php` — raw availability in list + variants; removed `resolveStockStatus()`.

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Code style (php-cs-fixer) passed
- [x] Core file only; branched off upstream/main (no unrelated commits)