### PR TITLE
fix(payment_paypal): charge renewal order_total not renewal_amount

### DIFF
--- a/plugins/j2commerce/payment_paypal/src/Extension/PaymentPaypal.php
+++ b/plugins/j2commerce/payment_paypal/src/Extension/PaymentPaypal.php
@@ -971,7 +971,7 @@ final class PaymentPaypal extends CMSPlugin implements SubscriberInterface
         try {
             $response = $nvp->doReferenceTransaction(
                 referenceId:    $baid,
-                amount:         CurrencyHelper::convertForOrder((float) ($subscription->renewal_amount ?? $order->order_total ?? 0), $order),
+                amount:         CurrencyHelper::convertForOrder((float) ($order->order_total ?? $subscription->renewal_amount ?? 0), $order),
                 currencyCode:   strtoupper((string) ($order->currency_code ?? 'USD')),
                 invoiceNumber:  (string) ($order->order_id ?? ''),
                 description:    'J2Commerce subscription renewal #' . ($subscription->id ?? '')

--- a/plugins/j2commerce/payment_paypal/src/Service/PayPalSubscriptions.php
+++ b/plugins/j2commerce/payment_paypal/src/Service/PayPalSubscriptions.php
@@ -99,7 +99,7 @@ final class PayPalSubscriptions
         // entry in billing_cycles[] — extend this array accordingly.
         $totalCycles   = max(0, (int) ($subscription->subscription_length ?? 0));
         $renewalAmount = $this->formatAmount(
-            CurrencyHelper::convertForOrder((float) ($subscription->renewal_amount ?? $order->order_total ?? 0), $order),
+            CurrencyHelper::convertForOrder((float) ($order->order_total ?? $subscription->renewal_amount ?? 0), $order),
             (string) $context['currency_code']
         );
         $sitename      = (string) $context['brand_name'];
@@ -275,7 +275,7 @@ final class PayPalSubscriptions
         }
 
         $currency = strtoupper((string) ($order->currency_code ?? 'USD'));
-        $amount   = $this->formatAmount(CurrencyHelper::convertForOrder((float) ($subscription->renewal_amount ?? $order->order_total ?? 0), $order), $currency);
+        $amount   = $this->formatAmount(CurrencyHelper::convertForOrder((float) ($order->order_total ?? $subscription->renewal_amount ?? 0), $order), $currency);
         $body     = [
             'note'         => 'J2Commerce renewal — Order #' . ($order->order_id ?? ''),
             'capture_type' => 'OUTSTANDING_BALANCE',


### PR DESCRIPTION
## Summary
Fixes #1185

`payment_paypal` charged subscription **renewals** for `subscription->renewal_amount` (the recurring **item subtotal**) instead of the renewal order's **`order_total`** (subtotal + recurring tax + shipping + fees), undercharging every renewal by the tax/shipping portion. The amount was already wrapped in `CurrencyHelper::convertForOrder()` (from #1183) but the **inner precedence** preferred `renewal_amount`.

The renewal order is rebuilt fresh by `app_subscriptionproduct` with `order_total` recalculated per cycle, so `order_total` is the authoritative per-cycle charge. Downstream effect of the bug: a later full refund can 422 because the refund cap is based on `order_total` while only the subtotal was captured.

## Changes
Swap the inner precedence to `order_total ?? renewal_amount` on all three renewal price/charge paths (keeping the `CurrencyHelper::convertForOrder()` wrapping):

- `PaymentPaypal.php:974` — NVP `DoReferenceTransaction` (saved-BAID renewal charge)
- `PayPalSubscriptions.php:102` — PayPal plan `billing_cycles` fixed_price (auto-billed each cycle)
- `PayPalSubscriptions.php:278` — `OUTSTANDING_BALANCE` subscription capture

Matches the reference implementations in `payment_finix` and `payment_mollie` (`order_total ?? renewal_amount`).

## Out of scope
`PayPalWebhooks.php:201/:236` use `renewal_amount` to **store** the recorded amount — flagged in the issue for separate evaluation, not changed here.

This is the core-plugin counterpart of j2commerce6extensions#459 (clover/square, j2commerce6extensions PR #463).

## Testing
1. Admin → subscription product with tax/shipping (renewal `order_total` > `renewal_amount`).
2. Trigger a renewal via each path: native PayPal subscription capture, and a legacy J2Store BAID via NVP reference; create a new subscription to set the plan fixed_price.
3. Verify the PayPal charge equals the renewal order's `order_total`, not `renewal_amount`.

## Files Changed
- `plugins/j2commerce/payment_paypal/src/Extension/PaymentPaypal.php` — NVP reference renewal amount precedence
- `plugins/j2commerce/payment_paypal/src/Service/PayPalSubscriptions.php` — plan fixed_price + OUTSTANDING_BALANCE capture amount precedence
