### PR TITLE
fix(checkout): re-sync confirmation to the finalized order for offsite gateways

### DIFF
--- a/components/com_j2commerce/src/Controller/CheckoutController.php
+++ b/components/com_j2commerce/src/Controller/CheckoutController.php
@@ -1638,6 +1638,22 @@ class CheckoutController extends BaseController
             $orderTable->load(['order_id' => $orderId]);
         }
 
+        // Offsite/return-flow gateways (3DS, hosted pages) finalize inside the
+        // PostPayment event above, and the order they finalize is NOT always the
+        // one the session was primed with at the confirm step: an earlier
+        // abandoned attempt can leave a stale j2commerce.order_id behind. Such a
+        // plugin re-primes the session to the order it actually finalized, so
+        // re-read it here and reload the order before sending emails / clearing
+        // the cart / redirecting — otherwise the confirmation page renders the
+        // stale order alongside the real success message. Inline gateways leave
+        // the session untouched, so this is a no-op for them. (#1208)
+        $finalizedOrderId = (string) $this->app->getUserState('j2commerce.order_id', '');
+
+        if ($finalizedOrderId !== '' && $finalizedOrderId !== (string) $orderId) {
+            $orderId = $finalizedOrderId;
+            $orderTable->load(['order_id' => $orderId]);
+        }
+
         // The paction=display call is the confirmation page after an AJAX
         // payment (paction=process) already sent emails and dispatched
         // AfterPayment.  Only fire these for the initial payment path.


### PR DESCRIPTION
## Summary

Fixes #1208

The frontend confirmation page could render a **stale order** for any payment gateway that finalizes via an offsite/browser-return flow (3DS, hosted pages) — showing "Payment Not Completed" for an old abandoned order while the real paid order's success message appeared on the same page, and putting the wrong `order_id` in the confirmation URL.

## Root cause

`CheckoutController::confirmPayment()` captures the order id from session (`j2commerce.order_id`) into a **local variable** *before* dispatching the `PostPayment` event. An offsite gateway finalizes the correct order *inside* that event (using the trusted order id from its return URL) and re-primes the session to match — but the local variable stays pointed at the stale order primed during the earlier confirm step. Everything downstream (confirmation emails, cart-clear state check, `AfterPayment`, the redirect) then targets the stale order.

A URL-based central fix isn't safe: the `order_id` request param is semantically inconsistent across gateways (inline `payment_cash` sends the human order **number**, offsite `payment_moyasar` sends the integer **PK**), so the session value is the only stable cross-gateway signal.

## Fix

After the `PostPayment` event, re-read session `j2commerce.order_id`; if it changed (an offsite plugin re-primed it to the order it actually finalized), adopt it and reload `$orderTable` before sending emails / clearing the cart / redirecting. Inline gateways never change the session mid-event, so the guard is a no-op for them — zero regression.

## Changes

- `components/com_j2commerce/src/Controller/CheckoutController.php` — re-sync local `$orderId` / `$orderTable` from the (possibly plugin-updated) session after payment processing, before the confirmation redirect.

## Testing

1. Enable an offsite/3DS-return gateway (reproduced with `payment_moyasar` sandbox).
2. Start a checkout, reach the payment step (primes order A), then abandon.
3. Start a second checkout for the same cart and complete payment (order B).
4. Verify: confirmation URL + header reference **order B**, a single success message shows (no "Payment Not Completed"), admin Orders lists **B** as Completed.
5. Regression: pay with an inline gateway (cash / bank transfer) — lands on its own correct confirmation page.

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only (single file)