### PR TITLE
fix(core): live tracking-number display + always-available manual tracking

### DIFF
--- a/administrator/components/com_j2commerce/tmpl/order/view_details.php
+++ b/administrator/components/com_j2commerce/tmpl/order/view_details.php
@@ -180,16 +180,13 @@ if ($hasDetails) {
 
                     <div class="flex-grow-1">
                         <div class="fw-bold fs-6"><?php echo $this->escape($orderShipping->ordershipping_name); ?></div>
-                        <?php if (!empty($item->transaction_id)) : ?>
-                            <div class="text-body-secondary small">
-                                <?php echo Text::_('COM_J2COMMERCE_FIELD_TRACKING_NUMBER'); ?>:
-                                <strong class="text-body"><?php echo $this->escape($orderShipping->ordershipping_tracking_id ?: '-'); ?></strong>
-                            </div>
-                        <?php endif; ?>
+                        <div class="text-body-secondary small">
+                            <?php echo Text::_('COM_J2COMMERCE_FIELD_TRACKING_NUMBER'); ?>:
+                            <strong class="text-body" id="trackingValue"><?php echo $this->escape($orderShipping->ordershipping_tracking_id ?: '-'); ?></strong>
+                        </div>
                     </div>
                 </div>
                 <div class="j2c-detail-card-shipping-buttons d-flex align-items-center gap-2">
-                    <?php if ($hasDetails) : ?>
                         <span id="trackingEdit" class="d-none">
                         <span class="input-group input-group-sm d-inline-flex w-auto">
                             <input type="text" class="form-control form-control-sm" id="trackingInput" style="max-width: 200px;" value="<?php echo $this->escape($orderShipping->ordershipping_tracking_id ?? ''); ?>">
@@ -207,7 +204,6 @@ if ($hasDetails) {
                             <span class="ms-1"><?php echo Text::_('JACTION_EDIT'); ?></span>
                         </button>
                     </span>
-                    <?php endif; ?>
                     <?php echo J2CommerceHelper::plugin()->eventWithHtml('AfterAdminOrderShippingButton', array($item))->getArgument('html', ''); ?>
                 </div>
             </div>


### PR DESCRIPTION
## Core Update — admin order view tracking number

### Problem
In the backend order view, clicking **Edit tracking** (`#editTrackingBtn`) saves the number via AJAX, but the displayed tracking number didn't update until a page refresh. Also, the tracking number + inline editor only rendered when the order had a payment-gateway transaction (`$item->transaction_id` / `$hasDetails`), so manually-entered tracking couldn't be shown/edited on offline/manual orders.

### Changes (`administrator/components/com_j2commerce/tmpl/order/view_details.php`)
- Add `id="trackingValue"` to the displayed tracking-number `<strong>`. The existing `media/com_j2commerce/js/administrator/admin-order.js` already does `trackingValue.textContent = …` on save success — it was a no-op because no element had that id. Now the number updates live (no refresh).
- Always render the tracking-number line + the inline tracking editor on shippable orders (drop the `transaction_id` / `$hasDetails` gates), so a manually entered tracking number shows and is editable without a payment-gateway transaction.

No JS change required. Output remains `$this->escape()`-d.

### Files Modified
| Type | Count |
|------|-------|
| PHP (template) | 1 |

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core file only (branch cut clean from upstream/main; only this file changed)
- [x] Security gate: PASS (0 critical / 0 high / 0 medium) — write path (`OrderController::ajaxSaveTracking` → `OrderModel::saveTrackingNumber`) is CSRF-validated + parameterized; exposing the editor UI adds no new write/authorization path

### Note
Pre-existing advisory (not in this diff): the order AJAX tasks enforce CSRF but lack an explicit `core.edit`/`core.manage` component ACL check — recommend a separate hardening pass.