### PR TITLE
fix(core): TaxProfile field None option + Linux casing in scaffold stubs

### DIFF
--- a/administrator/components/com_j2commerce/src/Field/TaxprofileField.php
+++ b/administrator/components/com_j2commerce/src/Field/TaxprofileField.php
@@ -33,8 +33,10 @@ class TaxprofileField extends ListField
     {
         $options = parent::getOptions();
 
-        // Add "Not Taxable" option at the start
-        //array_unshift($options, HTMLHelper::_('select.option', '', Text::_('COM_J2COMMERCE_NOT_TAXABLE')));
+        // Empty value = no tax profile (not taxable). Listed first so a freshly
+        // saved form defaults to "Not Taxable" instead of auto-charging the first
+        // tax profile in the list.
+        array_unshift($options, HTMLHelper::_('select.option', '', Text::_('COM_J2COMMERCE_NOT_TAXABLE')));
 
         try {
             $db = Factory::getContainer()->get(DatabaseInterface::class);

--- a/administrator/components/com_j2commerce/stubs/payment/manifest.xml.stub
+++ b/administrator/components/com_j2commerce/stubs/payment/manifest.xml.stub
@@ -146,7 +146,7 @@
                 />
                 <field
                     name="surcharge_tax_class_id"
-                    type="TaxProfile"
+                    type="Taxprofile"
                     default=""
                     label="COM_J2COMMERCE_PLUGIN_SURCHARGE_TAX_CLASS"
                     description="COM_J2COMMERCE_PLUGIN_SURCHARGE_TAX_CLASS_DESC"

--- a/administrator/components/com_j2commerce/stubs/shipping/forms/shippingmethod.xml.stub
+++ b/administrator/components/com_j2commerce/stubs/shipping/forms/shippingmethod.xml.stub
@@ -37,7 +37,7 @@
 {{#if shipping_tax}}
         <field
             name="tax_class_id"
-            type="TaxProfile"
+            type="Taxprofile"
             label="COM_J2COMMERCE_FIELD_TAX_CLASS"
             description="COM_J2COMMERCE_FIELD_TAX_CLASS_DESC"
             addfieldprefix="J2Commerce\Component\J2commerce\Administrator\Field"

--- a/administrator/components/com_j2commerce/stubs/shipping/manifest.xml.stub
+++ b/administrator/components/com_j2commerce/stubs/shipping/manifest.xml.stub
@@ -101,7 +101,7 @@
 {{#if shipping_tax}}
                 <field
                     name="tax_class_id"
-                    type="TaxProfile"
+                    type="Taxprofile"
                     label="COM_J2COMMERCE_FIELD_TAX_CLASS"
                     description="COM_J2COMMERCE_FIELD_TAX_CLASS_DESC"
                     addfieldprefix="J2Commerce\Component\J2commerce\Administrator\Field"
@@ -137,7 +137,7 @@
                 />
                 <field
                     name="surcharge_tax_class_id"
-                    type="TaxProfile"
+                    type="Taxprofile"
                     default=""
                     label="COM_J2COMMERCE_PLUGIN_SURCHARGE_TAX_CLASS"
                     description="COM_J2COMMERCE_PLUGIN_SURCHARGE_TAX_CLASS_DESC"


### PR DESCRIPTION
## Core Update

### Changes
- **TaxProfile field — "Not Taxable" default option.** `TaxprofileField::getOptions()` now prepends an empty-value `Not Taxable` option as the first entry, so a field with a blank/absent default no longer silently auto-selects (and charges) the first tax profile in the list. Mirrors the existing `GeozoneField` "All" pattern.
- **Linux field-type case fix in scaffold stubs.** Three scaffolding stubs declared `type="TaxProfile"` (capital P), which derives a non-existent `TaxProfileField.php` on case-sensitive filesystems → the tax-profile dropdown silently falls back to a plain text input on Linux. Changed to `type="Taxprofile"` to match the real class file `TaxprofileField.php` (same root cause/class as the prior `GeozoneField` fix). Because `joomla-plugin-builder` scaffolds new plugins from these stubs, this prevents future plugins from inheriting the bug.

### Files Modified
| File | Change |
|------|--------|
| `administrator/components/com_j2commerce/src/Field/TaxprofileField.php` | Add empty-value "Not Taxable" first option |
| `administrator/components/com_j2commerce/stubs/payment/manifest.xml.stub` | `type="TaxProfile"` → `type="Taxprofile"` |
| `administrator/components/com_j2commerce/stubs/shipping/manifest.xml.stub` | `type="TaxProfile"` → `type="Taxprofile"` (×2) |
| `administrator/components/com_j2commerce/stubs/shipping/forms/shippingmethod.xml.stub` | `type="TaxProfile"` → `type="Taxprofile"` |

### Note
The 52 already-shipped **non-core** plugins (payment_*/shipping_* in `j2commerce6extensions`) still carry `type="TaxProfile"` and need a separate extensions-repo PR (same split as the Geozone fix: core PR #1151 + ext PR #379).

### Pre-Flight
- [x] PHP syntax check passed (`php -l`)
- [x] No secrets detected
- [x] No FOF remnants / `JFactory::`
- [x] Core files only
- [x] `COM_J2COMMERCE_NOT_TAXABLE` string exists (en-US + en-GB)