### PR TITLE
feat(order): plugin extension points for order summary + payment info

### DIFF
--- a/administrator/components/com_j2commerce/src/Helper/EmailHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/EmailHelper.php
@@ -487,6 +487,16 @@ class EmailHelper
             (float) ($order->currency_value ?? 1)
         );
 
+        // Plugin-contributed extra order summary rows
+        $extraRowsHtml = '';
+        foreach (J2CommerceHelper::plugin()->eventWithArray('GetOrderSummaryExtraRows', [$order]) as $extraRow) {
+            if (\is_array($extraRow) && isset($extraRow['label'], $extraRow['value'])) {
+                $extraRowsHtml .= '<div class="j2c-order-extra-row"><strong>'
+                    . htmlspecialchars((string) $extraRow['label'], ENT_QUOTES, 'UTF-8') . ':</strong> '
+                    . htmlspecialchars((string) $extraRow['value'], ENT_QUOTES, 'UTF-8') . '</div>';
+            }
+        }
+
         $tags = [
             "\\n"                         => "\n",
             '[SITENAME]'                  => $sitename,
@@ -539,6 +549,7 @@ class EmailHelper
             '[DISCOUNT_AMOUNT]'           => ((float) ($order->order_discount ?? 0)) > 0 ? CurrencyHelper::format((float) $order->order_discount, $order->currency_code ?? '', (float) ($order->currency_value ?? 1)) : '',
             '[TAX_AMOUNT]'                => ((float) ($order->order_tax ?? 0)) > 0 ? CurrencyHelper::format((float) $order->order_tax, $order->currency_code ?? '', (float) ($order->currency_value ?? 1)) : '',
             '[SUBTOTAL]'                  => CurrencyHelper::format((float) ($order->order_subtotal ?? 0), $order->currency_code ?? '', (float) ($order->currency_value ?? 1)),
+            '[ORDER_EXTRA_ROWS]'          => $extraRowsHtml,
             '[CURRENT_YEAR]'              => date('Y'),
             '[ITEMS]'                     => $items,
             '[PACKING_ITEMS]'             => $this->loadPackingItemsTemplate($order),

--- a/administrator/components/com_j2commerce/tmpl/order/view_details.php
+++ b/administrator/components/com_j2commerce/tmpl/order/view_details.php
@@ -88,6 +88,7 @@ if ($hasDetails) {
                             <strong class="text-body"><?php echo $this->escape($item->transaction_id); ?></strong>
                         </div>
                     <?php endif; ?>
+                    <?php echo J2CommerceHelper::plugin()->eventWithHtml('AfterAdminOrderPaymentInfo', array($item))->getArgument('html', ''); ?>
                 </div>
             </div>
             <div class="j2c-detail-card-payment-buttons d-flex align-items-center gap-2">

--- a/administrator/components/com_j2commerce/tmpl/order/view_summary.php
+++ b/administrator/components/com_j2commerce/tmpl/order/view_summary.php
@@ -46,6 +46,15 @@ $fees      = $item->orderfees ?? [];
                     </tr>
                 </thead>
                 <tbody>
+                    <?php // Plugin-contributed extra summary rows ?>
+                    <?php foreach (J2CommerceHelper::plugin()->eventWithArray('GetOrderSummaryExtraRows', [$item]) as $extraRow) : ?>
+                        <?php if (\is_array($extraRow) && isset($extraRow['label'], $extraRow['value'])) : ?>
+                            <tr>
+                                <th scope="row"><?php echo $this->escape($extraRow['label']); ?></th>
+                                <td class="text-end"><?php echo $this->escape($extraRow['value']); ?></td>
+                            </tr>
+                        <?php endif; ?>
+                    <?php endforeach; ?>
                     <tr>
                         <th scope="row"><?php echo Text::_('COM_J2COMMERCE_SUBTOTAL'); ?></th>
                         <td class="text-end"><?php echo $fmt((float) $item->order_subtotal); ?></td>

--- a/components/com_j2commerce/tmpl/confirmation/bootstrap5/default.php
+++ b/components/com_j2commerce/tmpl/confirmation/bootstrap5/default.php
@@ -434,6 +434,15 @@ if ($info) {
 
                     <?php // Summary lines ?>
                     <div class="small">
+                        <?php // Plugin-contributed extra summary lines ?>
+                        <?php foreach (J2CommerceHelper::plugin()->eventWithArray('GetOrderSummaryExtraRows', [$order]) as $extraRow) : ?>
+                            <?php if (\is_array($extraRow) && isset($extraRow['label'], $extraRow['value'])) : ?>
+                                <div class="d-flex justify-content-between mb-2">
+                                    <span><?php echo $this->escape($extraRow['label']); ?></span>
+                                    <span><?php echo $this->escape($extraRow['value']); ?></span>
+                                </div>
+                            <?php endif; ?>
+                        <?php endforeach; ?>
                         <?php // Subtotal ?>
                         <div class="d-flex justify-content-between mb-2">
                             <span><?php echo Text::_('COM_J2COMMERCE_CART_SUBTOTAL'); ?></span>

--- a/components/com_j2commerce/tmpl/confirmation/uikit3/default.php
+++ b/components/com_j2commerce/tmpl/confirmation/uikit3/default.php
@@ -439,6 +439,15 @@ if ($info) {
 
                     <?php // Summary lines ?>
                     <div class="uk-text-small">
+                        <?php // Plugin-contributed extra summary lines ?>
+                        <?php foreach (J2CommerceHelper::plugin()->eventWithArray('GetOrderSummaryExtraRows', [$order]) as $extraRow) : ?>
+                            <?php if (\is_array($extraRow) && isset($extraRow['label'], $extraRow['value'])) : ?>
+                                <div class="uk-flex uk-flex-between uk-margin-small-bottom">
+                                    <span><?php echo $this->escape($extraRow['label']); ?></span>
+                                    <span><?php echo $this->escape($extraRow['value']); ?></span>
+                                </div>
+                            <?php endif; ?>
+                        <?php endforeach; ?>
                         <?php // Subtotal ?>
                         <div class="uk-flex uk-flex-between uk-margin-small-bottom">
                             <span><?php echo Text::_('COM_J2COMMERCE_CART_SUBTOTAL'); ?></span>

--- a/components/com_j2commerce/tmpl/myprofile/bootstrap5/order.php
+++ b/components/com_j2commerce/tmpl/myprofile/bootstrap5/order.php
@@ -202,6 +202,15 @@ $statusName = !empty($order->orderstatus_name) ? Text::_($order->orderstatus_nam
         <div class="col-md-6 offset-md-6">
             <table class="table table-sm">
                 <tbody>
+                    <?php // Plugin-contributed extra summary rows ?>
+                    <?php foreach (J2CommerceHelper::plugin()->eventWithArray('GetOrderSummaryExtraRows', [$order]) as $extraRow): ?>
+                        <?php if (\is_array($extraRow) && isset($extraRow['label'], $extraRow['value'])): ?>
+                        <tr>
+                            <td class="text-end"><?php echo $this->escape($extraRow['label']); ?></td>
+                            <td class="text-end fw-bold"><?php echo $this->escape($extraRow['value']); ?></td>
+                        </tr>
+                        <?php endif; ?>
+                    <?php endforeach; ?>
                     <tr>
                         <td class="text-end"><?php echo Text::_('COM_J2COMMERCE_CART_SUBTOTAL'); ?></td>
                         <td class="text-end fw-bold"><?php echo $fmt((float) ($order->order_subtotal ?? 0)); ?></td>

--- a/components/com_j2commerce/tmpl/myprofile/uikit3/order.php
+++ b/components/com_j2commerce/tmpl/myprofile/uikit3/order.php
@@ -203,6 +203,15 @@ $statusName = !empty($order->orderstatus_name) ? Text::_($order->orderstatus_nam
         <div class="uk-width-1-2@m uk-push-1-2@m">
             <table class="uk-table uk-table-small">
                 <tbody>
+                    <?php // Plugin-contributed extra summary rows ?>
+                    <?php foreach (J2CommerceHelper::plugin()->eventWithArray('GetOrderSummaryExtraRows', [$order]) as $extraRow): ?>
+                        <?php if (\is_array($extraRow) && isset($extraRow['label'], $extraRow['value'])): ?>
+                        <tr>
+                            <td class="uk-text-right"><?php echo $this->escape($extraRow['label']); ?></td>
+                            <td class="uk-text-right uk-text-bold"><?php echo $this->escape($extraRow['value']); ?></td>
+                        </tr>
+                        <?php endif; ?>
+                    <?php endforeach; ?>
                     <tr>
                         <td class="uk-text-right"><?php echo Text::_('COM_J2COMMERCE_CART_SUBTOTAL'); ?></td>
                         <td class="uk-text-right uk-text-bold"><?php echo $fmt((float) ($order->order_subtotal ?? 0)); ?></td>


### PR DESCRIPTION
## Core Update

### Changes
Adds plugin extension points so app plugins can inject content into order displays without core edits.

**`GetOrderSummaryExtraRows`** — returns extra `label`/`value` rows appended to the order summary, rendered in:
- Admin/email order summary, plus a new `[ORDER_EXTRA_ROWS]` email template tag (`EmailHelper`)
- Frontend confirmation view (Bootstrap 5 + UIkit)
- Frontend my-profile order view (Bootstrap 5 + UIkit)

**`AfterAdminOrderPaymentInfo`** — renders plugin HTML directly after the admin order payment details block.

All injected `label`/`value` output is escaped at the render site (`$this->escape()` / `htmlspecialchars`).

### Files Modified
| Type | Count |
|------|-------|
| PHP (src helper) | 1 |
| PHP (admin tmpl) | 2 |
| PHP (site tmpl) | 4 |

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Code style (php-cs-fixer) passed
- [x] No text-muted / innerHTML
- [x] Core files only (UIkit twin committed as the clean 9-line change, no whitespace churn)