### PR TITLE
feat(core): manufacturer filter restriction and AJAX sidebar state seeding

### DIFF
--- a/administrator/components/com_j2commerce/src/Helper/ProductHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/ProductHelper.php
@@ -2938,7 +2938,7 @@ class ProductHelper
      *
      * @since   6.0.3
      */
-    public static function getManufacturers(): array
+    public static function getManufacturers(array $restrictIds = []): array
     {
         $db    = self::getDatabase();
         $query = $db->getQuery(true);
@@ -2955,6 +2955,12 @@ class ProductHelper
             )
             ->where($db->quoteName('m.enabled') . ' = 1')
             ->order($db->quoteName('a.company') . ' ASC');
+
+        // Restrict to a specific set of manufacturers (e.g. only those represented in
+        // the current product listing when the menu uses the 'selected' filter type).
+        if (!empty($restrictIds)) {
+            $query->whereIn($db->quoteName('m.j2commerce_manufacturer_id'), array_map('intval', $restrictIds));
+        }
 
         $db->setQuery($query);
 
@@ -3957,7 +3963,7 @@ class ProductHelper
      *
      * @since   6.0.3
      */
-    public static function getFilters(array $items = [], array $catids = []): array
+    public static function getFilters(array $items = [], array $catids = [], ?array $restrictManufacturerIds = null): array
     {
         $filters                      = [];
         $filters['filter_categories'] = [];
@@ -3976,8 +3982,17 @@ class ProductHelper
             }
         }
 
-        // Get manufacturers
-        $filters['manufacturers'] = self::getManufacturers();
+        // Get manufacturers. $restrictManufacturerIds === null means "show every store
+        // manufacturer" (default). A (possibly empty) array means the caller asked for the
+        // 'selected' list type: show only manufacturers in the array — an empty array
+        // therefore yields no manufacturers rather than all of them.
+        if ($restrictManufacturerIds === null) {
+            $filters['manufacturers'] = self::getManufacturers();
+        } elseif (!empty($restrictManufacturerIds)) {
+            $filters['manufacturers'] = self::getManufacturers($restrictManufacturerIds);
+        } else {
+            $filters['manufacturers'] = [];
+        }
 
         // Get vendors with first_name and last_name
         $filters['vendors'] = self::getVendorsWithNames();

--- a/components/com_j2commerce/src/Controller/ProductsController.php
+++ b/components/com_j2commerce/src/Controller/ProductsController.php
@@ -174,8 +174,18 @@ class ProductsController extends AdminProductsController
                 $model->setState('list.limit', $pageLimit);
             }
 
-            // filter.manufacturer_ids / vendor_ids / productfilter_ids / price_from / price_to
-            // are seeded by ProductsModel::populateState() via ProductFilterRequestHelper.
+            // Seed the sidebar filter state explicitly. This AJAX task bypasses the normal
+            // view chain, and the model's populateState() does not run via this controller
+            // path, so manufacturer / vendor / product-filter / price selections must be set
+            // here (same as tag_ids / search / sort above) or they are silently ignored.
+            $model->setState('filter.manufacturer_ids', array_map('intval', $manufacturerIds));
+            $model->setState('filter.vendor_ids', array_map('intval', $vendorIds));
+            $model->setState('filter.productfilter_ids', array_map('intval', $productfilterIds));
+            if ($priceFrom > 0 || $priceTo > 0) {
+                $model->setState('filter.price_from', $priceFrom);
+                $model->setState('filter.price_to', $priceTo);
+            }
+
             if (!empty($search)) {
                 $model->setState('filter.search', $search);
             }

--- a/components/com_j2commerce/src/Model/ProductsModel.php
+++ b/components/com_j2commerce/src/Model/ProductsModel.php
@@ -588,7 +588,46 @@ class ProductsModel extends ListModel
             $filterCategoryIds = $this->getState('filter.catids', []);
         }
 
-        return ProductHelper::getFilters($items, $filterCategoryIds);
+        // Honour the `list_manufacturer_filter_list_type` menu param: 'selected' restricts
+        // the manufacturer filter to brands represented in the current category listing.
+        $manufacturerListType    = $params->get('list_manufacturer_filter_list_type', 'all');
+        $restrictManufacturerIds = $manufacturerListType === 'selected'
+            ? $this->getMatchingManufacturerIds()
+            : null;
+
+        return ProductHelper::getFilters($items, $filterCategoryIds, $restrictManufacturerIds);
+    }
+
+    /**
+     * Get the IDs of manufacturers represented in the current category-filtered product set.
+     *
+     * Re-uses getListQuery() so the manufacturer list reflects the same category / search /
+     * price / vendor / product-filter constraints as the listing. Any active manufacturer
+     * selection is intentionally ignored so choosing a brand does not collapse the brand list.
+     *
+     * @return  int[]
+     *
+     * @since   6.0.3
+     */
+    protected function getMatchingManufacturerIds(): array
+    {
+        $db = $this->getDatabase();
+
+        $savedManufacturerIds = $this->getState('filter.manufacturer_ids', []);
+        $this->setState('filter.manufacturer_ids', []);
+
+        try {
+            $query = $this->getListQuery();
+        } finally {
+            $this->setState('filter.manufacturer_ids', $savedManufacturerIds);
+        }
+
+        $query->clear('select')->clear('order')->clear('group')
+            ->select('DISTINCT ' . $db->quoteName('p.manufacturer_id'));
+
+        $db->setQuery($query);
+
+        return array_values(array_filter(array_map('intval', $db->loadColumn() ?: [])));
     }
 
     protected function getSiblingCategoryIds(int $categoryId): array

