### PR TITLE
feat(core): add CustomizeRenderLayout instrumentation seam to ProductLayoutService

### DIFF
--- a/components/com_j2commerce/src/Service/ProductLayoutService.php
+++ b/components/com_j2commerce/src/Service/ProductLayoutService.php
@@ -179,8 +179,27 @@ final class ProductLayoutService
             $layout->setIncludePaths($paths);
         }
 
+        $output = $layout->render($displayData);
 
-        return $layout->render($displayData);
+        // Page-builder in-context instrumentation seam: a no-op unless the request carries the
+        // customize flag. When active, a subscriber may wrap the rendered sub-layout (for example
+        // with data-customize-* markers) by returning the new markup via $event->setEventResult().
+        if (Factory::getApplication()->getInput()->getInt('j2c_customize', 0) === 1) {
+            $event  = J2CommerceHelper::plugin()->event('CustomizeRenderLayout', [
+                'output'        => $output,
+                'layoutId'      => $layoutId,
+                'pluginElement' => $pluginElement,
+                'paths'         => $paths,
+                'displayData'   => $displayData,
+            ]);
+            $result = $event->getEventResult();
+
+            if (\is_string($result) && $result !== '') {
+                $output = $result;
+            }
+        }
+
+        return $output;
     }
 
     private static function getActivePluginElement(): string


### PR DESCRIPTION
## Core Update

Adds a single, guarded plugin-event seam to `ProductLayoutService::renderLayout()` so an external (non-core) extension can instrument rendered product sub-layouts **in context** — without any further core edits. This is the enabling hook for an upcoming optional **in-context visual page builder** app plugin (`plg_j2commerce_app_pagebuilder`), the friendlier successor to the GrapesJS template-override builder.

### What it does
At the end of `renderLayout()`, when (and only when) the request carries `j2c_customize=1`, it fires `onJ2CommerceCustomizeRenderLayout` via `J2CommerceHelper::plugin()->event('CustomizeRenderLayout', …)` passing the rendered `output`, `layoutId`, `pluginElement`, `paths`, and `displayData`. A subscriber may return replacement markup (e.g. wrapping the block with `data-customize-*` attributes) via `$event->setEventResult()`; the result is used only when it is a non-empty string.

### Why it's safe
- **Strict no-op for normal traffic** — the event is never dispatched unless the per-request `j2c_customize` flag is present. No behavior change for any existing site.
- **Generic & reusable** — fires for every product sub-layout of every subtemplate (app_bootstrap5, app_uikit, any `app_*`), so one seam covers all.
- Uses the established `J2CommerceHelper::plugin()->event()` / `setEventResult()` / `getEventResult()` contract (verified against `PluginEvent` `MUTABLE_ARGUMENTS`).

### Changes
- `components/com_j2commerce/src/Service/ProductLayoutService.php` — capture render output, guarded event dispatch, return (possibly) wrapped output.

### Files Modified
| Type | Count |
|------|-------|
| PHP files | 1 |
| JS/CSS assets | 0 |
| Language files | 0 |
| XML/Config | 0 |

### Pre-Flight
- [x] PHP syntax check passed (`php -l`)
- [x] No secrets detected
- [x] No FOF remnants / JFactory
- [x] Core file only (single file; non-core & untracked excluded)
- [ ] php-cs-fixer — binary not present in this env; edit matches surrounding style