### PR TITLE
fix(core): use framework HttpFactory in GeocodingHelper (Joomla 7 prep)

### DIFF
--- a/plugins/system/j2commerce/src/Helper/GeocodingHelper.php
+++ b/plugins/system/j2commerce/src/Helper/GeocodingHelper.php
@@ -15,9 +15,9 @@ namespace J2Commerce\Plugin\System\J2Commerce\Helper;
 \defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
-use Joomla\CMS\Http\HttpFactory;
 use Joomla\CMS\Log\Log;
 use Joomla\Database\DatabaseInterface;
+use Joomla\Http\HttpFactory;
 
 class GeocodingHelper
 {
@@ -140,7 +140,7 @@ class GeocodingHelper
         $url = self::NOMINATIM_URL . '?' . http_build_query($params);
 
         try {
-            $http     = HttpFactory::getHttp([
+            $http     = (new HttpFactory())->getHttp([
                 'transport.curl' => [
                     \CURLOPT_SSL_VERIFYPEER => false,
                     \CURLOPT_SSL_VERIFYHOST => 0,
@@ -151,9 +151,9 @@ class GeocodingHelper
                 'Accept'     => 'application/json',
             ]);
 
-            if ($response->code !== 200) {
+            if ($response->getStatusCode() !== 200) {
                 Log::add(
-                    'Nominatim API returned HTTP ' . $response->code . ' for: ' . $address,
+                    'Nominatim API returned HTTP ' . $response->getStatusCode() . ' for: ' . $address,
                     Log::WARNING,
                     'plg_system_j2commerce'
                 );
@@ -161,7 +161,7 @@ class GeocodingHelper
                 return null;
             }
 
-            $data = json_decode($response->body, true);
+            $data = json_decode((string) $response->getBody(), true);
 
             if (empty($data) || !isset($data[0]['lat'], $data[0]['lon'])) {
                 Log::add(


### PR DESCRIPTION
## Core Update

Joomla 7 removes `Joomla\CMS\Http\HttpFactory` (deprecated 6.0.0). This swaps `plg_system_j2commerce` `GeocodingHelper` to the framework `Joomla\Http\HttpFactory`.

### Key detail (not a pure import swap)
The framework `getHttp()` is an **instance** method (the deprecated CMS one was static), so the call changes:
```php
-use Joomla\CMS\Http\HttpFactory;
+use Joomla\Http\HttpFactory;

-$http = HttpFactory::getHttp([...]);
+$http = (new HttpFactory())->getHttp([...]);
```
Same `$options` (transport.curl SSL flags), same `Joomla\Http\Http` transport — no behaviour change.

### Files Modified
| Type | Count |
|------|-------|
| PHP files | 1 |

### Pre-Flight
- [x] PHP syntax (`php -l`)
- [x] No secrets / no FOF remnants
- [x] php-cs-fixer (core config) clean — import reordered per ruleset
- [x] PHPStan deprecation rules: 0 findings
- [x] Security gate: PASS (0 findings)
- [x] Live Nominatim geocode smoke test: HTTP 200, coords resolved
- [x] Core file only

First slice of the pre-Joomla-7 HttpFactory deprecation bucket (54 more files across non-core extensions + j2connections to follow in their own repos).