### PR TITLE
fix(order): replace banned text-muted with text-body-secondary in order view

### DIFF
--- a/administrator/components/com_j2commerce/tmpl/order/view_details.php
+++ b/administrator/components/com_j2commerce/tmpl/order/view_details.php
@@ -83,7 +83,7 @@ if ($hasDetails) {
                 <div class="flex-grow-1">
                     <div class="fw-bold fs-6"><?php echo $this->escape($paymentName); ?></div>
                     <?php if (!empty($item->transaction_id)) : ?>
-                        <div class="text-muted small">
+                        <div class="text-body-secondary small">
                             <?php echo Text::_('COM_J2COMMERCE_FIELD_TRANSACTION_ID'); ?>:
                             <strong class="text-body"><?php echo $this->escape($item->transaction_id); ?></strong>
                         </div>
@@ -181,7 +181,7 @@ if ($hasDetails) {
                     <div class="flex-grow-1">
                         <div class="fw-bold fs-6"><?php echo $this->escape($orderShipping->ordershipping_name); ?></div>
                         <?php if (!empty($item->transaction_id)) : ?>
-                            <div class="text-muted small">
+                            <div class="text-body-secondary small">
                                 <?php echo Text::_('COM_J2COMMERCE_FIELD_TRACKING_NUMBER'); ?>:
                                 <strong class="text-body"><?php echo $this->escape($orderShipping->ordershipping_tracking_id ?: '-'); ?></strong>
                             </div>


### PR DESCRIPTION
## Summary
Fixes #1228

The core admin order-view template used the project-banned Bootstrap `text-muted` class. Swapped to the canonical `text-body-secondary` (Bootstrap 5.3+).

## Changes
- `administrator/components/com_j2commerce/tmpl/order/view_details.php`
  - line 86: `text-muted small` → `text-body-secondary small` (Transaction ID label)
  - line 184: `text-muted small` → `text-body-secondary small` (Tracking Number label)

## Testing
1. Admin → J2Commerce → Orders → open a paid order with a transaction id (and a shipment with a tracking number)
2. View the order-details panel
3. Verify the "Transaction ID:" and "Tracking Number:" lines render de-emphasized (secondary), no visual regression

## Files Changed
| Type | Count |
|------|-------|
| PHP templates | 1 (2 lines) |

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets / FOF remnants
- [x] Security gate: PASS (presentational class swap, zero exploit surface)
- [x] Core file only; minimal change
- [x] 0 `text-muted` remaining in the file