### PR TITLE
fix(core): require core.edit ACL on order AJAX endpoints

### DIFF
--- a/administrator/components/com_j2commerce/src/Controller/OrderController.php
+++ b/administrator/components/com_j2commerce/src/Controller/OrderController.php
@@ -167,9 +167,7 @@ class OrderController extends FormController
     {
         header('Content-Type: application/json; charset=utf-8');
 
-        if (!$this->validateAjaxToken()) {
-            echo json_encode(['success' => false, 'message' => Text::_('JINVALID_TOKEN')]);
-            $this->app->close();
+        if (!$this->checkAjaxAccess()) {
             return;
         }
 
@@ -199,9 +197,7 @@ class OrderController extends FormController
     {
         header('Content-Type: application/json; charset=utf-8');
 
-        if (!$this->validateAjaxToken()) {
-            echo json_encode(['success' => false, 'message' => Text::_('JINVALID_TOKEN')]);
-            $this->app->close();
+        if (!$this->checkAjaxAccess()) {
             return;
         }
 
@@ -261,9 +257,7 @@ class OrderController extends FormController
     {
         header('Content-Type: application/json; charset=utf-8');
 
-        if (!$this->validateAjaxToken()) {
-            echo json_encode(['success' => false, 'message' => Text::_('JINVALID_TOKEN')]);
-            $this->app->close();
+        if (!$this->checkAjaxAccess()) {
             return;
         }
 
@@ -308,9 +302,7 @@ class OrderController extends FormController
     {
         header('Content-Type: application/json; charset=utf-8');
 
-        if (!$this->validateAjaxToken()) {
-            echo json_encode(['success' => false, 'message' => Text::_('JINVALID_TOKEN')]);
-            $this->app->close();
+        if (!$this->checkAjaxAccess()) {
             return;
         }
 
@@ -349,9 +341,7 @@ class OrderController extends FormController
     {
         header('Content-Type: application/json; charset=utf-8');
 
-        if (!$this->validateAjaxToken()) {
-            echo json_encode(['success' => false, 'message' => Text::_('JINVALID_TOKEN')]);
-            $this->app->close();
+        if (!$this->checkAjaxAccess()) {
             return;
         }
 
@@ -381,9 +371,7 @@ class OrderController extends FormController
     {
         header('Content-Type: application/json; charset=utf-8');
 
-        if (!$this->validateAjaxToken()) {
-            echo json_encode(['success' => false, 'message' => Text::_('JINVALID_TOKEN')]);
-            $this->app->close();
+        if (!$this->checkAjaxAccess()) {
             return;
         }
 
@@ -655,6 +643,30 @@ class OrderController extends FormController
         return $this->input->post->get($token, '', 'alnum') === '1';
     }
 
+    /**
+     * CSRF token + backend ACL gate for the order AJAX endpoints. On failure it
+     * emits the JSON error and closes the app, returning false so the caller
+     * can just `return`.
+     */
+    protected function checkAjaxAccess(string $action = 'core.edit'): bool
+    {
+        if (!$this->validateAjaxToken()) {
+            echo json_encode(['success' => false, 'message' => Text::_('JINVALID_TOKEN')]);
+            $this->app->close();
+
+            return false;
+        }
+
+        if (!$this->app->getIdentity()->authorise($action, 'com_j2commerce')) {
+            echo json_encode(['success' => false, 'message' => Text::_('JLIB_APPLICATION_ERROR_ACCESS_FORBIDDEN')]);
+            $this->app->close();
+
+            return false;
+        }
+
+        return true;
+    }
+
     private function getStatusInfo(int $statusId): ?object
     {
         $db    = Factory::getContainer()->get(\Joomla\Database\DatabaseInterface::class);
@@ -676,9 +688,7 @@ class OrderController extends FormController
     {
         header('Content-Type: application/json; charset=utf-8');
 
-        if (!$this->validateAjaxToken()) {
-            echo json_encode(['success' => false, 'message' => Text::_('JINVALID_TOKEN')]);
-            $this->app->close();
+        if (!$this->checkAjaxAccess()) {
             return;
         }
 


### PR DESCRIPTION
## Core Security Hardening — order AJAX ACL

### Problem
The order AJAX endpoints in `OrderController` enforced only a CSRF form token (`validateAjaxToken()`) with **no component ACL**. A logged-in back-office user without J2Commerce edit rights (or a CSRF-tricked low-privilege session) could mutate orders: save tracking, change status, add/delete notes, resend customer emails, queue faker data.

### Fix (`administrator/components/com_j2commerce/src/Controller/OrderController.php`)
- New `checkAjaxAccess(string $action = 'core.edit')` helper: validates the CSRF token AND `$this->app->getIdentity()->authorise($action, 'com_j2commerce')`; on failure emits a JSON error (`JINVALID_TOKEN` or `JLIB_APPLICATION_ERROR_ACCESS_FORBIDDEN`) and closes the app.
- All 7 endpoints (`ajaxSaveTracking`, `ajaxUpdateStatus`, `ajaxResendEmail`, `ajaxAddNote`, `ajaxDeleteNote`, `ajaxGetHistory`, `ajaxQueueFaker`) now call `if (!$this->checkAjaxAccess()) { return; }` instead of the bare token block.

Purely additive — no existing check removed; CSRF still enforced.

### Files Modified
| Type | Count |
|------|-------|
| PHP (controller) | 1 |

### Pre-Flight
- [x] PHP syntax check passed
- [x] php-cs-fixer clean
- [x] Core file only (clean branch off upstream/main; only this file changed)
- [x] Security gate: PASS (0 critical / 0 high / 0 medium) — closes the prior "order AJAX tasks lack explicit component ACL" advisory; cross-validated by joomla6-code-reviewer