### PR TITLE
Fix: Display price should use display options (for tax information)

### DIFF
--- a/administrator/components/com_j2commerce/src/Helper/ProductHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/ProductHelper.php
@@ -3692,14 +3692,41 @@ class ProductHelper
     public function displayPrice(float|string $price, ?object $product = null, ?Registry $params = null, string $context = ''): string
     {
         $price = (float) $price;
-        $html  = '';
+        $this->reset_tax_text();
 
-        // Format the price using currency helper
+        $taxProfileId = (int) ($product->taxprofile_id ?? 0);
+
+        if ($taxProfileId > 0) {
+            $isIncludingTax     = (int) J2CommerceHelper::config()->get('config_including_tax', 0);
+            $priceDisplayOption = ConfigHelper::getPriceDisplayOption();
+            $taxRate            = $this->getTaxRateForProfile($taxProfileId);
+
+            if ($priceDisplayOption === 2) {
+                // Display price inclusive of tax
+                if (!$isIncludingTax && $taxRate > 0) {
+                    $price += $price * ($taxRate / 100);
+                }
+
+                if ($taxRate > 0) {
+                    $this->_tax_info = Text::sprintf('COM_J2COMMERCE_PRICE_INCLUDING_TAX', round($taxRate, 2) . '%');
+                }
+            } else {
+                // Display price exclusive of tax (default)
+                if ($isIncludingTax && $taxRate > 0) {
+                    $price /= (1 + ($taxRate / 100));
+                }
+
+                if ($taxRate > 0) {
+                    $this->_tax_info = Text::sprintf('COM_J2COMMERCE_PRICE_EXCLUDING_TAX_WITH_PERCENTAGE', round($taxRate, 2) . '%');
+                } else {
+                    $this->_tax_info = Text::_('COM_J2COMMERCE_PRICE_EXCLUDING_TAX');
+                }
+            }
+        }
+
         $formattedPrice = J2CommerceHelper::currency()->format($price);
+        $html           = '<span class="j2commerce-product-price">' . $formattedPrice . '</span>';
 
-        $html = '<span class="j2commerce-product-price">' . $formattedPrice . '</span>';
-
-        // Add tax info if available
         if (!empty($this->_tax_info)) {
             $html .= '<span class="j2commerce-product-tax-info">' . $this->_tax_info . '</span>';
         }

--- a/administrator/components/com_j2commerce/src/Model/Behavior/Flexivariable.php
+++ b/administrator/components/com_j2commerce/src/Model/Behavior/Flexivariable.php
@@ -1043,8 +1043,8 @@ class Flexivariable
         }
 
         $return['pricing']                           = [];
-        $return['pricing']['base_price']             = J2CommerceHelper::currency()->format((float) $variant->pricing->base_price);
-        $return['pricing']['price']                  = J2CommerceHelper::currency()->format((float) $variant->pricing->price);
+        $return['pricing']['base_price']             = $productHelper->displayPrice((float) $variant->pricing->base_price, $product, $config);
+        $return['pricing']['price']                  = $productHelper->displayPrice((float) $variant->pricing->price, $product, $config);
         $return['pricing']['original']               = [];
         $return['pricing']['original']['base_price'] = number_format((float) $variant->pricing->base_price, 5, '.', '');
         $return['pricing']['original']['price']      = number_format((float) $variant->pricing->price, 5, '.', '');

--- a/administrator/components/com_j2commerce/src/Model/Behavior/Variable.php
+++ b/administrator/components/com_j2commerce/src/Model/Behavior/Variable.php
@@ -811,8 +811,8 @@ class Variable
         }
 
         $return['pricing']               = [];
-        $return['pricing']['base_price'] = J2CommerceHelper::currency()->format((float) $variant->pricing->base_price);
-        $return['pricing']['price']      = J2CommerceHelper::currency()->format((float) $variant->pricing->price);
+        $return['pricing']['base_price'] = $productHelper->displayPrice((float) $variant->pricing->base_price, $product, $config);
+        $return['pricing']['price']      = $productHelper->displayPrice((float) $variant->pricing->price, $product, $config);
         $return['pricing']['original']   = [
             'base_price' => number_format((float) $variant->pricing->base_price, 5, '.', ''),
             'price'      => number_format((float) $variant->pricing->price, 5, '.', ''),


### PR DESCRIPTION
In v4 (j2cart), displayPrice() read price_display_options from config and applied the appropriate tax adjustment before formatting. In v6, displayPrice() was reimplemented but lost this logic entirely. It just formatted the raw DB price with no tax calculation.                                                              
                                                                                                                                                                        
The config key price_display_options (1=price only, 2=price+tax) and ConfigHelper::getPriceDisplayOption() existed in v6 but were never wired into displayPrice().    

PR#1218 fixed the cart line-item prices but displayPrice() (used by product pages, category listings, tag listings, and configurable option prices) remained broken.

Additionally, Variable and Flexivariable AJAX variant-switch responses bypassed displayPrice() entirely, using currency()->format() directly (inconsistent with Simple which correctly used displayPrice()).

`administrator/…/Helper/ProductHelper.php`
Restored tax-adjustment logic: reads price_display_options and config_including_tax, adjusts price, sets _tax_info text

`administrator/…/Model/Behavior/Variable.php`
AJAX update: replaced currency()->format() with displayPrice()

`administrator/…/Model/Behavior/Flexivariable.php`
AJAX update: replaced currency()->format() with displayPrice()

  The logic (mirrors PR#1218's approach for the cart):
  - price_display_options = 2 (price + tax, for Germany): if config_including_tax = 0, multiply price by (1 + rate/100); set "includes X% tax" label
  - price_display_options = 1 (price only, default): if config_including_tax = 1, divide price by (1 + rate/100); set "excludes X% tax" label

To enable tax-inclusive display for your German store: set price_display_options = 2 in the J2Commerce component configuration (Taxes → Price Display).
