### PR TITLE
feat(core): dispatch onJ2CommerceAfterSaveTrackingNumber on tracking save

### DIFF
--- a/administrator/components/com_j2commerce/src/Model/OrderModel.php
+++ b/administrator/components/com_j2commerce/src/Model/OrderModel.php
@@ -17,6 +17,7 @@ namespace J2Commerce\Component\J2commerce\Administrator\Model;
 use J2Commerce\Component\J2commerce\Administrator\Helper\ConfigHelper;
 use J2Commerce\Component\J2commerce\Administrator\Helper\DownloadHelper;
 use J2Commerce\Component\J2commerce\Administrator\Helper\EmailHelper;
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 use J2Commerce\Component\J2commerce\Administrator\Helper\OrderItemAttributeHelper;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
@@ -959,8 +960,18 @@ class OrderModel extends AdminModel
             ->bind(':orderIdStr', $orderIdStr);
 
         $db->setQuery($updateQuery);
+        $executed = $db->execute();
 
-        return $db->execute();
+        // Let extensions (e.g. payment/fulfillment plugins) react to a tracking
+        // number being added — there is otherwise no signal for this.
+        if ($executed) {
+            J2CommerceHelper::plugin()->event(
+                'AfterSaveTrackingNumber',
+                ['order_id' => $orderIdStr, 'tracking_id' => $trackingId]
+            );
+        }
+
+        return (bool) $executed;
     }
 
     /**


### PR DESCRIPTION
## Core Update

Adds a reusable plugin event so payment/fulfillment extensions can react when a tracking number is saved on an order.

### Problem
`OrderModel::saveTrackingNumber()` updates `#__j2commerce_ordershippings.ordershipping_tracking_id` and fires **no event** — there is currently no signal for a 3rd-party extension (payment gateway, shipping integration, etc.) to react to a tracking number being added.

### Change
After a successful UPDATE, dispatch a new event:
```php
J2CommerceHelper::plugin()->event(
    'AfterSaveTrackingNumber',
    ['order_id' => $orderIdStr, 'tracking_id' => $trackingId]
);
```
- New reusable hook: **`onJ2CommerceAfterSaveTrackingNumber`** — args `order_id` (varchar order number) + `tracking_id`.
- The bool return contract is preserved (`return (bool) $executed;`); the dispatch only runs on a successful update and cannot alter the return value.
- No behavior change for existing flows — purely additive.

### Files Modified
| Type | Count |
|------|-------|
| PHP files | 1 |

`administrator/components/com_j2commerce/src/Model/OrderModel.php` (+12/-1)

### Pre-Flight
- [x] PHP syntax check passed (`php -l`)
- [x] No secrets detected
- [x] No FOF remnants / no `JFactory::`
- [x] Code style (php-cs-fixer) passed
- [x] Security gate (J2Commerce release gate + cross-validation): PASS
- [x] Core file only; branch based on current `upstream/main`