--- a/components/com_j2commerce/src/Model/ProducttagsModel.php
+++ b/components/com_j2commerce/src/Model/ProducttagsModel.php
@@ -15,6 +15,7 @@ namespace J2Commerce\Component\J2commerce\Site\Model;
 \defined('_JEXEC') or die;
 
 use J2Commerce\Component\J2commerce\Administrator\Helper\ProductHelper;
+use J2Commerce\Component\J2commerce\Site\Helper\ProductFilterRequestHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\MVC\Model\ListModel;
@@ -209,6 +210,20 @@ class ProducttagsModel extends ListModel
         $limitstart = $input->getInt('limitstart', 0);
         $this->setState('list.limit', (int) $limit);
         $this->setState('list.start', $limitstart);
+
+        // Sidebar filter state — single source of truth via ProductFilterRequestHelper.
+        // Reads ?manufacturer_ids[]/?brands=, ?vendor_ids[]/?vendors=, ?productfilter_ids[]/?filters=,
+        // pricefrom/priceto from the current request so a clicked filter (or cold-pasted filtered URL)
+        // actually narrows the tagged-product list. tag_ids/tag_match are intentionally NOT taken from
+        // the request here — on a tag menu item they are fixed by the menu item (set above).
+        $filterState = ProductFilterRequestHelper::resolveFromRequest($input);
+        $this->setState('filter.manufacturer_ids', $filterState['manufacturer_ids']);
+        $this->setState('filter.vendor_ids', $filterState['vendor_ids']);
+        $this->setState('filter.productfilter_ids', $filterState['productfilter_ids']);
+        if ($filterState['price_from'] > 0 || $filterState['price_to'] > 0) {
+            $this->setState('filter.price_from', $filterState['price_from']);
+            $this->setState('filter.price_to', $filterState['price_to']);
+        }
 
         // Language filter
         $this->setState('filter.language', Multilanguage::isEnabled());
