### PR TITLE
feat(analytics): onJ2CommerceGetAnalyticsChartTabs plugin event

### DIFF
--- a/administrator/components/com_j2commerce/src/View/Analytics/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Analytics/HtmlView.php
@@ -42,6 +42,7 @@ class HtmlView extends BaseHtmlView
     public array $statusDistribution   = [];
     public array $checkoutFunnel       = [];
     public array $pluginWidgets        = [];
+    public array $pluginChartTabs      = [];
     public array $liveUsers            = [];
     public string $fromDate            = '';
     public string $toDate              = '';
@@ -175,11 +176,17 @@ class HtmlView extends BaseHtmlView
         Text::script('COM_J2COMMERCE_LIVE_USERS_MINUTES_AGO');
         Text::script('COM_J2COMMERCE_ANALYTICS_NO_DATA');
 
-        // Dispatch plugin widget hook
+        // Dispatch plugin hooks
         PluginHelper::importPlugin('j2commerce');
-        $event = new \Joomla\Event\Event('onJ2CommerceGetAnalyticsWidgets', [$this->fromDate, $this->toDate]);
-        Factory::getApplication()->getDispatcher()->dispatch('onJ2CommerceGetAnalyticsWidgets', $event);
-        $this->pluginWidgets = $event->getArgument('result', []);
+        $dispatcher = Factory::getApplication()->getDispatcher();
+
+        $widgetsEvent = new \Joomla\Event\Event('onJ2CommerceGetAnalyticsWidgets', [$this->fromDate, $this->toDate]);
+        $dispatcher->dispatch('onJ2CommerceGetAnalyticsWidgets', $widgetsEvent);
+        $this->pluginWidgets = $widgetsEvent->getArgument('result', []);
+
+        $tabsEvent = new \Joomla\Event\Event('onJ2CommerceGetAnalyticsChartTabs', [$this->fromDate, $this->toDate]);
+        $dispatcher->dispatch('onJ2CommerceGetAnalyticsChartTabs', $tabsEvent);
+        $this->pluginChartTabs = $tabsEvent->getArgument('result', []);
 
         $this->addToolbar();
         parent::display($tpl);

--- a/administrator/components/com_j2commerce/tmpl/analytics/default.php
+++ b/administrator/components/com_j2commerce/tmpl/analytics/default.php
@@ -167,6 +167,15 @@ $changeHtml = function (array $change): string {
                             <div style="min-height:350px"><canvas id="chart-revenue"></canvas></div>
                         <?php echo HTMLHelper::_('uitab.endTab'); ?>
 
+                        <?php foreach ($this->pluginChartTabs as $pluginTab) :
+                            $tabId    = htmlspecialchars((string) ($pluginTab['id'] ?? ''), ENT_QUOTES, 'UTF-8');
+                            $tabTitle = htmlspecialchars((string) ($pluginTab['title'] ?? ''), ENT_QUOTES, 'UTF-8');
+                            if ($tabId === '' || $tabTitle === '') continue;
+                            echo HTMLHelper::_('uitab.addTab', 'analyticsMainTabs', $tabId, $tabTitle);
+                            echo $pluginTab['body'] ?? '';
+                            echo HTMLHelper::_('uitab.endTab');
+                        endforeach; ?>
+
                         <?php $analyticsMainModules = ModuleHelper::getModules('j2commerce-analytics-main-tab');
                         foreach ($analyticsMainModules as $analyticsMainTab) :
                             $analyticsMainTabId    = 'analytmain' . (int) $analyticsMainTab->id;


### PR DESCRIPTION
## Core Update

### Changes
Adds a new admin Analytics extension point: `onJ2CommerceGetAnalyticsChartTabs`. App plugins can now contribute their own chart tab (id/title/body) into the main Analytics tab set, complementing the existing `onJ2CommerceGetAnalyticsWidgets` widget hook.

- `View/Analytics/HtmlView.php` — dispatch the new event, expose `$pluginChartTabs`
- `tmpl/analytics/default.php` — render returned tabs (id/title escaped) via `uitab`

### Files Modified
| Type | Count |
|------|-------|
| PHP (src) | 1 |
| PHP (tmpl) | 1 |

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Code style (php-cs-fixer) passed
- [x] Core files only