### PR TITLE
fix(cart): respect config_including_tax in line-item price display

### DIFF
--- a/administrator/components/com_j2commerce/src/Helper/CartOrder.php
+++ b/administrator/components/com_j2commerce/src/Helper/CartOrder.php
@@ -1157,12 +1157,20 @@ class CartOrder
         $optionPrice = (float) ($item->option_price ?? $item->orderitem_option_price ?? 0);
         $unitPrice   = $basePrice + $optionPrice;
 
-        // Add tax when displayMode requests tax-inclusive display
-        if ($displayMode == 1) {
-            $taxProfileId = (int) ($item->taxprofile_id ?? $item->orderitem_taxprofile_id ?? 0);
-            if ($taxProfileId > 0) {
-                $productHelper = new ProductHelper();
-                $unitPrice     = $productHelper->get_price_including_tax($unitPrice, $taxProfileId);
+        $taxProfileId = (int) ($item->taxprofile_id ?? $item->orderitem_taxprofile_id ?? 0);
+
+        if ($taxProfileId > 0) {
+            $productHelper  = new ProductHelper();
+            $isIncludingTax = (int) J2CommerceHelper::config()->get('config_including_tax', 0);
+
+            if ($isIncludingTax) {
+                // Stored price already includes tax; strip it for tax-exclusive display only.
+                if ($displayMode == 0) {
+                    $unitPrice = $productHelper->get_price_excluding_tax($unitPrice, $taxProfileId);
+                }
+            } elseif ($displayMode == 1) {
+                // Stored price is net; add tax for tax-inclusive display.
+                $unitPrice = $productHelper->get_price_including_tax($unitPrice, $taxProfileId);
             }
         }
 


### PR DESCRIPTION
## Summary
Fixes #1215

When **Prices include tax** (`config_including_tax = 1`) is enabled, product prices are stored tax-inclusive. The line-item display helper `CartOrder::get_formatted_lineitem_price()` ignored this setting and re-added tax whenever the price-display mode requested a tax-inclusive figure, so cart and checkout line items showed the price taxed **twice** (e.g. a 25 product displayed as 30), while the order total — which uses a separate, correct tax path — stayed right at 25. This mismatch is exactly what the reporter observed in `cart-item-option-value`, `line-total-value`, and `checkout-sidecart-content`.

## Changes
- `get_formatted_lineitem_price()` now branches on `config_including_tax`:
  - **Inclusive (=1):** stored price already includes tax → returned as-is for tax-inclusive display; tax is stripped (`get_price_excluding_tax`) only for tax-exclusive display.
  - **Exclusive (=0):** unchanged — net price, tax added for tax-inclusive display.
- `get_formatted_lineitem_total()` and `get_lineitem_discount_info()` call this method, so all reported cart/checkout locations are fixed by the single change.

## Testing
1. Admin → J2Commerce → Configuration: **Prices include tax = Yes**, **Checkout price display = Including tax**.
2. Product priced 25 with a 20% tax profile → product page shows 25.
3. Add to cart → item unit price and line total show **25** (not 30); cart total 25.
4. Checkout → `checkout-sidecart-content` item price 25, total 25.
5. Regression: **Prices include tax = No** → net price + tax displays as before.

## Files Changed
- `administrator/components/com_j2commerce/src/Helper/CartOrder.php` — make line-item price display `config_including_tax`-aware.

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] php-cs-fixer clean on the changed file
- [x] Security gate (j2commerce-security): PASS
- [x] Core file only (single file)