@@ -499,7 +514,17 @@ class ProducttagsModel extends ListModel
      */
     public function getFilters(array $items = []): array
     {
-        $filters = ProductHelper::getFilters($items, []);
+        // Honour the `list_manufacturer_filter_list_type` menu param: when set to
+        // 'selected', restrict the manufacturer filter list to manufacturers actually
+        // represented in the current (tag-matched) product set instead of every store
+        // manufacturer. null = show all (default behaviour).
+        $params                  = $this->getState('params');
+        $manufacturerListType    = $params ? $params->get('list_manufacturer_filter_list_type', 'all') : 'all';
+        $restrictManufacturerIds = $manufacturerListType === 'selected'
+            ? $this->getMatchingManufacturerIds()
+            : null;
+
+        $filters = ProductHelper::getFilters($items, [], $restrictManufacturerIds);
 
         // Override price range with actual prices from tag-filtered items
         if (!empty($items)) {
@@ -519,6 +544,39 @@ class ProducttagsModel extends ListModel
         }
 
         return $filters;
+    }
+
+    /**
+     * Get the IDs of manufacturers represented in the current tag-matched product set.
+     *
+     * Re-uses getListQuery() so the manufacturer list reflects the same tag / search /
+     * price / vendor / product-filter constraints as the listing. Any active manufacturer
+     * selection is intentionally ignored so choosing a brand does not collapse the brand
+     * list to that single brand.
+     *
+     * @return  int[]
+     *
+     * @since   6.0.3
+     */
+    protected function getMatchingManufacturerIds(): array
+    {
+        $db = $this->getDatabase();
+
+        $savedManufacturerIds = $this->getState('filter.manufacturer_ids', []);
+        $this->setState('filter.manufacturer_ids', []);
+
+        try {
+            $query = $this->getListQuery();
+        } finally {
+            $this->setState('filter.manufacturer_ids', $savedManufacturerIds);
+        }
+
+        $query->clear('select')->clear('order')->clear('group')
+            ->select('DISTINCT ' . $db->quoteName('p.manufacturer_id'));
+
+        $db->setQuery($query);
+
+        return array_values(array_filter(array_map('intval', $db->loadColumn() ?: [])));
     }
 
     protected function applyPriceRangeFilter(

--- a/components/com_j2commerce/src/Service/ProductLayoutService.php
+++ b/components/com_j2commerce/src/Service/ProductLayoutService.php
@@ -46,24 +46,24 @@ final class ProductLayoutService
         $contextParts  = self::parseContext($context);
 
         $displayData = [
-            'product'         => $product,
-            'params'          => $params,
-            'context'         => $context,
-            'contextBase'     => $contextParts['base'],
-            'contextSub'      => $contextParts['sub'],
-            'contextChain'    => $contextParts['chain'],
-            'itemId'          => $itemId,
-            'columns'         => (int) $params->get('list_no_of_columns', 3),
-            'imageWidth'      => self::getImageWidth($params, $context),
-            'showImage'       => (bool) $params->get('list_show_image', 1),
-            'showTitle'       => (bool) $params->get('list_show_title', 1),
+            'product'             => $product,
+            'params'              => $params,
+            'context'             => $context,
+            'contextBase'         => $contextParts['base'],
+            'contextSub'          => $contextParts['sub'],
+            'contextChain'        => $contextParts['chain'],
+            'itemId'              => $itemId,
+            'columns'             => (int) $params->get('list_no_of_columns', 3),
+            'imageWidth'          => self::getImageWidth($params, $context),
+            'showImage'           => (bool) $params->get('list_show_image', 1),
+            'showTitle'           => (bool) $params->get('list_show_title', 1),
             'showDescription'     => (bool) $params->get('list_show_short_desc', $params->get('list_show_description', 0)),
             'showLongDescription' => (bool) $params->get('list_show_long_desc', 0),
-            'showPrice'       => $productHelper->canShowprice($params),
-            'showCart'        => $productHelper->canShowCart($params),
-            'showSku'         => (bool) $params->get('list_show_product_sku', 0),
-            'showUpc'         => (bool) $params->get('list_show_product_upc', 0),
-            'showStock'       => (bool) $params->get('list_show_product_stock', 0)
+            'showPrice'           => $productHelper->canShowprice($params),
+            'showCart'            => $productHelper->canShowCart($params),
+            'showSku'             => (bool) $params->get('list_show_product_sku', 0),
+            'showUpc'             => (bool) $params->get('list_show_product_upc', 0),
+            'showStock'           => (bool) $params->get('list_show_product_stock', 0)
                                  && isset($product->variant)
                                  && \is_object($product->variant),
             'showQuickview' => (bool) $params->get('list_enable_quickview', 0),
@@ -261,10 +261,18 @@ final class ProductLayoutService
             $subtemplate = substr($subtemplate, 4);
         }
 
+        // Strip view-scope prefixes (tag_, categories_, categories_tag_). These are
+        // menu-selectable aliases (e.g. tag_superstore, categories_tag_bootstrap5) that
+        // all map to the SAME owning app plugin folder (app_superstore, app_bootstrap5).
+        // Without this, e.g. 'tag_superstore' resolved to the non-existent
+        // 'app_tag_superstore', leaving FileLayout with no include paths so product
+        // items rendered empty in the AJAX filter response.
+        $subtemplate = preg_replace('/^(categories_tag_|categories_|tag_)/', '', $subtemplate) ?? $subtemplate;
+
         return match ($subtemplate) {
-            'bootstrap5', 'tag_bootstrap5' => 'app_bootstrap5',
-            'uikit', 'tag_uikit'           => 'app_uikit',
-            default                        => 'app_' . $subtemplate,
+            'bootstrap5' => 'app_bootstrap5',
+            'uikit'      => 'app_uikit',
+            default      => 'app_' . $subtemplate,
         };
     }
 


### PR DESCRIPTION
## Core Update

### Changes
- Restrict the manufacturer filter to manufacturers present in the current product result set (`ProductHelper::getManufacturers(array $restrictIds)`, new `getMatchingManufacturerIds()` in `ProductsModel`/`ProducttagsModel`).
- Seed sidebar filter state on the AJAX `filter` task so the filters render with the active selection (`ProductsController::filter()`, CSRF-gated).
- Strip layout-prefix names (`categories_tag_` / `categories_` / `tag_`) in the product layout resolver (`ProductLayoutService::mapSubtemplateToPluginFolder()`).

### Files Modified
| Type | Count |
|------|-------|
| PHP files | 5 |
| JS/CSS assets | 0 |
| Language files | 0 |
| XML/Config | 0 |

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants / JFactory
- [x] Code style (php-cs-fixer) — alignment fix applied
- [x] Security gate (j2commerce-security): PASS
- [x] Core files only (non-core excluded)
