### PR TITLE
feat(core): add feed + json product views (fixes #1210)

### DIFF
--- a/components/com_j2commerce/src/View/Categories/FeedView.php
+++ b/components/com_j2commerce/src/View/Categories/FeedView.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Site\View\Categories;
+
+\defined('_JEXEC') or die;
+
+use J2Commerce\Component\J2commerce\Site\Helper\RouteHelper;
+use Joomla\CMS\Document\Feed\FeedItem;
+use Joomla\CMS\Factory;
+use Joomla\CMS\MVC\View\GenericDataException;
+use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
+use Joomla\CMS\Router\Route;
+
+class FeedView extends BaseHtmlView
+{
+    public function display($tpl = null): void
+    {
+        $app    = Factory::getApplication();
+        $model  = $this->getModel();
+        $params = $app->getParams();
+
+        if (\count($errors = $model->getErrors())) {
+            throw new GenericDataException(implode("\n", $errors), 500);
+        }
+
+        $doc = $this->getDocument();
+
+        $doc->title       = $params->get('page_title', '') ?: $app->get('sitename');
+        $doc->description = strip_tags((string) ($params->get('menu-meta_description', '')));
+        $doc->link        = Route::_('index.php?option=com_j2commerce&view=categories', true);
+        $doc->setGenerator('J2Commerce - Joomla Ecommerce Platform');
+
+        $items = $model->getItems();
+
+        foreach ($items as $item) {
+            $catid = (int) $item->id;
+
+            $feedItem              = new FeedItem();
+            $feedItem->title       = strip_tags((string) ($item->title ?? ''));
+            $feedItem->link        = Route::_(RouteHelper::getCategoryRoute($catid), true);
+            $feedItem->description = strip_tags((string) ($item->description ?? ''));
+
+            $doc->addItem($feedItem);
+        }
+    }
+}

--- a/components/com_j2commerce/src/View/Categories/JsonView.php
+++ b/components/com_j2commerce/src/View/Categories/JsonView.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Site\View\Categories;
+
+\defined('_JEXEC') or die;
+
+use J2Commerce\Component\J2commerce\Site\Helper\RouteHelper;
+use Joomla\CMS\MVC\View\GenericDataException;
+use Joomla\CMS\MVC\View\JsonView as BaseJsonView;
+use Joomla\CMS\Router\Route;
+
+class JsonView extends BaseJsonView
+{
+    public function display($tpl = null): void
+    {
+        $model = $this->getModel();
+
+        if (\count($errors = $model->getErrors())) {
+            throw new GenericDataException(implode("\n", $errors), 500);
+        }
+
+        $items  = $model->getItems();
+        $mapped = [];
+
+        foreach ($items as $item) {
+            $catid = (int) $item->id;
+
+            $mapped[] = [
+                'id'            => $catid,
+                'title'         => strip_tags((string) ($item->title ?? '')),
+                'alias'         => $item->alias ?? null,
+                'url'           => Route::_(RouteHelper::getCategoryRoute($catid), true),
+                'description'   => strip_tags((string) ($item->description ?? '')),
+                'parent_id'     => isset($item->parent_id) ? (int) $item->parent_id : null,
+                'product_count' => isset($item->product_count) ? (int) $item->product_count : 0,
+            ];
+        }
+
+        $this->_output = [
+            'categories' => $mapped,
+            'count'      => \count($mapped),
+        ];
+
+        // The site application overwrites the JSON document buffer with the
+        // component's echoed output, so emit the payload via echo rather than
+        // relying on the parent setBuffer() path.
+        echo json_encode(
+            $this->_output,
+            JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE
+        );
+    }
+}

--- a/components/com_j2commerce/src/View/Product/FeedView.php
+++ b/components/com_j2commerce/src/View/Product/FeedView.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Site\View\Product;
+
+\defined('_JEXEC') or die;
+
+use J2Commerce\Component\J2commerce\Site\Helper\RouteHelper;
+use Joomla\CMS\Document\Feed\FeedItem;
+use Joomla\CMS\Factory;
+use Joomla\CMS\MVC\View\GenericDataException;
+use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
+use Joomla\CMS\Router\Route;
+
+class FeedView extends BaseHtmlView
+{
+    public function display($tpl = null): void
+    {
+        $app    = Factory::getApplication();
+        $model  = $this->getModel();
+        $params = $app->getParams();
+
+        if (\count($errors = $model->getErrors())) {
+            throw new GenericDataException(implode("\n", $errors), 500);
+        }
+
+        $item = $model->getItem();
+
+        if ($item === null) {
+            throw new GenericDataException('Product not found', 404);
+        }
+
+        $doc = $this->getDocument();
+
+        $doc->title       = strip_tags((string) ($item->product_name ?? '')) ?: ($params->get('page_title', '') ?: $app->get('sitename'));
+        $doc->description = strip_tags((string) ($item->product_short_desc ?? ''));
+        $doc->link        = Route::_('index.php?option=com_j2commerce&view=products', true);
+        $doc->setGenerator('J2Commerce - Joomla Ecommerce Platform');
+
+        $id    = (int) $item->j2commerce_product_id;
+        $alias = $item->alias ?? null;
+        $catid = isset($item->catid) ? (int) $item->catid : null;
+
+        $feedItem              = new FeedItem();
+        $feedItem->title       = strip_tags((string) ($item->product_name ?? ''));
+        $feedItem->link        = Route::_(RouteHelper::getProductRoute($id, $alias, $catid), true);
+        $feedItem->description = strip_tags((string) ($item->product_short_desc ?? ''));
+
+        if (!empty($item->created)) {
+            $feedItem->date = $item->created;
+        }
+
+        $doc->addItem($feedItem);
+    }
+}

--- a/components/com_j2commerce/src/View/Product/JsonView.php
+++ b/components/com_j2commerce/src/View/Product/JsonView.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Site\View\Product;
+
+\defined('_JEXEC') or die;
+
+use J2Commerce\Component\J2commerce\Administrator\Helper\CurrencyHelper;
+use J2Commerce\Component\J2commerce\Site\Helper\RouteHelper;
+use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\MVC\View\GenericDataException;
+use Joomla\CMS\MVC\View\JsonView as BaseJsonView;
+use Joomla\CMS\Router\Route;
+use Joomla\CMS\Uri\Uri;
+
+class JsonView extends BaseJsonView
+{
+    public function display($tpl = null): void
+    {
+        $model = $this->getModel();
+
+        if (\count($errors = $model->getErrors())) {
+            throw new GenericDataException(implode("\n", $errors), 500);
+        }
+
+        $item = $model->getItem();
+
+        if ($item === null) {
+            throw new GenericDataException('Product not found', 404);
+        }
+
+        $id    = (int) $item->j2commerce_product_id;
+        $alias = $item->alias ?? null;
+        $catid = isset($item->catid) ? (int) $item->catid : null;
+
+        $url = Route::_(RouteHelper::getProductRoute($id, $alias, $catid), true);
+
+        $sku   = isset($item->variant->sku) ? (string) $item->variant->sku : null;
+        $price = isset($item->variant->price) ? (float) $item->variant->price : null;
+
+        $inStock = null;
+        if (isset($item->variant->availability)) {
+            $inStock = (int) $item->variant->availability > 0;
+        }
+
+        $this->_output = [
+            'product' => [
+                'id'               => $id,
+                'name'             => strip_tags((string) ($item->product_name ?? '')),
+                'sku'              => $sku,
+                'price'            => $price,
+                'currency'         => CurrencyHelper::getCode(),
+                'url'              => $url,
+                'image'            => $this->cleanImageUrl($item->main_image ?? null),
+                'description'      => strip_tags((string) ($item->product_short_desc ?? '')),
+                'full_description' => strip_tags((string) ($item->product_long_desc ?? '')),
+                'category_id'      => $catid,
+                'category_name'    => isset($item->source->category_title)
+                    ? strip_tags((string) $item->source->category_title)
+                    : '',
+                'in_stock'         => $inStock,
+            ],
+        ];
+
+        // The site application overwrites the JSON document buffer with the
+        // component's echoed output, so emit the payload via echo rather than
+        // relying on the parent setBuffer() path.
+        echo json_encode(
+            $this->_output,
+            JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE
+        );
+    }
+
+    /**
+     * Strip the #joomlaImage:// metadata fragment and return an absolute URL
+     * so external readers can resolve the image.
+     */
+    private function cleanImageUrl(?string $image): ?string
+    {
+        if (empty($image)) {
+            return null;
+        }
+
+        $clean = HTMLHelper::_('cleanImageURL', $image)->url;
+
+        return $clean === '' ? null : Uri::root() . ltrim($clean, '/');
+    }
+}

--- a/components/com_j2commerce/src/View/Products/FeedView.php
+++ b/components/com_j2commerce/src/View/Products/FeedView.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Site\View\Products;
+
+\defined('_JEXEC') or die;
+
+use J2Commerce\Component\J2commerce\Site\Helper\RouteHelper;
+use Joomla\CMS\Document\Feed\FeedItem;
+use Joomla\CMS\Factory;
+use Joomla\CMS\MVC\View\GenericDataException;
+use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
+use Joomla\CMS\Router\Route;
+
+/**
+ * RSS/Atom Feed Products list view for site frontend.
+ *
+ * @since  6.0.0
+ */
+class FeedView extends BaseHtmlView
+{
+    public function display($tpl = null): void
+    {
+        $app    = Factory::getApplication();
+        $model  = $this->getModel();
+        $params = $app->getParams();
+
+        if (\count($errors = $model->getErrors())) {
+            throw new GenericDataException(implode("\n", $errors), 500);
+        }
+
+        $doc = $this->getDocument();
+
+        $doc->title       = $params->get('page_title', '') ?: $app->get('sitename');
+        $doc->description = strip_tags((string) ($params->get('menu-meta_description', '')));
+        $doc->link        = Route::_('index.php?option=com_j2commerce&view=products', true);
+        $doc->setGenerator('J2Commerce - Joomla Ecommerce Platform');
+
+        $items = $model->getItems();
+
+        foreach ($items as $item) {
+            $id    = (int) $item->j2commerce_product_id;
+            $alias = $item->alias ?? null;
+            $catid = isset($item->catid) ? (int) $item->catid : null;
+
+            $feedItem              = new FeedItem();
+            $feedItem->title       = strip_tags((string) ($item->product_name ?? ''));
+            $feedItem->link        = Route::_(RouteHelper::getProductRoute($id, $alias, $catid), true);
+            $feedItem->description = strip_tags((string) ($item->product_short_desc ?? ''));
+
+            if (!empty($item->created)) {
+                $feedItem->date = $item->created;
+            }
+
+            $doc->addItem($feedItem);
+        }
+    }
+}

--- a/components/com_j2commerce/src/View/Products/JsonView.php
+++ b/components/com_j2commerce/src/View/Products/JsonView.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Site\View\Products;
+
+\defined('_JEXEC') or die;
+
+use J2Commerce\Component\J2commerce\Administrator\Helper\CurrencyHelper;
+use J2Commerce\Component\J2commerce\Site\Helper\RouteHelper;
+use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\MVC\View\GenericDataException;
+use Joomla\CMS\MVC\View\JsonView as BaseJsonView;
+use Joomla\CMS\Router\Route;
+use Joomla\CMS\Uri\Uri;
+
+/**
+ * JSON Products list view for site frontend.
+ *
+ * @since  6.0.0
+ */
+class JsonView extends BaseJsonView
+{
+    public function display($tpl = null): void
+    {
+        $model = $this->getModel();
+
+        if (\count($errors = $model->getErrors())) {
+            throw new GenericDataException(implode("\n", $errors), 500);
+        }
+
+        $items    = $model->getItems();
+        $currency = CurrencyHelper::getCode();
+        $mapped   = [];
+
+        foreach ($items as $item) {
+            $id    = (int) $item->j2commerce_product_id;
+            $alias = $item->alias ?? null;
+            $catid = isset($item->catid) ? (int) $item->catid : null;
+
+            $url = Route::_(
+                RouteHelper::getProductRoute($id, $alias, $catid),
+                true
+            );
+
+            $sku   = isset($item->variant->sku) ? (string) $item->variant->sku : null;
+            $price = isset($item->variant->price) ? (float) $item->variant->price : null;
+
+            $inStock = null;
+            if (isset($item->variant->availability)) {
+                $inStock = (int) $item->variant->availability > 0;
+            }
+
+            $mapped[] = [
+                'id'            => $id,
+                'name'          => strip_tags((string) ($item->product_name ?? '')),
+                'sku'           => $sku,
+                'price'         => $price,
+                'currency'      => $currency,
+                'url'           => $url,
+                'image'         => $this->cleanImageUrl($item->main_image ?? null),
+                'description'   => strip_tags((string) ($item->product_short_desc ?? '')),
+                'category_id'   => $catid,
+                'category_name' => isset($item->source->category_title)
+                    ? strip_tags((string) $item->source->category_title)
+                    : '',
+                'in_stock'      => $inStock,
+            ];
+        }
+
+        $this->_output = [
+            'products' => $mapped,
+            'count'    => \count($mapped),
+        ];
+
+        // The site application overwrites the JSON document buffer with the
+        // component's echoed output, so emit the payload via echo rather than
+        // relying on the parent setBuffer() path.
+        echo json_encode(
+            $this->_output,
+            JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE
+        );
+    }
+
+    /**
+     * Strip the #joomlaImage:// metadata fragment and return an absolute URL
+     * so external readers can resolve the image.
+     */
+    private function cleanImageUrl(?string $image): ?string
+    {
+        if (empty($image)) {
+            return null;
+        }
+
+        $clean = HTMLHelper::_('cleanImageURL', $image)->url;
+
+        return $clean === '' ? null : Uri::root() . ltrim($clean, '/');
+    }
+}

--- a/components/com_j2commerce/src/View/Producttags/FeedView.php
+++ b/components/com_j2commerce/src/View/Producttags/FeedView.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Site\View\Producttags;
+
+\defined('_JEXEC') or die;
+
+use J2Commerce\Component\J2commerce\Site\Helper\RouteHelper;
+use Joomla\CMS\Document\Feed\FeedItem;
+use Joomla\CMS\Factory;
+use Joomla\CMS\MVC\View\GenericDataException;
+use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
+use Joomla\CMS\Router\Route;
+
+class FeedView extends BaseHtmlView
+{
+    public function display($tpl = null): void
+    {
+        $app    = Factory::getApplication();
+        $model  = $this->getModel();
+        $params = $app->getParams();
+
+        if (\count($errors = $model->getErrors())) {
+            throw new GenericDataException(implode("\n", $errors), 500);
+        }
+
+        $doc = $this->getDocument();
+
+        $doc->title       = $params->get('page_title', '') ?: $app->get('sitename');
+        $doc->description = strip_tags((string) ($params->get('menu-meta_description', '')));
+        $doc->link        = Route::_('index.php?option=com_j2commerce&view=producttags', true);
+        $doc->setGenerator('J2Commerce - Joomla Ecommerce Platform');
+
+        $items = $model->getItems();
+
+        foreach ($items as $item) {
+            $id    = (int) $item->j2commerce_product_id;
+            $alias = $item->alias ?? null;
+            $catid = isset($item->catid) ? (int) $item->catid : null;
+
+            $feedItem              = new FeedItem();
+            $feedItem->title       = strip_tags((string) ($item->product_name ?? ''));
+            $feedItem->link        = Route::_(RouteHelper::getProductRoute($id, $alias, $catid), true);
+            $feedItem->description = strip_tags((string) ($item->product_short_desc ?? ''));
+
+            if (!empty($item->created)) {
+                $feedItem->date = $item->created;
+            }
+
+            $doc->addItem($feedItem);
+        }
+    }
+}

--- a/components/com_j2commerce/src/View/Producttags/JsonView.php
+++ b/components/com_j2commerce/src/View/Producttags/JsonView.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Site\View\Producttags;
+
+\defined('_JEXEC') or die;
+
+use J2Commerce\Component\J2commerce\Administrator\Helper\CurrencyHelper;
+use J2Commerce\Component\J2commerce\Site\Helper\RouteHelper;
+use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\MVC\View\GenericDataException;
+use Joomla\CMS\MVC\View\JsonView as BaseJsonView;
+use Joomla\CMS\Router\Route;
+use Joomla\CMS\Uri\Uri;
+
+class JsonView extends BaseJsonView
+{
+    public function display($tpl = null): void
+    {
+        $model = $this->getModel();
+
+        if (\count($errors = $model->getErrors())) {
+            throw new GenericDataException(implode("\n", $errors), 500);
+        }
+
+        $items    = $model->getItems();
+        $currency = CurrencyHelper::getCode();
+        $mapped   = [];
+
+        foreach ($items as $item) {
+            $id    = (int) $item->j2commerce_product_id;
+            $alias = $item->alias ?? null;
+            $catid = isset($item->catid) ? (int) $item->catid : null;
+
+            $url = Route::_(RouteHelper::getProductRoute($id, $alias, $catid), true);
+
+            $sku   = isset($item->variant->sku) ? (string) $item->variant->sku : null;
+            $price = isset($item->variant->price) ? (float) $item->variant->price : null;
+
+            $inStock = null;
+            if (isset($item->variant->availability)) {
+                $inStock = (int) $item->variant->availability > 0;
+            }
+
+            $mapped[] = [
+                'id'            => $id,
+                'name'          => strip_tags((string) ($item->product_name ?? '')),
+                'sku'           => $sku,
+                'price'         => $price,
+                'currency'      => $currency,
+                'url'           => $url,
+                'image'         => $this->cleanImageUrl($item->main_image ?? null),
+                'description'   => strip_tags((string) ($item->product_short_desc ?? '')),
+                'category_id'   => $catid,
+                'category_name' => isset($item->source->category_title)
+                    ? strip_tags((string) $item->source->category_title)
+                    : '',
+                'in_stock'      => $inStock,
+            ];
+        }
+
+        $this->_output = [
+            'products' => $mapped,
+            'count'    => \count($mapped),
+        ];
+
+        // The site application overwrites the JSON document buffer with the
+        // component's echoed output, so emit the payload via echo rather than
+        // relying on the parent setBuffer() path.
+        echo json_encode(
+            $this->_output,
+            JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE
+        );
+    }
+
+    /**
+     * Strip the #joomlaImage:// metadata fragment and return an absolute URL
+     * so external readers can resolve the image.
+     */
+    private function cleanImageUrl(?string $image): ?string
+    {
+        if (empty($image)) {
+            return null;
+        }
+
+        $clean = HTMLHelper::_('cleanImageURL', $image)->url;
+
+        return $clean === '' ? null : Uri::root() . ltrim($clean, '/');
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1210 — adds machine-readable **JSON** and **RSS feed** output to the front-end product views, so `?format=json` and `?format=feed` return consumable data. Each format view reuses the existing model (no new queries), inheriting the same category/visibility/published/multilingual filters as the HTML view.

## Changes

- **8 new format views** across four view families (Products list, single Product, Categories, Producttags):
  - `JsonView` for each — whitelisted public JSON (id, name, sku, price, currency, url, image, description, category id/name, in_stock; single product adds full_description).
  - `FeedView` for each — RSS 2.0 via `FeedDocument`; channel generator set to `J2Commerce - Joomla Ecommerce Platform`.
- JSON views **echo** the payload — Joomla's `SiteApplication::dispatch()` overwrites the static JSON document buffer with the component's echoed output, so `setBuffer()` is clobbered (would render a blank 200). Echoing lets `renderComponent()` capture the body.
- Image URLs cleaned via `HTMLHelper::_('cleanImageURL', …)->url` (strips the `#joomlaImage://…` metadata fragment) and absolutized with `Uri::root()` for external readers.
- Currency from `CurrencyHelper::getCode()`; category name from the hydrated article join (`$item->source->category_title`).

## Testing

Live-verified (curl) on the local site:
- Products list / single product / category list / tag views all return valid non-empty JSON and valid RSS 2.0.
- JSON exposes only whitelisted fields; unpublished/out-of-category products excluded.
- Images resolve to clean absolute URLs; currency + category name populated; feed generator correct.

## Files Changed

| Type | Count |
|------|-------|
| PHP view classes (new) | 8 |

No existing files modified; no language strings added.

## Pre-Flight
- [x] PHP syntax check passed (8/8)
- [x] No secrets detected
- [x] No FOF remnants / JFactory
- [x] Code style (php-cs-fixer) clean
- [x] Core files only