### PR TITLE
fix(payment): convert gateway amounts by currency_value for multi-currency orders

### DIFF
--- a/administrator/components/com_j2commerce/src/Helper/CurrencyHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/CurrencyHelper.php
@@ -609,6 +609,33 @@ class CurrencyHelper
         return $value * ($toRate / $fromRate);
     }
 
+    /**
+     * Convert a base-currency order amount to the order's display currency.
+     *
+     * Order money fields are stored in the store base currency; `currency_value`
+     * is the rate to the order's `currency_code`. Payment gateways must be charged
+     * the converted amount (display currency), not the raw base figure. Returns the
+     * unrounded product so callers can sum a breakdown before final gateway rounding.
+     *
+     * @since   6.0.0
+     */
+    public static function convertForOrder(float $number, object $order): float
+    {
+        $rate = (float) ($order->currency_value ?? 1.0);
+
+        if ($rate <= 0) {
+            $rate = 1.0;
+        }
+
+        return $number * $rate;
+    }
+
+    /** Gateway charge amount for an order's grand total, in its display currency. */
+    public static function gatewayAmount(object $order): float
+    {
+        return self::convertForOrder((float) ($order->order_total ?? 0.0), $order);
+    }
+
     // =========================================================================
     // ISO 4217 NUMERIC CODE METHODS
     // =========================================================================

--- a/plugins/j2commerce/payment_paypal/src/Extension/PaymentPaypal.php
+++ b/plugins/j2commerce/payment_paypal/src/Extension/PaymentPaypal.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace J2Commerce\Plugin\J2Commerce\PaymentPaypal\Extension;
 
+use J2Commerce\Component\J2commerce\Administrator\Helper\CurrencyHelper;
 use J2Commerce\Component\J2commerce\Administrator\Helper\OrderHistoryHelper;
 use J2Commerce\Component\J2commerce\Administrator\Library\Plugins\Base;
 use J2Commerce\Component\J2commerce\Administrator\Library\Plugins\Payment;
@@ -337,10 +338,10 @@ final class PaymentPaypal extends CMSPlugin implements SubscriberInterface
 
     public function onRefundPayment(Event $event): void
     {
-        $args    = $event->getArguments();
-        $element = $args[0] ?? '';
-        $orderId = $args[1] ?? 0;
-        $amount  = $args[2] ?? null;
+        $args      = $event->getArguments();
+        $element   = $args[0] ?? '';
+        $orderId   = $args[1] ?? 0;
+        $rawAmount = $args[2] ?? null;
 
         if ($element !== $this->_name) {
             return;
@@ -365,6 +366,9 @@ final class PaymentPaypal extends CMSPlugin implements SubscriberInterface
             }
 
             $currency = $this->getCurrency($orderTable);
+            $amount   = $rawAmount !== null
+                ? CurrencyHelper::convertForOrder((float) $rawAmount, $orderTable)
+                : null;
 
             $refunds = $this->getPayPalRefunds();
             $result  = $refunds->refundCapture($captureId, $amount, $currency);
@@ -385,7 +389,7 @@ final class PaymentPaypal extends CMSPlugin implements SubscriberInterface
                     orderId: $orderTable->order_id,
                     comment: Text::sprintf(
                         'COM_J2COMMERCE_ORDER_HISTORY_REFUND_PROCESSED',
-                        $amount ?? $orderTable->order_total,
+                        $amount ?? CurrencyHelper::gatewayAmount($orderTable),
                         $currency
                     ),
                     orderStateId: $refundedStateId
@@ -697,7 +701,7 @@ final class PaymentPaypal extends CMSPlugin implements SubscriberInterface
             }
 
             $currency = $this->getCurrency($orderTable);
-            $amount   = (float) ($orderTable->order_total ?? 0);
+            $amount   = CurrencyHelper::gatewayAmount($orderTable);
 
             $returnUrl = Route::_(
                 'index.php?option=com_j2commerce&task=checkout.confirmPayment'
@@ -806,7 +810,7 @@ final class PaymentPaypal extends CMSPlugin implements SubscriberInterface
             }
 
             $currency = $this->getCurrency($orderTable);
