### PR TITLE
fix(core): keep product gallery thumbnails square

### DIFF
--- a/media/com_j2commerce/css/administrator/j2commerce_admin.css
+++ b/media/com_j2commerce/css/administrator/j2commerce_admin.css
@@ -252,7 +252,7 @@ body.com_j2commerce #content,
         background-color: #007bff !important;
     }
 
-    .subform-repeatable-group .control-group { margin-bottom : 0; }
+    /* .subform-repeatable-group .control-group { margin-bottom : 0; } */
     .progress { background-color: #e9ecef !important; }
     .box-shadow-none { box-shadow : none !important; }
 

--- a/media/com_j2commerce/css/site/j2commerce.css
+++ b/media/com_j2commerce/css/site/j2commerce.css
@@ -203,7 +203,11 @@
     padding: 0.75rem 0 0;
 }
 .product-gallery-thumbs .swiper-slide {
-    height: 100px;
+    /* Swiper sets the slide width inline (slidesPerView), so a fixed height makes the
+       thumb non-square. Track the swiper-computed width with aspect-ratio so thumbs
+       stay perfectly square regardless of how many fit across. */
+    aspect-ratio: 1 / 1;
+    height: auto;
     width: 100px;
     cursor: pointer;
     border: 2px solid transparent;
@@ -214,6 +218,7 @@
     background: var(--product-color-bg-muted);
 }
 .product-gallery-thumbs .swiper-slide img {
+    display: block;
     width: 100%;
     height: 100%;
     object-fit: cover;


### PR DESCRIPTION
## Core Update

Fixes the product gallery thumbnail strip so thumbnails stay perfectly square.

### Changes
- `media/com_j2commerce/css/site/j2commerce.css`: Swiper sets the thumb slide width inline (`slidesPerView`), so a fixed `height: 100px` produced non-square thumbs. Switched to `aspect-ratio: 1 / 1` with `height: auto`, and set the thumb `img` to `display: block`.
- `media/com_j2commerce/css/administrator/j2commerce_admin.css`: comments out an unused `.subform-repeatable-group .control-group` margin rule.

### Files Modified
| Type | Count |
|------|-------|
| CSS assets | 2 |

### Pre-Flight
- [x] No secrets detected
- [x] Core files only (CSS only — no PHP/JS)