### PR TITLE
fix(tax): surface plugin-injected tax profiles in product/category dropdowns

### DIFF
--- a/administrator/components/com_j2commerce/forms/category_defaults.xml
+++ b/administrator/components/com_j2commerce/forms/category_defaults.xml
@@ -2,13 +2,10 @@
 <form>
     <fields name="params">
         <fieldset name="basic" label="COM_J2COMMERCE_CATEGORY_PRODUCT_DEFAULTS">
-            <field name="default_taxprofile_id" type="sql"
-                   query="SELECT j2commerce_taxprofile_id AS value, taxprofile_name AS text FROM #__j2commerce_taxprofiles WHERE enabled = 1 ORDER BY ordering"
-                   key_field="value" value_field="text"
+            <field name="default_taxprofile_id" type="Taxprofile"
+                   nonelabel="COM_J2COMMERCE_CATEGORY_USE_GLOBAL"
                    label="COM_J2COMMERCE_CATEGORY_DEFAULT_TAX_PROFILE"
-                   description="COM_J2COMMERCE_CATEGORY_DEFAULT_TAX_PROFILE_DESC">
-                <option value="">COM_J2COMMERCE_CATEGORY_USE_GLOBAL</option>
-            </field>
+                   description="COM_J2COMMERCE_CATEGORY_DEFAULT_TAX_PROFILE_DESC"/>
 
             <field name="default_manufacturer_id" type="sql"
                    query="SELECT j2commerce_manufacturer_id AS value, manufacturer_name AS text FROM #__j2commerce_manufacturers WHERE enabled = 1 ORDER BY manufacturer_name"

--- a/administrator/components/com_j2commerce/forms/product.xml
+++ b/administrator/components/com_j2commerce/forms/product.xml
@@ -112,17 +112,12 @@
         <!-- Tax Profile -->
         <field
             name="taxprofile_id"
-            type="sql"
+            type="Taxprofile"
             label="COM_J2COMMERCE_FIELD_PRODUCT_TAXPROFILE"
             description="COM_J2COMMERCE_FIELD_PRODUCT_TAXPROFILE_DESC"
-            query="SELECT j2commerce_taxprofile_id AS value, taxprofile_name AS text FROM #__j2commerce_taxprofiles WHERE enabled = 1 ORDER BY taxprofile_name"
-            key_field="value"
-            value_field="text"
             class="form-select"
             default=""
-        >
-            <option value="">COM_J2COMMERCE_SELECT_TAX_PROFILE</option>
-        </field>
+        />
 
         <!-- Manufacturer -->
         <field

--- a/administrator/components/com_j2commerce/src/Field/TaxprofileField.php
+++ b/administrator/components/com_j2commerce/src/Field/TaxprofileField.php
@@ -14,6 +14,7 @@ namespace J2Commerce\Component\J2commerce\Administrator\Field;
 
 \defined('_JEXEC') or die;
 
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Field\ListField;
 use Joomla\CMS\HTML\HTMLHelper;
