### PR TITLE
fix(core): import j2commerce plugin group before queue dispatch

### DIFF
--- a/plugins/task/j2commerce/src/Extension/J2Commerce.php
+++ b/plugins/task/j2commerce/src/Extension/J2Commerce.php
@@ -188,6 +188,9 @@ final class J2Commerce extends CMSPlugin implements SubscriberInterface
         $batchSize            = (int) ($params->batch_size ?? 10);
         $releaseStaleMinutes  = (int) ($params->release_stale_minutes ?? 30);
 
+        // Register j2commerce-group subscribers before dispatching to them below.
+        PluginHelper::importPlugin('j2commerce');
+
         QueueHelper::releaseStale($releaseStaleMinutes);
 
         $items = QueueHelper::claimBatch($queueType ?: '', $batchSize);


### PR DESCRIPTION
## Core Update

### Changes
The Scheduled Task plugin's queue processor (`onExecuteTask` → batch processing) dispatches `onJ2CommerceQueueProcess` to j2commerce-group subscribers (app/payment/shipping queue handlers). On a cron/CLI request those plugins are not registered in the dispatcher yet, so the event reaches no listeners and queued jobs silently never run. This adds `PluginHelper::importPlugin('j2commerce')` before the batch loop — mirroring the existing import already present in the other dispatch path of the same file.

### Files Modified
| Type | Count |
|------|-------|
| PHP files | 1 |
| JS/CSS assets | 0 |
| Language files | 0 |
| XML/Config | 0 |

`plugins/task/j2commerce/src/Extension/J2Commerce.php` (+3 lines)

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only (non-core excluded)
- [x] Branch based on upstream/main (no unrelated commits)