### PR TITLE
feat(api): expose linked article and custom fields on product item endpoint

### DIFF
--- a/api/components/com_j2commerce/src/Controller/ProductsController.php
+++ b/api/components/com_j2commerce/src/Controller/ProductsController.php
@@ -23,6 +23,16 @@ class ProductsController extends J2CommerceApiController
 
     protected $default_view = 'products';
 
+    public function getModel($name = '', $prefix = '', $config = [])
+    {
+        // Use API-layer ProductModel (article + jcfields) for single-item requests
+        if (strtolower($name) === 'product') {
+            $prefix = 'Api';
+        }
+
+        return parent::getModel($name, $prefix, $config);
+    }
+
     public function displayList()
     {
         $apiFilterInfo = $this->input->get('filter', [], 'array');

--- a/api/components/com_j2commerce/src/Model/ProductModel.php
+++ b/api/components/com_j2commerce/src/Model/ProductModel.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace J2Commerce\Component\J2commerce\Api\Model;
+
+\defined('_JEXEC') or die;
+
+use J2Commerce\Component\J2commerce\Administrator\Model\ProductModel as AdminProductModel;
+use Joomla\Component\Fields\Administrator\Helper\FieldsHelper;
+
+/** @since  6.0.16 */
+class ProductModel extends AdminProductModel
+{
+    public function getItem($pk = null): object|bool
+    {
+        $item = parent::getItem($pk);
+
+        if (!$item || empty($item->j2commerce_product_id)) {
+            return $item;
+        }
+
+        $article = $item->source ?? null;
+
+        if ($article !== null && isset($article->id)) {
+            $user    = $this->getCurrentUser();
+            $visible = (int) ($article->state ?? 0) === 1
+                && \in_array((int) ($article->access ?? 0), $user->getAuthorisedViewLevels(), true);
+
+            if ($visible) {
+                $safe              = new \stdClass();
+                $safe->id          = $article->id ?? null;
+                $safe->title       = $article->title ?? null;
+                $safe->alias       = $article->alias ?? null;
+                $safe->introtext   = $article->introtext ?? null;
+                $safe->fulltext    = $article->fulltext ?? null;
+                $safe->state       = $article->state ?? null;
+                $safe->catid       = $article->catid ?? null;
+                $safe->language    = $article->language ?? null;
+                $safe->created     = $article->created ?? null;
+                $safe->modified    = $article->modified ?? null;
+                $safe->publish_up  = $article->publish_up ?? null;
+                $safe->publish_down = $article->publish_down ?? null;
+
+                $item->article  = $safe;
+                // $f->value is prepared/rendered HTML (prepareValue=true); rawvalue dropped intentionally.
+                $item->jcfields = array_map(
+                    static fn ($f) => (object) [
+                        'id'    => $f->id,
+                        'name'  => $f->name,
+                        'label' => $f->label,
+                        'value' => $f->value,
+                        'type'  => $f->type,
+                    ],
+                    FieldsHelper::getFields('com_content.article', $article, true)
+                );
+            } else {
+                $item->article  = null;
+                $item->jcfields = [];
+            }
+        } else {
+            $item->article  = null;
+            $item->jcfields = [];
+        }
+
+        return $item;
+    }
+}

--- a/api/components/com_j2commerce/src/View/Products/JsonapiView.php
+++ b/api/components/com_j2commerce/src/View/Products/JsonapiView.php
@@ -40,6 +40,8 @@ class JsonapiView extends J2CommerceJsonapiView
         'main_image',
         'created_on',
         'modified_on',
+        'article',
+        'jcfields',
     ];
 
     protected $fieldsToRenderList = [


### PR DESCRIPTION
## Core Update

Adds the linked Joomla article and its custom fields to the JSON:API product **item** response, mirroring how core `com_content` exposes `jcfields`.

`GET /api/index.php/v1/j2commerce/products/{id}` now returns, in `data.attributes`:
- `article` — a safe whitelist of the linked `com_content` article fields (id, title, alias, introtext, fulltext, state, catid, language, created, modified, publish_up, publish_down), only when `product_source` is `com_content`.
- `jcfields` — the article's custom fields, reduced to `{id, name, label, value, type}` with prepared values.

### Changes
- **New** `api/.../src/Model/ProductModel.php` — Api-layer model extending the Administrator `ProductModel`; `getItem()` attaches `article` + `jcfields`. The article is gated on published `state` **and** the caller's authorised view levels (fails closed → `article=null, jcfields=[]`). Custom fields resolved via `FieldsHelper::getFields('com_content.article', $article, true)` (published + access filtered by core for the API client); `rawvalue` intentionally dropped.
- **Modified** `api/.../src/Controller/ProductsController.php` — `getModel()` routes the single-item `product` model to the `Api` prefix; the `products` list model is unchanged.
- **Modified** `api/.../src/View/Products/JsonapiView.php` — added `article` + `jcfields` to the item render whitelist (list view unchanged).

### Files Modified
| Type | Count |
|------|-------|
| PHP files | 3 |

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants / JFactory
- [x] Code style (php-cs-fixer) passed
- [x] Security gate passed (no CRITICAL/HIGH; one non-blocking MEDIUM advisory re: article publish-window/category-access gate, optional future hardening)
- [x] Core files only (non-core excluded)
- [x] Verified live: `products/1` returns the article object + 7 jcfields