### PR TITLE
fix(checkout): treat blank min/max_subtotal as no limit

### DIFF
--- a/components/com_j2commerce/src/Controller/CheckoutController.php
+++ b/components/com_j2commerce/src/Controller/CheckoutController.php
@@ -1123,8 +1123,14 @@ class CheckoutController extends BaseController
                 return false;
             }
 
-            $minSubtotal = (float) $params->get('min_subtotal', 0);
-            $maxSubtotal = (float) $params->get('max_subtotal', -1);
+            $minRaw = $params->get('min_subtotal', '');
+            $maxRaw = $params->get('max_subtotal', '');
+
+            // A blank field means "no limit" — only the -1 sentinel or a real
+            // number constrains. Without this, a saved-empty max_subtotal casts
+            // to 0.0 and (0 >= 0) silently hides the method for any non-zero cart.
+            $minSubtotal = ($minRaw === '' || $minRaw === null) ? 0.0 : (float) $minRaw;
+            $maxSubtotal = ($maxRaw === '' || $maxRaw === null) ? -1.0 : (float) $maxRaw;
 
             if ($minSubtotal > 0 && $subtotal < $minSubtotal) {
                 return false;


### PR DESCRIPTION
## Core Update

### Problem
A payment plugin saved with an **empty** Max Subtotal field silently disappears from checkout. In `CheckoutController::filterUnavailablePaymentMethods()`, `(float) $params->get('max_subtotal', -1)` returns the `-1` "no limit" sentinel **only when the key is absent**. A field saved blank is `''`, which casts to `0.0`, so `($maxSubtotal >= 0 && $subtotal > $maxSubtotal)` becomes an active zero ceiling and hides the method for any non-zero cart. Affects every payment plugin saved with that field blank.

### Fix
Treat `''`/`null` as "no limit" before the float cast (min → `0.0`, max → `-1.0`).

### Files Modified
| Type | Count |
|------|-------|
| PHP files | 1 |

`components/com_j2commerce/src/Controller/CheckoutController.php`

### Pre-Flight
- [x] PHP syntax check passed (`php -l`)
- [x] No secrets detected
- [x] No FOF remnants
- [x] php-cs-fixer clean
- [x] Core file only (single-file branch off upstream/main)