### PR TITLE
fix(zones): add missing Iran province Alborz

### DIFF
--- a/administrator/components/com_j2commerce/sql/install/mysql/zones.sql
+++ b/administrator/components/com_j2commerce/sql/install/mysql/zones.sql
@@ -3986,4 +3986,5 @@ INSERT IGNORE INTO `#__j2commerce_zones` (`j2commerce_zone_id`, `country_id`, `z
 (4012, 73,'FR-MTQ','Martinique', 1, 0),
 (4013, 73,'FR-GUF','Guyane', 1, 0),
 (4014, 73,'FR-REU','La Réunion', 1, 0),
-(4015, 73,'FR-MAY','Mayotte', 1, 0);
+(4015, 73,'FR-MAY','Mayotte', 1, 0),
+(4016, 101, 'ALB', 'Alborz', 1, 0);

--- a/administrator/components/com_j2commerce/sql/updates/mysql/6.3.5-2026-06-07.sql
+++ b/administrator/components/com_j2commerce/sql/updates/mysql/6.3.5-2026-06-07.sql
@@ -1,0 +1,3 @@
+-- Add Iran province "Alborz" (split from Tehran province in 2010), missing from initial zone seed data. See issue #1176.
+INSERT IGNORE INTO `#__j2commerce_zones` (`j2commerce_zone_id`, `country_id`, `zone_code`, `zone_name`, `enabled`, `ordering`) VALUES
+(4016, 101, 'ALB', 'Alborz', 1, 0);


### PR DESCRIPTION
## Summary
Fixes #1176

Iran (country_id 101) has 31 provinces but the zone seed data shipped only 30 (ids 1538–1567). **Alborz** — carved out of Tehran province in 2010 — was never added, so it is absent from the Onboarding Wizard province dropdown and anywhere else `#__j2commerce_zones` is consumed.

## Changes
- **`administrator/components/com_j2commerce/sql/install/mysql/zones.sql`** — append Alborz row (id 4016) so fresh installs seed all 31 Iran provinces.
- **`administrator/components/com_j2commerce/sql/updates/mysql/6.3.5-2026-06-07.sql`** (new) — `INSERT IGNORE` the Alborz row so existing installs pick it up on schema update. Dated-suffix name follows the existing convention so it re-runs even on a site already at 6.3.5. Idempotent.

Row: `(4016, 101, 'ALB', 'Alborz', 1, 0)`. `zone_code` `'ALB'` matches the dataset's 3-letter abbreviation style for Iran (TEH/QOM/…); the dataset does not use ISO 3166-2 codes for Iran.

## Testing
1. Admin → J2Commerce → Onboarding Wizard → Shop Info step
2. Country = Iran (Islamic Republic of) → open the Province dropdown
3. Verify **Alborz** is present (dropdown sorts by `zone_name ASC`)

## Files Changed
- `administrator/components/com_j2commerce/sql/install/mysql/zones.sql` — +1 row (fresh installs)
- `administrator/components/com_j2commerce/sql/updates/mysql/6.3.5-2026-06-07.sql` — new update script (existing installs)