### PR TITLE
fix(core): drop bogus Content-Type on body-less GET (415 on variant AJAX)

### DIFF
--- a/media/com_j2commerce/js/site/j2commerce.js
+++ b/media/com_j2commerce/js/site/j2commerce.js
@@ -262,10 +262,7 @@ const J2Commerce = {
         try {
             const response = await fetch(`${url}&${params.toString()}`, {
                 method: 'GET',
-                headers: {
-                    'Cache-Control': 'no-cache',
-                    'Content-Type': 'application/json; charset=utf-8'
-                }
+                headers: { 'Cache-Control': 'no-cache' }
             });
             const json = await response.json();
 


### PR DESCRIPTION
## Core Update

### Problem
On sites behind a hardened WAF/mod_security (OWASP CRS), changing a product **size/variant** select threw **415 Unsupported Media Type** in the console, breaking the variant price/image refresh.

### Root cause
`doTask()` in `media/com_j2commerce/js/site/j2commerce.js` sent `Content-Type: application/json; charset=utf-8` on a `method: GET` fetch. A GET has no body, so the JSON content-type is meaningless — and it trips **CRS rule 920420** ("request content type not allowed by policy"), which returns **415**. Servers without that rule silently ignored it, which is why most sites never saw the error.

`doTask` was the last handler still carrying the header; `doAjaxPrice` and `doAjaxFilter` already send clean GETs.

### Change
Remove the `Content-Type` header from the `doTask` GET fetch (keep `Cache-Control: no-cache`).

> Rule of thumb: never set a request `Content-Type` on a body-less GET.

### Files Modified
| Type | Count |
|------|-------|
| JS assets | 1 |

### Pre-Flight
- [x] Core file only (non-core working-tree changes excluded)
- [x] No PHP changed (php-l / php-cs-fixer N/A)
- [x] No secrets
- [x] Security gate: PASS (security-neutral header removal)

https://claude.ai/code/session_01LV9UsWjMMqk872V2VxbCue