### PR TITLE
fix(core): retry failed queue rows in QueueHelper::claimBatch

### DIFF
--- a/administrator/components/com_j2commerce/src/Helper/QueueHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/QueueHelper.php
@@ -70,19 +70,23 @@ final class QueueHelper
         $db         = self::db();
         $lockId     = $lockId ?? uniqid('queue_', true);
         $now        = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
-        $status     = 'pending';
+        $pending    = 'pending';
+        $failed     = 'failed';
         $processing = 'processing';
 
+        // Claim fresh 'pending' rows AND 'failed' rows whose backoff window has elapsed,
+        // so transient failures actually retry. 'dead' rows (max attempts reached) are terminal.
         $selectQuery = $db->getQuery(true)
             ->select($db->quoteName('j2commerce_queue_id'))
             ->from($db->quoteName('#__j2commerce_queues'))
             ->where($db->quoteName('queue_type') . ' = :queue_type')
-            ->where($db->quoteName('status') . ' = :status')
+            ->where('(' . $db->quoteName('status') . ' = :pending OR ' . $db->quoteName('status') . ' = :failed)')
             ->where('(' . $db->quoteName('next_attempt_at') . ' IS NULL OR ' . $db->quoteName('next_attempt_at') . ' <= :now)')
             ->order($db->quoteName('priority') . ' DESC')
             ->order($db->quoteName('created_on') . ' ASC')
             ->bind(':queue_type', $queueType)
-            ->bind(':status', $status)
+            ->bind(':pending', $pending)
+            ->bind(':failed', $failed)
             ->bind(':now', $now)
             ->setLimit($limit);
 


### PR DESCRIPTION
## Core Update

### Problem
`QueueHelper::claimBatch()` only ever selected rows with `status = 'pending'`. When an item fails, `QueueHelper::fail()` sets it to `status = 'failed'` with a `next_attempt_at` backoff — but nothing ever flips a `failed` row back to `pending`. Result: **any queue item that fails even once is never retried** and stays stuck forever. The `next_attempt_at <= now` retry condition was dead code because the status gate already excluded it.

This affects **every** queue consumer (omnisend, shipstation, app_reviews, edi_export, …), not just one plugin. It was surfaced while debugging Omnisend order events that queued but never delivered.

### Fix
`claimBatch()` now claims fresh `pending` rows **and** `failed` rows whose backoff window (`next_attempt_at`) has elapsed. `dead` rows (max attempts reached) remain terminal. Per-`queue_type` scoping is unchanged, so consumers stay isolated.

### Files Modified
| Type | Count |
|------|-------|
| PHP files | 1 |

`administrator/components/com_j2commerce/src/Helper/QueueHelper.php` (+7 / -3)

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants / JFactory
- [x] Core files only (single file, branched off upstream/main)