### PR TITLE
fix(core): set value_field on queue filter sql fields

### DIFF
--- a/administrator/components/com_j2commerce/forms/filter_queuelogs.xml
+++ b/administrator/components/com_j2commerce/forms/filter_queuelogs.xml
@@ -29,6 +29,8 @@
             type="sql"
             label="COM_J2COMMERCE_HEADING_QUEUE_TYPE"
             query="SELECT DISTINCT queue_type AS value, queue_type AS text FROM #__j2commerce_queue_logs ORDER BY queue_type ASC"
+            key_field="value"
+            value_field="text"
             class="js-select-submit-on-change"
             header="COM_J2COMMERCE_FILTER_SELECT_QUEUE_TYPE"
         />

--- a/administrator/components/com_j2commerce/forms/filter_queues.xml
+++ b/administrator/components/com_j2commerce/forms/filter_queues.xml
@@ -15,6 +15,8 @@
             type="sql"
             label="COM_J2COMMERCE_HEADING_QUEUE_TYPE"
             query="SELECT DISTINCT queue_type AS value, queue_type AS text FROM #__j2commerce_queues ORDER BY queue_type ASC"
+            key_field="value"
+            value_field="text"
             class="js-select-submit-on-change"
             header="COM_J2COMMERCE_FILTER_SELECT_QUEUE_TYPE"
         />
@@ -24,6 +26,8 @@
             type="sql"
             label="COM_J2COMMERCE_HEADING_ITEM_TYPE"
             query="SELECT DISTINCT item_type AS value, item_type AS text FROM #__j2commerce_queues ORDER BY item_type ASC"
+            key_field="value"
+            value_field="text"
             class="js-select-submit-on-change"
             header="COM_J2COMMERCE_FILTER_SELECT_ITEM_TYPE"
         />


### PR DESCRIPTION
## Core Update

### Problem
The Queues and Queue Logs admin list views threw PHP warnings when opening the filter dropdowns:
```
Warning: Undefined property: stdClass::$queue_type in libraries/src/Form/Field/SqlField.php on line 305
Warning: Undefined property: stdClass::$item_type in .../SqlField.php on line 305
Deprecated: trim(): Passing null to parameter #1 ($string) ... in libraries/src/HTML/Helpers/Select.php on line 423
```
`SqlField` defaults `value_field` to the **field name** when the attribute is absent (`SqlField.php:186`: `$this->element['value_field'] ?: $this->element['name']`). The filter fields are named `queue_type` / `item_type`, but their queries alias the column `AS text` — so `SqlField` read a nonexistent `$item->queue_type` / `$item->item_type` property (→ Undefined property), yielding null option text (→ `trim(null)` deprecation).

### Fix
Set `key_field="value"` and `value_field="text"` explicitly on each `type="sql"` filter field so they read the aliased columns. Pure form-XML attribute change, no logic/query change.

### Files Modified
| Type | Count |
|------|-------|
| Form XML | 2 |

- `administrator/components/com_j2commerce/forms/filter_queues.xml` (queue_type + item_type)
- `administrator/components/com_j2commerce/forms/filter_queuelogs.xml` (queue_type)

### Pre-Flight
- [x] XML well-formed (simplexml validated)
- [x] No secrets / logic changes
- [x] Core files only (2 files, branched off upstream/main)