### PR TITLE
[Fix] Inconsistencies between product display and cart with inclusive/exclusive prices + fix adding tax twice

### DIFF
--- a/administrator/components/com_j2commerce/src/Helper/CartOrder.php
+++ b/administrator/components/com_j2commerce/src/Helper/CartOrder.php
@@ -440,9 +440,10 @@ class CartOrder
      */
     protected function calculateTotals(): void
     {
-        $subtotal = 0.0;
-        $taxTotal = 0.0;
-        $taxRates = [];
+        $subtotal       = 0.0;
+        $taxTotal       = 0.0;
+        $taxRates       = [];
+        $isIncludingTax = (int) J2CommerceHelper::config()->get('config_including_tax', 0);
 
         // Resolve customer geozones once for all items
         $customerGeozones = $this->getCustomerGeozones();
@@ -484,11 +485,27 @@ class CartOrder
                         $itemTaxTotal = 0.0;
                         $effectivePct = 0.0;
 
+                        // Sum total rate percent for inclusive extraction
+                        $totalRatePct = 0.0;
+                        foreach ($ratesets as $rate) {
+                            $totalRatePct += (float) ($rate->rate ?? $rate->tax_percent ?? 0);
+                        }
+
+                        // Total tax for this line (inclusive extraction or exclusive addition)
+                        $lineTotal = $itemPrice * $quantity;
+                        $lineTaxTotal = $isIncludingTax
+                            ? ($totalRatePct > 0 ? $lineTotal * $totalRatePct / (100 + $totalRatePct) : 0.0)
+                            : $lineTotal * ($totalRatePct / 100);
+
                         foreach ($ratesets as $rate) {
                             $rateName    = (string) ($rate->name ?? $rate->taxrate_name ?? '');
                             $ratePercent = (float) ($rate->rate ?? $rate->tax_percent ?? 0);
                             $rateId      = (int) ($rate->j2commerce_taxrate_id ?? 0);
-                            $rateAmount  = $itemPrice * $quantity * ($ratePercent / 100);
+
+                            // Distribute total tax proportionally across rates
+                            $rateAmount = $totalRatePct > 0
+                                ? $lineTaxTotal * ($ratePercent / $totalRatePct)
+                                : 0.0;
 
                             $itemTaxTotal += $rateAmount;
                             $effectivePct += $ratePercent;
@@ -539,7 +556,9 @@ class CartOrder
         $this->order_subtotal = $subtotal;
         $this->order_tax      = $taxTotal;
         $this->taxRates       = array_values($taxRates);
-        $this->order_total    = $subtotal + $taxTotal;
+        // When prices are stored inclusive of tax the subtotal already contains the tax;
+        // adding taxTotal again would double-count it.
+        $this->order_total = $isIncludingTax ? $subtotal : $subtotal + $taxTotal;
     }
 
     /**
@@ -584,11 +603,18 @@ class CartOrder
         $taxReduction    = $oldTaxTotal - $newTaxTotal;
         $this->order_tax = $newTaxTotal;
 
-        // Subtract both the discount amount AND the tax reduction from total
-        // order_total was set to (subtotal + tax) in calculateTotals()
-        // After discount: total = (subtotal - discount) + (tax - taxReduction)
-        // So we need to subtract: discount + taxReduction
-        $this->order_total -= ($totalDiscount + $taxReduction);
+        $isIncludingTax = (int) J2CommerceHelper::config()->get('config_including_tax', 0);
+
+        if ($isIncludingTax) {
+            // For inclusive pricing, order_total = subtotal (tax is embedded).
+            // Only the discount reduces the total; the tax reduction is already
+            // captured proportionally within that discount amount.
+            $this->order_total -= $totalDiscount;
+        } else {
+            // For exclusive pricing, order_total = subtotal + tax.
+            // Both the discount and the proportional tax reduction must be subtracted.
+            $this->order_total -= ($totalDiscount + $taxReduction);
+        }
     }
 
     private function getCustomerGeozones(): array
@@ -599,7 +625,20 @@ class CartOrder
         $this->customerZoneId    = (int) $address->zone_id;
         $this->customerPostcode  = (string) $address->postcode;
 
-        return TaxHelper::getCustomerGeozones($address);
+        $geozones = TaxHelper::getCustomerGeozones($address);
+
+        // No shipping address entered yet — fall back to the store's own address so that
+        // tax rates (and the tax line in the cart totals) are visible from the first page load,
+        // consistent with how displayPrice() computes tax on product/category pages.
+        if (empty($geozones)) {
+            $storeAddress = TaxHelper::getStoreAddress();
+            $this->customerCountryId = (int) $storeAddress->country_id;
+            $this->customerZoneId    = (int) $storeAddress->zone_id;
+            $this->customerPostcode  = (string) $storeAddress->postcode;
+            $geozones = TaxHelper::getCustomerGeozones($storeAddress);
+        }
+
+        return $geozones;
     }
 
     /**
@@ -2063,15 +2102,26 @@ class CartOrder
      */
     public function get_formatted_order_totals(): array
     {
-        $totals     = [];
-        $currency   = J2CommerceHelper::currency();
-        $params     = J2CommerceHelper::config();
-        $combineTax = (int) $params->get('combine_tax_calculations', 1);
+        $totals               = [];
+        $currency             = J2CommerceHelper::currency();
+        $params               = J2CommerceHelper::config();
+        $combineTax           = (int) $params->get('combine_tax_calculations', 1);
+        $checkoutPriceDisplay = (int) $params->get('checkout_price_display_options', 0);
 
-        // Subtotal (before tax) - use keyed index so plugins can target it
+        // Subtotal row — when showing inclusive prices, sum displayed line-item totals
+        // so the subtotal matches what the customer sees (regardless of geozone resolution)
+        if ($checkoutPriceDisplay && !empty($this->items)) {
+            $displaySubtotal = 0.0;
+            foreach ($this->items as $item) {
+                $displaySubtotal += $this->get_formatted_lineitem_total($item, $checkoutPriceDisplay);
+            }
+        } else {
+            $displaySubtotal = $this->order_subtotal;
+        }
+
         $totals['subtotal'] = [
             'label' => Text::_('COM_J2COMMERCE_CART_SUBTOTAL'),
-            'value' => $currency->format($this->order_subtotal),
+            'value' => $currency->format($displaySubtotal),
         ];
 
         // Shipping - placed before tax
@@ -2098,7 +2148,6 @@ class CartOrder
         // Fees - allow plugins to add custom fees via session
         $fees = $this->get_fees();
         if (!empty($fees)) {
-            $checkoutPriceDisplay = (int) $params->get('checkout_price_display_options', 0);
             foreach ($fees as $fee) {
                 $feeKey          = 'fee_' . preg_replace('/[^a-z0-9_]/', '_', strtolower($fee->name ?? 'custom'));
                 $totals[$feeKey] = [
@@ -2128,7 +2177,7 @@ class CartOrder
 
                     if ($discountType === 'coupon') {
                         $label = $discountTitle;
-                        $link  = '<a class="j2commerce-remove j2commerce-remove-coupon remove-icon text-danger ms-2 text-decoration-none" href="#" data-id=" '
+                        $link  = '<a class="j2commerce-remove j2commerce-remove-coupon remove-icon text-danger ms-2 text-decoration-none" '
                             . 'href="javascript:void(0)" title="' . Text::_('COM_J2COMMERCE_REMOVE_COUPON') . '">x</a>';
                     } elseif ($discountType === 'voucher') {
                         $label = $discountTitle;
@@ -2157,8 +2206,6 @@ class CartOrder
 
         // Tax totals — always show Tax Profile Name; combine shipping tax when enabled
         if (!empty($this->taxRates) || ($combineTax && $this->order_shipping_tax > 0)) {
-            $checkoutPriceDisplay = (int) $params->get('checkout_price_display_options', 0);
-
             // Clone taxRates for display to avoid mutating calculated values
             $displayRates = [];
 

--- a/administrator/components/com_j2commerce/src/Helper/TaxHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/TaxHelper.php
@@ -93,6 +93,24 @@ final class TaxHelper
     }
 
     /**
+     * Get the store's own address (country, zone, postcode) from config.
+     *
+     * Used as a fallback for tax calculations when no customer address is available.
+     *
+     * @return  \stdClass  Address object with country_id, zone_id, postcode.
+     *
+     * @since   6.3.8
+     */
+    public static function getStoreAddress(): \stdClass
+    {
+        return (object) [
+            'country_id' => ConfigHelper::getStoreCountryId(),
+            'zone_id'    => ConfigHelper::getStoreZoneId(),
+            'postcode'   => (string) ConfigHelper::get('store_zip', ''),
+        ];
+    }
+
+    /**
      * Resolve the geozone IDs that match the given customer address.
      *
      * @param   \stdClass|null  $address  Pre-resolved address; null → use getCustomerAddress().


### PR DESCRIPTION
What changed with the store-address fallback is that calculateTotals() now always populates $this->taxRates, so the tax line in the totals will now appear even before a shipping address is entered. The label on that tax line still correctly says "included" or "excluded" based on checkout_price_display_options. Previously, with no shipping address, the tax section was silently skipped entirely — which wasn't intentional behavior, just a side effect of empty geozones.

In displayPrice():
  - No geozone lookup — it uses the raw tax rate from the tax rules table
  - No customer address — it doesn't care where the customer is

In calculateTotals() (cart):
  - Geozone-aware — calls getCustomerGeozones() then getTaxRatesForProfile($taxprofileId, $customerGeozones) which filters rates by matching geozone
  - If geozones are empty → no tax computed → $this->taxRates stays empty → tax line disappears

This means there's an inconsistency: product page prices use the unfiltered tax rate (fine for a single-country store), while cart tax calculation requires a matching geozone. The proposed fallback to the store's own address would make calculateTotals() consistent with displayPrice() — both would effectively use the store-country rate when no customer address is known.

  - Before: cart opened without a shipping address → taxRates empty → subtotal showed ex-tax, tax line missing, grand total showed ex-tax
  - After: cart opened without a shipping address → falls back to store's Germany geozone → tax rates computed from store's tax rules → subtotal shows inclusive price, tax line shows "included 19%" (or whatever rate matches), grand total is consistent

### FIX: it's adding tax a second time to an already inclusive price in basket and checkout
                                                                                                                                               
The bug is a pre-existing issue in CartOrder::calculateTotals() — unrelated to our previous displayPrice() fix. The method always uses the tax-exclusive formula regardless of config_including_tax:
                                                            
Config                                     │ Correct formula                   │ What was used
config_including_tax = 0 (ex-tax storage)  │ tax = price × rate / 100          │ price × rate / 100 ✓
config_including_tax = 1 (inc-tax storage) │ tax = price × rate / (100 + rate) │ price × rate / 100 ✗

And order_total = subtotal + taxTotal was always used, but when prices are inclusive, the subtotal already contains the tax — adding taxTotal again is double-counting.

Two methods fixed in CartOrder.php

calculateTotals():
  - Tax formula: now uses price × totalRate / (100 + totalRate) when config_including_tax = 1
  - order_total: now = subtotal (not + taxTotal) when inclusive — the tax is already embedded

recalculateTaxAfterDiscounts():
  - For inclusive pricing: only subtracts the discount from order_total (the proportional tax reduction is already captured within the discount amount, since both live inside the subtotal)
  - For exclusive pricing: existing behaviour unchanged (discount + taxReduction)

