### PR TITLE
fix(core): finder product links inherit article access, not p.access default 0

### DIFF
--- a/plugins/finder/j2commerce/src/Extension/J2commerce.php
+++ b/plugins/finder/j2commerce/src/Extension/J2commerce.php
@@ -789,6 +789,21 @@ final class J2commerce extends Adapter implements SubscriberInterface
         // Add product fields
         $query->select($db->quoteName('p') . '.*');
 
+        // p.* re-introduces product columns whose names collide with the content
+        // article columns selected above (access, params, created_by, modified_by,
+        // ordering). On a duplicate column name the later one wins in the result
+        // row, so p.* would clobber the article values — critically a.access, since
+        // #__j2commerce_products.access defaults to 0 (an invalid view level), which
+        // drops every product from frontend Smart Search. Re-select the article
+        // columns last so the content values win.
+        $query->select([
+            $db->quoteName('a.access', 'access'),
+            $db->quoteName('a.attribs', 'params'),
+            $db->quoteName('a.created_by', 'created_by'),
+            $db->quoteName('a.modified_by', 'modified_by'),
+            $db->quoteName('a.ordering', 'ordering'),
+        ]);
+
         // Handle the alias CASE WHEN portion of the query
         $a_id                 = $query->castAs('CHAR', 'a.id');
         $case_when_item_alias = ' CASE WHEN ' . $query->charLength('a.alias', '!=', '0');


### PR DESCRIPTION
## Core Update — Smart Search returns zero J2Commerce products on stores whose products table has the `access` column

### Problem
`plg_finder_j2commerce`'s `getListQuery()` selects `a.access` (the backing content article's view level) and then `$query->select('p.*')`. The `#__j2commerce_products` table defines `access int UNSIGNED NOT NULL DEFAULT '0'`, so `p.access` (an unset, invalid view level `0`) **overwrites** the article's real access in the result row. Every product finder link is stamped `access = 0`, and since no user is ever authorized for view level 0, **all products are filtered out of frontend Smart Search results** — both the core `com_finder` search and the `mod_j2commerce_findbar` box. They still appear in the admin Indexed Content list (which ignores the access filter), so the index looks healthy.

`p.*` clobbers four other article columns the same way: `params` (vs `a.attribs`), `created_by`, `modified_by`, `ordering`.

Installs whose products table predates the `access` column are unaffected (no collision) — which is why this can pass locally and fail in production.

### Fix
Re-select the five colliding article columns **after** `p.*` so the content-article values win on duplicate-name collision. Product-only columns still come through `p.*` unchanged.

### Files Modified
| Type | Count |
|------|-------|
| PHP files | 1 |

`plugins/finder/j2commerce/src/Extension/J2commerce.php` — `getListQuery()`

### Deploy note
After merge + package install, rebuild the index: `php cli/joomla.php finder:index --purge`.

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Code style (php-cs-fixer, dist ruleset) passed
- [x] Security gate passed (identifier-only change, ACL-neutral — restores article's existing access)
- [x] Core files only