### PR TITLE
fix(core): repair fulfilment API POST id resolution and displayItem signature

### DIFF
--- a/api/components/com_j2commerce/src/Controller/OrderfulfilmentController.php
+++ b/api/components/com_j2commerce/src/Controller/OrderfulfilmentController.php
@@ -32,11 +32,11 @@ class OrderfulfilmentController extends J2CommerceApiController
     protected $default_view = 'orderfulfilment';
 
     /** Gap 3 — order detail with ship-to block, chosen method and tracking. */
-    public function displayItem()
+    public function displayItem($id = null)
     {
         $this->assertCan(['core.fulfilment', 'core.edit', 'core.manage', 'j2commerce.vieworders']);
 
-        $pk    = $this->input->get('id', 0, 'int');
+        $pk    = ((int) $id) ?: $this->getRouteId();
         $order = $this->getModel('Order')->getItem($pk);
 
         if ($order === false || empty($order->j2commerce_order_id)) {
@@ -80,7 +80,7 @@ class OrderfulfilmentController extends J2CommerceApiController
     {
         $this->assertCan(['core.fulfilment', 'core.edit']);
 
-        $pk       = $this->input->get('id', 0, 'int');
+        $pk       = $this->getRouteId();
         $statusId = $this->input->json->getInt('status_id', 0);
         $notify   = (bool) $this->input->json->get('notify', false, 'BOOLEAN');
         $comment  = (string) $this->input->json->getString('comment', '');
@@ -104,7 +104,7 @@ class OrderfulfilmentController extends J2CommerceApiController
     {
         $this->assertCan(['core.fulfilment', 'core.edit']);
 
-        $pk         = $this->input->get('id', 0, 'int');
+        $pk         = $this->getRouteId();
         $trackingId = trim((string) $this->input->json->getString('tracking_id', ''));
 
         if ($trackingId === '') {
@@ -118,6 +118,14 @@ class OrderfulfilmentController extends J2CommerceApiController
             'ordershipping_tracking_id' => $trackingId,
             'success'                   => $ok,
         ]);
+    }
+
+    /** ApiApplication injects the :id route var into input->post (not top-level input) for POST requests. */
+    private function getRouteId(): int
+    {
+        $id = $this->input->getInt('id', 0);
+
+        return $id > 0 ? $id : $this->input->post->getInt('id', 0);
     }
 
     private function assertCan(array $actions): void


### PR DESCRIPTION
## Core Update

### Changes
Two defects in `api/components/com_j2commerce/src/Controller/OrderfulfilmentController.php` (the #1187 warehouse fulfilment endpoints) that together made all three routes unusable:

1. **POST `:id` resolved to 0.** `ApiApplication::doExecute()` injects route vars into `input->post` (not top-level input) for POST requests, but `changeStatus()` and `saveTracking()` read `input->get('id')` — so every `POST orders/:id/status` and `POST orders/:id/tracking` call acted on order 0. A new `getRouteId()` helper reads top-level input first and falls back to `input->post`, and all three actions now use it.
2. **Load-time fatal.** `displayItem()` was declared without a parameter, incompatible with `ApiController::displayItem($id = null)` — a compile-time fatal that 500'd every fulfilment route the moment the class loaded. The signature now matches the parent.

Verified live against a real order: `POST .../tracking` persists to `ordershipping_tracking_id`, `POST .../status` writes exactly one order-history row via `OrderModel::updateOrderStatus()` (notify flag controls the customer email), and `GET .../fulfilment` returns the full ship-to block.

### Files Modified
| Type | Count |
|------|-------|
| PHP files | 1 |
| JS/CSS assets | 0 |
| Language files | 0 |
| XML/Config | 0 |

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Code style (php-cs-fixer) passed on 3.95.1 and 3.95.10
- [x] Security review of the diff passed (route-id resolution, ACL gates, injection surfaces)
- [x] Core files only (non-core excluded)

Note: PHPStan does not currently analyze the `api/` tree (`phpstan.neon` `paths`/`scanDirectories` omit it), so `api/` controllers report unresolved symbols when analyzed manually — pre-existing configuration gap, unrelated to this diff.
