### PR TITLE
fix(core): deterministic order-history sort with id tiebreak

### DIFF
--- a/administrator/components/com_j2commerce/src/Model/OrderModel.php
+++ b/administrator/components/com_j2commerce/src/Model/OrderModel.php
@@ -454,6 +454,7 @@ class OrderModel extends AdminModel
             )
             ->where($db->quoteName('oh.order_id') . ' = :orderId')
             ->order($db->quoteName('oh.created_on') . ' DESC')
+            ->order($db->quoteName('oh.j2commerce_orderhistory_id') . ' DESC')
             ->bind(':orderId', $orderId);
 
         $db->setQuery($query);
@@ -491,6 +492,7 @@ class OrderModel extends AdminModel
             )
             ->where($db->quoteName('oh.order_id') . ' = :orderId')
             ->order($db->quoteName('oh.created_on') . ' DESC')
+            ->order($db->quoteName('oh.j2commerce_orderhistory_id') . ' DESC')
             ->bind(':orderId', $orderId, ParameterType::STRING);
 
         $db->setQuery($query, $offset, $limit);


### PR DESCRIPTION
## Core Update

### Changes
Order-history rows created within the same second were sorted only by `created_on DESC`. When several rows share the same timestamp (e.g. a webhook that creates an order and writes the first history note in the same request), they rendered in arbitrary order — the "order created" note could appear above later notes.

Added a `j2commerce_orderhistory_id DESC` secondary sort to **both** history queries so the newest row is always first, deterministically:
- `getOrderHistory()` — order-view initial render (via `getItem`)
- `getOrderHistoryPaginated()` — AJAX pagination

### Files Modified
| Type | Count |
|------|-------|
| PHP files | 1 |

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only (non-core excluded)