### PR TITLE
fix(plugins): add admin Help links for shipping_standard and report plugins

### DIFF
--- a/plugins/j2commerce/report_itemised/src/Extension/ReportItemised.php
+++ b/plugins/j2commerce/report_itemised/src/Extension/ReportItemised.php
@@ -188,6 +188,8 @@ final class ReportItemised extends CMSPlugin implements SubscriberInterface
             $toolbar->linkButton('export', 'PLG_J2COMMERCE_REPORT_ITEMISED_EXPORT_CSV')
                 ->url($exportUrl)
                 ->icon('icon-download');
+
+            $toolbar->help('', false, 'https://docs.j2commerce.com/v6/reports/report-itemised');
         }
 
         // Load plugin language so filter form labels resolve correctly

--- a/plugins/j2commerce/report_products/src/Extension/ReportProducts.php
+++ b/plugins/j2commerce/report_products/src/Extension/ReportProducts.php
@@ -186,6 +186,8 @@ final class ReportProducts extends CMSPlugin implements SubscriberInterface
             $toolbar->linkButton('export', 'PLG_J2COMMERCE_REPORT_PRODUCTS_EXPORT_CSV')
                 ->url($exportUrl)
                 ->icon('icon-download');
+
+            $toolbar->help('', false, 'https://docs.j2commerce.com/v6/reports/report-products');
         }
 
         // Load plugin language so filter form labels resolve correctly

--- a/plugins/j2commerce/shipping_standard/src/Extension/ShippingStandard.php
+++ b/plugins/j2commerce/shipping_standard/src/Extension/ShippingStandard.php
@@ -873,6 +873,8 @@ final class ShippingStandard extends CMSPlugin implements SubscriberInterface
             ->message('JGLOBAL_CONFIRM_DELETE')
             ->listCheck(true);
 
+        $toolbar->help('', false, 'https://docs.j2commerce.com/v6/shipping-methods/shipping-standard');
+
         // Build the query
         $db  = $this->getDatabase();
         $app = Factory::getApplication();


### PR DESCRIPTION
## Summary
Fixes #1159

Wires the admin **Help** toolbar button into the core j2commerce plugins that render their own plugin-view with a toolbar.

## Changes
- `shipping_standard` — `renderMethodsList()` adds a Help button → `https://docs.j2commerce.com/v6/shipping-methods/shipping-standard`
- `report_itemised` — `onReportPluginView()` adds a Help button → `https://docs.j2commerce.com/v6/reports/report-itemised`
- `report_products` — `onReportPluginView()` adds a Help button → `https://docs.j2commerce.com/v6/reports/report-products`

Each is a single `$toolbar->help('', false, $url)` line added beside the existing toolbar buttons. No language strings, no XML, no version edits.

## Scope note
Of the 10 core plugins in #1159, only these 3 render a per-plugin admin view that exposes a `$toolbar`. The other 7 have no per-plugin view/toolbar to host a Help button:
- `payment_cash`, `payment_moneyorder`, `payment_banktransfer`, `payment_paypal` — no per-payment config view; the Payment Methods **list** already carries a generic help link.
- `shipping_free`, `app_currencyupdater`, `app_flexivariable` — register no plugin-view handler.

## Testing
1. Admin → J2Commerce → Shipping Methods → open *Standard Shipping* → Help button (top-right) opens the shipping-standard doc.
2. Admin → J2Commerce → Reports → *Itemised* → Help opens the report-itemised doc.
3. Admin → J2Commerce → Reports → *Products* → Help opens the report-products doc.

## Files Changed
- `plugins/j2commerce/shipping_standard/src/Extension/ShippingStandard.php`
- `plugins/j2commerce/report_itemised/src/Extension/ReportItemised.php`
- `plugins/j2commerce/report_products/src/Extension/ReportProducts.php`

## Pre-Flight
- [x] PHP syntax check passed (3/3)
- [x] No secrets detected
- [x] No FOF remnants
- [x] Code style (php-cs-fixer) passed
- [x] Core plugin files only