### PR TITLE
fix(router): sub-category links in a Product Categories View (fixes #1164)

### DIFF
--- a/components/com_j2commerce/src/Service/Router.php
+++ b/components/com_j2commerce/src/Service/Router.php
@@ -198,6 +198,15 @@ class Router extends RouterView
             $catid    = (int) $query['catid'];
             $menuItem = $this->findProductsMenuByCatid($catid);
 
+            // Fall back to a categories menu that roots this category, so buildSefRoute()
+            // resolves a menu BEFORE build() runs. Without this, a subcategory with no
+            // dedicated products menu loses its Itemid here and falls back to the raw
+            // /component/j2commerce/<alias> URL even though build() sets the Itemid later.
+            if (!$menuItem) {
+                $result   = $this->findCategoriesMenuForCategory($catid);
+                $menuItem = $result ? $result['menu'] : null;
+            }
+
             if ($menuItem) {
                 $query['Itemid'] = $menuItem->id;
             }


### PR DESCRIPTION
## Summary

Fixes #1164

In a **Product Categories View**, sub-category links pointed at the raw component URL `/component/j2commerce/<alias>?Itemid=...` instead of the SEF path `/<menu-alias>/<sub-category>`. Affected only sub-categories that have **no dedicated products menu** of their own (a sub-category that also has a Products List menu routed correctly — the reporter's observation).

## Root cause

PR #1156 reworked category routing onto the nestable `products` view and added a categories-menu fallback (PRIORITY 2) to `build()` CASE 1 — but **not** to the matching branch in `preprocess()`.

Joomla's `SiteRouter::buildSefRoute()` resolves the menu item from the Itemid set in `preprocess()` **before** it calls `build()`. So for a sub-category with no products menu, `preprocess()` set no Itemid → SiteRouter chose the `/component/...` base → the Itemid that `build()` sets afterwards was too late to matter. The `product` branch of `preprocess()` already had this fallback, which is why product links worked but the bare category link did not.

## Change

`components/com_j2commerce/src/Service/Router.php` — mirror the product branch's `findCategoriesMenuForCategory()` fallback into the products-view branch of `preprocess()` (8 lines), so the categories-menu Itemid is resolved up front.

## Testing

Verified live against a "Product Categories View" menu (`/shop-categories`):

| Link | Before | After |
|------|--------|-------|
| Sub-category **without** its own products menu | `/component/j2commerce/others?Itemid=221` | `/shop-categories/others` |
| Sub-category **with** a products menu | `/j2commerce-chocolate` | `/j2commerce-chocolate` (unchanged) |
| Product under that sub-category | `/shop-categories/others/<product>` | `/shop-categories/others/<product>` (unchanged) |

## Files Changed

- `components/com_j2commerce/src/Service/Router.php` — add categories-menu Itemid fallback to the `preprocess()` products-view branch.