### PR TITLE
Fixed accented characters in any language will be safely escaped as proper JS string literals

### DIFF
--- a/administrator/components/com_j2commerce/src/Field/CategoryduallistboxField.php
+++ b/administrator/components/com_j2commerce/src/Field/CategoryduallistboxField.php
@@ -137,13 +137,13 @@ class CategoryduallistboxField extends ListField
     protected function getInitScript(array $selected): string
     {
         $selectedJson        = json_encode($selected);
-        $availableLabel      = Text::_('COM_J2COMMERCE_DUALLISTBOX_AVAILABLE');
-        $selectedLabel       = Text::_('COM_J2COMMERCE_DUALLISTBOX_SELECTED');
-        $searchPlaceholder   = Text::_('COM_J2COMMERCE_DUALLISTBOX_SEARCH');
-        $addButtonText       = Text::_('COM_J2COMMERCE_DUALLISTBOX_BUTTON_ADD');
-        $addAllButtonText    = Text::_('COM_J2COMMERCE_DUALLISTBOX_BUTTON_ADDALL');
-        $removeButtonText    = Text::_('COM_J2COMMERCE_DUALLISTBOX_BUTTON_REMOVE');
-        $removeAllButtonText = Text::_('COM_J2COMMERCE_DUALLISTBOX_BUTTON_REMOVEALL');
+        $availableLabel      = json_encode(Text::_('COM_J2COMMERCE_DUALLISTBOX_AVAILABLE'));
+        $selectedLabel       = json_encode(Text::_('COM_J2COMMERCE_DUALLISTBOX_SELECTED'));
+        $searchPlaceholder   = json_encode(Text::_('COM_J2COMMERCE_DUALLISTBOX_SEARCH'));
+        $addButtonText       = json_encode(Text::_('COM_J2COMMERCE_DUALLISTBOX_BUTTON_ADD'));
+        $addAllButtonText    = json_encode(Text::_('COM_J2COMMERCE_DUALLISTBOX_BUTTON_ADDALL'));
+        $removeButtonText    = json_encode(Text::_('COM_J2COMMERCE_DUALLISTBOX_BUTTON_REMOVE'));
+        $removeAllButtonText = json_encode(Text::_('COM_J2COMMERCE_DUALLISTBOX_BUTTON_REMOVEALL'));
 
         return <<<JS
 <script>
@@ -152,13 +152,13 @@ document.addEventListener('DOMContentLoaded', function() {
         const selectElement = document.getElementById('{$this->id}');
         if (selectElement) {
             const dualListbox = new DualListbox(selectElement, {
-                availableTitle: '{$availableLabel}',
-                selectedTitle: '{$selectedLabel}',
-                searchPlaceholder: '{$searchPlaceholder}',
-                addButtonText: '{$addButtonText}',
-                addAllButtonText: '{$addAllButtonText}',
-                removeButtonText: '{$removeButtonText}',
-                removeAllButtonText: '{$removeAllButtonText}',
+                availableTitle: {$availableLabel},
+                selectedTitle: {$selectedLabel},
+                searchPlaceholder: {$searchPlaceholder},
+                addButtonText: {$addButtonText},
+                addAllButtonText: {$addAllButtonText},
+                removeButtonText: {$removeButtonText},
+                removeAllButtonText: {$removeAllButtonText},
                 showAddAllButton: true,
                 showRemoveAllButton: true,
                 showSearchFilter: true,


### PR DESCRIPTION
If a language string contains a single quote (e.g. French "Disponible" is fine, but something like "Tout ajouter" is also fine — however any string with ' would break the JS, and accented characters in some locales could cause issues if the page charset isn't UTF-8).

The fix: use json_encode() on each value so they become self-quoted, properly escaped JS strings.

 The labels are inside a <script> block (not an HTML attribute). Inside <script>, the browser's HTML parser is not active — only the JavaScript engine runs. So HTML entities like &#039; are not decoded. A French label like "Tout ajouter" is fine, but if any language had "Don't add", htmlspecialchars would produce:                                                                                                          
                                                                                                                                                                                                                    
addButtonText: 'Don&#039;t add',  // JS sees: Don&#039;t add — broken!                                                                                                                                            
                                                                                                                                                                                                                    
The &#039; is not interpreted as ' by JavaScript — it's treated as literal characters &, #, 0, 3, 9, ;.

json_encode() is the right tool because it produces proper JavaScript string escapes:

addButtonText: "Don't add",  // json_encode produces double-quoted, single quotes unescaped — safe

Rule of thumb:
  - htmlspecialchars() → text going into HTML attributes (title="...", placeholder="...")
  - json_encode() → text going into <script> blocks or JS string literals

