### PR TITLE
Drop .gitignore change from PR #1194 revert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,12 @@
 !components/com_j2commerce/
 !components/com_j2commerce/**
 
+# API component (web-services / JSON:API)
+!api/
+!api/components/
+!api/components/com_j2commerce/
+!api/components/com_j2commerce/**
+
 # J2Commerce core plugins (only those in the package skill)
 !plugins/
 !plugins/j2commerce/


### PR DESCRIPTION
Restores .gitignore to main's version on the #1194 revert branch so the revert no longer modifies .gitignore (keeps the api/ un-ignore rules). Removes .gitignore from PR #1194's diff.