### PR TITLE
Fix clearContentCaches catches Throwable instead of Exception

### DIFF
--- a/plugins/content/j2commerce/src/Extension/J2Commerce.php
+++ b/plugins/content/j2commerce/src/Extension/J2Commerce.php
@@ -742,7 +742,7 @@ final class J2Commerce extends CMSPlugin implements SubscriberInterface
             $j2commerceCache->clean();
 
             $this->cacheCleared = true;
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             // Silently fail on cache clear
         }
     }


### PR DESCRIPTION
Exception Type: ArgumentCountError
File: /libraries/src/Language/Text.php
Line: 280
Message: 3 arguments are required, 2 given

#0 /libraries/src/Language/Text.php(280): sprintf()
#1 /libraries/src/Cache/Storage/FileStorage.php(536): Joomla\CMS\Language\Text::sprintf()
#2 /libraries/src/Cache/Storage/FileStorage.php(279): Joomla\CMS\Cache\Storage\FileStorage->_deleteFolder()
#3 /libraries/src/Cache/Cache.php(319): Joomla\CMS\Cache\Storage\FileStorage->clean()
#4 /libraries/src/Cache/CacheController.php(76): Joomla\CMS\Cache\Cache->clean()
#5 /plugins/content/j2commerce/src/Extension/J2Commerce.php(739): Joomla\CMS\Cache\CacheController->__call()
#6 /plugins/content/j2commerce/src/Extension/J2Commerce.php(161): J2Commerce\Plugin\Content\J2Commerce\Extension\J2Commerce->clearContentCaches()
#7 /libraries/vendor/joomla/event/src/Dispatcher.php(454): J2Commerce\Plugin\Content\J2Commerce\Extension\J2Commerce->onContentPrepare()

Root cause: In PHP, ArgumentCountError extends Error, not Exception. The catch (\Exception $e) block was designed to silently swallow cache-clear failures, but it only catches Exception subclasses — not Error subclasses like ArgumentCountError. So the error escaped the try/catch and crashed the page.

Changing to catch (\Throwable $e) catches both Error and Exception hierarchies, which is the correct approach for "silently fail" guard blocks around non-critical operations like cache clearing.