### PR TITLE
fix(build): package the web-services API component (fixes #1188)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,12 @@
 !components/com_j2commerce/
 !components/com_j2commerce/**
 
+# API component (web-services / JSON:API)
+!api/
+!api/components/
+!api/components/com_j2commerce/
+!api/components/com_j2commerce/**
+
 # J2Commerce core plugins (only those in the package skill)
 !plugins/
 !plugins/j2commerce/

--- a/administrator/components/com_j2commerce/j2commerce.xml
+++ b/administrator/components/com_j2commerce/j2commerce.xml
@@ -164,6 +164,12 @@
 
     </administration>
 
+    <api>
+        <files folder="api/components/com_j2commerce">
+            <folder>src</folder>
+        </files>
+    </api>
+
     <scriptfile>script.j2commerce.php</scriptfile>
 
 

--- a/api/components/com_j2commerce/src/Controller/AddressesController.php
+++ b/api/components/com_j2commerce/src/Controller/AddressesController.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Api\Controller;
+
+\defined('_JEXEC') or die;
+
+use J2Commerce\Component\J2commerce\Api\Controller\J2CommerceApiController;
+
+class AddressesController extends J2CommerceApiController
+{
+    protected $contentType = 'addresses';
+
+    protected $default_view = 'addresses';
+
+    public function displayList()
+    {
+        $userId = $this->input->get('id', 0, 'int');
+        $this->modelState->set('filter.user_id', $userId);
+
+        return parent::displayList();
+    }
+}

--- a/api/components/com_j2commerce/src/Controller/CategoriesController.php
+++ b/api/components/com_j2commerce/src/Controller/CategoriesController.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Api\Controller;
+
+\defined('_JEXEC') or die;
+
+use J2Commerce\Component\J2commerce\Api\Controller\J2CommerceApiController;
+
+class CategoriesController extends J2CommerceApiController
+{
+    protected $contentType = 'categories';
+
+    protected $default_view = 'categories';
+}

--- a/api/components/com_j2commerce/src/Controller/ConfigController.php
+++ b/api/components/com_j2commerce/src/Controller/ConfigController.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Api\Controller;
+
+\defined('_JEXEC') or die;
+
+use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\MVC\Controller\ApiController;
+use Tobscure\JsonApi\AbstractSerializer;
+use Tobscure\JsonApi\Resource;
+
+class ConfigController extends ApiController
+{
+    protected $contentType = 'config';
+
+    protected $default_view = 'config';
+
+    public function displayList()
+    {
+        $params = ComponentHelper::getParams('com_j2commerce');
+        $data = (object) array_merge(['id' => 1], $params->toArray());
+
+        $serializer = new class extends AbstractSerializer {
+            protected $type = 'config';
+
+            public function getId($model): string
+            {
+                return '1';
+            }
+
+            public function getAttributes($model, ?array $fields = null): array
+            {
+                $attrs = (array) $model;
+                unset($attrs['id']);
+
+                return $attrs;
+            }
+        };
+
+        $this->app->getDocument()->setData(new Resource($data, $serializer));
+
+        return $this;
+    }
+}

--- a/api/components/com_j2commerce/src/Controller/CountriesController.php
+++ b/api/components/com_j2commerce/src/Controller/CountriesController.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Api\Controller;
+
+\defined('_JEXEC') or die;
+
+use Joomla\CMS\Filter\InputFilter;
+use J2Commerce\Component\J2commerce\Api\Controller\J2CommerceApiController;
+
+class CountriesController extends J2CommerceApiController
+{
+    protected $contentType = 'countries';
+
+    protected $default_view = 'countries';
+
+    public function displayList()
+    {
+        $apiFilterInfo = $this->input->get('filter', [], 'array');
+        $filter = InputFilter::getInstance();
+
+        if (\array_key_exists('search', $apiFilterInfo)) {
+            $this->modelState->set('filter.search', $filter->clean($apiFilterInfo['search'], 'STRING'));
+        }
+
+        if (\array_key_exists('enabled', $apiFilterInfo)) {
+            $this->modelState->set('filter.enabled', $filter->clean($apiFilterInfo['enabled'], 'INT'));
+        }
+
+        return parent::displayList();
+    }
+}

--- a/api/components/com_j2commerce/src/Controller/CouponsController.php
+++ b/api/components/com_j2commerce/src/Controller/CouponsController.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Api\Controller;
+
+\defined('_JEXEC') or die;
+
+use Joomla\CMS\Filter\InputFilter;
+use J2Commerce\Component\J2commerce\Api\Controller\J2CommerceApiController;
+
+class CouponsController extends J2CommerceApiController
+{
+    protected $contentType = 'coupons';
+
+    protected $default_view = 'coupons';
+
+    public function displayList()
+    {
+        $apiFilterInfo = $this->input->get('filter', [], 'array');
+        $filter = InputFilter::getInstance();
+
+        if (\array_key_exists('search', $apiFilterInfo)) {
+            $this->modelState->set('filter.search', $filter->clean($apiFilterInfo['search'], 'STRING'));
+        }
+
+        if (\array_key_exists('enabled', $apiFilterInfo)) {
+            $this->modelState->set('filter.enabled', $filter->clean($apiFilterInfo['enabled'], 'INT'));
+        }
+
+        return parent::displayList();
+    }
+}

--- a/api/components/com_j2commerce/src/Controller/CurrenciesController.php
+++ b/api/components/com_j2commerce/src/Controller/CurrenciesController.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Api\Controller;
+
+\defined('_JEXEC') or die;
+
+use J2Commerce\Component\J2commerce\Api\Controller\J2CommerceApiController;
+
+class CurrenciesController extends J2CommerceApiController
+{
+    protected $contentType = 'currencies';
+
+    protected $default_view = 'currencies';
+}

--- a/api/components/com_j2commerce/src/Controller/CustomerordersController.php
+++ b/api/components/com_j2commerce/src/Controller/CustomerordersController.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Api\Controller;
+
+\defined('_JEXEC') or die;
+
+use J2Commerce\Component\J2commerce\Api\Controller\J2CommerceApiController;
+
+class CustomerordersController extends J2CommerceApiController
+{
+    protected $contentType = 'orders';
+
+    protected $default_view = 'orders';
+
+    public function displayList()
+    {
+        $userId = $this->input->get('id', 0, 'int');
+        $this->modelState->set('filter.user_id', $userId);
+
+        return parent::displayList();
+    }
+}

--- a/api/components/com_j2commerce/src/Controller/CustomersController.php
+++ b/api/components/com_j2commerce/src/Controller/CustomersController.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Api\Controller;
+
+\defined('_JEXEC') or die;
+
+use Joomla\CMS\Filter\InputFilter;
+use J2Commerce\Component\J2commerce\Api\Controller\J2CommerceApiController;
+
+class CustomersController extends J2CommerceApiController
+{
+    protected $contentType = 'customers';
+
+    protected $default_view = 'customers';
+
+    public function displayList()
+    {
+        $apiFilterInfo = $this->input->get('filter', [], 'array');
+        $filter = InputFilter::getInstance();
+
+        if (\array_key_exists('search', $apiFilterInfo)) {
+            $this->modelState->set('filter.search', $filter->clean($apiFilterInfo['search'], 'STRING'));
+        }
+
+        if (\array_key_exists('country', $apiFilterInfo)) {
+            $this->modelState->set('filter.country_id', $filter->clean($apiFilterInfo['country'], 'INT'));
+        }
+
+        $apiListInfo = $this->input->get('list', [], 'array');
+
+        if (\array_key_exists('ordering', $apiListInfo)) {
+            $this->modelState->set('list.ordering', $filter->clean($apiListInfo['ordering'], 'STRING'));
+        }
+
+        if (\array_key_exists('direction', $apiListInfo)) {
+            $this->modelState->set('list.direction', $filter->clean($apiListInfo['direction'], 'STRING'));
+        }
+
+        return parent::displayList();
+    }
+}

--- a/api/components/com_j2commerce/src/Controller/InventoryController.php
+++ b/api/components/com_j2commerce/src/Controller/InventoryController.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Api\Controller;
+
+\defined('_JEXEC') or die;
+
+use J2Commerce\Component\J2commerce\Api\Controller\J2CommerceApiController;
+
+class InventoryController extends J2CommerceApiController
+{
+    protected $contentType = 'inventory';
+
+    protected $default_view = 'inventory';
+}

--- a/api/components/com_j2commerce/src/Controller/J2CommerceApiController.php
+++ b/api/components/com_j2commerce/src/Controller/J2CommerceApiController.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Api\Controller;
+
+\defined('_JEXEC') or die;
+
+use Joomla\CMS\MVC\Controller\ApiController;
+
+/**
+ * Base API controller for J2Commerce.
+ *
+ * Forces 'Administrator' prefix for model resolution since J2Commerce
+ * API controllers reuse admin models (no API-specific models exist).
+ *
+ * @since  6.0.15
+ */
+abstract class J2CommerceApiController extends ApiController
+{
+    public function getModel($name = '', $prefix = '', $config = [])
+    {
+        if (!$prefix) {
+            $prefix = 'Administrator';
+        }
+
+        return parent::getModel($name, $prefix, $config);
+    }
+}

--- a/api/components/com_j2commerce/src/Controller/ManufacturersController.php
+++ b/api/components/com_j2commerce/src/Controller/ManufacturersController.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Api\Controller;
+
+\defined('_JEXEC') or die;
+
+use Joomla\CMS\Filter\InputFilter;
+use J2Commerce\Component\J2commerce\Api\Controller\J2CommerceApiController;
+
+class ManufacturersController extends J2CommerceApiController
+{
+    protected $contentType = 'manufacturers';
+
+    protected $default_view = 'manufacturers';
+
+    public function displayList()
+    {
+        $apiFilterInfo = $this->input->get('filter', [], 'array');
+        $filter = InputFilter::getInstance();
+
+        if (\array_key_exists('search', $apiFilterInfo)) {
+            $this->modelState->set('filter.search', $filter->clean($apiFilterInfo['search'], 'STRING'));
+        }
+
+        if (\array_key_exists('enabled', $apiFilterInfo)) {
+            $this->modelState->set('filter.enabled', $filter->clean($apiFilterInfo['enabled'], 'INT'));
+        }
+
+        return parent::displayList();
+    }
+}

--- a/api/components/com_j2commerce/src/Controller/OrderhistoriesController.php
+++ b/api/components/com_j2commerce/src/Controller/OrderhistoriesController.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Api\Controller;
+
+\defined('_JEXEC') or die;
+
+use J2Commerce\Component\J2commerce\Api\Controller\J2CommerceApiController;
+
+class OrderhistoriesController extends J2CommerceApiController
+{
+    protected $contentType = 'orderhistories';
+
+    protected $default_view = 'orderhistories';
+
+    public function displayList()
+    {
+        $orderId = $this->input->get('id', 0, 'int');
+        $this->modelState->set('filter.order_id', $orderId);
+
+        return parent::displayList();
+    }
+}

--- a/api/components/com_j2commerce/src/Controller/OrderitemsController.php
+++ b/api/components/com_j2commerce/src/Controller/OrderitemsController.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Api\Controller;
+
+\defined('_JEXEC') or die;
+
+use J2Commerce\Component\J2commerce\Api\Controller\J2CommerceApiController;
+
+class OrderitemsController extends J2CommerceApiController
+{
+    protected $contentType = 'orderitems';
+
+    protected $default_view = 'orderitems';
+
+    public function displayList()
+    {
+        $orderId = $this->input->get('id', 0, 'int');
+        $this->modelState->set('filter.order_id', $orderId);
+
+        return parent::displayList();
+    }
+}

--- a/api/components/com_j2commerce/src/Controller/OrdersController.php
+++ b/api/components/com_j2commerce/src/Controller/OrdersController.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Api\Controller;
+
+\defined('_JEXEC') or die;
+
+use Joomla\CMS\Filter\InputFilter;
+use J2Commerce\Component\J2commerce\Api\Controller\J2CommerceApiController;
+
+class OrdersController extends J2CommerceApiController
+{
+    protected $contentType = 'orders';
+
+    protected $default_view = 'orders';
+
+    public function displayList()
+    {
+        $apiFilterInfo = $this->input->get('filter', [], 'array');
+        $filter = InputFilter::getInstance();
+
+        if (\array_key_exists('search', $apiFilterInfo)) {
+            $this->modelState->set('filter.search', $filter->clean($apiFilterInfo['search'], 'STRING'));
+        }
+
+        if (\array_key_exists('status', $apiFilterInfo)) {
+            $this->modelState->set('filter.order_state_id', $filter->clean($apiFilterInfo['status'], 'INT'));
+        }
+
+        if (\array_key_exists('customer_id', $apiFilterInfo)) {
+            $this->modelState->set('filter.user_id', $filter->clean($apiFilterInfo['customer_id'], 'INT'));
+        }
+
+        if (\array_key_exists('date_from', $apiFilterInfo)) {
+            $this->modelState->set('filter.since', $filter->clean($apiFilterInfo['date_from'], 'STRING'));
+        }
+
+        if (\array_key_exists('date_to', $apiFilterInfo)) {
+            $this->modelState->set('filter.until', $filter->clean($apiFilterInfo['date_to'], 'STRING'));
+        }
+
+        if (\array_key_exists('payment_type', $apiFilterInfo)) {
+            $this->modelState->set('filter.payment_type', $filter->clean($apiFilterInfo['payment_type'], 'STRING'));
+        }
+
+        $apiListInfo = $this->input->get('list', [], 'array');
+
+        if (\array_key_exists('ordering', $apiListInfo)) {
+            $this->modelState->set('list.ordering', $filter->clean($apiListInfo['ordering'], 'STRING'));
+        }
+
+        if (\array_key_exists('direction', $apiListInfo)) {
+            $this->modelState->set('list.direction', $filter->clean($apiListInfo['direction'], 'STRING'));
+        }
+
+        return parent::displayList();
+    }
+}

--- a/api/components/com_j2commerce/src/Controller/OrderstatusesController.php
+++ b/api/components/com_j2commerce/src/Controller/OrderstatusesController.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Api\Controller;
+
+\defined('_JEXEC') or die;
+
+use J2Commerce\Component\J2commerce\Api\Controller\J2CommerceApiController;
+
+class OrderstatusesController extends J2CommerceApiController
+{
+    protected $contentType = 'orderstatuses';
+
+    protected $default_view = 'orderstatuses';
+}

--- a/api/components/com_j2commerce/src/Controller/PaymentmethodsController.php
+++ b/api/components/com_j2commerce/src/Controller/PaymentmethodsController.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Api\Controller;
+
+\defined('_JEXEC') or die;
+
+use J2Commerce\Component\J2commerce\Api\Controller\J2CommerceApiController;
+
+class PaymentmethodsController extends J2CommerceApiController
+{
+    protected $contentType = 'paymentmethods';
+
+    protected $default_view = 'paymentmethods';
+}

--- a/api/components/com_j2commerce/src/Controller/ProductsController.php
+++ b/api/components/com_j2commerce/src/Controller/ProductsController.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Api\Controller;
+
+\defined('_JEXEC') or die;
+
+use Joomla\CMS\Filter\InputFilter;
+use J2Commerce\Component\J2commerce\Api\Controller\J2CommerceApiController;
+
+class ProductsController extends J2CommerceApiController
+{
+    protected $contentType = 'products';
+
+    protected $default_view = 'products';
+
+    public function displayList()
+    {
+        $apiFilterInfo = $this->input->get('filter', [], 'array');
+        $filter = InputFilter::getInstance();
+
+        if (\array_key_exists('search', $apiFilterInfo)) {
+            $this->modelState->set('filter.search', $filter->clean($apiFilterInfo['search'], 'STRING'));
+        }
+
+        if (\array_key_exists('category', $apiFilterInfo)) {
+            $this->modelState->set('filter.category_id', $filter->clean($apiFilterInfo['category'], 'INT'));
+        }
+
+        if (\array_key_exists('manufacturer', $apiFilterInfo)) {
+            $this->modelState->set('filter.manufacturer_id', $filter->clean($apiFilterInfo['manufacturer'], 'INT'));
+        }
+
+        if (\array_key_exists('product_type', $apiFilterInfo)) {
+            $this->modelState->set('filter.product_type', $filter->clean($apiFilterInfo['product_type'], 'STRING'));
+        }
+
+        if (\array_key_exists('enabled', $apiFilterInfo)) {
+            $this->modelState->set('filter.state', $filter->clean($apiFilterInfo['enabled'], 'INT'));
+        }
+
+        if (\array_key_exists('sku', $apiFilterInfo)) {
+            $this->modelState->set('filter.search', 'sku:' . $filter->clean($apiFilterInfo['sku'], 'STRING'));
+        }
+
+        if (\array_key_exists('visibility', $apiFilterInfo)) {
+            $this->modelState->set('filter.visibility', $filter->clean($apiFilterInfo['visibility'], 'INT'));
+        }
+
+        $apiListInfo = $this->input->get('list', [], 'array');
+
+        if (\array_key_exists('ordering', $apiListInfo)) {
+            $this->modelState->set('list.ordering', $filter->clean($apiListInfo['ordering'], 'STRING'));
+        }
+
+        if (\array_key_exists('direction', $apiListInfo)) {
+            $this->modelState->set('list.direction', $filter->clean($apiListInfo['direction'], 'STRING'));
+        }
+
+        return parent::displayList();
+    }
+}

--- a/api/components/com_j2commerce/src/Controller/ReportsController.php
+++ b/api/components/com_j2commerce/src/Controller/ReportsController.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Api\Controller;
+
+\defined('_JEXEC') or die;
+
+use Joomla\CMS\Filter\InputFilter;
+use J2Commerce\Component\J2commerce\Api\Controller\J2CommerceApiController;
+
+class ReportsController extends J2CommerceApiController
+{
+    protected $contentType = 'reports';
+
+    protected $default_view = 'reports';
+
+    public function displayList()
+    {
+        $apiFilterInfo = $this->input->get('filter', [], 'array');
+        $filter = InputFilter::getInstance();
+
+        $reportType = $this->input->get('report_type', 'sales', 'string');
+        $this->modelState->set('filter.report_type', $filter->clean($reportType, 'STRING'));
+
+        if (\array_key_exists('date_from', $apiFilterInfo)) {
+            $this->modelState->set('filter.since', $filter->clean($apiFilterInfo['date_from'], 'STRING'));
+        }
+
+        if (\array_key_exists('date_to', $apiFilterInfo)) {
+            $this->modelState->set('filter.until', $filter->clean($apiFilterInfo['date_to'], 'STRING'));
+        }
+
+        if (\array_key_exists('period', $apiFilterInfo)) {
+            $this->modelState->set('filter.period', $filter->clean($apiFilterInfo['period'], 'STRING'));
+        }
+
+        return parent::displayList();
+    }
+}

--- a/api/components/com_j2commerce/src/Controller/ShippingmethodsController.php
+++ b/api/components/com_j2commerce/src/Controller/ShippingmethodsController.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Api\Controller;
+
+\defined('_JEXEC') or die;
+
+use J2Commerce\Component\J2commerce\Api\Controller\J2CommerceApiController;
+
+class ShippingmethodsController extends J2CommerceApiController
+{
+    protected $contentType = 'shippingmethods';
+
+    protected $default_view = 'shippingmethods';
+}

--- a/api/components/com_j2commerce/src/Controller/TaxprofilesController.php
+++ b/api/components/com_j2commerce/src/Controller/TaxprofilesController.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Api\Controller;
+
+\defined('_JEXEC') or die;
+
+use J2Commerce\Component\J2commerce\Api\Controller\J2CommerceApiController;
+
+class TaxprofilesController extends J2CommerceApiController
+{
+    protected $contentType = 'taxprofiles';
+
+    protected $default_view = 'taxprofiles';
+}

--- a/api/components/com_j2commerce/src/Controller/TaxratesController.php
+++ b/api/components/com_j2commerce/src/Controller/TaxratesController.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Api\Controller;
+
+\defined('_JEXEC') or die;
+
+use J2Commerce\Component\J2commerce\Api\Controller\J2CommerceApiController;
+
+class TaxratesController extends J2CommerceApiController
+{
+    protected $contentType = 'taxrates';
+
+    protected $default_view = 'taxrates';
+}

--- a/api/components/com_j2commerce/src/Controller/VariantsController.php
+++ b/api/components/com_j2commerce/src/Controller/VariantsController.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Api\Controller;
+
+\defined('_JEXEC') or die;
+
+use J2Commerce\Component\J2commerce\Api\Controller\J2CommerceApiController;
+
+class VariantsController extends J2CommerceApiController
+{
+    protected $contentType = 'variants';
+
+    protected $default_view = 'variants';
+
+    public function displayList()
+    {
+        $productId = $this->input->get('id', 0, 'int');
+        $this->modelState->set('filter.product_id', $productId);
+
+        return parent::displayList();
+    }
+}

--- a/api/components/com_j2commerce/src/Controller/VouchersController.php
+++ b/api/components/com_j2commerce/src/Controller/VouchersController.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Api\Controller;
+
+\defined('_JEXEC') or die;
+
+use J2Commerce\Component\J2commerce\Api\Controller\J2CommerceApiController;
+
+class VouchersController extends J2CommerceApiController
+{
+    protected $contentType = 'vouchers';
+
+    protected $default_view = 'vouchers';
+}

--- a/api/components/com_j2commerce/src/Controller/ZonesController.php
+++ b/api/components/com_j2commerce/src/Controller/ZonesController.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Api\Controller;
+
+\defined('_JEXEC') or die;
+
+use Joomla\CMS\Filter\InputFilter;
+use J2Commerce\Component\J2commerce\Api\Controller\J2CommerceApiController;
+
+class ZonesController extends J2CommerceApiController
+{
+    protected $contentType = 'zones';
+
+    protected $default_view = 'zones';
+
+    public function displayList()
+    {
+        $apiFilterInfo = $this->input->get('filter', [], 'array');
+        $filter = InputFilter::getInstance();
+
+        $countryId = $this->input->get('id', 0, 'int');
+
+        if ($countryId) {
+            $this->modelState->set('filter.country_id', $countryId);
+        }
+
+        if (\array_key_exists('search', $apiFilterInfo)) {
+            $this->modelState->set('filter.search', $filter->clean($apiFilterInfo['search'], 'STRING'));
+        }
+
+        return parent::displayList();
+    }
+}

--- a/api/components/com_j2commerce/src/View/Addresses/JsonapiView.php
+++ b/api/components/com_j2commerce/src/View/Addresses/JsonapiView.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Api\View\Addresses;
+
+\defined('_JEXEC') or die;
+
+use J2Commerce\Component\J2commerce\Api\View\J2CommerceJsonapiView;
+
+class JsonapiView extends J2CommerceJsonapiView
+{
+    protected string $pkField = 'j2commerce_address_id';
+
+    protected $fieldsToRenderItem = [
+        'j2commerce_address_id',
+        'user_id',
+        'first_name',
+        'last_name',
+        'email',
+        'address_1',
+        'address_2',
+        'city',
+        'zip',
+        'zone_id',
+        'country_id',
+        'phone_1',
+        'phone_2',
+        'company',
+        'tax_number',
+        'type',
+        'country_name',
+        'zone_name',
+    ];
+
+    protected $fieldsToRenderList = [
+        'j2commerce_address_id',
+        'user_id',
+        'first_name',
+        'last_name',
+        'email',
+        'city',
+        'country_name',
+        'zone_name',
+        'phone_1',
+        'type',
+    ];
+
+    protected $relationship = [
+        'country_id',
+        'zone_id',
+    ];
+}

--- a/api/components/com_j2commerce/src/View/Categories/JsonapiView.php
+++ b/api/components/com_j2commerce/src/View/Categories/JsonapiView.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Api\View\Categories;
+
+\defined('_JEXEC') or die;
+
+use J2Commerce\Component\J2commerce\Api\View\J2CommerceJsonapiView;
+
+class JsonapiView extends J2CommerceJsonapiView
+{
+    protected $fieldsToRenderItem = [
+        'id',
+        'title',
+        'alias',
+        'description',
+        'published',
+        'parent_id',
+        'level',
+        'path',
+        'language',
+    ];
+
+    protected $fieldsToRenderList = [
+        'id',
+        'title',
+        'alias',
+        'published',
+        'parent_id',
+        'level',
+    ];
+
+    protected $relationship = [
+        'parent_id',
+    ];
+}

--- a/api/components/com_j2commerce/src/View/Config/JsonapiView.php
+++ b/api/components/com_j2commerce/src/View/Config/JsonapiView.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Api\View\Config;
+
+\defined('_JEXEC') or die;
+
+use J2Commerce\Component\J2commerce\Api\View\J2CommerceJsonapiView;
+
+class JsonapiView extends J2CommerceJsonapiView
+{
+}

--- a/api/components/com_j2commerce/src/View/Countries/JsonapiView.php
+++ b/api/components/com_j2commerce/src/View/Countries/JsonapiView.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Api\View\Countries;
+
+\defined('_JEXEC') or die;
+
+use J2Commerce\Component\J2commerce\Api\View\J2CommerceJsonapiView;
+
+class JsonapiView extends J2CommerceJsonapiView
+{
+    protected string $pkField = 'j2commerce_country_id';
+
+
+    protected $fieldsToRenderItem = [
+        'j2commerce_country_id',
+        'country_name',
+        'country_isocode_2',
+        'country_isocode_3',
+        'enabled',
+    ];
+
+    protected $fieldsToRenderList = [
+        'j2commerce_country_id',
+        'country_name',
+        'country_isocode_2',
+        'country_isocode_3',
+        'enabled',
+    ];
+
+    protected $relationship = [];
+}

--- a/api/components/com_j2commerce/src/View/Coupons/JsonapiView.php
+++ b/api/components/com_j2commerce/src/View/Coupons/JsonapiView.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Api\View\Coupons;
+
+\defined('_JEXEC') or die;
+
+use J2Commerce\Component\J2commerce\Api\View\J2CommerceJsonapiView;
+
+class JsonapiView extends J2CommerceJsonapiView
+{
+    protected string $pkField = 'j2commerce_coupon_id';
+
+
+    protected $fieldsToRenderItem = [
+        'j2commerce_coupon_id',
+        'coupon_name',
+        'coupon_code',
+        'enabled',
+        'value',
+        'value_type',
+        'max_value',
+        'free_shipping',
+        'max_uses',
+        'max_customer_uses',
+        'max_quantity',
+        'valid_from',
+        'valid_to',
+        'product_category',
+        'products',
+        'min_subtotal',
+        'brand_ids',
+    ];
+
+    protected $fieldsToRenderList = [
+        'j2commerce_coupon_id',
+        'coupon_name',
+        'coupon_code',
+        'enabled',
+        'value',
+        'value_type',
+        'valid_from',
+        'valid_to',
+    ];
+
+    protected $relationship = [];
+}

--- a/api/components/com_j2commerce/src/View/Currencies/JsonapiView.php
+++ b/api/components/com_j2commerce/src/View/Currencies/JsonapiView.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Api\View\Currencies;
+
+\defined('_JEXEC') or die;
+
+use J2Commerce\Component\J2commerce\Api\View\J2CommerceJsonapiView;
+
+class JsonapiView extends J2CommerceJsonapiView
+{
+    protected string $pkField = 'j2commerce_currency_id';
+
+
+    protected $fieldsToRenderItem = [
+        'j2commerce_currency_id',
+        'currency_title',
+        'currency_code',
+        'currency_position',
+        'currency_num_decimals',
+        'currency_decimal',
+        'currency_thousands',
+        'currency_value',
+        'enabled',
+    ];
+
+    protected $fieldsToRenderList = [
+        'j2commerce_currency_id',
+        'currency_title',
+        'currency_code',
+        'currency_value',
+        'enabled',
+    ];
+
+    protected $relationship = [];
+}

--- a/api/components/com_j2commerce/src/View/Customers/JsonapiView.php
+++ b/api/components/com_j2commerce/src/View/Customers/JsonapiView.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Api\View\Customers;
+
+\defined('_JEXEC') or die;
+
+use J2Commerce\Component\J2commerce\Api\View\J2CommerceJsonapiView;
+
+class JsonapiView extends J2CommerceJsonapiView
+{
+    protected string $pkField = 'j2commerce_address_id';
+
+
+    protected $fieldsToRenderItem = [
+        'j2commerce_address_id',
+        'user_id',
+        'first_name',
+        'last_name',
+        'email',
+        'address_1',
+        'address_2',
+        'city',
+        'zip',
+        'zone_id',
+        'country_id',
+        'phone_1',
+        'company',
+        'country_name',
+        'zone_name',
+    ];
+
+    protected $fieldsToRenderList = [
+        'j2commerce_address_id',
+        'user_id',
+        'first_name',
+        'last_name',
+        'email',
+        'city',
+        'country_name',
+        'zone_name',
+        'phone_1',
+        'company',
+    ];
+
+    protected $relationship = [
+        'country_id',
+        'zone_id',
+    ];
+}

--- a/api/components/com_j2commerce/src/View/Inventory/JsonapiView.php
+++ b/api/components/com_j2commerce/src/View/Inventory/JsonapiView.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Api\View\Inventory;
+
+\defined('_JEXEC') or die;
+
+use J2Commerce\Component\J2commerce\Api\View\J2CommerceJsonapiView;
+
+class JsonapiView extends J2CommerceJsonapiView
+{
+    protected string $pkField = 'j2commerce_product_id';
+
+
+    protected $fieldsToRenderItem = [
+        'j2commerce_product_id',
+        'product_source_id',
+        'sku',
+        'quantity',
+        'manage_stock',
+        'min_out_qty',
+        'min_sale_qty',
+        'max_sale_qty',
+        'notify_qty',
+    ];
+
+    protected $fieldsToRenderList = [
+        'j2commerce_product_id',
+        'sku',
+        'quantity',
+        'manage_stock',
+    ];
+
+    protected $relationship = [];
+}

--- a/api/components/com_j2commerce/src/View/J2CommerceJsonapiView.php
+++ b/api/components/com_j2commerce/src/View/J2CommerceJsonapiView.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Api\View;
+
+\defined('_JEXEC') or die;
+
+use Joomla\CMS\MVC\View\JsonApiView;
+
+/**
+ * Base JSON:API view for J2Commerce.
+ *
+ * Maps custom primary keys (e.g. j2commerce_product_id) to the standard
+ * 'id' field expected by the tobscure/json-api serializer.
+ *
+ * @since  6.0.15
+ */
+abstract class J2CommerceJsonapiView extends JsonApiView
+{
+    protected string $pkField = 'id';
+
+    protected function prepareItem($item)
+    {
+        if ($this->pkField !== 'id' && isset($item->{$this->pkField})) {
+            $item->id = $item->{$this->pkField};
+        }
+
+        return $item;
+    }
+}

--- a/api/components/com_j2commerce/src/View/Manufacturers/JsonapiView.php
+++ b/api/components/com_j2commerce/src/View/Manufacturers/JsonapiView.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Api\View\Manufacturers;
+
+\defined('_JEXEC') or die;
+
+use J2Commerce\Component\J2commerce\Api\View\J2CommerceJsonapiView;
+
+class JsonapiView extends J2CommerceJsonapiView
+{
+    protected string $pkField = 'j2commerce_manufacturer_id';
+
+
+    protected $fieldsToRenderItem = [
+        'j2commerce_manufacturer_id',
+        'manufacturer_name',
+        'manufacturer_desc',
+        'enabled',
+        'ordering',
+    ];
+
+    protected $fieldsToRenderList = [
+        'j2commerce_manufacturer_id',
+        'manufacturer_name',
+        'enabled',
+        'ordering',
+    ];
+
+    protected $relationship = [];
+}

--- a/api/components/com_j2commerce/src/View/Orderhistories/JsonapiView.php
+++ b/api/components/com_j2commerce/src/View/Orderhistories/JsonapiView.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Api\View\Orderhistories;
+
+\defined('_JEXEC') or die;
+
+use J2Commerce\Component\J2commerce\Api\View\J2CommerceJsonapiView;
+
+class JsonapiView extends J2CommerceJsonapiView
+{
+    protected string $pkField = 'j2commerce_orderhistory_id';
+
+
+    protected $fieldsToRenderItem = [
+        'j2commerce_orderhistory_id',
+        'order_id',
+        'order_state_id',
+        'notify_customer',
+        'comment',
+        'created_on',
+        'created_by',
+    ];
+
+    protected $fieldsToRenderList = [
+        'j2commerce_orderhistory_id',
+        'order_id',
+        'order_state_id',
+        'comment',
+        'created_on',
+    ];
+
+    protected $relationship = [
+        'order_state_id',
+    ];
+}

--- a/api/components/com_j2commerce/src/View/Orderitems/JsonapiView.php
+++ b/api/components/com_j2commerce/src/View/Orderitems/JsonapiView.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Api\View\Orderitems;
+
+\defined('_JEXEC') or die;
+
+use J2Commerce\Component\J2commerce\Api\View\J2CommerceJsonapiView;
+
+class JsonapiView extends J2CommerceJsonapiView
+{
+    protected string $pkField = 'j2commerce_orderitem_id';
+
+
+    protected $fieldsToRenderItem = [
+        'j2commerce_orderitem_id',
+        'order_id',
+        'product_id',
+        'variant_id',
+        'orderitem_sku',
+        'orderitem_name',
+        'orderitem_attributes',
+        'orderitem_quantity',
+        'orderitem_price',
+        'orderitem_option_price',
+        'orderitem_finalprice',
+        'orderitem_finalprice_with_tax',
+        'orderitem_tax',
+        'orderitem_discount',
+        'orderitem_weight',
+        'created_on',
+    ];
+
+    protected $fieldsToRenderList = [
+        'j2commerce_orderitem_id',
+        'order_id',
+        'orderitem_sku',
+        'orderitem_name',
+        'orderitem_quantity',
+        'orderitem_finalprice',
+        'orderitem_tax',
+    ];
+
+    protected $relationship = [
+        'product_id',
+        'variant_id',
+    ];
+}

--- a/api/components/com_j2commerce/src/View/Orders/JsonapiView.php
+++ b/api/components/com_j2commerce/src/View/Orders/JsonapiView.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Api\View\Orders;
+
+\defined('_JEXEC') or die;
+
+use J2Commerce\Component\J2commerce\Api\View\J2CommerceJsonapiView;
+
+class JsonapiView extends J2CommerceJsonapiView
+{
+    protected string $pkField = 'j2commerce_order_id';
+
+
+    protected $fieldsToRenderItem = [
+        'j2commerce_order_id',
+        'order_id',
+        'user_id',
+        'user_email',
+        'order_state_id',
+        'order_state',
+        'orderstatus_name',
+        'order_total',
+        'order_subtotal',
+        'order_tax',
+        'order_shipping',
+        'order_shipping_tax',
+        'order_discount',
+        'order_surcharge',
+        'order_fees',
+        'order_credit',
+        'order_refund',
+        'orderpayment_type',
+        'transaction_id',
+        'transaction_status',
+        'currency_code',
+        'currency_value',
+        'customer_note',
+        'customer_language',
+        'is_shippable',
+        'invoice_prefix',
+        'invoice_number',
+        'billing_first_name',
+        'billing_last_name',
+        'created_on',
+        'modified_on',
+    ];
+
+    protected $fieldsToRenderList = [
+        'j2commerce_order_id',
+        'order_id',
+        'user_id',
+        'user_email',
+        'order_state_id',
+        'orderstatus_name',
+        'order_total',
+        'orderpayment_type',
+        'currency_code',
+        'billing_first_name',
+        'billing_last_name',
+        'created_on',
+    ];
+
+    protected $relationship = [
+        'user_id',
+        'order_state_id',
+    ];
+}

--- a/api/components/com_j2commerce/src/View/Orderstatuses/JsonapiView.php
+++ b/api/components/com_j2commerce/src/View/Orderstatuses/JsonapiView.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Api\View\Orderstatuses;
+
+\defined('_JEXEC') or die;
+
+use J2Commerce\Component\J2commerce\Api\View\J2CommerceJsonapiView;
+
+class JsonapiView extends J2CommerceJsonapiView
+{
+    protected string $pkField = 'j2commerce_orderstatus_id';
+
+
+    protected $fieldsToRenderItem = [
+        'j2commerce_orderstatus_id',
+        'orderstatus_name',
+        'orderstatus_core',
+        'enabled',
+    ];
+
+    protected $fieldsToRenderList = [
+        'j2commerce_orderstatus_id',
+        'orderstatus_name',
+        'orderstatus_core',
+        'enabled',
+    ];
+
+    protected $relationship = [];
+}

--- a/api/components/com_j2commerce/src/View/Paymentmethods/JsonapiView.php
+++ b/api/components/com_j2commerce/src/View/Paymentmethods/JsonapiView.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Api\View\Paymentmethods;
+
+\defined('_JEXEC') or die;
+
+use J2Commerce\Component\J2commerce\Api\View\J2CommerceJsonapiView;
+
+class JsonapiView extends J2CommerceJsonapiView
+{
+    protected string $pkField = 'extension_id';
+
+    protected $fieldsToRenderItem = [
+        'extension_id',
+        'name',
+        'element',
+        'enabled',
+        'ordering',
+        'params',
+    ];
+
+    protected $fieldsToRenderList = [
+        'extension_id',
+        'name',
+        'element',
+        'enabled',
+        'ordering',
+    ];
+
+    protected $relationship = [];
+}

--- a/api/components/com_j2commerce/src/View/Products/JsonapiView.php
+++ b/api/components/com_j2commerce/src/View/Products/JsonapiView.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Api\View\Products;
+
+\defined('_JEXEC') or die;
+
+use J2Commerce\Component\J2commerce\Api\View\J2CommerceJsonapiView;
+
+class JsonapiView extends J2CommerceJsonapiView
+{
+    protected string $pkField = 'j2commerce_product_id';
+
+
+    protected $fieldsToRenderItem = [
+        'j2commerce_product_id',
+        'product_source_id',
+        'product_type',
+        'product_name',
+        'visibility',
+        'enabled',
+        'taxprofile_id',
+        'manufacturer_id',
+        'vendor_id',
+        'has_options',
+        'sku',
+        'upc',
+        'price',
+        'sale_price',
+        'quantity',
+        'main_image',
+        'created_on',
+        'modified_on',
+    ];
+
+    protected $fieldsToRenderList = [
+        'j2commerce_product_id',
+        'product_source_id',
+        'product_type',
+        'product_name',
+        'visibility',
+        'enabled',
+        'manufacturer_id',
+        'has_options',
+        'sku',
+        'price',
+        'sale_price',
+        'quantity',
+        'main_image',
+        'created_on',
+    ];
+
+    protected $relationship = [
+        'manufacturer_id',
+        'taxprofile_id',
+    ];
+}

--- a/api/components/com_j2commerce/src/View/Reports/JsonapiView.php
+++ b/api/components/com_j2commerce/src/View/Reports/JsonapiView.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Api\View\Reports;
+
+\defined('_JEXEC') or die;
+
+use J2Commerce\Component\J2commerce\Api\View\J2CommerceJsonapiView;
+
+class JsonapiView extends J2CommerceJsonapiView
+{
+    protected string $pkField = 'extension_id';
+
+    protected $fieldsToRenderItem = [
+        'extension_id',
+        'name',
+        'element',
+        'enabled',
+        'ordering',
+        'params',
+    ];
+
+    protected $fieldsToRenderList = [
+        'extension_id',
+        'name',
+        'element',
+        'enabled',
+        'ordering',
+    ];
+
+    protected $relationship = [];
+}

--- a/api/components/com_j2commerce/src/View/Shippingmethods/JsonapiView.php
+++ b/api/components/com_j2commerce/src/View/Shippingmethods/JsonapiView.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Api\View\Shippingmethods;
+
+\defined('_JEXEC') or die;
+
+use J2Commerce\Component\J2commerce\Api\View\J2CommerceJsonapiView;
+
+class JsonapiView extends J2CommerceJsonapiView
+{
+    protected string $pkField = 'extension_id';
+
+    protected $fieldsToRenderItem = [
+        'extension_id',
+        'name',
+        'element',
+        'enabled',
+        'ordering',
+        'params',
+    ];
+
+    protected $fieldsToRenderList = [
+        'extension_id',
+        'name',
+        'element',
+        'enabled',
+        'ordering',
+    ];
+
+    protected $relationship = [];
+}

--- a/api/components/com_j2commerce/src/View/Taxprofiles/JsonapiView.php
+++ b/api/components/com_j2commerce/src/View/Taxprofiles/JsonapiView.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Api\View\Taxprofiles;
+
+\defined('_JEXEC') or die;
+
+use J2Commerce\Component\J2commerce\Api\View\J2CommerceJsonapiView;
+
+class JsonapiView extends J2CommerceJsonapiView
+{
+    protected string $pkField = 'j2commerce_taxprofile_id';
+
+
+    protected $fieldsToRenderItem = [
+        'j2commerce_taxprofile_id',
+        'taxprofile_name',
+        'enabled',
+    ];
+
+    protected $fieldsToRenderList = [
+        'j2commerce_taxprofile_id',
+        'taxprofile_name',
+        'enabled',
+    ];
+
+    protected $relationship = [];
+}

--- a/api/components/com_j2commerce/src/View/Taxrates/JsonapiView.php
+++ b/api/components/com_j2commerce/src/View/Taxrates/JsonapiView.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Api\View\Taxrates;
+
+\defined('_JEXEC') or die;
+
+use J2Commerce\Component\J2commerce\Api\View\J2CommerceJsonapiView;
+
+class JsonapiView extends J2CommerceJsonapiView
+{
+    protected string $pkField = 'j2commerce_taxrate_id';
+
+
+    protected $fieldsToRenderItem = [
+        'j2commerce_taxrate_id',
+        'taxrate_name',
+        'tax_percent',
+        'geozone_id',
+        'enabled',
+    ];
+
+    protected $fieldsToRenderList = [
+        'j2commerce_taxrate_id',
+        'taxrate_name',
+        'tax_percent',
+        'geozone_id',
+        'enabled',
+    ];
+
+    protected $relationship = [
+        'geozone_id',
+    ];
+}

--- a/api/components/com_j2commerce/src/View/Variants/JsonapiView.php
+++ b/api/components/com_j2commerce/src/View/Variants/JsonapiView.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Api\View\Variants;
+
+\defined('_JEXEC') or die;
+
+use J2Commerce\Component\J2commerce\Api\View\J2CommerceJsonapiView;
+
+class JsonapiView extends J2CommerceJsonapiView
+{
+    protected string $pkField = 'j2commerce_variant_id';
+
+    protected $fieldsToRenderItem = [
+        'j2commerce_variant_id',
+        'product_id',
+        'is_master',
+        'sku',
+        'upc',
+        'price',
+        'manage_stock',
+        'quantity_restriction',
+        'min_sale_qty',
+        'max_sale_qty',
+        'availability',
+        'sold',
+        'allow_backorder',
+        'isdefault_variant',
+        'weight',
+        'length',
+        'width',
+        'height',
+        'shipping',
+    ];
+
+    protected $fieldsToRenderList = [
+        'j2commerce_variant_id',
+        'product_id',
+        'is_master',
+        'sku',
+        'price',
+        'manage_stock',
+        'availability',
+        'sold',
+        'isdefault_variant',
+    ];
+
+    protected $relationship = [
+        'product_id',
+    ];
+}

--- a/api/components/com_j2commerce/src/View/Vouchers/JsonapiView.php
+++ b/api/components/com_j2commerce/src/View/Vouchers/JsonapiView.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Api\View\Vouchers;
+
+\defined('_JEXEC') or die;
+
+use J2Commerce\Component\J2commerce\Api\View\J2CommerceJsonapiView;
+
+class JsonapiView extends J2CommerceJsonapiView
+{
+    protected string $pkField = 'j2commerce_voucher_id';
+
+
+    protected $fieldsToRenderItem = [
+        'j2commerce_voucher_id',
+        'order_id',
+        'email_to',
+        'voucher_code',
+        'voucher_type',
+        'subject',
+        'voucher_value',
+        'valid_from',
+        'valid_to',
+        'enabled',
+        'created_on',
+    ];
+
+    protected $fieldsToRenderList = [
+        'j2commerce_voucher_id',
+        'voucher_code',
+        'voucher_type',
+        'email_to',
+        'voucher_value',
+        'enabled',
+        'created_on',
+    ];
+
+    protected $relationship = [];
+}

--- a/api/components/com_j2commerce/src/View/Zones/JsonapiView.php
+++ b/api/components/com_j2commerce/src/View/Zones/JsonapiView.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Api\View\Zones;
+
+\defined('_JEXEC') or die;
+
+use J2Commerce\Component\J2commerce\Api\View\J2CommerceJsonapiView;
+
+class JsonapiView extends J2CommerceJsonapiView
+{
+    protected string $pkField = 'j2commerce_zone_id';
+
+
+    protected $fieldsToRenderItem = [
+        'j2commerce_zone_id',
+        'zone_name',
+        'zone_code',
+        'country_id',
+        'enabled',
+    ];
+
+    protected $fieldsToRenderList = [
+        'j2commerce_zone_id',
+        'zone_name',
+        'zone_code',
+        'country_id',
+        'enabled',
+    ];
+
+    protected $relationship = [
+        'country_id',
+    ];
+}

--- a/build/build_package.php
+++ b/build/build_package.php
@@ -325,6 +325,16 @@ function buildComponentZip(string $joomlaRoot, string $tempDir, string $version,
         $count++;
     }
 
+    // 4b. API component files (web-services / JSON:API — declared via <api> in the manifest)
+    $apiDir = $joomlaRoot . '/api/components/com_j2commerce';
+    if (is_dir($apiDir)) {
+        $apiFiles = collectFiles($apiDir, $excludePatterns);
+        foreach ($apiFiles as $rel => $absPath) {
+            $zip->addFile($absPath, 'api/components/com_j2commerce/' . $rel);
+            $count++;
+        }
+    }
+
     // 5. Media files
     $mediaDir = $joomlaRoot . '/media/com_j2commerce';
     $mediaFiles = collectFiles($mediaDir, $excludePatterns);


### PR DESCRIPTION
## Summary

Fixes #1188

The J2Commerce **web-services API component** (`api/components/com_j2commerce/` — 47 JSON:API controllers + views) was shipping in **no** packaged or manifest-driven install. Investigation found the true root cause runs deeper than "missing from the build script":

- The repo `.gitignore` is a **whitelist** (ignore all Joomla-core territory, then `!`-negate each J2Commerce path). The `api/` tree was **never whitelisted**, so all 47 files were **gitignored and never committed** — absent from the repo entirely, not just from the package.
- The manifest had no `<api>` install section.
- `build/build_package.php` never collected the `api/` tree.

A build from a clean checkout therefore had nothing to bundle.

## Changes

- **`.gitignore`** — whitelist `api/`, `api/components/`, `api/components/com_j2commerce/**` (mirrors the existing admin/site/plugin negations).
- **Track the 47 API files** (previously gitignored) so they reach the repo.
- **`administrator/components/com_j2commerce/j2commerce.xml`** — add an `<api><files folder="api/components/com_j2commerce"><folder>src</folder></files></api>` block so the installer copies the files. The existing `<namespace path="src">` already maps the `…\Api\…` namespace to the installed tree.
- **`build/build_package.php`** — bundle the api tree into `com_j2commerce.zip` (mirrors the site-files block).

### Deliberately NOT done
`api/language/` is **not** declared — it contains Joomla **core** files (`com_media.ini`, `joomla.ini`, `langmetadata.xml`), not a J2Commerce API language file. Declaring it would wrongly ship/overwrite core language files. (The issue's suggested `<languages folder="api/language">` was intentionally dropped.)

### Note on `.gitignore`
This PR intentionally includes a `.gitignore` change — the whitelist negation **is** the fix, not dev-local drift.

## Testing

- [x] `php build/build_package.php` → inner `com_j2commerce.zip` now contains **47** `api/components/com_j2commerce/` files (previously 0); component zip 1405 → 1452 files.
- [x] All 47 API PHP files + the build script pass `php -l`.
- [ ] Install the built package on a clean Joomla 6 site → confirm `api/components/com_j2commerce/` lands on disk.
- [ ] With `plg_webservices_j2commerce` enabled, hit a JSON:API endpoint and confirm it responds.

## Files Changed

| Type | Count |
|------|-------|
| `.gitignore` | 1 |
| Manifest (`j2commerce.xml`) | 1 |
| Build script (`build_package.php`) | 1 |
| API component files (newly tracked) | 47 |