### PR TITLE
Fix price filter does not function properly in category list view

### DIFF
--- a/components/com_j2commerce/src/Model/ProductsModel.php
+++ b/components/com_j2commerce/src/Model/ProductsModel.php
@@ -595,7 +595,25 @@ class ProductsModel extends ListModel
             ? $this->getMatchingManufacturerIds()
             : null;
 
-        return ProductHelper::getFilters($items, $filterCategoryIds, $restrictManufacturerIds);
+        $filters = ProductHelper::getFilters($items, $filterCategoryIds, $restrictManufacturerIds);
+
+        if (!empty($items)) {
+            $prices = [];
+
+            foreach ($items as $item) {
+                $price = (float) ($item->pricing->price ?? $item->price ?? 0);
+
+                if ($price > 0) {
+                    $prices[] = $price;
+                }
+            }
+
+            if (!empty($prices)) {
+                $filters['pricefilters'] = ['min_price' => min($prices), 'max_price' => max($prices)];
+            }
+        }
+
+        return $filters;
     }
 
     /**

--- a/components/com_j2commerce/tmpl/products/default_filters.php
+++ b/components/com_j2commerce/tmpl/products/default_filters.php
@@ -126,9 +126,9 @@ HTMLHelper::_('bootstrap.collapse');
                     <?php
                     $minPrice = 0;
                     $maxPrice = (float) $this->filters['pricefilters']['max_price'];
-                    $hasActivePrice = !empty($this->state->pricefrom) || !empty($this->state->priceto);
-                    $priceFrom = $hasActivePrice && $this->state->pricefrom ? (float) $this->state->pricefrom : $minPrice;
-                    $priceTo = $hasActivePrice && $this->state->priceto ? (float) $this->state->priceto : $maxPrice;
+                    $hasActivePrice = $this->state->get('filter.price_from', 0) > 0 || $this->state->get('filter.price_to', 0) > 0;
+                    $priceFrom = $hasActivePrice && $this->state->get('filter.price_from', 0) ? (float) $this->state->get('filter.price_from') : $minPrice;
+                    $priceTo   = $hasActivePrice && $this->state->get('filter.price_to', 0)   ? (float) $this->state->get('filter.price_to')   : $maxPrice;
                     $dPriceFrom = CurrencyHelper::format($priceFrom, $currencyCode, $currencyValue, false);
                     $dPriceTo = CurrencyHelper::format($priceTo, $currencyCode, $currencyValue, false);
                     ?>

--- a/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/default_filters.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/bootstrap5/default_filters.php
@@ -126,9 +126,9 @@ HTMLHelper::_('bootstrap.collapse');
                     <?php
                     $minPrice = 0;
                     $maxPrice = (float) $this->filters['pricefilters']['max_price'];
-                    $hasActivePrice = !empty($this->state->pricefrom) || !empty($this->state->priceto);
-                    $priceFrom = $hasActivePrice && $this->state->pricefrom ? (float) $this->state->pricefrom : $minPrice;
-                    $priceTo = $hasActivePrice && $this->state->priceto ? (float) $this->state->priceto : $maxPrice;
+                    $hasActivePrice = $this->state->get('filter.price_from', 0) > 0 || $this->state->get('filter.price_to', 0) > 0;
+                    $priceFrom = $hasActivePrice && $this->state->get('filter.price_from', 0) ? (float) $this->state->get('filter.price_from') : $minPrice;
+                    $priceTo   = $hasActivePrice && $this->state->get('filter.price_to', 0)   ? (float) $this->state->get('filter.price_to')   : $maxPrice;
                     $dPriceFrom = CurrencyHelper::format($priceFrom, $currencyCode, $currencyValue, false);
                     $dPriceTo = CurrencyHelper::format($priceTo, $currencyCode, $currencyValue, false);
                     ?>

--- a/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/default_filters.php
+++ b/plugins/j2commerce/app_bootstrap5/tmpl/tag_bootstrap5/default_filters.php
@@ -124,9 +124,9 @@ HTMLHelper::_('bootstrap.collapse');
                     <?php
                     $minPrice = 0;
                     $maxPrice = (float) $this->filters['pricefilters']['max_price'];
-                    $hasActivePrice = !empty($this->state->pricefrom) || !empty($this->state->priceto);
-                    $priceFrom = $hasActivePrice && $this->state->pricefrom ? (float) $this->state->pricefrom : $minPrice;
-                    $priceTo = $hasActivePrice && $this->state->priceto ? (float) $this->state->priceto : $maxPrice;
+                    $hasActivePrice = $this->state->get('filter.price_from', 0) > 0 || $this->state->get('filter.price_to', 0) > 0;
+                    $priceFrom = $hasActivePrice && $this->state->get('filter.price_from', 0) ? (float) $this->state->get('filter.price_from') : $minPrice;
+                    $priceTo   = $hasActivePrice && $this->state->get('filter.price_to', 0)   ? (float) $this->state->get('filter.price_to')   : $maxPrice;
                     $dPriceFrom = CurrencyHelper::format($priceFrom, $currencyCode, $currencyValue, false);
                     $dPriceTo = CurrencyHelper::format($priceTo, $currencyCode, $currencyValue, false);
                     ?>

--- a/plugins/j2commerce/app_uikit/tmpl/tag_uikit/default_filters.php
+++ b/plugins/j2commerce/app_uikit/tmpl/tag_uikit/default_filters.php
@@ -111,9 +111,9 @@ $filtersCollapsed = ((int) $this->params->get('list_filter_category_toggle', 1) 
                     <?php
                     $minPrice = 0;
                     $maxPrice = (float) $this->filters['pricefilters']['max_price'];
-                    $hasActivePrice = !empty($this->state->pricefrom) || !empty($this->state->priceto);
-                    $priceFrom = $hasActivePrice && $this->state->pricefrom ? (float) $this->state->pricefrom : $minPrice;
-                    $priceTo = $hasActivePrice && $this->state->priceto ? (float) $this->state->priceto : $maxPrice;
+                    $hasActivePrice = $this->state->get('filter.price_from', 0) > 0 || $this->state->get('filter.price_to', 0) > 0;
+                    $priceFrom = $hasActivePrice && $this->state->get('filter.price_from', 0) ? (float) $this->state->get('filter.price_from') : $minPrice;
+                    $priceTo   = $hasActivePrice && $this->state->get('filter.price_to', 0)   ? (float) $this->state->get('filter.price_to')   : $maxPrice;
                     $dPriceFrom = CurrencyHelper::format($priceFrom, $currencyCode, $currencyValue, false);
                     $dPriceTo = CurrencyHelper::format($priceTo, $currencyCode, $currencyValue, false);
                     ?>

--- a/plugins/j2commerce/app_uikit/tmpl/uikit/default_filters.php
+++ b/plugins/j2commerce/app_uikit/tmpl/uikit/default_filters.php
@@ -112,9 +112,9 @@ $filtersCollapsed = ((int) $this->params->get('list_filter_category_toggle', 1) 
                     <?php
                     $minPrice = 0;
                     $maxPrice = (float) $this->filters['pricefilters']['max_price'];
-                    $hasActivePrice = !empty($this->state->pricefrom) || !empty($this->state->priceto);
-                    $priceFrom = $hasActivePrice && $this->state->pricefrom ? (float) $this->state->pricefrom : $minPrice;
-                    $priceTo = $hasActivePrice && $this->state->priceto ? (float) $this->state->priceto : $maxPrice;
+                    $hasActivePrice = $this->state->get('filter.price_from', 0) > 0 || $this->state->get('filter.price_to', 0) > 0;
+                    $priceFrom = $hasActivePrice && $this->state->get('filter.price_from', 0) ? (float) $this->state->get('filter.price_from') : $minPrice;
+                    $priceTo   = $hasActivePrice && $this->state->get('filter.price_to', 0)   ? (float) $this->state->get('filter.price_to')   : $maxPrice;
                     $dPriceFrom = CurrencyHelper::format($priceFrom, $currencyCode, $currencyValue, false);
                     $dPriceTo = CurrencyHelper::format($priceTo, $currencyCode, $currencyValue, false);
                     ?>
@@ -281,9 +281,9 @@ $filtersCollapsed = ((int) $this->params->get('list_filter_category_toggle', 1) 
                 <?php
                 $minPrice = 0;
                 $maxPrice = (float) $this->filters['pricefilters']['max_price'];
-                $hasActivePrice = !empty($this->state->pricefrom) || !empty($this->state->priceto);
-                $priceFrom = $hasActivePrice && $this->state->pricefrom ? (float) $this->state->pricefrom : $minPrice;
-                $priceTo = $hasActivePrice && $this->state->priceto ? (float) $this->state->priceto : $maxPrice;
+                $hasActivePrice = $this->state->get('filter.price_from', 0) > 0 || $this->state->get('filter.price_to', 0) > 0;
+                $priceFrom = $hasActivePrice && $this->state->get('filter.price_from', 0) ? (float) $this->state->get('filter.price_from') : $minPrice;
+                $priceTo   = $hasActivePrice && $this->state->get('filter.price_to', 0)   ? (float) $this->state->get('filter.price_to')   : $maxPrice;
                 $dPriceFrom = CurrencyHelper::format($priceFrom, $currencyCode, $currencyValue, false);
                 $dPriceTo = CurrencyHelper::format($priceTo, $currencyCode, $currencyValue, false);
                 ?>


### PR DESCRIPTION
The bug

  Both filter templates read price state with:
  $hasActivePrice = !empty($this->state->pricefrom) || !empty($this->state->priceto);
  $priceFrom = $hasActivePrice && $this->state->pricefrom ? ... : $minPrice;
  $priceTo   = $hasActivePrice && $this->state->priceto   ? ... : $maxPrice;

  $this->state->pricefrom accesses the Registry at the top-level key pricefrom — but the models store it as filter.price_from (nested). So
  $this->state->pricefrom is always null, meaning $hasActivePrice is always false, and the slider always resets to the full 0–$maxPrice range.

  Why it's worse in category than tag

  The difference is in getFilters():

  - Tag model (ProducttagsModel::getFilters(), line 530–543): overrides pricefilters.max_price with max($prices) from the currently-loaded (already filtered) items. So if price is filtered to 50–150, the loaded items only contain products up to 150, making $maxPrice = 150. The slider resets to 0–150, and priceto=150 gets re-submitted — the filter accidentally holds.
  - Category model (ProductsModel::getFilters()): calls ProductHelper::getPriceFilters($filterCategoryIds) which runs a raw DB query returning the full range for those categories (e.g. 0–500). So the slider always resets to 0–500, priceto=500 gets re-submitted, and the price filter is cleared.

  The fixes:

  1. The state reading in all default_filters.php templates (5 files: core + BS5 + UIKit, category + tag):

  ```
// WRONG — always null
  $hasActivePrice = !empty($this->state->pricefrom) || !empty($this->state->priceto);
  $priceFrom = $hasActivePrice && $this->state->pricefrom ? (float) $this->state->pricefrom : $minPrice;
  $priceTo   = $hasActivePrice && $this->state->priceto   ? (float) $this->state->priceto   : $maxPrice;

  // CORRECT
  $hasActivePrice = $this->state->get('filter.price_from', 0) > 0 || $this->state->get('filter.price_to', 0) > 0;
  $priceFrom = $hasActivePrice && $this->state->get('filter.price_from', 0) ? (float) $this->state->get('filter.price_from') : $minPrice;
  $priceTo   = $hasActivePrice && $this->state->get('filter.price_to', 0)   ? (float) $this->state->get('filter.price_to')   : $maxPrice;
```

  2. ProductsModel::getFilters() should override price range from items (like the tag model does), so the slider max contracts to reflect the current filtered set.