@@ -33,30 +34,38 @@ class TaxprofileField extends ListField
     {
         $options = parent::getOptions();
 
-        // Empty value = no tax profile (not taxable). Listed first so a freshly
-        // saved form defaults to "Not Taxable" instead of auto-charging the first
-        // tax profile in the list.
-        array_unshift($options, HTMLHelper::_('select.option', '', Text::_('COM_J2COMMERCE_NOT_TAXABLE')));
+        // Empty value = no tax profile. The label is configurable via the
+        // `nonelabel` attribute so each form can express its own semantics
+        // (product: "Not Taxable"; category default: "Use Global"). Listed
+        // first so a freshly saved form defaults to it.
+        $noneLabel = (string) ($this->element['nonelabel'] ?? '');
+        $noneLabel = $noneLabel !== '' ? $noneLabel : 'COM_J2COMMERCE_NOT_TAXABLE';
+        array_unshift($options, HTMLHelper::_('select.option', '', Text::_($noneLabel)));
 
         try {
             $db = Factory::getContainer()->get(DatabaseInterface::class);
 
             $query = $db->getQuery(true)
-                ->select([
-                    $db->quoteName('j2commerce_taxprofile_id', 'value'),
-                    $db->quoteName('taxprofile_name', 'text'),
-                ])
+                ->select($db->quoteName(['j2commerce_taxprofile_id', 'taxprofile_name']))
                 ->from($db->quoteName('#__j2commerce_taxprofiles'))
                 ->where($db->quoteName('enabled') . ' = 1')
                 ->order($db->quoteName('taxprofile_name') . ' ASC');
 
             $db->setQuery($query);
-            $profiles = $db->loadObjectList();
+            $profiles = $db->loadObjectList() ?: [];
 
-            if ($profiles) {
-                foreach ($profiles as $profile) {
-                    $options[] = HTMLHelper::_('select.option', $profile->value, $profile->text);
+            // Let plugins inject virtual tax profiles (e.g. app_taxmanager tax
+            // classes, app_avalaratax) via the same seam TaxprofilesModel uses.
+            $event    = J2CommerceHelper::plugin()->event('AfterGetTaxprofiles', ['result' => $profiles]);
+            $merged   = $event->getEventResult();
+            $profiles = \is_array($merged) ? $merged : $profiles;
+
+            foreach ($profiles as $profile) {
+                if (!isset($profile->j2commerce_taxprofile_id, $profile->taxprofile_name)) {
+                    continue;
                 }
+
+                $options[] = HTMLHelper::_('select.option', $profile->j2commerce_taxprofile_id, $profile->taxprofile_name);
             }
         } catch (\Exception $e) {
             Factory::getApplication()->enqueueMessage(

--- a/administrator/components/com_j2commerce/tmpl/category/form_j2commerce.php
+++ b/administrator/components/com_j2commerce/tmpl/category/form_j2commerce.php
@@ -14,7 +14,12 @@ defined('_JEXEC') or die;
 use J2Commerce\Component\J2commerce\Administrator\Helper\CategoryHelper;
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 use Joomla\CMS\Form\Form;
+use Joomla\CMS\Form\FormHelper;
 use Joomla\CMS\Language\Text;
+
+// Register the component field namespace so J2Commerce custom field types
+// (e.g. Taxprofile) resolve in the app forms loaded via Form::getInstance().
+FormHelper::addFieldPrefix('J2Commerce\\Component\\J2commerce\\Administrator\\Field');
 
 $this->item = $displayData['category'] ?? $displayData['item'] ?? null;
 $this->form_prefix = $displayData['form_prefix'] ?? 'jform[attribs][j2commerce]';


### PR DESCRIPTION
## Summary
Fixes #1225

The product and category-default **tax-profile dropdowns** built their option lists by querying `#__j2commerce_taxprofiles` directly and never dispatched `onJ2CommerceAfterGetTaxprofiles`. Only the back-office Tax Profiles *list* view fired that seam, so virtual tax profiles injected by plugins (Tax Manager tax classes via `app_taxmanager`, `app_avalaratax`) never appeared on products or category defaults.

Originating report: j2commerce/j2commerce6extensions#518.

## Changes
- **`src/Field/TaxprofileField.php`** — after loading enabled rows, dispatch `onJ2CommerceAfterGetTaxprofiles` (the same `['result' => …]` seam `TaxprofilesModel::getItems()` uses) and build options from the merged list. Query the real columns (`j2commerce_taxprofile_id`, `taxprofile_name`) so DB rows and plugin-injected objects share one shape. Add a configurable `nonelabel` attribute for the empty option.
- **`forms/product.xml`** — `taxprofile_id`: `type="sql"` → `type="Taxprofile"`; dropped the sql-only attrs and the duplicate empty `<option>` (the field self-prepends "Not Taxable").
- **`forms/category_defaults.xml`** — `default_taxprofile_id`: same switch, with `nonelabel="COM_J2COMMERCE_CATEGORY_USE_GLOBAL"` so the empty option keeps "Use Global" semantics (no regression).
- **`tmpl/category/form_j2commerce.php`** — register the component Field namespace so `type="Taxprofile"` resolves in the manual `Form::getInstance()` path used by category app forms.

One event-aware field now backs the product, filter, payment, shipping, and category-default dropdowns — fixing every tax-injector plugin at once.

> Companion plugin-side fix tracked in j2commerce/j2commerce6extensions#518 (`app_taxmanager` handler must read/write the `result` key). Both are required for Tax Manager classes to appear; this PR provides the core seam.

## Testing
1. Edit a Product → **Associations** → Tax Profile dropdown lists real profiles; empty option reads "Not Taxable" (no duplicate blank).
2. Edit a Category → **Product Defaults** → Default Tax Profile dropdown renders; empty option reads "Use Global".
3. With a tax-injector plugin enabled (e.g. Avalara, or Tax Manager once #518 lands), its virtual profile/class appears in both dropdowns.
4. Save/reopen → selection persists.

## Files Changed
| Type | Count |
|------|-------|
| PHP | 2 |
| Form XML | 2 |

## Pre-Flight
- [x] PHP syntax check passed
- [x] XML well-formed
- [x] Code style (php-cs-fixer) passed
- [x] No secrets / FOF remnants / JFactory
- [x] Security gate (j2commerce-security): PASS
- [x] Core files only