### PR TITLE
fix(content): load J2Commerce product field on case-sensitive FS (fixes #1167)

### DIFF
--- a/plugins/content/j2commerce/forms/j2commerce.xml
+++ b/plugins/content/j2commerce/forms/j2commerce.xml
@@ -4,7 +4,7 @@
         <fieldset name="j2commerce" label="PLG_CONTENT_J2COMMERCE_TAB_LABEL">
             <field
                 name="j2commerce"
-                type="J2Commerce"
+                type="J2commerce"
                 id="j2commerce"
                 description="PLG_CONTENT_J2COMMERCE_FIELD_DESC"
                 label="PLG_CONTENT_J2COMMERCE_FIELD_LABEL"


### PR DESCRIPTION
## Summary

Fixes #1167

The content plugin's J2Commerce product tab fails to load on case-sensitive (Linux) filesystems, leaving users unable to edit products via the article editor.

## Root cause

PR #1129 renamed `plugins/content/j2commerce/src/Field/J2CommerceField.php` → `J2commerceField.php` (and deleted the old file) but left the form field declaration as `type="J2Commerce"`. Joomla's `FormHelper::loadClass` upper-cases only the **first** letter of the type, so `J2Commerce` resolves to class `J2CommerceField` → file `J2CommerceField.php`, which no longer exists. On a case-sensitive FS the autoload 404s and the product field never renders. (Windows hides it — the case-insensitive FS still finds the renamed file.)

PR #1163 corrected the class's `protected $type` property to `J2commerce`, but that property is informational and does not drive class loading — the XML `type=` attribute does. The form attribute was the missed straggler (the "additional fallout not caught").

## Change

```diff
plugins/content/j2commerce/forms/j2commerce.xml
-                type="J2Commerce"
+                type="J2commerce"
```

Now `ucfirst('J2commerce')` → `J2commerceField` → `J2commerceField.php` (exists), matching the class property #1163 already aligned.

## Files Modified

| Type | Count |
|------|-------|
| XML/Config | 1 |

## Testing

1. On a case-sensitive (Linux) install, edit any J2Commerce product's article → open the **J2Commerce** tab.
2. Before: product field/tab fails to render; product data uneditable.
3. After: product panel renders and is editable.
4. Windows unaffected either way.

## Pre-Flight
- [x] XML well-formed (`simplexml_load_file` valid)
- [x] No secrets detected
- [x] No FOF / JFactory remnants
- [x] Core files only — single 1-line change