### PR TITLE
feat(core): payment-method description subtitle in checkout

### DIFF
--- a/components/com_j2commerce/tmpl/checkout/bootstrap5/default_shipping_payment.php
+++ b/components/com_j2commerce/tmpl/checkout/bootstrap5/default_shipping_payment.php
@@ -85,11 +85,17 @@ $currency = J2CommerceHelper::currency();
                     $element = $method['element'] ?? $method->element ?? '';
                     $name = $method['name'] ?? $method->name ?? $element;
                     $image = $method['image'] ?? $method->image ?? '';
+                    $desc = $method['desc'] ?? $method->desc ?? '';
                     $isSelected = ($element === $selectedPayment) || (\count($paymentMethods) === 1);
                     ?>
                     <label class="payment-method-item list-group-item list-group-item-action d-flex align-items-center gap-3 py-3" for="payment-method-<?php echo $i; ?>">
                         <input class="form-check-input flex-shrink-0 mt-0" type="radio" name="payment_plugin" value="<?php echo htmlspecialchars($element); ?>" id="payment-method-<?php echo $i; ?>" <?php echo $isSelected ? 'checked' : ''; ?>>
-                        <div class="fw-medium flex-grow-1"><?php echo htmlspecialchars($name); ?></div>
+                        <div class="payment-method-display flex-grow-1">
+                            <div class="payment-method-name fw-medium"><?php echo htmlspecialchars($name); ?></div>
+                            <?php if (!empty($desc)) : ?>
+                                <div class="payment-method-desc"><small class="text-body-secondary"><?php echo htmlspecialchars($desc); ?></small></div>
+                            <?php endif; ?>
+                        </div>
 
                         <?php echo J2CommerceHelper::plugin()->eventWithHtml('BeforeCheckoutPaymentImage', [$method, 'onJ2Commerce'])->getArgument('html', ''); ?>
                         <?php echo J2CommerceHelper::getPaymentCardIcons($element); ?>


### PR DESCRIPTION
## Core Update

Renders an optional `desc` subtitle under each payment method name in the checkout shipping/payment step, mirroring the existing **shipping-method** `desc` a few lines above. Payment plugins can now surface a short tagline under the method title (e.g. a Klarna Invoice "Pay within N days of delivery" note).

### Change
- `components/com_j2commerce/tmpl/checkout/bootstrap5/default_shipping_payment.php`
  - extract `$desc = $method['desc'] ?? $method->desc ?? ''`
  - wrap the name in `payment-method-display` / `payment-method-name` and render an optional `payment-method-desc` (`<small class="text-body-secondary">`), escaped with `htmlspecialchars`
- Backward compatible: only renders when a plugin returns a non-empty `desc` (guarded by `!empty`). Plugins surface the value via their `onJ2CommerceGetPaymentPlugins` result array.

### Files Modified
| Type | Count |
|------|-------|
| PHP (template) | 1 |

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] `text-body-secondary` (not banned `text-muted`)
- [x] Core file only — single template, branched from upstream/main