### PR TITLE
feat(checkout): add paymentMethodsOnly task for fast payment-list refresh

### DIFF
--- a/components/com_j2commerce/src/Controller/CheckoutController.php
+++ b/components/com_j2commerce/src/Controller/CheckoutController.php
@@ -1080,6 +1080,51 @@ class CheckoutController extends BaseController
     }
 
     /**
+     * Re-render ONLY the payment-methods group, without recomputing shipping rates.
+     *
+     * shippingPaymentMethod() re-queries live carrier rates (UPS/FedEx) on every
+     * call, which is costly. When a listener (e.g. app_conditionalpayment) only
+     * needs the payment list re-pruned after a shipping change, this task skips
+     * the GetShippingRates lookup entirely.
+     */
+    public function paymentMethodsOnly(): void
+    {
+        $this->validateAjaxToken() or $this->jsonResponse(['error' => ['warning' => Text::_('JINVALID_TOKEN')]]);
+
+        $session = $this->app->getSession();
+        $order   = $this->getCartOrder();
+
+        $paymentMethods = [];
+        $paymentResults = J2CommerceHelper::plugin()->eventWithArray('GetPaymentPlugins', [$order]);
+
+        foreach ($paymentResults as $result) {
+            if (\is_array($result) && isset($result['element'])) {
+                $paymentMethods[] = $result;
+            } elseif (\is_array($result)) {
+                $paymentMethods = array_merge($paymentMethods, $result);
+            }
+        }
+
+        $paymentMethods = $this->filterUnavailablePaymentMethods($paymentMethods, $order);
+
+        $defaultPaymentMethod = J2CommerceHelper::config()->get('default_payment_method', '');
+        $selectedPayment      = $session->get('payment_method', $defaultPaymentMethod, 'j2commerce');
+
+        $showPayment = true;
+
+        if ($order && (float) ($order->order_total ?? 0) === 0.0) {
+            $showPayment = false;
+            J2CommerceHelper::plugin()->event('ChangeShowPaymentOnTotalZero', [$order, &$showPayment]);
+        }
+
+        $this->renderStep('payment_methods', [
+            'paymentMethods'  => $paymentMethods,
+            'selectedPayment' => $selectedPayment,
+            'showPayment'     => $showPayment,
+        ]);
+    }
+
+    /**
      * Drop payment methods whose plugin restricts them out of range.
      *
      * Applies the geozone (billing address) and subtotal-range restrictions

--- a/components/com_j2commerce/tmpl/checkout/bootstrap5/default_payment_methods.php
+++ b/components/com_j2commerce/tmpl/checkout/bootstrap5/default_payment_methods.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
+use Joomla\CMS\Language\Text;
+
+/** @var \J2Commerce\Component\J2commerce\Site\View\Checkout\HtmlView $this */
+
+$paymentMethods  = $this->paymentMethods ?? [];
+$selectedPayment = $this->selectedPayment ?? '';
+$showPayment     = $this->showPayment ?? true;
+?>
+<div class="payment-methods-group list-group mb-4" role="radiogroup" aria-label="<?php echo Text::_('COM_J2COMMERCE_PAYMENT_METHOD', true); ?>">
+    <?php if ($showPayment && !empty($paymentMethods)) : ?>
+        <?php foreach ($paymentMethods as $i => $method) : ?>
+            <?php
+            $element = $method['element'] ?? $method->element ?? '';
+            $name = $method['name'] ?? $method->name ?? $element;
+            $image = $method['image'] ?? $method->image ?? '';
+            $isSelected = ($element === $selectedPayment) || (\count($paymentMethods) === 1);
+            ?>
+            <label class="payment-method-item list-group-item list-group-item-action d-flex align-items-center gap-3 py-3" for="payment-method-<?php echo $i; ?>">
+                <input class="form-check-input flex-shrink-0 mt-0" type="radio" name="payment_plugin" value="<?php echo htmlspecialchars($element); ?>" id="payment-method-<?php echo $i; ?>" <?php echo $isSelected ? 'checked' : ''; ?>>
+                <div class="fw-medium flex-grow-1"><?php echo htmlspecialchars($name); ?></div>
+
+                <?php echo J2CommerceHelper::plugin()->eventWithHtml('BeforeCheckoutPaymentImage', [$method, 'onJ2Commerce'])->getArgument('html', ''); ?>
+                <?php echo J2CommerceHelper::getPaymentCardIcons($element); ?>
+
+                <?php if (!empty($image)) : ?>
+                    <img src="<?php echo htmlspecialchars($image); ?>" alt="" class="flex-shrink-0" style="height:24px;">
+                <?php endif; ?>
+            </label>
+        <?php endforeach; ?>
+    <?php elseif ($showPayment) : ?>
+        <div class="alert alert-warning">
+            <?php echo Text::_('COM_J2COMMERCE_CHECKOUT_NO_PAYMENT_METHODS'); ?>
+        </div>
+    <?php endif; ?>
+</div>

