### PR TITLE
Tag views must match category list views in structure and behavior

### DIFF
--- a/components/com_j2commerce/layouts/app_bootstrap5/list/tag/item_cart.php
+++ b/components/com_j2commerce/layouts/app_bootstrap5/list/tag/item_cart.php
@@ -70,19 +70,22 @@ $afterCart = J2CommerceHelper::plugin()->eventWithHtml(
             </div>
 
             <div id="add-to-cart-<?php echo $productId; ?>" class="j2commerce-add-to-cart">
-                <?php if ($params->get('show_qty_field', J2CommerceHelper::config()->showQuantityField())): ?>
-                    <?php echo $productHelper->displayQuantity('com_j2commerce.productlist.bootstrap5', $product, $params, ['class' => 'input-mini form-control']); ?>
-                <?php endif; ?>
-
                 <input type="hidden" name="product_id" value="<?php echo $productId; ?>" />
-
-                <button type="submit"
-                        class="j2commerce-cart-button <?php echo $btnClass; ?>"
-                        data-cart-action-always="<?php echo Text::_('COM_J2COMMERCE_ADDING_TO_CART'); ?>"
-                        data-cart-action-done="<?php echo htmlspecialchars($cartText ?? '', ENT_QUOTES, 'UTF-8'); ?>"
-                        data-cart-action-timeout="1000">
-                    <?php echo htmlspecialchars($cartText ?? '', ENT_QUOTES, 'UTF-8'); ?>
-                </button>
+                <div class="j2commerce-cart-buttons d-flex align-items-center">
+                    <div class="input-group">
+                        <?php if ($params->get('show_qty_field', J2CommerceHelper::config()->showQuantityField())): ?>
+                            <?php echo $productHelper->displayQuantity('com_j2commerce.productlist.bootstrap5', $product, $params, ['class' => 'form-control qty-input', 'show_buttons' => false]); ?>
+                        <?php endif; ?>
+                        <button type="submit"
+                                class="j2commerce-cart-button flex-fill <?php echo $btnClass; ?>"
+                                data-cart-action-always="<?php echo Text::_('COM_J2COMMERCE_ADDING_TO_CART'); ?>"
+                                data-cart-action-done="<?php echo htmlspecialchars($cartText ?? '', ENT_QUOTES, 'UTF-8'); ?>"
+                                data-cart-action-timeout="1000">
+                            <?php echo htmlspecialchars($cartText ?? '', ENT_QUOTES, 'UTF-8'); ?>
+                        </button>
+                    </div>
+                    <?php echo J2CommerceHelper::plugin()->eventWithHtml('AfterAddToCartButtonIcon', [$product, $context])->getArgument('html', ''); ?>
+                </div>
             </div>
 
             <input type="hidden" name="option" value="com_j2commerce" />

--- a/components/com_j2commerce/layouts/app_bootstrap5/list/tag/item_configurable.php
+++ b/components/com_j2commerce/layouts/app_bootstrap5/list/tag/item_configurable.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Language\Text;
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 use J2Commerce\Component\J2commerce\Site\Service\ProductLayoutService;
 
@@ -19,18 +20,12 @@ extract($displayData);
 $productId = (int) $product->j2commerce_product_id;
 $cssClass = htmlspecialchars($product->params->get('product_css_class', '') ?? '', ENT_QUOTES, 'UTF-8');
 $productType = htmlspecialchars($product->product_type ?? '', ENT_QUOTES, 'UTF-8');
-
-$beforeHtml = J2CommerceHelper::plugin()->eventWithHtml(
-    'BeforeProductListItemDisplay',
-    [$product, $context, &$displayData]
-)->getArgument('html', '');
-
-$afterHtml = J2CommerceHelper::plugin()->eventWithHtml(
-    'AfterProductListItemDisplay',
-    [$product, $context, &$displayData]
-)->getArgument('html', '');
+$beforeHtml = J2CommerceHelper::plugin()->eventWithHtml('BeforeProductListItemDisplay',[$product, $context, &$displayData])->getArgument('html', '');
+$afterHtml = J2CommerceHelper::plugin()->eventWithHtml('AfterProductListItemDisplay',[$product, $context, &$displayData])->getArgument('html', '');
+$cartType = (int) $params->get('list_show_cart', 1);
 ?>
-<div class="j2commerce-product-item j2commerce-product-<?php echo $productId; ?> j2commerce-type-<?php echo $productType;?> <?php echo $cssClass; ?> d-flex flex-column h-100"
+
+<div class="j2commerce-product-item j2commerce-product-<?php echo $productId; ?> j2commerce-type-<?php echo $productType; ?> <?php echo $cssClass; ?> d-flex flex-column h-100"
      data-product-id="<?php echo $productId; ?>"
      data-product-type="<?php echo $productType;?>">
 
@@ -56,25 +51,44 @@ $afterHtml = J2CommerceHelper::plugin()->eventWithHtml(
         <?php echo ProductLayoutService::renderLayout('list.tag.item_description', $displayData); ?>
     <?php endif; ?>
 
-    <?php if ($showPrice): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_price', $displayData); ?>
-    <?php endif; ?>
+    <div class="j2commerce-price-sku-container d-flex flex-wrap align-items-center justify-content-between gap-1 mb-4">
+        <?php if ($showPrice): ?>
+            <?php echo ProductLayoutService::renderLayout('list.tag.item_price', $displayData); ?>
+        <?php endif; ?>
+        <?php if ($showSku): ?>
+            <?php echo ProductLayoutService::renderLayout('list.tag.item_sku', $displayData); ?>
+        <?php endif; ?>
+        <?php if ($showUpc): ?>
+            <?php echo ProductLayoutService::renderLayout('list.tag.item_upc', $displayData); ?>
+        <?php endif; ?>
+    </div>
 
-    <?php if ($showSku): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_sku', $displayData); ?>
-    <?php endif; ?>
-    <?php if ($showUpc): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_upc', $displayData); ?>
+    <?php if ($showCart): ?>
+        <form action="<?php echo htmlspecialchars($product->cart_form_action ?? '', ENT_QUOTES, 'UTF-8'); ?>"
+              method="post"
+              class="j2commerce-addtocart-form mt-auto"
+              id="j2commerce-addtocart-form-<?php echo $productId; ?>"
+              data-product_id="<?php echo $productId; ?>"
+              data-product_type="<?php echo $productType; ?>"
+              data-product_variants="<?php echo htmlspecialchars($product->variant_json ?? '{}', ENT_QUOTES, 'UTF-8'); ?>"
+              enctype="multipart/form-data"
+              >
+
+            <?php if ($cartType == 1) : ?>
+                <?php echo ProductLayoutService::renderLayout('list.tag.item_configurableoptions', $displayData); ?>
+                <?php echo ProductLayoutService::renderLayout('list.tag.item_cart', $displayData); ?>
+            <?php elseif (($cartType == 2 && !empty($product->options)) || $cartType == 3) : ?>
+                <a href="<?php echo htmlspecialchars($productLink ?? '', ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-outline-primary w-100">
+                    <?php echo Text::_('COM_J2COMMERCE_VIEW_PRODUCT_DETAILS'); ?>
+                </a>
+            <?php else : ?>
+                <?php echo ProductLayoutService::renderLayout('list.tag.item_cart', $displayData); ?>
+            <?php endif; ?>
+        </form>
     <?php endif; ?>
 
     <?php if ($showStock): ?>
         <?php echo ProductLayoutService::renderLayout('list.tag.item_stock', $displayData); ?>
-    <?php endif; ?>
-
-    <?php echo ProductLayoutService::renderLayout('list.tag.item_configurableoptions', $displayData); ?>
-
-    <?php if ($showQuickview): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_quickview', $displayData); ?>
     <?php endif; ?>
 
     <?php if (isset($product->event->afterDisplayContent)): ?>

--- a/components/com_j2commerce/layouts/app_bootstrap5/list/tag/item_downloadable.php
+++ b/components/com_j2commerce/layouts/app_bootstrap5/list/tag/item_downloadable.php
@@ -11,26 +11,20 @@ declare(strict_types=1);
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Language\Text;
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 use J2Commerce\Component\J2commerce\Site\Service\ProductLayoutService;
 
 extract($displayData);
 
 $productId = (int) $product->j2commerce_product_id;
+$cartType = (int) $params->get('list_show_cart', 1);
 $cssClass = htmlspecialchars($product->params->get('product_css_class', '') ?? '', ENT_QUOTES, 'UTF-8');
 $productType = htmlspecialchars($product->product_type ?? '', ENT_QUOTES, 'UTF-8');
-
-$beforeHtml = J2CommerceHelper::plugin()->eventWithHtml(
-    'BeforeProductListItemDisplay',
-    [$product, $context, &$displayData]
-)->getArgument('html', '');
-
-$afterHtml = J2CommerceHelper::plugin()->eventWithHtml(
-    'AfterProductListItemDisplay',
-    [$product, $context, &$displayData]
-)->getArgument('html', '');
+$beforeHtml = J2CommerceHelper::plugin()->eventWithHtml('BeforeProductListItemDisplay',[$product, $context, &$displayData])->getArgument('html', '');
+$afterHtml = J2CommerceHelper::plugin()->eventWithHtml('AfterProductListItemDisplay',[$product, $context, &$displayData])->getArgument('html', '');
 ?>
-<div class="j2commerce-product-item j2commerce-product-<?php echo $productId; ?> j2commerce-type-<?php echo $productType;?> <?php echo $cssClass; ?> d-flex flex-column h-100"
+<div class="j2commerce-product-item j2commerce-product-<?php echo $productId; ?> j2commerce-type-<?php echo $productType; ?> <?php echo $cssClass; ?> d-flex flex-column h-100"
      data-product-id="<?php echo $productId; ?>"
      data-product-type="<?php echo $productType;?>">
 
@@ -56,27 +50,42 @@ $afterHtml = J2CommerceHelper::plugin()->eventWithHtml(
         <?php echo ProductLayoutService::renderLayout('list.tag.item_description', $displayData); ?>
     <?php endif; ?>
 
-    <?php if ($showPrice): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_price', $displayData); ?>
-    <?php endif; ?>
+    <div class="j2commerce-price-sku-container d-flex flex-wrap align-items-center justify-content-between gap-1 mb-4">
+        <?php if ($showPrice): ?>
+            <?php echo ProductLayoutService::renderLayout('list.tag.item_price', $displayData); ?>
+        <?php endif; ?>
+        <?php if ($showSku): ?>
+            <?php echo ProductLayoutService::renderLayout('list.tag.item_sku', $displayData); ?>
+        <?php endif; ?>
+        <?php if ($showUpc): ?>
+            <?php echo ProductLayoutService::renderLayout('list.tag.item_upc', $displayData); ?>
+        <?php endif; ?>
+    </div>
 
-    <?php if ($showSku): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_sku', $displayData); ?>
-    <?php endif; ?>
-    <?php if ($showUpc): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_upc', $displayData); ?>
+    <?php if ($showCart): ?>
+        <form action="<?php echo htmlspecialchars($product->cart_form_action ?? '', ENT_QUOTES, 'UTF-8'); ?>"
+              method="post"
+              class="j2commerce-addtocart-form mt-auto"
+              id="j2commerce-addtocart-form-<?php echo $productId; ?>"
+              data-product_id="<?php echo $productId; ?>"
+              data-product_type="<?php echo $productType; ?>"
+              enctype="multipart/form-data"
+        >
+            <?php if ($cartType == 1) : ?>
+                <?php echo ProductLayoutService::renderLayout('list.tag.item_options', $displayData); ?>
+                <?php echo ProductLayoutService::renderLayout('list.tag.item_cart', $displayData); ?>
+            <?php elseif (($cartType == 2 && !empty($product->options)) || $cartType == 3) : ?>
+                <a href="<?php echo htmlspecialchars($productLink ?? '', ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-outline-primary w-100">
+                    <?php echo Text::_('COM_J2COMMERCE_VIEW_PRODUCT_DETAILS'); ?>
+                </a>
+            <?php else : ?>
+                <?php echo ProductLayoutService::renderLayout('list.tag.item_cart', $displayData); ?>
+            <?php endif; ?>
+        </form>
     <?php endif; ?>
 
     <?php if ($showStock): ?>
         <?php echo ProductLayoutService::renderLayout('list.tag.item_stock', $displayData); ?>
-    <?php endif; ?>
-
-    <?php if ($showCart): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_cart', $displayData); ?>
-    <?php endif; ?>
-
-    <?php if ($showQuickview): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_quickview', $displayData); ?>
     <?php endif; ?>
 
     <?php if (isset($product->event->afterDisplayContent)): ?>

--- a/components/com_j2commerce/layouts/app_bootstrap5/list/tag/item_simple.php
+++ b/components/com_j2commerce/layouts/app_bootstrap5/list/tag/item_simple.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Language\Text;
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 use J2Commerce\Component\J2commerce\Site\Service\ProductLayoutService;
 
@@ -19,18 +20,12 @@ extract($displayData);
 $productId = (int) $product->j2commerce_product_id;
 $cssClass = htmlspecialchars($product->params->get('product_css_class', '') ?? '', ENT_QUOTES, 'UTF-8');
 $productType = htmlspecialchars($product->product_type ?? '', ENT_QUOTES, 'UTF-8');
-
-$beforeHtml = J2CommerceHelper::plugin()->eventWithHtml(
-    'BeforeProductListItemDisplay',
-    [$product, $context, &$displayData]
-)->getArgument('html', '');
-
-$afterHtml = J2CommerceHelper::plugin()->eventWithHtml(
-    'AfterProductListItemDisplay',
-    [$product, $context, &$displayData]
-)->getArgument('html', '');
+$beforeHtml = J2CommerceHelper::plugin()->eventWithHtml('BeforeProductListItemDisplay',[$product, $context, &$displayData])->getArgument('html', '');
+$afterHtml = J2CommerceHelper::plugin()->eventWithHtml('AfterProductListItemDisplay',[$product, $context, &$displayData])->getArgument('html', '');
+$cartType = (int) $params->get('list_show_cart', 1);
 ?>
-<div class="j2commerce-product-item j2commerce-product-<?php echo $productId; ?> j2commerce-type-<?php echo $productType;?> <?php echo $cssClass; ?> d-flex flex-column h-100"
+
+<div class="j2commerce-product-item j2commerce-product-<?php echo $productId; ?> j2commerce-type-<?php echo $productType; ?> <?php echo $cssClass; ?> d-flex flex-column h-100"
      data-product-id="<?php echo $productId; ?>"
      data-product-type="<?php echo $productType;?>">
 
@@ -56,27 +51,43 @@ $afterHtml = J2CommerceHelper::plugin()->eventWithHtml(
         <?php echo ProductLayoutService::renderLayout('list.tag.item_description', $displayData); ?>
     <?php endif; ?>
 
-    <?php if ($showPrice): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_price', $displayData); ?>
-    <?php endif; ?>
+    <div class="j2commerce-price-sku-container d-flex flex-wrap align-items-center justify-content-between gap-1 mb-4">
+        <?php if ($showPrice): ?>
+            <?php echo ProductLayoutService::renderLayout('list.tag.item_price', $displayData); ?>
+        <?php endif; ?>
+        <?php if ($showSku): ?>
+            <?php echo ProductLayoutService::renderLayout('list.tag.item_sku', $displayData); ?>
+        <?php endif; ?>
+        <?php if ($showUpc): ?>
+            <?php echo ProductLayoutService::renderLayout('list.tag.item_upc', $displayData); ?>
+        <?php endif; ?>
+    </div>
 
-    <?php if ($showSku): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_sku', $displayData); ?>
-    <?php endif; ?>
-    <?php if ($showUpc): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_upc', $displayData); ?>
+    <?php if ($showCart): ?>
+        <form action="<?php echo htmlspecialchars($product->cart_form_action ?? '', ENT_QUOTES, 'UTF-8'); ?>"
+              method="post"
+              class="j2commerce-addtocart-form mt-auto"
+              id="j2commerce-addtocart-form-<?php echo $productId; ?>"
+              data-product_id="<?php echo $productId; ?>"
+              data-product_type="<?php echo $productType; ?>"
+              enctype="multipart/form-data"
+              >
+
+            <?php if ($cartType == 1) : ?>
+                <?php echo ProductLayoutService::renderLayout('list.tag.item_options', $displayData); ?>
+                <?php echo ProductLayoutService::renderLayout('list.tag.item_cart', $displayData); ?>
+            <?php elseif (($cartType == 2 && !empty($product->options)) || $cartType == 3) : ?>
+                <a href="<?php echo htmlspecialchars($productLink ?? '', ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-outline-primary w-100">
+                    <?php echo Text::_('COM_J2COMMERCE_VIEW_PRODUCT_DETAILS'); ?>
+                </a>
+            <?php else : ?>
+                <?php echo ProductLayoutService::renderLayout('list.tag.item_cart', $displayData); ?>
+            <?php endif; ?>
+        </form>
     <?php endif; ?>
 
     <?php if ($showStock): ?>
         <?php echo ProductLayoutService::renderLayout('list.tag.item_stock', $displayData); ?>
-    <?php endif; ?>
-
-    <?php if ($showCart): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_cart', $displayData); ?>
-    <?php endif; ?>
-
-    <?php if ($showQuickview): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_quickview', $displayData); ?>
     <?php endif; ?>
 
     <?php if (isset($product->event->afterDisplayContent)): ?>

--- a/components/com_j2commerce/layouts/app_bootstrap5/list/tag/item_variable.php
+++ b/components/com_j2commerce/layouts/app_bootstrap5/list/tag/item_variable.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Language\Text;
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 use J2Commerce\Component\J2commerce\Site\Service\ProductLayoutService;
 
@@ -19,18 +20,11 @@ extract($displayData);
 $productId = (int) $product->j2commerce_product_id;
 $cssClass = htmlspecialchars($product->params->get('product_css_class', '') ?? '', ENT_QUOTES, 'UTF-8');
 $productType = htmlspecialchars($product->product_type ?? '', ENT_QUOTES, 'UTF-8');
-
-$beforeHtml = J2CommerceHelper::plugin()->eventWithHtml(
-    'BeforeProductListItemDisplay',
-    [$product, $context, &$displayData]
-)->getArgument('html', '');
-
-$afterHtml = J2CommerceHelper::plugin()->eventWithHtml(
-    'AfterProductListItemDisplay',
-    [$product, $context, &$displayData]
-)->getArgument('html', '');
+$beforeHtml = J2CommerceHelper::plugin()->eventWithHtml('BeforeProductListItemDisplay', [$product, $context, &$displayData])->getArgument('html', '');
+$afterHtml = J2CommerceHelper::plugin()->eventWithHtml('AfterProductListItemDisplay', [$product, $context, &$displayData])->getArgument('html', '');
+$cartType = (int) $params->get('list_show_cart', 1);
 ?>
-<div class="j2commerce-product-item j2commerce-product-<?php echo $productId; ?> j2commerce-type-<?php echo $productType;?> <?php echo $cssClass; ?> d-flex flex-column h-100"
+<div class="j2commerce-product-item j2commerce-product-<?php echo $productId; ?> j2commerce-type-<?php echo $productType; ?> <?php echo $cssClass; ?> d-flex flex-column h-100"
      data-product-id="<?php echo $productId; ?>"
      data-product-type="<?php echo $productType;?>">
 
@@ -56,22 +50,46 @@ $afterHtml = J2CommerceHelper::plugin()->eventWithHtml(
         <?php echo ProductLayoutService::renderLayout('list.tag.item_description', $displayData); ?>
     <?php endif; ?>
 
-    <?php if ($showPrice): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_price', $displayData); ?>
-    <?php endif; ?>
+    <div class="j2commerce-price-sku-container d-flex flex-wrap align-items-center justify-content-between gap-1<?php echo ($showCart && $cartType == 1) ? '' : ' mb-4' ?>">
+        <?php if ($showPrice): ?>
+            <?php echo ProductLayoutService::renderLayout('list.tag.item_flexiprice', $displayData); ?>
+        <?php endif; ?>
+        <?php if ($showSku): ?>
+            <?php echo ProductLayoutService::renderLayout('list.tag.item_sku', $displayData); ?>
+        <?php endif; ?>
+        <?php if ($showUpc): ?>
+            <?php echo ProductLayoutService::renderLayout('list.tag.item_upc', $displayData); ?>
+        <?php endif; ?>
+    </div>
 
-    <?php if ($showSku): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_sku', $displayData); ?>
-    <?php endif; ?>
-    <?php if ($showUpc): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_upc', $displayData); ?>
+    <?php if ($showCart): ?>
+        <form action="<?php echo htmlspecialchars($product->cart_form_action ?? '', ENT_QUOTES, 'UTF-8'); ?>"
+              method="post"
+              class="j2commerce-addtocart-form mt-auto"
+              id="j2commerce-addtocart-form-<?php echo $productId; ?>"
+              data-product_id="<?php echo $productId; ?>"
+              data-product_type="<?php echo $productType; ?>"
+              data-product_variants="<?php echo htmlspecialchars($product->variant_json ?? '{}', ENT_QUOTES, 'UTF-8'); ?>"
+              enctype="multipart/form-data"
+              >
+
+            <?php if ($cartType == 1) : ?>
+                <?php echo ProductLayoutService::renderLayout('list.tag.item_variableoptions', $displayData); ?>
+                <?php echo ProductLayoutService::renderLayout('list.tag.item_cart', $displayData); ?>
+            <?php elseif (($cartType == 2 && !empty($product->options)) || $cartType == 3) : ?>
+                <a href="<?php echo htmlspecialchars($productLink ?? '', ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-outline-primary w-100">
+                    <?php echo Text::_('COM_J2COMMERCE_VIEW_PRODUCT_DETAILS'); ?>
+                </a>
+            <?php else : ?>
+                <?php echo ProductLayoutService::renderLayout('list.tag.item_cart', $displayData); ?>
+            <?php endif; ?>
+            <input type="hidden" name="variant_id" value="<?php echo (int) ($product->variant->j2commerce_variant_id ?? 0); ?>">
+        </form>
     <?php endif; ?>
 
     <?php if ($showStock): ?>
         <?php echo ProductLayoutService::renderLayout('list.tag.item_stock', $displayData); ?>
     <?php endif; ?>
-
-    <?php echo ProductLayoutService::renderLayout('list.tag.item_variableoptions', $displayData); ?>
 
     <?php if ($showQuickview): ?>
         <?php echo ProductLayoutService::renderLayout('list.tag.item_quickview', $displayData); ?>

--- a/components/com_j2commerce/layouts/app_uikit/list/tag/item_cart.php
+++ b/components/com_j2commerce/layouts/app_uikit/list/tag/item_cart.php
@@ -70,19 +70,20 @@ $afterCart = J2CommerceHelper::plugin()->eventWithHtml(
             </div>
 
             <div id="add-to-cart-<?php echo $productId; ?>" class="j2commerce-add-to-cart">
-                <?php if ($params->get('show_qty_field', J2CommerceHelper::config()->showQuantityField())): ?>
-                    <?php echo $productHelper->displayQuantity('com_j2commerce.productlist.uikit', $product, $params, ['class' => 'input-mini uk-input']); ?>
-                <?php endif; ?>
-
                 <input type="hidden" name="product_id" value="<?php echo $productId; ?>" />
-
-                <button type="submit"
-                        class="j2commerce-cart-button <?php echo $btnClass; ?>"
-                        data-cart-action-always="<?php echo Text::_('COM_J2COMMERCE_ADDING_TO_CART'); ?>"
-                        data-cart-action-done="<?php echo htmlspecialchars($cartText ?? '', ENT_QUOTES, 'UTF-8'); ?>"
-                        data-cart-action-timeout="1000">
-                    <?php echo htmlspecialchars($cartText ?? '', ENT_QUOTES, 'UTF-8'); ?>
-                </button>
+                <div class="j2commerce-cart-buttons uk-flex uk-flex-middle">
+                    <?php if ($params->get('show_qty_field', J2CommerceHelper::config()->showQuantityField())): ?>
+                        <?php echo $productHelper->displayQuantity('com_j2commerce.productlist.uikit', $product, $params, ['class' => 'uk-input qty-input', 'show_buttons' => false]); ?>
+                    <?php endif; ?>
+                    <button type="submit"
+                            class="j2commerce-cart-button uk-width-expand <?php echo $btnClass; ?>"
+                            data-cart-action-always="<?php echo Text::_('COM_J2COMMERCE_ADDING_TO_CART'); ?>"
+                            data-cart-action-done="<?php echo htmlspecialchars($cartText ?? '', ENT_QUOTES, 'UTF-8'); ?>"
+                            data-cart-action-timeout="1000">
+                        <?php echo htmlspecialchars($cartText ?? '', ENT_QUOTES, 'UTF-8'); ?>
+                    </button>
+                    <?php echo J2CommerceHelper::plugin()->eventWithHtml('AfterAddToCartButtonIcon', [$product, $context])->getArgument('html', ''); ?>
+                </div>
             </div>
 
             <input type="hidden" name="option" value="com_j2commerce" />

--- a/components/com_j2commerce/layouts/app_uikit/list/tag/item_configurable.php
+++ b/components/com_j2commerce/layouts/app_uikit/list/tag/item_configurable.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Language\Text;
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 use J2Commerce\Component\J2commerce\Site\Service\ProductLayoutService;
 
@@ -19,20 +20,15 @@ extract($displayData);
 $productId = $product->j2commerce_product_id;
 $cssClass = $product->params->get('product_css_class', '') ?? '';
 $productType = htmlspecialchars($product->product_type ?? '', ENT_QUOTES, 'UTF-8');
-
-$beforeHtml = J2CommerceHelper::plugin()->eventWithHtml(
-    'BeforeProductListItemDisplay',
-    [$product, $context, &$displayData]
-)->getArgument('html', '');
-
-$afterHtml = J2CommerceHelper::plugin()->eventWithHtml(
-    'AfterProductListItemDisplay',
-    [$product, $context, &$displayData]
-)->getArgument('html', '');
+$beforeHtml = J2CommerceHelper::plugin()->eventWithHtml('BeforeProductListItemDisplay',[$product, $context, &$displayData])->getArgument('html', '');
+$afterHtml = J2CommerceHelper::plugin()->eventWithHtml('AfterProductListItemDisplay',[$product, $context, &$displayData])->getArgument('html', '');
+$cartType = (int) $params->get('list_show_cart', 1);
 ?>
+
 <div class="j2commerce-product-item j2commerce-product-<?php echo $productId; ?> j2commerce-type-<?php echo $productType;?> <?php echo $cssClass; ?> uk-flex uk-flex-column uk-height-1-1"
      data-product-id="<?php echo $productId; ?>"
-     data-product-type="<?php echo $productType;?>">
+     data-product-type="<?php echo $productType;?>"
+     data-equal-height="itemContainer">
 
     <?php echo $beforeHtml; ?>
 
@@ -56,25 +52,44 @@ $afterHtml = J2CommerceHelper::plugin()->eventWithHtml(
         <?php echo ProductLayoutService::renderLayout('list.tag.item_description', $displayData); ?>
     <?php endif; ?>
 
-    <?php if ($showPrice): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_price', $displayData); ?>
-    <?php endif; ?>
+    <div class="j2commerce-price-sku-container uk-flex uk-flex-wrap uk-flex-middle uk-flex-between uk-margin-bottom" style="gap: .25rem">
+        <?php if ($showPrice): ?>
+            <?php echo ProductLayoutService::renderLayout('list.tag.item_price', $displayData); ?>
+        <?php endif; ?>
+        <?php if ($showSku): ?>
+            <?php echo ProductLayoutService::renderLayout('list.tag.item_sku', $displayData); ?>
+        <?php endif; ?>
+        <?php if ($showUpc): ?>
+            <?php echo ProductLayoutService::renderLayout('list.tag.item_upc', $displayData); ?>
+        <?php endif; ?>
+    </div>
 
-    <?php if ($showSku): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_sku', $displayData); ?>
-    <?php endif; ?>
-    <?php if ($showUpc): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_upc', $displayData); ?>
+    <?php if ($showCart): ?>
+        <form action="<?php echo htmlspecialchars($product->cart_form_action ?? '', ENT_QUOTES, 'UTF-8'); ?>"
+              method="post"
+              class="j2commerce-addtocart-form uk-margin-auto-top"
+              id="j2commerce-addtocart-form-<?php echo $productId; ?>"
+              data-product_id="<?php echo $productId; ?>"
+              data-product_type="<?php echo $productType; ?>"
+              data-product_variants="<?php echo htmlspecialchars($product->variant_json ?? '{}', ENT_QUOTES, 'UTF-8'); ?>"
+              enctype="multipart/form-data"
+              >
+
+            <?php if ($cartType == 1) : ?>
+                <?php echo ProductLayoutService::renderLayout('list.tag.item_configurableoptions', $displayData); ?>
+                <?php echo ProductLayoutService::renderLayout('list.tag.item_cart', $displayData); ?>
+            <?php elseif (($cartType == 2 && !empty($product->options)) || $cartType == 3) : ?>
+                <a href="<?php echo htmlspecialchars($productLink ?? '', ENT_QUOTES, 'UTF-8'); ?>" class="uk-button uk-button-default uk-width-1-1">
+                    <?php echo Text::_('COM_J2COMMERCE_VIEW_PRODUCT_DETAILS'); ?>
+                </a>
+            <?php else : ?>
+                <?php echo ProductLayoutService::renderLayout('list.tag.item_cart', $displayData); ?>
+            <?php endif; ?>
+        </form>
     <?php endif; ?>
 
     <?php if ($showStock): ?>
         <?php echo ProductLayoutService::renderLayout('list.tag.item_stock', $displayData); ?>
-    <?php endif; ?>
-
-    <?php echo ProductLayoutService::renderLayout('list.tag.item_configurableoptions', $displayData); ?>
-
-    <?php if ($showQuickview): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_quickview', $displayData); ?>
     <?php endif; ?>
 
     <?php if (isset($product->event->afterDisplayContent)): ?>

--- a/components/com_j2commerce/layouts/app_uikit/list/tag/item_downloadable.php
+++ b/components/com_j2commerce/layouts/app_uikit/list/tag/item_downloadable.php
@@ -11,28 +11,23 @@ declare(strict_types=1);
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Language\Text;
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 use J2Commerce\Component\J2commerce\Site\Service\ProductLayoutService;
 
 extract($displayData);
 
 $productId = $product->j2commerce_product_id;
+$cartType = (int) $params->get('list_show_cart', 1);
 $cssClass = $product->params->get('product_css_class', '') ?? '';
 $productType = htmlspecialchars($product->product_type ?? '', ENT_QUOTES, 'UTF-8');
-
-$beforeHtml = J2CommerceHelper::plugin()->eventWithHtml(
-    'BeforeProductListItemDisplay',
-    [$product, $context, &$displayData]
-)->getArgument('html', '');
-
-$afterHtml = J2CommerceHelper::plugin()->eventWithHtml(
-    'AfterProductListItemDisplay',
-    [$product, $context, &$displayData]
-)->getArgument('html', '');
+$beforeHtml = J2CommerceHelper::plugin()->eventWithHtml('BeforeProductListItemDisplay',[$product, $context, &$displayData])->getArgument('html', '');
+$afterHtml = J2CommerceHelper::plugin()->eventWithHtml('AfterProductListItemDisplay',[$product, $context, &$displayData])->getArgument('html', '');
 ?>
 <div class="j2commerce-product-item j2commerce-product-<?php echo $productId; ?> j2commerce-type-<?php echo $productType;?> <?php echo $cssClass; ?> uk-flex uk-flex-column uk-height-1-1"
      data-product-id="<?php echo $productId; ?>"
-     data-product-type="<?php echo $productType;?>">
+     data-product-type="<?php echo $productType;?>"
+     data-equal-height="itemContainer">
 
     <?php echo $beforeHtml; ?>
 
@@ -56,27 +51,42 @@ $afterHtml = J2CommerceHelper::plugin()->eventWithHtml(
         <?php echo ProductLayoutService::renderLayout('list.tag.item_description', $displayData); ?>
     <?php endif; ?>
 
-    <?php if ($showPrice): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_price', $displayData); ?>
-    <?php endif; ?>
+    <div class="j2commerce-price-sku-container uk-flex uk-flex-wrap uk-flex-middle uk-flex-between uk-margin-bottom" style="gap: .25rem">
+        <?php if ($showPrice): ?>
+            <?php echo ProductLayoutService::renderLayout('list.tag.item_price', $displayData); ?>
+        <?php endif; ?>
+        <?php if ($showSku): ?>
+            <?php echo ProductLayoutService::renderLayout('list.tag.item_sku', $displayData); ?>
+        <?php endif; ?>
+        <?php if ($showUpc): ?>
+            <?php echo ProductLayoutService::renderLayout('list.tag.item_upc', $displayData); ?>
+        <?php endif; ?>
+    </div>
 
-    <?php if ($showSku): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_sku', $displayData); ?>
-    <?php endif; ?>
-    <?php if ($showUpc): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_upc', $displayData); ?>
+    <?php if ($showCart): ?>
+        <form action="<?php echo htmlspecialchars($product->cart_form_action ?? '', ENT_QUOTES, 'UTF-8'); ?>"
+              method="post"
+              class="j2commerce-addtocart-form uk-margin-auto-top"
+              id="j2commerce-addtocart-form-<?php echo $productId; ?>"
+              data-product_id="<?php echo $productId; ?>"
+              data-product_type="<?php echo $productType; ?>"
+              enctype="multipart/form-data"
+        >
+            <?php if ($cartType == 1) : ?>
+                <?php echo ProductLayoutService::renderLayout('list.tag.item_options', $displayData); ?>
+                <?php echo ProductLayoutService::renderLayout('list.tag.item_cart', $displayData); ?>
+            <?php elseif (($cartType == 2 && !empty($product->options)) || $cartType == 3) : ?>
+                <a href="<?php echo htmlspecialchars($productLink ?? '', ENT_QUOTES, 'UTF-8'); ?>" class="uk-button uk-button-default uk-width-1-1">
+                    <?php echo Text::_('COM_J2COMMERCE_VIEW_PRODUCT_DETAILS'); ?>
+                </a>
+            <?php else : ?>
+                <?php echo ProductLayoutService::renderLayout('list.tag.item_cart', $displayData); ?>
+            <?php endif; ?>
+        </form>
     <?php endif; ?>
 
     <?php if ($showStock): ?>
         <?php echo ProductLayoutService::renderLayout('list.tag.item_stock', $displayData); ?>
-    <?php endif; ?>
-
-    <?php if ($showCart): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_cart', $displayData); ?>
-    <?php endif; ?>
-
-    <?php if ($showQuickview): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_quickview', $displayData); ?>
     <?php endif; ?>
 
     <?php if (isset($product->event->afterDisplayContent)): ?>

--- a/components/com_j2commerce/layouts/app_uikit/list/tag/item_simple.php
+++ b/components/com_j2commerce/layouts/app_uikit/list/tag/item_simple.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Language\Text;
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 use J2Commerce\Component\J2commerce\Site\Service\ProductLayoutService;
 
@@ -19,20 +20,15 @@ extract($displayData);
 $productId = $product->j2commerce_product_id;
 $cssClass = $product->params->get('product_css_class', '') ?? '';
 $productType = htmlspecialchars($product->product_type ?? '', ENT_QUOTES, 'UTF-8');
-
-$beforeHtml = J2CommerceHelper::plugin()->eventWithHtml(
-    'BeforeProductListItemDisplay',
-    [$product, $context, &$displayData]
-)->getArgument('html', '');
-
-$afterHtml = J2CommerceHelper::plugin()->eventWithHtml(
-    'AfterProductListItemDisplay',
-    [$product, $context, &$displayData]
-)->getArgument('html', '');
+$beforeHtml = J2CommerceHelper::plugin()->eventWithHtml('BeforeProductListItemDisplay',[$product, $context, &$displayData])->getArgument('html', '');
+$afterHtml = J2CommerceHelper::plugin()->eventWithHtml('AfterProductListItemDisplay',[$product, $context, &$displayData])->getArgument('html', '');
+$cartType = (int) $params->get('list_show_cart', 1);
 ?>
+
 <div class="j2commerce-product-item j2commerce-product-<?php echo $productId; ?> j2commerce-type-<?php echo $productType;?> <?php echo $cssClass; ?> uk-flex uk-flex-column uk-height-1-1"
      data-product-id="<?php echo $productId; ?>"
-     data-product-type="<?php echo $productType;?>">
+     data-product-type="<?php echo $productType;?>"
+     data-equal-height="itemContainer">
 
     <?php echo $beforeHtml; ?>
 
@@ -56,27 +52,43 @@ $afterHtml = J2CommerceHelper::plugin()->eventWithHtml(
         <?php echo ProductLayoutService::renderLayout('list.tag.item_description', $displayData); ?>
     <?php endif; ?>
 
-    <?php if ($showPrice): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_price', $displayData); ?>
-    <?php endif; ?>
+    <div class="j2commerce-price-sku-container uk-flex uk-flex-wrap uk-flex-middle uk-flex-between uk-margin-bottom" style="gap: .25rem">
+        <?php if ($showPrice): ?>
+            <?php echo ProductLayoutService::renderLayout('list.tag.item_price', $displayData); ?>
+        <?php endif; ?>
+        <?php if ($showSku): ?>
+            <?php echo ProductLayoutService::renderLayout('list.tag.item_sku', $displayData); ?>
+        <?php endif; ?>
+        <?php if ($showUpc): ?>
+            <?php echo ProductLayoutService::renderLayout('list.tag.item_upc', $displayData); ?>
+        <?php endif; ?>
+    </div>
 
-    <?php if ($showSku): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_sku', $displayData); ?>
-    <?php endif; ?>
-    <?php if ($showUpc): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_upc', $displayData); ?>
+    <?php if ($showCart): ?>
+        <form action="<?php echo htmlspecialchars($product->cart_form_action ?? '', ENT_QUOTES, 'UTF-8'); ?>"
+              method="post"
+              class="j2commerce-addtocart-form uk-margin-auto-top"
+              id="j2commerce-addtocart-form-<?php echo $productId; ?>"
+              data-product_id="<?php echo $productId; ?>"
+              data-product_type="<?php echo $productType; ?>"
+              enctype="multipart/form-data"
+              >
+
+            <?php if ($cartType == 1) : ?>
+                <?php echo ProductLayoutService::renderLayout('list.tag.item_options', $displayData); ?>
+                <?php echo ProductLayoutService::renderLayout('list.tag.item_cart', $displayData); ?>
+            <?php elseif (($cartType == 2 && !empty($product->options)) || $cartType == 3) : ?>
+                <a href="<?php echo htmlspecialchars($productLink ?? '', ENT_QUOTES, 'UTF-8'); ?>" class="uk-button uk-button-default uk-width-1-1">
+                    <?php echo Text::_('COM_J2COMMERCE_VIEW_PRODUCT_DETAILS'); ?>
+                </a>
+            <?php else : ?>
+                <?php echo ProductLayoutService::renderLayout('list.tag.item_cart', $displayData); ?>
+            <?php endif; ?>
+        </form>
     <?php endif; ?>
 
     <?php if ($showStock): ?>
         <?php echo ProductLayoutService::renderLayout('list.tag.item_stock', $displayData); ?>
-    <?php endif; ?>
-
-    <?php if ($showCart): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_cart', $displayData); ?>
-    <?php endif; ?>
-
-    <?php if ($showQuickview): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_quickview', $displayData); ?>
     <?php endif; ?>
 
     <?php if (isset($product->event->afterDisplayContent)): ?>

--- a/components/com_j2commerce/layouts/app_uikit/list/tag/item_variable.php
+++ b/components/com_j2commerce/layouts/app_uikit/list/tag/item_variable.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Language\Text;
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 use J2Commerce\Component\J2commerce\Site\Service\ProductLayoutService;
 
@@ -19,20 +20,14 @@ extract($displayData);
 $productId = $product->j2commerce_product_id;
 $cssClass = $product->params->get('product_css_class', '') ?? '';
 $productType = htmlspecialchars($product->product_type ?? '', ENT_QUOTES, 'UTF-8');
-
-$beforeHtml = J2CommerceHelper::plugin()->eventWithHtml(
-    'BeforeProductListItemDisplay',
-    [$product, $context, &$displayData]
-)->getArgument('html', '');
-
-$afterHtml = J2CommerceHelper::plugin()->eventWithHtml(
-    'AfterProductListItemDisplay',
-    [$product, $context, &$displayData]
-)->getArgument('html', '');
+$beforeHtml = J2CommerceHelper::plugin()->eventWithHtml('BeforeProductListItemDisplay', [$product, $context, &$displayData])->getArgument('html', '');
+$afterHtml = J2CommerceHelper::plugin()->eventWithHtml('AfterProductListItemDisplay', [$product, $context, &$displayData])->getArgument('html', '');
+$cartType = (int) $params->get('list_show_cart', 1);
 ?>
 <div class="j2commerce-product-item j2commerce-product-<?php echo $productId; ?> j2commerce-type-<?php echo $productType;?> <?php echo $cssClass; ?> uk-flex uk-flex-column uk-height-1-1"
      data-product-id="<?php echo $productId; ?>"
-     data-product-type="<?php echo $productType;?>">
+     data-product-type="<?php echo $productType;?>"
+     data-equal-height="itemContainer">
 
     <?php echo $beforeHtml; ?>
 
@@ -56,22 +51,46 @@ $afterHtml = J2CommerceHelper::plugin()->eventWithHtml(
         <?php echo ProductLayoutService::renderLayout('list.tag.item_description', $displayData); ?>
     <?php endif; ?>
 
-    <?php if ($showPrice): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_price', $displayData); ?>
-    <?php endif; ?>
+    <div class="j2commerce-price-sku-container uk-flex uk-flex-wrap uk-flex-middle uk-flex-between<?php echo ($showCart && $cartType == 1) ? '' : ' uk-margin-bottom' ?>" style="gap: .25rem">
+        <?php if ($showPrice): ?>
+            <?php echo ProductLayoutService::renderLayout('list.tag.item_flexiprice', $displayData); ?>
+        <?php endif; ?>
+        <?php if ($showSku): ?>
+            <?php echo ProductLayoutService::renderLayout('list.tag.item_sku', $displayData); ?>
+        <?php endif; ?>
+        <?php if ($showUpc): ?>
+            <?php echo ProductLayoutService::renderLayout('list.tag.item_upc', $displayData); ?>
+        <?php endif; ?>
+    </div>
 
-    <?php if ($showSku): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_sku', $displayData); ?>
-    <?php endif; ?>
-    <?php if ($showUpc): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_upc', $displayData); ?>
+    <?php if ($showCart): ?>
+        <form action="<?php echo htmlspecialchars($product->cart_form_action ?? '', ENT_QUOTES, 'UTF-8'); ?>"
+              method="post"
+              class="j2commerce-addtocart-form uk-margin-auto-top"
+              id="j2commerce-addtocart-form-<?php echo $productId; ?>"
+              data-product_id="<?php echo $productId; ?>"
+              data-product_type="<?php echo $productType; ?>"
+              data-product_variants="<?php echo htmlspecialchars($product->variant_json ?? '{}', ENT_QUOTES, 'UTF-8'); ?>"
+              enctype="multipart/form-data"
+              >
+
+            <?php if ($cartType == 1) : ?>
+                <?php echo ProductLayoutService::renderLayout('list.tag.item_variableoptions', $displayData); ?>
+                <?php echo ProductLayoutService::renderLayout('list.tag.item_cart', $displayData); ?>
+            <?php elseif (($cartType == 2 && !empty($product->options)) || $cartType == 3) : ?>
+                <a href="<?php echo htmlspecialchars($productLink ?? '', ENT_QUOTES, 'UTF-8'); ?>" class="uk-button uk-button-default uk-width-1-1">
+                    <?php echo Text::_('COM_J2COMMERCE_VIEW_PRODUCT_DETAILS'); ?>
+                </a>
+            <?php else : ?>
+                <?php echo ProductLayoutService::renderLayout('list.tag.item_cart', $displayData); ?>
+            <?php endif; ?>
+            <input type="hidden" name="variant_id" value="<?php echo (int) ($product->variant->j2commerce_variant_id ?? 0); ?>">
+        </form>
     <?php endif; ?>
 
     <?php if ($showStock): ?>
         <?php echo ProductLayoutService::renderLayout('list.tag.item_stock', $displayData); ?>
     <?php endif; ?>
-
-    <?php echo ProductLayoutService::renderLayout('list.tag.item_variableoptions', $displayData); ?>
 
     <?php if ($showQuickview): ?>
         <?php echo ProductLayoutService::renderLayout('list.tag.item_quickview', $displayData); ?>

--- a/plugins/j2commerce/app_bootstrap5/layouts/list/tag/item_cart.php
+++ b/plugins/j2commerce/app_bootstrap5/layouts/list/tag/item_cart.php
@@ -70,19 +70,22 @@ $afterCart = J2CommerceHelper::plugin()->eventWithHtml(
             </div>
 
             <div id="add-to-cart-<?php echo $productId; ?>" class="j2commerce-add-to-cart">
-                <?php if ($params->get('show_qty_field', J2CommerceHelper::config()->showQuantityField())): ?>
-                    <?php echo $productHelper->displayQuantity('com_j2commerce.productlist.bootstrap5', $product, $params, ['class' => 'input-mini form-control']); ?>
-                <?php endif; ?>
-
                 <input type="hidden" name="product_id" value="<?php echo $productId; ?>" />
-
-                <button type="submit"
-                        class="j2commerce-cart-button <?php echo $btnClass; ?>"
-                        data-cart-action-always="<?php echo Text::_('COM_J2COMMERCE_ADDING_TO_CART'); ?>"
-                        data-cart-action-done="<?php echo htmlspecialchars($cartText ?? '', ENT_QUOTES, 'UTF-8'); ?>"
-                        data-cart-action-timeout="1000">
-                    <?php echo htmlspecialchars($cartText ?? '', ENT_QUOTES, 'UTF-8'); ?>
-                </button>
+                <div class="j2commerce-cart-buttons d-flex align-items-center">
+                    <div class="input-group">
+                        <?php if ($params->get('show_qty_field', J2CommerceHelper::config()->showQuantityField())): ?>
+                            <?php echo $productHelper->displayQuantity('com_j2commerce.productlist.bootstrap5', $product, $params, ['class' => 'form-control qty-input', 'show_buttons' => false]); ?>
+                        <?php endif; ?>
+                        <button type="submit"
+                                class="j2commerce-cart-button flex-fill <?php echo $btnClass; ?>"
+                                data-cart-action-always="<?php echo Text::_('COM_J2COMMERCE_ADDING_TO_CART'); ?>"
+                                data-cart-action-done="<?php echo htmlspecialchars($cartText ?? '', ENT_QUOTES, 'UTF-8'); ?>"
+                                data-cart-action-timeout="1000">
+                            <?php echo htmlspecialchars($cartText ?? '', ENT_QUOTES, 'UTF-8'); ?>
+                        </button>
+                    </div>
+                    <?php echo J2CommerceHelper::plugin()->eventWithHtml('AfterAddToCartButtonIcon', [$product, $context])->getArgument('html', ''); ?>
+                </div>
             </div>
 
             <input type="hidden" name="option" value="com_j2commerce" />

--- a/plugins/j2commerce/app_bootstrap5/layouts/list/tag/item_configurable.php
+++ b/plugins/j2commerce/app_bootstrap5/layouts/list/tag/item_configurable.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Language\Text;
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 use J2Commerce\Component\J2commerce\Site\Service\ProductLayoutService;
 
@@ -19,18 +20,12 @@ extract($displayData);
 $productId = (int) $product->j2commerce_product_id;
 $cssClass = htmlspecialchars($product->params->get('product_css_class', '') ?? '', ENT_QUOTES, 'UTF-8');
 $productType = htmlspecialchars($product->product_type ?? '', ENT_QUOTES, 'UTF-8');
-
-$beforeHtml = J2CommerceHelper::plugin()->eventWithHtml(
-    'BeforeProductListItemDisplay',
-    [$product, $context, &$displayData]
-)->getArgument('html', '');
-
-$afterHtml = J2CommerceHelper::plugin()->eventWithHtml(
-    'AfterProductListItemDisplay',
-    [$product, $context, &$displayData]
-)->getArgument('html', '');
+$beforeHtml = J2CommerceHelper::plugin()->eventWithHtml('BeforeProductListItemDisplay',[$product, $context, &$displayData])->getArgument('html', '');
+$afterHtml = J2CommerceHelper::plugin()->eventWithHtml('AfterProductListItemDisplay',[$product, $context, &$displayData])->getArgument('html', '');
+$cartType = (int) $params->get('list_show_cart', 1);
 ?>
-<div class="j2commerce-product-item j2commerce-product-<?php echo $productId; ?> j2commerce-type-<?php echo $productType;?> <?php echo $cssClass; ?> d-flex flex-column h-100"
+
+<div class="j2commerce-product-item j2commerce-product-<?php echo $productId; ?> j2commerce-type-<?php echo $productType; ?> <?php echo $cssClass; ?> d-flex flex-column h-100"
      data-product-id="<?php echo $productId; ?>"
      data-product-type="<?php echo $productType;?>">
 
@@ -56,22 +51,41 @@ $afterHtml = J2CommerceHelper::plugin()->eventWithHtml(
         <?php echo ProductLayoutService::renderLayout('list.tag.item_description', $displayData); ?>
     <?php endif; ?>
 
-    <?php if ($showPrice): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_price', $displayData); ?>
-    <?php endif; ?>
+    <div class="j2commerce-price-sku-container d-flex flex-wrap align-items-center justify-content-between gap-1 mb-4">
+        <?php if ($showPrice): ?>
+            <?php echo ProductLayoutService::renderLayout('list.tag.item_price', $displayData); ?>
+        <?php endif; ?>
+        <?php if ($showSku): ?>
+            <?php echo ProductLayoutService::renderLayout('list.tag.item_sku', $displayData); ?>
+        <?php endif; ?>
+    </div>
 
-    <?php if ($showSku): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_sku', $displayData); ?>
+    <?php if ($showCart): ?>
+        <form action="<?php echo htmlspecialchars($product->cart_form_action ?? '', ENT_QUOTES, 'UTF-8'); ?>"
+              method="post"
+              class="j2commerce-addtocart-form mt-auto"
+              id="j2commerce-addtocart-form-<?php echo $productId; ?>"
+              data-product_id="<?php echo $productId; ?>"
+              data-product_type="<?php echo $productType; ?>"
+              data-product_variants="<?php echo htmlspecialchars($product->variant_json ?? '{}', ENT_QUOTES, 'UTF-8'); ?>"
+              enctype="multipart/form-data"
+              >
+
+            <?php if ($cartType == 1) : ?>
+                <?php echo ProductLayoutService::renderLayout('list.tag.item_configurableoptions', $displayData); ?>
+                <?php echo ProductLayoutService::renderLayout('list.tag.item_cart', $displayData); ?>
+            <?php elseif (($cartType == 2 && !empty($product->options)) || $cartType == 3) : ?>
+                <a href="<?php echo htmlspecialchars($productLink ?? '', ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-outline-primary w-100">
+                    <?php echo Text::_('COM_J2COMMERCE_VIEW_PRODUCT_DETAILS'); ?>
+                </a>
+            <?php else : ?>
+                <?php echo ProductLayoutService::renderLayout('list.tag.item_cart', $displayData); ?>
+            <?php endif; ?>
+        </form>
     <?php endif; ?>
 
     <?php if ($showStock): ?>
         <?php echo ProductLayoutService::renderLayout('list.tag.item_stock', $displayData); ?>
-    <?php endif; ?>
-
-    <?php echo ProductLayoutService::renderLayout('list.tag.item_configurableoptions', $displayData); ?>
-
-    <?php if ($showQuickview): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_quickview', $displayData); ?>
     <?php endif; ?>
 
     <?php if (isset($product->event->afterDisplayContent)): ?>

--- a/plugins/j2commerce/app_bootstrap5/layouts/list/tag/item_downloadable.php
+++ b/plugins/j2commerce/app_bootstrap5/layouts/list/tag/item_downloadable.php
@@ -11,26 +11,20 @@ declare(strict_types=1);
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Language\Text;
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 use J2Commerce\Component\J2commerce\Site\Service\ProductLayoutService;
 
 extract($displayData);
 
 $productId = (int) $product->j2commerce_product_id;
+$cartType = (int) $params->get('list_show_cart', 1);
 $cssClass = htmlspecialchars($product->params->get('product_css_class', '') ?? '', ENT_QUOTES, 'UTF-8');
 $productType = htmlspecialchars($product->product_type ?? '', ENT_QUOTES, 'UTF-8');
-
-$beforeHtml = J2CommerceHelper::plugin()->eventWithHtml(
-    'BeforeProductListItemDisplay',
-    [$product, $context, &$displayData]
-)->getArgument('html', '');
-
-$afterHtml = J2CommerceHelper::plugin()->eventWithHtml(
-    'AfterProductListItemDisplay',
-    [$product, $context, &$displayData]
-)->getArgument('html', '');
+$beforeHtml = J2CommerceHelper::plugin()->eventWithHtml('BeforeProductListItemDisplay',[$product, $context, &$displayData])->getArgument('html', '');
+$afterHtml = J2CommerceHelper::plugin()->eventWithHtml('AfterProductListItemDisplay',[$product, $context, &$displayData])->getArgument('html', '');
 ?>
-<div class="j2commerce-product-item j2commerce-product-<?php echo $productId; ?> j2commerce-type-<?php echo $productType;?> <?php echo $cssClass; ?> d-flex flex-column h-100"
+<div class="j2commerce-product-item j2commerce-product-<?php echo $productId; ?> j2commerce-type-<?php echo $productType; ?> <?php echo $cssClass; ?> d-flex flex-column h-100"
      data-product-id="<?php echo $productId; ?>"
      data-product-type="<?php echo $productType;?>">
 
@@ -56,24 +50,39 @@ $afterHtml = J2CommerceHelper::plugin()->eventWithHtml(
         <?php echo ProductLayoutService::renderLayout('list.tag.item_description', $displayData); ?>
     <?php endif; ?>
 
-    <?php if ($showPrice): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_price', $displayData); ?>
-    <?php endif; ?>
+    <div class="j2commerce-price-sku-container d-flex flex-wrap align-items-center justify-content-between gap-1 mb-4">
+        <?php if ($showPrice): ?>
+            <?php echo ProductLayoutService::renderLayout('list.tag.item_price', $displayData); ?>
+        <?php endif; ?>
+        <?php if ($showSku): ?>
+            <?php echo ProductLayoutService::renderLayout('list.tag.item_sku', $displayData); ?>
+        <?php endif; ?>
+    </div>
 
-    <?php if ($showSku): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_sku', $displayData); ?>
+    <?php if ($showCart): ?>
+        <form action="<?php echo htmlspecialchars($product->cart_form_action ?? '', ENT_QUOTES, 'UTF-8'); ?>"
+              method="post"
+              class="j2commerce-addtocart-form mt-auto"
+              id="j2commerce-addtocart-form-<?php echo $productId; ?>"
+              data-product_id="<?php echo $productId; ?>"
+              data-product_type="<?php echo $productType; ?>"
+              enctype="multipart/form-data"
+        >
+            <?php if ($cartType == 1) : ?>
+                <?php echo ProductLayoutService::renderLayout('list.tag.item_options', $displayData); ?>
+                <?php echo ProductLayoutService::renderLayout('list.tag.item_cart', $displayData); ?>
+            <?php elseif (($cartType == 2 && !empty($product->options)) || $cartType == 3) : ?>
+                <a href="<?php echo htmlspecialchars($productLink ?? '', ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-outline-primary w-100">
+                    <?php echo Text::_('COM_J2COMMERCE_VIEW_PRODUCT_DETAILS'); ?>
+                </a>
+            <?php else : ?>
+                <?php echo ProductLayoutService::renderLayout('list.tag.item_cart', $displayData); ?>
+            <?php endif; ?>
+        </form>
     <?php endif; ?>
 
     <?php if ($showStock): ?>
         <?php echo ProductLayoutService::renderLayout('list.tag.item_stock', $displayData); ?>
-    <?php endif; ?>
-
-    <?php if ($showCart): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_cart', $displayData); ?>
-    <?php endif; ?>
-
-    <?php if ($showQuickview): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_quickview', $displayData); ?>
     <?php endif; ?>
 
     <?php if (isset($product->event->afterDisplayContent)): ?>

--- a/plugins/j2commerce/app_bootstrap5/layouts/list/tag/item_simple.php
+++ b/plugins/j2commerce/app_bootstrap5/layouts/list/tag/item_simple.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Language\Text;
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 use J2Commerce\Component\J2commerce\Site\Service\ProductLayoutService;
 
@@ -19,18 +20,12 @@ extract($displayData);
 $productId = (int) $product->j2commerce_product_id;
 $cssClass = htmlspecialchars($product->params->get('product_css_class', '') ?? '', ENT_QUOTES, 'UTF-8');
 $productType = htmlspecialchars($product->product_type ?? '', ENT_QUOTES, 'UTF-8');
-
-$beforeHtml = J2CommerceHelper::plugin()->eventWithHtml(
-    'BeforeProductListItemDisplay',
-    [$product, $context, &$displayData]
-)->getArgument('html', '');
-
-$afterHtml = J2CommerceHelper::plugin()->eventWithHtml(
-    'AfterProductListItemDisplay',
-    [$product, $context, &$displayData]
-)->getArgument('html', '');
+$beforeHtml = J2CommerceHelper::plugin()->eventWithHtml('BeforeProductListItemDisplay',[$product, $context, &$displayData])->getArgument('html', '');
+$afterHtml = J2CommerceHelper::plugin()->eventWithHtml('AfterProductListItemDisplay',[$product, $context, &$displayData])->getArgument('html', '');
+$cartType = (int) $params->get('list_show_cart', 1);
 ?>
-<div class="j2commerce-product-item j2commerce-product-<?php echo $productId; ?> j2commerce-type-<?php echo $productType;?> <?php echo $cssClass; ?> d-flex flex-column h-100"
+
+<div class="j2commerce-product-item j2commerce-product-<?php echo $productId; ?> j2commerce-type-<?php echo $productType; ?> <?php echo $cssClass; ?> d-flex flex-column h-100"
      data-product-id="<?php echo $productId; ?>"
      data-product-type="<?php echo $productType;?>">
 
@@ -56,24 +51,40 @@ $afterHtml = J2CommerceHelper::plugin()->eventWithHtml(
         <?php echo ProductLayoutService::renderLayout('list.tag.item_description', $displayData); ?>
     <?php endif; ?>
 
-    <?php if ($showPrice): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_price', $displayData); ?>
-    <?php endif; ?>
+    <div class="j2commerce-price-sku-container d-flex flex-wrap align-items-center justify-content-between gap-1 mb-4">
+        <?php if ($showPrice): ?>
+            <?php echo ProductLayoutService::renderLayout('list.tag.item_price', $displayData); ?>
+        <?php endif; ?>
+        <?php if ($showSku): ?>
+            <?php echo ProductLayoutService::renderLayout('list.tag.item_sku', $displayData); ?>
+        <?php endif; ?>
+    </div>
 
-    <?php if ($showSku): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_sku', $displayData); ?>
+    <?php if ($showCart): ?>
+        <form action="<?php echo htmlspecialchars($product->cart_form_action ?? '', ENT_QUOTES, 'UTF-8'); ?>"
+              method="post"
+              class="j2commerce-addtocart-form mt-auto"
+              id="j2commerce-addtocart-form-<?php echo $productId; ?>"
+              data-product_id="<?php echo $productId; ?>"
+              data-product_type="<?php echo $productType; ?>"
+              enctype="multipart/form-data"
+              >
+
+            <?php if ($cartType == 1) : ?>
+                <?php echo ProductLayoutService::renderLayout('list.tag.item_options', $displayData); ?>
+                <?php echo ProductLayoutService::renderLayout('list.tag.item_cart', $displayData); ?>
+            <?php elseif (($cartType == 2 && !empty($product->options)) || $cartType == 3) : ?>
+                <a href="<?php echo htmlspecialchars($productLink ?? '', ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-outline-primary w-100">
+                    <?php echo Text::_('COM_J2COMMERCE_VIEW_PRODUCT_DETAILS'); ?>
+                </a>
+            <?php else : ?>
+                <?php echo ProductLayoutService::renderLayout('list.tag.item_cart', $displayData); ?>
+            <?php endif; ?>
+        </form>
     <?php endif; ?>
 
     <?php if ($showStock): ?>
         <?php echo ProductLayoutService::renderLayout('list.tag.item_stock', $displayData); ?>
-    <?php endif; ?>
-
-    <?php if ($showCart): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_cart', $displayData); ?>
-    <?php endif; ?>
-
-    <?php if ($showQuickview): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_quickview', $displayData); ?>
     <?php endif; ?>
 
     <?php if (isset($product->event->afterDisplayContent)): ?>

--- a/plugins/j2commerce/app_bootstrap5/layouts/list/tag/item_variable.php
+++ b/plugins/j2commerce/app_bootstrap5/layouts/list/tag/item_variable.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Language\Text;
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 use J2Commerce\Component\J2commerce\Site\Service\ProductLayoutService;
 
@@ -19,18 +20,11 @@ extract($displayData);
 $productId = (int) $product->j2commerce_product_id;
 $cssClass = htmlspecialchars($product->params->get('product_css_class', '') ?? '', ENT_QUOTES, 'UTF-8');
 $productType = htmlspecialchars($product->product_type ?? '', ENT_QUOTES, 'UTF-8');
-
-$beforeHtml = J2CommerceHelper::plugin()->eventWithHtml(
-    'BeforeProductListItemDisplay',
-    [$product, $context, &$displayData]
-)->getArgument('html', '');
-
-$afterHtml = J2CommerceHelper::plugin()->eventWithHtml(
-    'AfterProductListItemDisplay',
-    [$product, $context, &$displayData]
-)->getArgument('html', '');
+$beforeHtml = J2CommerceHelper::plugin()->eventWithHtml('BeforeProductListItemDisplay', [$product, $context, &$displayData])->getArgument('html', '');
+$afterHtml = J2CommerceHelper::plugin()->eventWithHtml('AfterProductListItemDisplay', [$product, $context, &$displayData])->getArgument('html', '');
+$cartType = (int) $params->get('list_show_cart', 1);
 ?>
-<div class="j2commerce-product-item j2commerce-product-<?php echo $productId; ?> j2commerce-type-<?php echo $productType;?> <?php echo $cssClass; ?> d-flex flex-column h-100"
+<div class="j2commerce-product-item j2commerce-product-<?php echo $productId; ?> j2commerce-type-<?php echo $productType; ?> <?php echo $cssClass; ?> d-flex flex-column h-100"
      data-product-id="<?php echo $productId; ?>"
      data-product-type="<?php echo $productType;?>">
 
@@ -56,19 +50,43 @@ $afterHtml = J2CommerceHelper::plugin()->eventWithHtml(
         <?php echo ProductLayoutService::renderLayout('list.tag.item_description', $displayData); ?>
     <?php endif; ?>
 
-    <?php if ($showPrice): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_price', $displayData); ?>
-    <?php endif; ?>
+    <div class="j2commerce-price-sku-container d-flex flex-wrap align-items-center justify-content-between gap-1<?php echo ($showCart && $cartType == 1) ? '' : ' mb-4' ?>">
+        <?php if ($showPrice): ?>
+            <?php echo ProductLayoutService::renderLayout('list.tag.item_flexiprice', $displayData); ?>
+        <?php endif; ?>
+        <?php if ($showSku): ?>
+            <?php echo ProductLayoutService::renderLayout('list.tag.item_sku', $displayData); ?>
+        <?php endif; ?>
+    </div>
 
-    <?php if ($showSku): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_sku', $displayData); ?>
+    <?php if ($showCart): ?>
+        <form action="<?php echo htmlspecialchars($product->cart_form_action ?? '', ENT_QUOTES, 'UTF-8'); ?>"
+              method="post"
+              class="j2commerce-addtocart-form mt-auto"
+              id="j2commerce-addtocart-form-<?php echo $productId; ?>"
+              data-product_id="<?php echo $productId; ?>"
+              data-product_type="<?php echo $productType; ?>"
+              data-product_variants="<?php echo htmlspecialchars($product->variant_json ?? '{}', ENT_QUOTES, 'UTF-8'); ?>"
+              enctype="multipart/form-data"
+              >
+
+            <?php if ($cartType == 1) : ?>
+                <?php echo ProductLayoutService::renderLayout('list.tag.item_variableoptions', $displayData); ?>
+                <?php echo ProductLayoutService::renderLayout('list.tag.item_cart', $displayData); ?>
+            <?php elseif (($cartType == 2 && !empty($product->options)) || $cartType == 3) : ?>
+                <a href="<?php echo htmlspecialchars($productLink ?? '', ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-outline-primary w-100">
+                    <?php echo Text::_('COM_J2COMMERCE_VIEW_PRODUCT_DETAILS'); ?>
+                </a>
+            <?php else : ?>
+                <?php echo ProductLayoutService::renderLayout('list.tag.item_cart', $displayData); ?>
+            <?php endif; ?>
+            <input type="hidden" name="variant_id" value="<?php echo (int) ($product->variant->j2commerce_variant_id ?? 0); ?>">
+        </form>
     <?php endif; ?>
 
     <?php if ($showStock): ?>
         <?php echo ProductLayoutService::renderLayout('list.tag.item_stock', $displayData); ?>
     <?php endif; ?>
-
-    <?php echo ProductLayoutService::renderLayout('list.tag.item_variableoptions', $displayData); ?>
 
     <?php if ($showQuickview): ?>
         <?php echo ProductLayoutService::renderLayout('list.tag.item_quickview', $displayData); ?>

--- a/plugins/j2commerce/app_uikit/layouts/list/tag/item_cart.php
+++ b/plugins/j2commerce/app_uikit/layouts/list/tag/item_cart.php
@@ -70,19 +70,20 @@ $afterCart = J2CommerceHelper::plugin()->eventWithHtml(
             </div>
 
             <div id="add-to-cart-<?php echo $productId; ?>" class="j2commerce-add-to-cart">
-                <?php if ($params->get('show_qty_field', J2CommerceHelper::config()->showQuantityField())): ?>
-                    <?php echo $productHelper->displayQuantity('com_j2commerce.productlist.uikit', $product, $params, ['class' => 'input-mini uk-input']); ?>
-                <?php endif; ?>
-
                 <input type="hidden" name="product_id" value="<?php echo $productId; ?>" />
-
-                <button type="submit"
-                        class="j2commerce-cart-button <?php echo $btnClass; ?>"
-                        data-cart-action-always="<?php echo Text::_('COM_J2COMMERCE_ADDING_TO_CART'); ?>"
-                        data-cart-action-done="<?php echo htmlspecialchars($cartText ?? '', ENT_QUOTES, 'UTF-8'); ?>"
-                        data-cart-action-timeout="1000">
-                    <?php echo htmlspecialchars($cartText ?? '', ENT_QUOTES, 'UTF-8'); ?>
-                </button>
+                <div class="j2commerce-cart-buttons uk-flex uk-flex-middle">
+                    <?php if ($params->get('show_qty_field', J2CommerceHelper::config()->showQuantityField())): ?>
+                        <?php echo $productHelper->displayQuantity('com_j2commerce.productlist.uikit', $product, $params, ['class' => 'uk-input qty-input', 'show_buttons' => false]); ?>
+                    <?php endif; ?>
+                    <button type="submit"
+                            class="j2commerce-cart-button uk-width-expand <?php echo $btnClass; ?>"
+                            data-cart-action-always="<?php echo Text::_('COM_J2COMMERCE_ADDING_TO_CART'); ?>"
+                            data-cart-action-done="<?php echo htmlspecialchars($cartText ?? '', ENT_QUOTES, 'UTF-8'); ?>"
+                            data-cart-action-timeout="1000">
+                        <?php echo htmlspecialchars($cartText ?? '', ENT_QUOTES, 'UTF-8'); ?>
+                    </button>
+                    <?php echo J2CommerceHelper::plugin()->eventWithHtml('AfterAddToCartButtonIcon', [$product, $context])->getArgument('html', ''); ?>
+                </div>
             </div>
 
             <input type="hidden" name="option" value="com_j2commerce" />

--- a/plugins/j2commerce/app_uikit/layouts/list/tag/item_configurable.php
+++ b/plugins/j2commerce/app_uikit/layouts/list/tag/item_configurable.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Language\Text;
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 use J2Commerce\Component\J2commerce\Site\Service\ProductLayoutService;
 
@@ -19,20 +20,15 @@ extract($displayData);
 $productId = $product->j2commerce_product_id;
 $cssClass = $product->params->get('product_css_class', '') ?? '';
 $productType = htmlspecialchars($product->product_type ?? '', ENT_QUOTES, 'UTF-8');
-
-$beforeHtml = J2CommerceHelper::plugin()->eventWithHtml(
-    'BeforeProductListItemDisplay',
-    [$product, $context, &$displayData]
-)->getArgument('html', '');
-
-$afterHtml = J2CommerceHelper::plugin()->eventWithHtml(
-    'AfterProductListItemDisplay',
-    [$product, $context, &$displayData]
-)->getArgument('html', '');
+$beforeHtml = J2CommerceHelper::plugin()->eventWithHtml('BeforeProductListItemDisplay',[$product, $context, &$displayData])->getArgument('html', '');
+$afterHtml = J2CommerceHelper::plugin()->eventWithHtml('AfterProductListItemDisplay',[$product, $context, &$displayData])->getArgument('html', '');
+$cartType = (int) $params->get('list_show_cart', 1);
 ?>
+
 <div class="j2commerce-product-item j2commerce-product-<?php echo $productId; ?> j2commerce-type-<?php echo $productType;?> <?php echo $cssClass; ?> uk-flex uk-flex-column uk-height-1-1"
      data-product-id="<?php echo $productId; ?>"
-     data-product-type="<?php echo $productType;?>">
+     data-product-type="<?php echo $productType;?>"
+     data-equal-height="itemContainer">
 
     <?php echo $beforeHtml; ?>
 
@@ -56,22 +52,41 @@ $afterHtml = J2CommerceHelper::plugin()->eventWithHtml(
         <?php echo ProductLayoutService::renderLayout('list.tag.item_description', $displayData); ?>
     <?php endif; ?>
 
-    <?php if ($showPrice): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_price', $displayData); ?>
-    <?php endif; ?>
+    <div class="j2commerce-price-sku-container uk-flex uk-flex-wrap uk-flex-middle uk-flex-between uk-margin-bottom" style="gap: .25rem">
+        <?php if ($showPrice): ?>
+            <?php echo ProductLayoutService::renderLayout('list.tag.item_price', $displayData); ?>
+        <?php endif; ?>
+        <?php if ($showSku): ?>
+            <?php echo ProductLayoutService::renderLayout('list.tag.item_sku', $displayData); ?>
+        <?php endif; ?>
+    </div>
 
-    <?php if ($showSku): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_sku', $displayData); ?>
+    <?php if ($showCart): ?>
+        <form action="<?php echo htmlspecialchars($product->cart_form_action ?? '', ENT_QUOTES, 'UTF-8'); ?>"
+              method="post"
+              class="j2commerce-addtocart-form uk-margin-auto-top"
+              id="j2commerce-addtocart-form-<?php echo $productId; ?>"
+              data-product_id="<?php echo $productId; ?>"
+              data-product_type="<?php echo $productType; ?>"
+              data-product_variants="<?php echo htmlspecialchars($product->variant_json ?? '{}', ENT_QUOTES, 'UTF-8'); ?>"
+              enctype="multipart/form-data"
+              >
+
+            <?php if ($cartType == 1) : ?>
+                <?php echo ProductLayoutService::renderLayout('list.tag.item_configurableoptions', $displayData); ?>
+                <?php echo ProductLayoutService::renderLayout('list.tag.item_cart', $displayData); ?>
+            <?php elseif (($cartType == 2 && !empty($product->options)) || $cartType == 3) : ?>
+                <a href="<?php echo htmlspecialchars($productLink ?? '', ENT_QUOTES, 'UTF-8'); ?>" class="uk-button uk-button-default uk-width-1-1">
+                    <?php echo Text::_('COM_J2COMMERCE_VIEW_PRODUCT_DETAILS'); ?>
+                </a>
+            <?php else : ?>
+                <?php echo ProductLayoutService::renderLayout('list.tag.item_cart', $displayData); ?>
+            <?php endif; ?>
+        </form>
     <?php endif; ?>
 
     <?php if ($showStock): ?>
         <?php echo ProductLayoutService::renderLayout('list.tag.item_stock', $displayData); ?>
-    <?php endif; ?>
-
-    <?php echo ProductLayoutService::renderLayout('list.tag.item_configurableoptions', $displayData); ?>
-
-    <?php if ($showQuickview): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_quickview', $displayData); ?>
     <?php endif; ?>
 
     <?php if (isset($product->event->afterDisplayContent)): ?>

--- a/plugins/j2commerce/app_uikit/layouts/list/tag/item_downloadable.php
+++ b/plugins/j2commerce/app_uikit/layouts/list/tag/item_downloadable.php
@@ -11,28 +11,23 @@ declare(strict_types=1);
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Language\Text;
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 use J2Commerce\Component\J2commerce\Site\Service\ProductLayoutService;
 
 extract($displayData);
 
 $productId = $product->j2commerce_product_id;
+$cartType = (int) $params->get('list_show_cart', 1);
 $cssClass = $product->params->get('product_css_class', '') ?? '';
 $productType = htmlspecialchars($product->product_type ?? '', ENT_QUOTES, 'UTF-8');
-
-$beforeHtml = J2CommerceHelper::plugin()->eventWithHtml(
-    'BeforeProductListItemDisplay',
-    [$product, $context, &$displayData]
-)->getArgument('html', '');
-
-$afterHtml = J2CommerceHelper::plugin()->eventWithHtml(
-    'AfterProductListItemDisplay',
-    [$product, $context, &$displayData]
-)->getArgument('html', '');
+$beforeHtml = J2CommerceHelper::plugin()->eventWithHtml('BeforeProductListItemDisplay',[$product, $context, &$displayData])->getArgument('html', '');
+$afterHtml = J2CommerceHelper::plugin()->eventWithHtml('AfterProductListItemDisplay',[$product, $context, &$displayData])->getArgument('html', '');
 ?>
 <div class="j2commerce-product-item j2commerce-product-<?php echo $productId; ?> j2commerce-type-<?php echo $productType;?> <?php echo $cssClass; ?> uk-flex uk-flex-column uk-height-1-1"
      data-product-id="<?php echo $productId; ?>"
-     data-product-type="<?php echo $productType;?>">
+     data-product-type="<?php echo $productType;?>"
+     data-equal-height="itemContainer">
 
     <?php echo $beforeHtml; ?>
 
@@ -56,24 +51,39 @@ $afterHtml = J2CommerceHelper::plugin()->eventWithHtml(
         <?php echo ProductLayoutService::renderLayout('list.tag.item_description', $displayData); ?>
     <?php endif; ?>
 
-    <?php if ($showPrice): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_price', $displayData); ?>
-    <?php endif; ?>
+    <div class="j2commerce-price-sku-container uk-flex uk-flex-wrap uk-flex-middle uk-flex-between uk-margin-bottom" style="gap: .25rem">
+        <?php if ($showPrice): ?>
+            <?php echo ProductLayoutService::renderLayout('list.tag.item_price', $displayData); ?>
+        <?php endif; ?>
+        <?php if ($showSku): ?>
+            <?php echo ProductLayoutService::renderLayout('list.tag.item_sku', $displayData); ?>
+        <?php endif; ?>
+    </div>
 
-    <?php if ($showSku): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_sku', $displayData); ?>
+    <?php if ($showCart): ?>
+        <form action="<?php echo htmlspecialchars($product->cart_form_action ?? '', ENT_QUOTES, 'UTF-8'); ?>"
+              method="post"
+              class="j2commerce-addtocart-form uk-margin-auto-top"
+              id="j2commerce-addtocart-form-<?php echo $productId; ?>"
+              data-product_id="<?php echo $productId; ?>"
+              data-product_type="<?php echo $productType; ?>"
+              enctype="multipart/form-data"
+        >
+            <?php if ($cartType == 1) : ?>
+                <?php echo ProductLayoutService::renderLayout('list.tag.item_options', $displayData); ?>
+                <?php echo ProductLayoutService::renderLayout('list.tag.item_cart', $displayData); ?>
+            <?php elseif (($cartType == 2 && !empty($product->options)) || $cartType == 3) : ?>
+                <a href="<?php echo htmlspecialchars($productLink ?? '', ENT_QUOTES, 'UTF-8'); ?>" class="uk-button uk-button-default uk-width-1-1">
+                    <?php echo Text::_('COM_J2COMMERCE_VIEW_PRODUCT_DETAILS'); ?>
+                </a>
+            <?php else : ?>
+                <?php echo ProductLayoutService::renderLayout('list.tag.item_cart', $displayData); ?>
+            <?php endif; ?>
+        </form>
     <?php endif; ?>
 
     <?php if ($showStock): ?>
         <?php echo ProductLayoutService::renderLayout('list.tag.item_stock', $displayData); ?>
-    <?php endif; ?>
-
-    <?php if ($showCart): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_cart', $displayData); ?>
-    <?php endif; ?>
-
-    <?php if ($showQuickview): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_quickview', $displayData); ?>
     <?php endif; ?>
 
     <?php if (isset($product->event->afterDisplayContent)): ?>

--- a/plugins/j2commerce/app_uikit/layouts/list/tag/item_simple.php
+++ b/plugins/j2commerce/app_uikit/layouts/list/tag/item_simple.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Language\Text;
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 use J2Commerce\Component\J2commerce\Site\Service\ProductLayoutService;
 
@@ -19,20 +20,15 @@ extract($displayData);
 $productId = $product->j2commerce_product_id;
 $cssClass = $product->params->get('product_css_class', '') ?? '';
 $productType = htmlspecialchars($product->product_type ?? '', ENT_QUOTES, 'UTF-8');
-
-$beforeHtml = J2CommerceHelper::plugin()->eventWithHtml(
-    'BeforeProductListItemDisplay',
-    [$product, $context, &$displayData]
-)->getArgument('html', '');
-
-$afterHtml = J2CommerceHelper::plugin()->eventWithHtml(
-    'AfterProductListItemDisplay',
-    [$product, $context, &$displayData]
-)->getArgument('html', '');
+$beforeHtml = J2CommerceHelper::plugin()->eventWithHtml('BeforeProductListItemDisplay',[$product, $context, &$displayData])->getArgument('html', '');
+$afterHtml = J2CommerceHelper::plugin()->eventWithHtml('AfterProductListItemDisplay',[$product, $context, &$displayData])->getArgument('html', '');
+$cartType = (int) $params->get('list_show_cart', 1);
 ?>
+
 <div class="j2commerce-product-item j2commerce-product-<?php echo $productId; ?> j2commerce-type-<?php echo $productType;?> <?php echo $cssClass; ?> uk-flex uk-flex-column uk-height-1-1"
      data-product-id="<?php echo $productId; ?>"
-     data-product-type="<?php echo $productType;?>">
+     data-product-type="<?php echo $productType;?>"
+     data-equal-height="itemContainer">
 
     <?php echo $beforeHtml; ?>
 
@@ -56,24 +52,40 @@ $afterHtml = J2CommerceHelper::plugin()->eventWithHtml(
         <?php echo ProductLayoutService::renderLayout('list.tag.item_description', $displayData); ?>
     <?php endif; ?>
 
-    <?php if ($showPrice): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_price', $displayData); ?>
-    <?php endif; ?>
+    <div class="j2commerce-price-sku-container uk-flex uk-flex-wrap uk-flex-middle uk-flex-between uk-margin-bottom" style="gap: .25rem">
+        <?php if ($showPrice): ?>
+            <?php echo ProductLayoutService::renderLayout('list.tag.item_price', $displayData); ?>
+        <?php endif; ?>
+        <?php if ($showSku): ?>
+            <?php echo ProductLayoutService::renderLayout('list.tag.item_sku', $displayData); ?>
+        <?php endif; ?>
+    </div>
 
-    <?php if ($showSku): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_sku', $displayData); ?>
+    <?php if ($showCart): ?>
+        <form action="<?php echo htmlspecialchars($product->cart_form_action ?? '', ENT_QUOTES, 'UTF-8'); ?>"
+              method="post"
+              class="j2commerce-addtocart-form uk-margin-auto-top"
+              id="j2commerce-addtocart-form-<?php echo $productId; ?>"
+              data-product_id="<?php echo $productId; ?>"
+              data-product_type="<?php echo $productType; ?>"
+              enctype="multipart/form-data"
+              >
+
+            <?php if ($cartType == 1) : ?>
+                <?php echo ProductLayoutService::renderLayout('list.tag.item_options', $displayData); ?>
+                <?php echo ProductLayoutService::renderLayout('list.tag.item_cart', $displayData); ?>
+            <?php elseif (($cartType == 2 && !empty($product->options)) || $cartType == 3) : ?>
+                <a href="<?php echo htmlspecialchars($productLink ?? '', ENT_QUOTES, 'UTF-8'); ?>" class="uk-button uk-button-default uk-width-1-1">
+                    <?php echo Text::_('COM_J2COMMERCE_VIEW_PRODUCT_DETAILS'); ?>
+                </a>
+            <?php else : ?>
+                <?php echo ProductLayoutService::renderLayout('list.tag.item_cart', $displayData); ?>
+            <?php endif; ?>
+        </form>
     <?php endif; ?>
 
     <?php if ($showStock): ?>
         <?php echo ProductLayoutService::renderLayout('list.tag.item_stock', $displayData); ?>
-    <?php endif; ?>
-
-    <?php if ($showCart): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_cart', $displayData); ?>
-    <?php endif; ?>
-
-    <?php if ($showQuickview): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_quickview', $displayData); ?>
     <?php endif; ?>
 
     <?php if (isset($product->event->afterDisplayContent)): ?>

--- a/plugins/j2commerce/app_uikit/layouts/list/tag/item_variable.php
+++ b/plugins/j2commerce/app_uikit/layouts/list/tag/item_variable.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Language\Text;
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 use J2Commerce\Component\J2commerce\Site\Service\ProductLayoutService;
 
@@ -19,20 +20,14 @@ extract($displayData);
 $productId = $product->j2commerce_product_id;
 $cssClass = $product->params->get('product_css_class', '') ?? '';
 $productType = htmlspecialchars($product->product_type ?? '', ENT_QUOTES, 'UTF-8');
-
-$beforeHtml = J2CommerceHelper::plugin()->eventWithHtml(
-    'BeforeProductListItemDisplay',
-    [$product, $context, &$displayData]
-)->getArgument('html', '');
-
-$afterHtml = J2CommerceHelper::plugin()->eventWithHtml(
-    'AfterProductListItemDisplay',
-    [$product, $context, &$displayData]
-)->getArgument('html', '');
+$beforeHtml = J2CommerceHelper::plugin()->eventWithHtml('BeforeProductListItemDisplay', [$product, $context, &$displayData])->getArgument('html', '');
+$afterHtml = J2CommerceHelper::plugin()->eventWithHtml('AfterProductListItemDisplay', [$product, $context, &$displayData])->getArgument('html', '');
+$cartType = (int) $params->get('list_show_cart', 1);
 ?>
 <div class="j2commerce-product-item j2commerce-product-<?php echo $productId; ?> j2commerce-type-<?php echo $productType;?> <?php echo $cssClass; ?> uk-flex uk-flex-column uk-height-1-1"
      data-product-id="<?php echo $productId; ?>"
-     data-product-type="<?php echo $productType;?>">
+     data-product-type="<?php echo $productType;?>"
+     data-equal-height="itemContainer">
 
     <?php echo $beforeHtml; ?>
 
@@ -56,19 +51,43 @@ $afterHtml = J2CommerceHelper::plugin()->eventWithHtml(
         <?php echo ProductLayoutService::renderLayout('list.tag.item_description', $displayData); ?>
     <?php endif; ?>
 
-    <?php if ($showPrice): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_price', $displayData); ?>
-    <?php endif; ?>
+    <div class="j2commerce-price-sku-container uk-flex uk-flex-wrap uk-flex-middle uk-flex-between<?php echo ($showCart && $cartType == 1) ? '' : ' uk-margin-bottom' ?>" style="gap: .25rem">
+        <?php if ($showPrice): ?>
+            <?php echo ProductLayoutService::renderLayout('list.tag.item_flexiprice', $displayData); ?>
+        <?php endif; ?>
+        <?php if ($showSku): ?>
+            <?php echo ProductLayoutService::renderLayout('list.tag.item_sku', $displayData); ?>
+        <?php endif; ?>
+    </div>
 
-    <?php if ($showSku): ?>
-        <?php echo ProductLayoutService::renderLayout('list.tag.item_sku', $displayData); ?>
+    <?php if ($showCart): ?>
+        <form action="<?php echo htmlspecialchars($product->cart_form_action ?? '', ENT_QUOTES, 'UTF-8'); ?>"
+              method="post"
+              class="j2commerce-addtocart-form uk-margin-auto-top"
+              id="j2commerce-addtocart-form-<?php echo $productId; ?>"
+              data-product_id="<?php echo $productId; ?>"
+              data-product_type="<?php echo $productType; ?>"
+              data-product_variants="<?php echo htmlspecialchars($product->variant_json ?? '{}', ENT_QUOTES, 'UTF-8'); ?>"
+              enctype="multipart/form-data"
+              >
+
+            <?php if ($cartType == 1) : ?>
+                <?php echo ProductLayoutService::renderLayout('list.tag.item_variableoptions', $displayData); ?>
+                <?php echo ProductLayoutService::renderLayout('list.tag.item_cart', $displayData); ?>
+            <?php elseif (($cartType == 2 && !empty($product->options)) || $cartType == 3) : ?>
+                <a href="<?php echo htmlspecialchars($productLink ?? '', ENT_QUOTES, 'UTF-8'); ?>" class="uk-button uk-button-default uk-width-1-1">
+                    <?php echo Text::_('COM_J2COMMERCE_VIEW_PRODUCT_DETAILS'); ?>
+                </a>
+            <?php else : ?>
+                <?php echo ProductLayoutService::renderLayout('list.tag.item_cart', $displayData); ?>
+            <?php endif; ?>
+            <input type="hidden" name="variant_id" value="<?php echo (int) ($product->variant->j2commerce_variant_id ?? 0); ?>">
+        </form>
     <?php endif; ?>
 
     <?php if ($showStock): ?>
         <?php echo ProductLayoutService::renderLayout('list.tag.item_stock', $displayData); ?>
     <?php endif; ?>
-
-    <?php echo ProductLayoutService::renderLayout('list.tag.item_variableoptions', $displayData); ?>
 
     <?php if ($showQuickview): ?>
         <?php echo ProductLayoutService::renderLayout('list.tag.item_quickview', $displayData); ?>


### PR DESCRIPTION
Here's a summary of what was fixed in each tag item_cart.php:

  ┌─────────────────────┬───────────────────────────────────────────────┬────────────────────────────────────────────────────────────────────────────────┐
  │       Change        │                    Before                     │                                     After                                      │
  ├─────────────────────┼───────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────┤
  │ Qty +/- buttons     │ displayQuantity(...) (default shows buttons)  │ displayQuantity(..., ['show_buttons' => false])                                │
  ├─────────────────────┼───────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────┤
  │ CSS class           │ input-mini form-control / input-mini uk-input │ form-control qty-input / uk-input qty-input                                    │
  ├─────────────────────┼───────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────┤
  │ Layout wrapper      │ None                                          │ d-flex align-items-center + input-group (BS5) / uk-flex uk-flex-middle (UIKit) │
  ├─────────────────────┼───────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────┤
  │ Button width        │ No fill class                                 │ flex-fill (BS5) / uk-width-expand (UIKit)                                      │
  ├─────────────────────┼───────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────┤
  │ Plugin icon event   │ Missing                                       │ AfterAddToCartButtonIcon added                                                 │
  ├─────────────────────┼───────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────┤
  │ product_id position │ Between qty and button                        │ Moved before the layout wrapper                                                │
  └─────────────────────┴───────────────────────────────────────────────┴────────────────────────────────────────────────────────────────────────────────┘

Remaining UI Differences: Tag vs Category

  The same structural pattern is broken across both themes (BS5/UIKit) and both locations (components + plugins) for the product-type layout files:

  1. item_simple.php — 4 files affected

  ┌────────────────────────────────────────────────────────────────────────────────────┬────────────────────────────────────────────────────┐
  │                                 Category (correct)                                 │                   Tag (outdated)                   │
  ├────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────┤
  │ $cartType variable defined                                                         │ Missing $cartType                                  │
  ├────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────┤
  │ Price/SKU/UPC in j2commerce-price-sku-container flex div                           │ Each rendered separately, no container             │
  ├────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────┤
  │ Cart in a <form> with cartType logic (options → cart / "View Details" / bare cart) │ Cart rendered directly with no form/cartType logic │
  ├────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────┤
  │ Stock rendered after the form                                                      │ Stock rendered before cart                         │
  ├────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────┤
  │ UIKit: data-equal-height="itemContainer" on root div                               │ Missing                                            │
  └────────────────────────────────────────────────────────────────────────────────────┴────────────────────────────────────────────────────┘

  2. item_variable.php — 4 files affected

  ┌────────────────────────────────────────────────────────────────────────────┬───────────────────────────────────────────────────────────────────────────┐
  │                             Category (correct)                             │                              Tag (outdated)                               │
  ├────────────────────────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────┤
  │ Price uses item_flexiprice                                                 │ Price uses item_price (wrong sub-layout)                                  │
  ├────────────────────────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────┤
  │ Price/SKU in j2commerce-price-sku-container                                │ No container                                                              │
  ├────────────────────────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────┤
  │ <form> with data-product_variants, cartType logic, variant_id hidden input │ item_variableoptions rendered unconditionally with no form, no cart logic │
  ├────────────────────────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────┤
  │ Stock after the form                                                       │ Stock before options                                                      │
  └────────────────────────────────────────────────────────────────────────────┴───────────────────────────────────────────────────────────────────────────┘

  3. item_configurable.php — 4 files affected

  ┌───────────────────────────────────────────────────┬────────────────────────────────────────────────────────────────────┐
  │                Category (correct)                 │                           Tag (outdated)                           │
  ├───────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────┤
  │ Price/SKU in j2commerce-price-sku-container       │ No container                                                       │
  ├───────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────┤
  │ <form> with data-product_variants, cartType logic │ item_configurableoptions rendered unconditionally outside any form │
  ├───────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────┤
  │ Stock after the form                              │ Stock before options                                               │
  └───────────────────────────────────────────────────┴────────────────────────────────────────────────────────────────────┘

  4. item_downloadable.php — 4 files affected

  ┌─────────────────────────────────────────────┬───────────────────┐
  │             Category (correct)              │  Tag (outdated)   │
  ├─────────────────────────────────────────────┼───────────────────┤
  │ Price/SKU in j2commerce-price-sku-container │ No container      │
  ├─────────────────────────────────────────────┼───────────────────┤
  │ Stock after the form                        │ Stock before cart │
  └─────────────────────────────────────────────┴───────────────────┘
