### PR TITLE
fix(core): replace deprecated Toolbar::getInstance() in 3 toolbar Field classes

### DIFF
--- a/plugins/j2commerce/report_itemised/src/Field/ReporttoolbarField.php
+++ b/plugins/j2commerce/report_itemised/src/Field/ReporttoolbarField.php
@@ -19,7 +19,6 @@ namespace J2Commerce\Plugin\J2Commerce\ReportItemised\Field;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\FormField;
 use Joomla\CMS\Toolbar\Button\LinkButton;
-use Joomla\CMS\Toolbar\Toolbar;
 
 /**
  * Custom form field that adds toolbar buttons to the plugin config page.
@@ -63,7 +62,7 @@ class ReporttoolbarField extends FormField
             true
         );
 
-        $toolbar = Toolbar::getInstance('toolbar');
+        $toolbar = Factory::getApplication()->getDocument()->getToolbar('toolbar');
 
         // Prepend so buttons appear to the LEFT of Save/Apply/Close/Help
         // (prependButton uses array_unshift, so add in reverse order)

--- a/plugins/j2commerce/report_products/src/Field/ReporttoolbarField.php
+++ b/plugins/j2commerce/report_products/src/Field/ReporttoolbarField.php
@@ -19,7 +19,6 @@ namespace J2Commerce\Plugin\J2Commerce\ReportProducts\Field;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\FormField;
 use Joomla\CMS\Toolbar\Button\LinkButton;
-use Joomla\CMS\Toolbar\Toolbar;
 
 /**
  * Custom form field that adds toolbar buttons to the plugin config page.
@@ -63,7 +62,7 @@ class ReporttoolbarField extends FormField
             true
         );
 
-        $toolbar = Toolbar::getInstance('toolbar');
+        $toolbar = Factory::getApplication()->getDocument()->getToolbar('toolbar');
 
         // Prepend so buttons appear to the LEFT of Save/Apply/Close/Help
         // (prependButton uses array_unshift, so add in reverse order)

--- a/plugins/j2commerce/shipping_standard/src/Field/ShippingtoolbarField.php
+++ b/plugins/j2commerce/shipping_standard/src/Field/ShippingtoolbarField.php
@@ -19,7 +19,6 @@ namespace J2Commerce\Plugin\J2Commerce\ShippingStandard\Field;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\FormField;
 use Joomla\CMS\Toolbar\Button\LinkButton;
-use Joomla\CMS\Toolbar\Toolbar;
 
 /**
  * Custom form field that adds toolbar buttons to the plugin config page.
@@ -60,7 +59,7 @@ class ShippingtoolbarField extends FormField
         // Load the component language file for button text
         $app->getLanguage()->load('com_j2commerce', JPATH_ADMINISTRATOR);
 
-        $toolbar = Toolbar::getInstance('toolbar');
+        $toolbar = Factory::getApplication()->getDocument()->getToolbar('toolbar');
 
         // Prepend so buttons appear to the LEFT of Save/Apply/Close/Help
         // (prependButton uses array_unshift, so add in reverse order)


### PR DESCRIPTION
## Summary
Fixes #1233

Joomla 7 removes `Joomla\CMS\Toolbar\Toolbar::getInstance()` (deprecated, "will be removed in 7.0"). Three core plugin toolbar `Field` classes still called it. Swapped to the supported accessor — zero behaviour change, since core `Toolbar::getInstance($name)` already delegates internally to `getToolbar($name)`.

## Changes
- `Toolbar::getInstance('toolbar')` → `Factory::getApplication()->getDocument()->getToolbar('toolbar')`
- Removed the now-unused `use Joomla\CMS\Toolbar\Toolbar;` import (Factory already imported in all 3)

## Files Changed
| File | Change |
|------|--------|
| `plugins/j2commerce/report_itemised/src/Field/ReporttoolbarField.php` | swap call + drop unused import |
| `plugins/j2commerce/report_products/src/Field/ReporttoolbarField.php` | swap call + drop unused import |
| `plugins/j2commerce/shipping_standard/src/Field/ShippingtoolbarField.php` | swap call + drop unused import |

## Testing
1. Admin → J2Commerce → Reports → open the Itemised report plugin config; confirm "View Report" + "Back to Reports" toolbar buttons render.
2. Open the Products report plugin config; confirm the same two buttons render.
3. Admin → Shipping → Standard plugin config; confirm "Manage Standard Methods" + "New Shipping Method" buttons render (left of Save/Apply/Close/Help).

## Pre-Flight
- [x] PHP syntax check passed (3 files)
- [x] php-cs-fixer: 0 violations
- [x] No secrets / no FOF remnants
- [x] Security gate: PASS
- [x] Core files only
- Detected by: phpstan/phpstan-deprecation-rules against Joomla 6.1.1 stubs