### PR TITLE
Fix: Checkbox for agreeing to the terms and conditions is not working properly

### DIFF
--- a/components/com_j2commerce/src/Controller/CheckoutController.php
+++ b/components/com_j2commerce/src/Controller/CheckoutController.php
@@ -1553,7 +1553,7 @@ class CheckoutController extends BaseController
         $orderpaymentType = $this->input->getString('orderpayment_type', '');
 
         if (empty($orderpaymentType)) {
-            Session::checkToken('get') or $this->app->redirect($this->getCheckoutUrl());
+            Session::checkToken('post') or $this->app->redirect($this->getCheckoutUrl());
         } elseif ($this->input->getMethod() === 'POST') {
             // On-site card-collecting plugins POST orderpayment_type alongside
             // raw PAN/CVV. Enforce CSRF on every browser POST here. Offsite

--- a/components/com_j2commerce/tmpl/checkout/bootstrap5/default.php
+++ b/components/com_j2commerce/tmpl/checkout/bootstrap5/default.php
@@ -332,7 +332,12 @@ document.addEventListener('DOMContentLoaded', function() {
         if (!container || !message) return;
         var field = container.querySelector('#' + fieldId);
         if (field) {
-            field.classList.add('j2-invalid');
+            var isCheckbox = field.type === 'checkbox' || field.type === 'radio';
+            // Don't apply j2-invalid to checkboxes/radios: the class injects a background
+            // SVG icon sized for text inputs which renders inside the small checkbox.
+            if (!isCheckbox) {
+                field.classList.add('j2-invalid');
+            }
             field.setAttribute('aria-invalid', 'true');
             field.setAttribute('aria-describedby', fieldId + '-error');
             var span = document.createElement('span');
@@ -340,9 +345,10 @@ document.addEventListener('DOMContentLoaded', function() {
             span.id = fieldId + '-error';
             span.setAttribute('role', 'alert');
             span.textContent = message;
-            // Anchor after the telephone wrapper (if any) so the error
-            // renders below the full widget, not inside its flex row.
-            var anchor = field.closest('.j2c-telephone-field') || field;
+            // Anchor to the immediate parent wrapper so the error appears after the complete
+            // widget: handles .form-check rows, .j2c-telephone-field flex rows,
+            // .form-floating groups, and plain .form-normal wrappers consistently.
+            var anchor = field.parentNode;
             anchor.parentNode.insertBefore(span, anchor.nextSibling);
         }
     }
@@ -1274,7 +1280,16 @@ document.addEventListener('DOMContentLoaded', function() {
             tosSyncField.value = tosBox.checked ? '1' : '0';
         }
 
-        if (!form.querySelector('input[name="orderpayment_type"]')) return;
+        if (!form.querySelector('input[name="orderpayment_type"]')) {
+            // Free order form: validate terms client-side before native POST.
+            var confirmEl = document.querySelector('.j2commerce-checkout-confirm');
+            if (tosBox && confirmEl && confirmEl.dataset.showTerms === '1' && confirmEl.dataset.termsDisplayType === 'checkbox' && !tosBox.checked) {
+                e.preventDefault();
+                var confirmContent = document.getElementById('confirm') && document.getElementById('confirm').querySelector('.checkout-content');
+                showFieldError(confirmContent, 'tos_check', Joomla.Text._('COM_J2COMMERCE_CHECKOUT_ERROR_AGREE_TERMS'));
+            }
+            return;
+        }
         e.preventDefault();
         var btn = form.querySelector('button[type="submit"]') || form.querySelector('button:not(.btn-close):not([data-bs-dismiss])');
         handlePaymentSubmit(form, btn);

--- a/components/com_j2commerce/tmpl/checkout/bootstrap5/default_confirm.php
+++ b/components/com_j2commerce/tmpl/checkout/bootstrap5/default_confirm.php
@@ -14,6 +14,7 @@
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
+use Joomla\CMS\Session\Session;
 use Joomla\Component\Content\Site\Helper\RouteHelper;
 
 /** @var \J2Commerce\Component\J2commerce\Site\View\Checkout\HtmlView $this */
@@ -55,7 +56,13 @@ if ($showTerms && $termsArticleId) {
             <div class="form-check">
                 <input class="form-check-input" type="checkbox" name="tos_check" value="1" id="tos_check">
                 <label class="form-check-label" for="tos_check">
-                    <?php if ($termsText !== '') : ?>
+                    <?php if ($termsText !== '' && $termsModalUrl !== '') : ?>
+                        <?php // Raw HTML — admin-controlled via filter="raw" ?>
+                        <?php echo $termsText; ?>
+                        <a href="<?php echo $termsUrl; ?>" data-bs-toggle="modal" data-bs-target="#j2c-terms-modal">
+                            <?php echo htmlspecialchars(Text::_('COM_J2COMMERCE_CHECKOUT_TERMS_AND_CONDITIONS')); ?>
+                        </a>
+                    <?php elseif ($termsText !== '') : ?>
                         <?php // Raw HTML — admin-controlled via filter="raw" ?>
                         <?php echo $termsText; ?>
                     <?php elseif ($termsModalUrl !== '') : ?>
@@ -73,7 +80,13 @@ if ($showTerms && $termsArticleId) {
         </div>
     <?php elseif ($showTerms === 1 && $termsDisplayType === 'link' && ($termsUrl !== '' || $termsText !== '')) : ?>
         <div class="j2commerce-terms-link mb-3">
-            <?php if ($termsText !== '') : ?>
+            <?php if ($termsText !== '' && $termsModalUrl !== '') : ?>
+                <?php // Raw HTML — admin-controlled via filter="raw" ?>
+                <?php echo $termsText; ?>
+                <a href="<?php echo $termsUrl; ?>" data-bs-toggle="modal" data-bs-target="#j2c-terms-modal">
+                    <?php echo htmlspecialchars(Text::_('COM_J2COMMERCE_CHECKOUT_TERMS_AND_CONDITIONS')); ?>
+                </a>
+            <?php elseif ($termsText !== '') : ?>
                 <?php // Raw HTML — admin-controlled via filter="raw" ?>
                 <?php echo $termsText; ?>
             <?php elseif ($termsModalUrl !== '') : ?>
@@ -115,6 +128,7 @@ if ($showTerms && $termsArticleId) {
             </button>
             <input type="hidden" name="option" value="com_j2commerce">
             <input type="hidden" name="task" value="checkout.confirmPayment">
+            <input type="hidden" name="<?php echo Session::getFormToken(); ?>" value="1">
             <input type="hidden" name="customer_note" value="" class="j2commerce-customer-note-sync">
             <input type="hidden" name="tos_check" value="" class="j2commerce-tos-sync">
         </form>

--- a/components/com_j2commerce/tmpl/checkout/uikit/default.php
+++ b/components/com_j2commerce/tmpl/checkout/uikit/default.php
@@ -330,7 +330,12 @@ document.addEventListener('DOMContentLoaded', function() {
         if (!container || !message) return;
         var field = container.querySelector('#' + fieldId);
         if (field) {
-            field.classList.add('j2-invalid');
+            var isCheckbox = field.type === 'checkbox' || field.type === 'radio';
+            // Don't apply j2-invalid to checkboxes/radios: the class injects a background
+            // SVG icon sized for text inputs which renders inside the small checkbox.
+            if (!isCheckbox) {
+                field.classList.add('j2-invalid');
+            }
             field.setAttribute('aria-invalid', 'true');
             field.setAttribute('aria-describedby', fieldId + '-error');
             var span = document.createElement('span');
@@ -338,9 +343,10 @@ document.addEventListener('DOMContentLoaded', function() {
             span.id = fieldId + '-error';
             span.setAttribute('role', 'alert');
             span.textContent = message;
-            // Anchor after the telephone wrapper (if any) so the error
-            // renders below the full widget, not inside its flex row.
-            var anchor = field.closest('.j2c-telephone-field') || field;
+            // Anchor to the immediate parent wrapper so the error appears after the complete
+            // widget: handles .form-check rows, .j2c-telephone-field flex rows,
+            // .form-floating groups, and plain .form-normal wrappers consistently.
+            var anchor = field.parentNode;
             anchor.parentNode.insertBefore(span, anchor.nextSibling);
         }
     }
@@ -1272,7 +1278,16 @@ document.addEventListener('DOMContentLoaded', function() {
             tosSyncField.value = tosBox.checked ? '1' : '0';
         }
 
-        if (!form.querySelector('input[name="orderpayment_type"]')) return;
+        if (!form.querySelector('input[name="orderpayment_type"]')) {
+            // Free order form: validate terms client-side before native POST.
+            var confirmEl = document.querySelector('.j2commerce-checkout-confirm');
+            if (tosBox && confirmEl && confirmEl.dataset.showTerms === '1' && confirmEl.dataset.termsDisplayType === 'checkbox' && !tosBox.checked) {
+                e.preventDefault();
+                var confirmContent = document.getElementById('confirm') && document.getElementById('confirm').querySelector('.checkout-content');
+                showFieldError(confirmContent, 'tos_check', Joomla.Text._('COM_J2COMMERCE_CHECKOUT_ERROR_AGREE_TERMS'));
+            }
+            return;
+        }
         e.preventDefault();
         var btn = form.querySelector('button[type="submit"]') || form.querySelector('button:not(.uk-alert-close):not([uk-close]):not([uk-modal-close])');
         handlePaymentSubmit(form, btn);

--- a/components/com_j2commerce/tmpl/checkout/uikit/default_confirm.php
+++ b/components/com_j2commerce/tmpl/checkout/uikit/default_confirm.php
@@ -14,6 +14,7 @@
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
+use Joomla\CMS\Session\Session;
 use Joomla\Component\Content\Site\Helper\RouteHelper;
 // UIkit JS is already loaded by app_uikit; no additional WAM dependency needed for uk-modal.
 
@@ -54,7 +55,13 @@ if ($showTerms && $termsArticleId) {
             <label class="uk-flex uk-flex-middle">
                 <input class="uk-checkbox uk-margin-small-right" type="checkbox" name="tos_check" value="1" id="tos_check">
                 <span>
-                    <?php if ($termsText !== '') : ?>
+                    <?php if ($termsText !== '' && $termsModalUrl !== '') : ?>
+                        <?php // Raw HTML — admin-controlled via filter="raw" ?>
+                        <?php echo $termsText; ?>
+                        <a href="<?php echo $termsUrl; ?>" uk-toggle="target: #j2c-terms-modal; preventdefault: true">
+                            <?php echo htmlspecialchars(Text::_('COM_J2COMMERCE_CHECKOUT_TERMS_AND_CONDITIONS')); ?>
+                        </a>
+                    <?php elseif ($termsText !== '') : ?>
                         <?php // Raw HTML — admin-controlled via filter="raw" ?>
                         <?php echo $termsText; ?>
                     <?php elseif ($termsModalUrl !== '') : ?>
@@ -72,7 +79,13 @@ if ($showTerms && $termsArticleId) {
         </div>
     <?php elseif ($showTerms === 1 && $termsDisplayType === 'link' && ($termsUrl !== '' || $termsText !== '')) : ?>
         <div class="j2commerce-terms-link uk-margin-bottom">
-            <?php if ($termsText !== '') : ?>
+            <?php if ($termsText !== '' && $termsModalUrl !== '') : ?>
+                <?php // Raw HTML — admin-controlled via filter="raw" ?>
+                <?php echo $termsText; ?>
+                <a href="<?php echo $termsUrl; ?>" uk-toggle="target: #j2c-terms-modal; preventdefault: true">
+                    <?php echo htmlspecialchars(Text::_('COM_J2COMMERCE_CHECKOUT_TERMS_AND_CONDITIONS')); ?>
+                </a>
+            <?php elseif ($termsText !== '') : ?>
                 <?php // Raw HTML — admin-controlled via filter="raw" ?>
                 <?php echo $termsText; ?>
             <?php elseif ($termsModalUrl !== '') : ?>
@@ -114,6 +127,7 @@ if ($showTerms && $termsArticleId) {
             </button>
             <input type="hidden" name="option" value="com_j2commerce">
             <input type="hidden" name="task" value="checkout.confirmPayment">
+            <input type="hidden" name="<?php echo Session::getFormToken(); ?>" value="1">
             <input type="hidden" name="customer_note" value="" class="j2commerce-customer-note-sync">
             <input type="hidden" name="tos_check" value="" class="j2commerce-tos-sync">
         </form>


### PR DESCRIPTION
Root Causes
                                                                                                                                                                                                 
Bug 1 — Free-order CSRF token missing (both themes)       

The free-order "Place Order" form (default_confirm.php) had no CSRF token. confirmPayment() called Session::checkToken('get') for free orders, which would never find the token → redirect loop
   → the terms checkbox check was never reached for free orders.

Fix: Added <input type="hidden" name="<?php echo Session::getFormToken(); ?>" value="1"> to the free form in both bootstrap5/default_confirm.php and uikit/default_confirm.php, and changed the server-side check from checkToken('get') to checkToken('post') to match the POST form.

Bug 2 — No client-side terms validation for free orders (both themes)

The form submit handler in default.php synced tos_check to the hidden mirror field, then returned early for free forms without checking whether the box was ticked. The user would click "Place Order" with an unchecked box and get a full-page redirect with a flash message instead of an inline error.

Fix: Added a terms check before the early return in the free-form branch of the submit handler in both bootstrap5/default.php and uikit/default.php — calls e.preventDefault() and shows the inline error via showFieldError if the box is required but unchecked.

termsText │ termsArticleId set │ Output 
set           │ yes                │ custom text + T&C link (opens modal)  
set           │ no                 │ custom text only 
empty     │ yes                │ "I have read and agree to the [Terms & Conditions]" (linked) 
empty     │ no                 │ "I have read and agree to the Terms & Conditions" (no link)

Fix bad UI when the visitor is notified of not having checked the terms and conditions

  - Checkbox/radio: skips j2-invalid on the input entirely (no SVG icon injected into the checkbox), anchors to field.parentNode so the red error text appears below the   
  whole checkbox+label row
  - All other inputs: unchanged — j2-invalid applied to the field, anchored to .j2c-telephone-field wrapper or the field itself                                            
                                                            
For Bootstrap5, field.parentNode is the .form-check div, so the error lands below the label. For UIkit, it's the label.uk-flex element, same result.