-            $amount   = (float) ($orderTable->order_total ?? 0);
+            $amount   = CurrencyHelper::gatewayAmount($orderTable);
 
             $response = $nvp->doExpressCheckoutPayment(
                 token:         $token,
@@ -967,7 +971,7 @@ final class PaymentPaypal extends CMSPlugin implements SubscriberInterface
         try {
             $response = $nvp->doReferenceTransaction(
                 referenceId:    $baid,
-                amount:         (float) ($subscription->renewal_amount ?? $order->order_total ?? 0),
+                amount:         CurrencyHelper::convertForOrder((float) ($subscription->renewal_amount ?? $order->order_total ?? 0), $order),
                 currencyCode:   strtoupper((string) ($order->currency_code ?? 'USD')),
                 invoiceNumber:  (string) ($order->order_id ?? ''),
                 description:    'J2Commerce subscription renewal #' . ($subscription->id ?? '')
@@ -1818,7 +1822,7 @@ final class PaymentPaypal extends CMSPlugin implements SubscriberInterface
             $itemTotal = 0.0;
 
             foreach ($orderItems as $item) {
-                $unitAmount = (float) $item->orderitem_price;
+                $unitAmount = CurrencyHelper::convertForOrder((float) $item->orderitem_price, $orderTable);
                 $quantity   = (int) $item->orderitem_quantity;
 
                 $items[] = [
@@ -1831,10 +1835,10 @@ final class PaymentPaypal extends CMSPlugin implements SubscriberInterface
                 $itemTotal += $unitAmount * $quantity;
             }
 
-            $shipping = (float) $orderTable->order_shipping + (float) $orderTable->order_shipping_tax;
-            $tax      = (float) $orderTable->order_tax;
-            $discount = (float) $orderTable->order_discount;
-            $total    = (float) $orderTable->order_total;
+            $shipping = CurrencyHelper::convertForOrder((float) $orderTable->order_shipping + (float) $orderTable->order_shipping_tax, $orderTable);
+            $tax      = CurrencyHelper::convertForOrder((float) $orderTable->order_tax, $orderTable);
+            $discount = CurrencyHelper::convertForOrder((float) $orderTable->order_discount, $orderTable);
+            $total    = CurrencyHelper::gatewayAmount($orderTable);
 
             $orderData = [
                 'order_id'            => $orderId,

--- a/plugins/j2commerce/payment_paypal/src/Service/PayPalSubscriptions.php
+++ b/plugins/j2commerce/payment_paypal/src/Service/PayPalSubscriptions.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace J2Commerce\Plugin\J2Commerce\PaymentPaypal\Service;
 
+use J2Commerce\Component\J2commerce\Administrator\Helper\CurrencyHelper;
+
 \defined('_JEXEC') or die;
 
 
@@ -97,7 +99,7 @@ final class PayPalSubscriptions
         // entry in billing_cycles[] — extend this array accordingly.
         $totalCycles   = max(0, (int) ($subscription->subscription_length ?? 0));
         $renewalAmount = $this->formatAmount(
-            (float) ($subscription->renewal_amount ?? $order->order_total ?? 0),
+            CurrencyHelper::convertForOrder((float) ($subscription->renewal_amount ?? $order->order_total ?? 0), $order),
             (string) $context['currency_code']
         );
         $sitename      = (string) $context['brand_name'];
@@ -273,7 +275,7 @@ final class PayPalSubscriptions
         }
 
         $currency = strtoupper((string) ($order->currency_code ?? 'USD'));
-        $amount   = $this->formatAmount((float) ($subscription->renewal_amount ?? $order->order_total ?? 0), $currency);
+        $amount   = $this->formatAmount(CurrencyHelper::convertForOrder((float) ($subscription->renewal_amount ?? $order->order_total ?? 0), $order), $currency);
         $body     = [
             'note'         => 'J2Commerce renewal — Order #' . ($order->order_id ?? ''),
             'capture_type' => 'OUTSTANDING_BALANCE',


### PR DESCRIPTION
## Summary

Fixes #1182

In a multi-currency store (base currency ≠ order display currency), every payment plugin sent the gateway the **base-currency `order_total` un-converted**, tagged with the order's `currency_code`. The customer saw the converted price everywhere but was charged the raw base number as if it were the foreign currency. Single-currency stores (`currency_value = 1`) were unaffected.

Order money is stored in the **base currency**; `currency_value` is the rate to the order's `currency_code`. The UI converts via `CurrencyHelper::format()`, but the FOF→native migration dropped J2Store's per-plugin `format(..., false)` charge-time conversion.

## Changes

- **`CurrencyHelper`** (core) — single conversion accessor, so it can't be forgotten per-plugin:
  - `convertForOrder(float $number, object $order): float` — `number × currency_value` (guards rate ≤ 0 → 1.0; returns unrounded so a breakdown stays linear before final gateway rounding).
  - `gatewayAmount(object $order): float` — convenience for `order_total`.
- **`payment_paypal`** — routed **every** charge path through the helper:
  - **Sale**: per-line `unit_amount` + `item_total` + `shipping` + `tax` + `discount` + `total` (all converted so PayPal's breakdown sum-validation still balances).
  - **NVP Express** (SetExpressCheckout + DoExpressCheckout).
  - **NVP reference renewal** (DoReferenceTransaction).
  - **Refund** — converts a supplied partial amount; `null` = full refund (PayPal refunds the already-converted captured sum → auto-correct). History line uses `gatewayAmount`.
  - **REST subscriptions** — plan `fixed_price` + outstanding-balance renewal capture.

Storage paths (webhook-recorded renewal stored as base `order_total`) are intentionally left un-converted to avoid double-converting the UI/reports.

## Why no regression

Single-currency stores have `currency_value = 1` → `× 1` → identical output to before.

## Scope

Core only (this repo). Non-core gateways (payone, worldpay, rapyd, clover, …) follow as separate PRs in the extensions repo. The same shared `CurrencyHelper::convertForOrder()` / `gatewayAmount()` accessor is now available for them.

## Testing

1. Base **USD**; add currency **EUR** rate **1.15590**.
2. Place an order in EUR whose base total is e.g. `$52.20` net.
3. PayPal sandbox → gateway must receive **€60.34** (= 52.20 × 1.15590), breakdown balanced, capture succeeds.
4. Single-currency store → charged amount unchanged (no regression).

## Files Changed
- `administrator/components/com_j2commerce/src/Helper/CurrencyHelper.php` — add `convertForOrder()` + `gatewayAmount()`
- `plugins/j2commerce/payment_paypal/src/Extension/PaymentPaypal.php` — convert sale / NVP / renewal / refund amounts
- `plugins/j2commerce/payment_paypal/src/Service/PayPalSubscriptions.php` — convert plan price + renewal capture