--- a/components/com_j2commerce/tmpl/checkout/uikit3/default_payment_methods.php
+++ b/components/com_j2commerce/tmpl/checkout/uikit3/default_payment_methods.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
+use Joomla\CMS\Language\Text;
+
+/** @var \J2Commerce\Component\J2commerce\Site\View\Checkout\HtmlView $this */
+
+$paymentMethods  = $this->paymentMethods ?? [];
+$selectedPayment = $this->selectedPayment ?? '';
+$showPayment     = $this->showPayment ?? true;
+?>
+<div class="payment-methods-group uk-margin-bottom" role="radiogroup" aria-label="<?php echo Text::_('COM_J2COMMERCE_PAYMENT_METHOD', true); ?>">
+    <?php if ($showPayment && !empty($paymentMethods)) : ?>
+        <?php foreach ($paymentMethods as $i => $method) : ?>
+            <?php
+            $element = $method['element'] ?? $method->element ?? '';
+            $name = $method['name'] ?? $method->name ?? $element;
+            $image = $method['image'] ?? $method->image ?? '';
+            $isSelected = ($element === $selectedPayment) || (\count($paymentMethods) === 1);
+            ?>
+            <label class="payment-method-item uk-flex uk-flex-middle uk-padding-small uk-margin-small-bottom" for="payment-method-<?php echo $i; ?>" style="gap: 12px; border: 1px solid #e5e5e5; border-radius: 4px;">
+                <input class="uk-radio uk-flex-none" type="radio" name="payment_plugin" value="<?php echo htmlspecialchars($element); ?>" id="payment-method-<?php echo $i; ?>" <?php echo $isSelected ? 'checked' : ''; ?>>
+                <div class="uk-text-bold uk-flex-1"><?php echo htmlspecialchars($name); ?></div>
+
+                <?php echo J2CommerceHelper::plugin()->eventWithHtml('BeforeCheckoutPaymentImage', [$method, 'onJ2Commerce'])->getArgument('html', ''); ?>
+                <?php echo J2CommerceHelper::getPaymentCardIcons($element); ?>
+
+                <?php if (!empty($image)) : ?>
+                    <img src="<?php echo htmlspecialchars($image); ?>" alt="" class="uk-flex-none" style="height:24px;">
+                <?php endif; ?>
+            </label>
+        <?php endforeach; ?>
+    <?php elseif ($showPayment) : ?>
+        <div class="uk-alert uk-alert-warning" uk-alert>
+            <?php echo Text::_('COM_J2COMMERCE_CHECKOUT_NO_PAYMENT_METHODS'); ?>
+        </div>
+    <?php endif; ?>
+</div>


### PR DESCRIPTION
## Core Update

Adds a lightweight checkout endpoint so a listener can re-prune the payment-methods list after a shipping change **without** re-running the costly live carrier-rate (UPS/FedEx) lookup that `shippingPaymentMethod()` performs on every call.

### Changes
- `CheckoutController::paymentMethodsOnly()` — fires `GetPaymentPlugins` + `filterUnavailablePaymentMethods`, applies the default/zero-total payment logic, and renders the `payment_methods` step. It deliberately skips the `GetShippingRates` event (the caller is responsible for having persisted the shipping selection first via `saveShippingSelection`).
- New `tmpl/checkout/bootstrap5/default_payment_methods.php` and `tmpl/checkout/uikit3/default_payment_methods.php` partials that render only the `.payment-methods-group` (a faithful 1:1 mirror of the payment block in `default_shipping_payment.php`).

### Why
The on-change payment refresh used by `app_conditionalpayment` (show/hide payment methods per selected shipping method) was calling `shippingPaymentMethod`, which re-queries live UPS+FedEx rates each time (~3.7s measured). Routing it through this payment-only endpoint drops the round-trip to ~1s.

### Files Modified
| Type | Count |
|------|-------|
| PHP (controller) | 1 |
| PHP (tmpl partials) | 2 |

### Pre-Flight
- [x] PHP syntax check passed (all 3 files)
- [x] No secrets detected
- [x] No FOF remnants / JFactory
- [x] Core files only (branch cut from upstream/main; diff is exactly these 3 files)
- [x] No unrelated local changes included