### PR TITLE
Fix Shipping tax items

### DIFF
--- a/administrator/components/com_j2commerce/src/Helper/CartOrder.php
+++ b/administrator/components/com_j2commerce/src/Helper/CartOrder.php
@@ -921,7 +921,17 @@ class CartOrder
 
             $this->order_shipping     = $shippingPrice + $shippingExtra;
             $this->order_shipping_tax = $shippingTax;
-            $this->order_total += $this->order_shipping + $this->order_shipping_tax;
+
+            // For inclusive pricing, the shipping price already embeds the tax so we must
+            // not add order_shipping_tax again — doing so would double-count and inflate
+            // the order total by the VAT amount.
+            $isIncludingTax = (int) ComponentHelper::getParams('com_j2commerce')->get('config_including_tax', 0);
+
+            if ($isIncludingTax) {
+                $this->order_total += $this->order_shipping;
+            } else {
+                $this->order_total += $this->order_shipping + $this->order_shipping_tax;
+            }
         }
     }
 
@@ -1891,7 +1901,46 @@ class CartOrder
      */
     protected function saveOrderTaxes(DatabaseInterface $db, string $orderId): void
     {
+        // Build display rates that include shipping tax merged in (mirrors the live-cart display
+        // logic in get_formatted_order_totals) so invoices, confirmation pages, and email
+        // templates show the full VAT amount including shipping VAT.
+        $displayRates = [];
+
         foreach ($this->taxRates as $taxRate) {
+            $displayRates[] = clone $taxRate;
+        }
+
+        if ($this->order_shipping_tax > 0 && $this->shippingRate) {
+            $shippingTaxClassId = $this->getShippingTaxClassId();
+
+            if ($shippingTaxClassId > 0) {
+                $merged = false;
+
+                foreach ($displayRates as $rate) {
+                    if ((int) ($rate->taxprofile_id ?? 0) === $shippingTaxClassId) {
+                        $rate->tax_amount += $this->order_shipping_tax;
+                        $merged = true;
+                        break;
+                    }
+                }
+
+                if (!$merged) {
+                    $profileInfo = $this->getTaxProfileInfo($shippingTaxClassId);
+
+                    if ($profileInfo) {
+                        $displayRates[] = (object) [
+                            'taxprofile_id'   => $shippingTaxClassId,
+                            'taxprofile_name' => $profileInfo->taxprofile_name ?? '',
+                            'taxrate_name'    => $profileInfo->taxrate_name ?? '',
+                            'tax_amount'      => $this->order_shipping_tax,
+                            'tax_percent'     => (float) ($profileInfo->tax_percent ?? 0),
+                        ];
+                    }
+                }
+            }
+        }
+
+        foreach ($displayRates as $taxRate) {
             $taxAmount = (float) ($taxRate->tax_amount ?? 0);
 
             if ($taxAmount <= 0) {

--- a/plugins/j2commerce/shipping_standard/src/Extension/ShippingStandard.php
+++ b/plugins/j2commerce/shipping_standard/src/Extension/ShippingStandard.php
@@ -19,6 +19,7 @@ namespace J2Commerce\Plugin\J2Commerce\ShippingStandard\Extension;
 use J2Commerce\Component\J2commerce\Administrator\Library\Plugins\PluginLayoutTrait;
 use J2Commerce\Plugin\J2Commerce\ShippingStandard\Table\ShippingMethodTable;
 use J2Commerce\Plugin\J2Commerce\ShippingStandard\Table\ShippingRateTable;
+use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\Text;
@@ -155,7 +156,16 @@ final class ShippingStandard extends CMSPlugin implements SubscriberInterface
                 );
             }
 
-            $total = $rateData->price + $rateData->handling + $taxAmount;
+            $isIncludingTax = (int) ComponentHelper::getParams('com_j2commerce')->get('config_including_tax', 0);
+
+            // For inclusive pricing the shipping rate entered in the admin already
+            // contains VAT, so the amount the customer pays is just price+handling.
+            // For exclusive pricing the tax is an additional charge on top.
+            if ($isIncludingTax) {
+                $total = $rateData->price + $rateData->handling;
+            } else {
+                $total = $rateData->price + $rateData->handling + $taxAmount;
+            }
 
             $selectText  = $params->get('shipping_select_text', '');
             $displayName = !empty($selectText) ? $selectText : $method->shipping_method_name;
@@ -796,7 +806,16 @@ final class ShippingStandard extends CMSPlugin implements SubscriberInterface
             return 0.0;
         }
 
-        return ($shippingAmount * (float) $taxPercent) / 100.0;
+        $pct            = (float) $taxPercent;
+        $isIncludingTax = (int) ComponentHelper::getParams('com_j2commerce')->get('config_including_tax', 0);
+
+        // When prices are stored inclusive of tax, extract the tax component from the
+        // shipping amount rather than adding tax on top.
+        if ($isIncludingTax) {
+            return $shippingAmount * $pct / (100.0 + $pct);
+        }
+
+        return ($shippingAmount * $pct) / 100.0;
     }
 
     // =========================================================================


### PR DESCRIPTION
Bug 1: Customer overcharged on shipping (£6 instead of £5)                                                                                                                             
                                                                                                                                                                                       
  Root cause: ShippingStandard::calculateShippingTax() always used the exclusive formula (price × rate / 100), treating the admin-entered £5 as ex-VAT even when config_including_tax = 1. This added £1 VAT on top of £5, charging £6.

  Fixes in ShippingStandard.php:
  - calculateShippingTax() now checks config_including_tax. When inclusive, it extracts tax from the price (£5 × 20 / 120 = £0.83) rather than adding it on top.
  - onGetShippingRates(): when inclusive, the total shown to the customer is price + handling (£5) — not price + handling + tax (£5.83). The tax field becomes the extracted/informational VAT.

  Fix in CartOrder::loadShipping():
  - When config_including_tax = 1, only adds order_shipping (£5, already inclusive) to the order total — not + order_shipping_tax again. Previously this caused order_total = £20 + £5 + £1 = £26 when it should be £20 + £5 = £25.

  Bug 2: Invoice/confirmation VAT doesn't add up

  Root cause: saveOrderTaxes() only wrote product tax rates to #__j2commerce_ordertaxes. Shipping VAT (£0.83) was stored on the order record but never appeared in invoice/confirmation tax lines. So invoices showed product VAT (£3.33) but not shipping VAT, while order_total correctly included it — making the numbers irreconcilable.

  Fix in CartOrder::saveOrderTaxes():
  - Now merges order_shipping_tax into the ordertaxes before saving (same logic as the live-cart display in get_formatted_order_totals). Shipping VAT is combined into the matching product tax profile entry, or saved as a separate line if shipping uses a different tax profile.

  Net result for UK inclusive-pricing store

  ┌───────────────────┬───────────────────────────────────┬───────────────────────────────────────────┐
  │                   │            Before fix             │                 After fix                 │
  ├───────────────────┼───────────────────────────────────┼───────────────────────────────────────────┤
  │ Shipping charge   │ £6 (£5 + £1 VAT added)            │ £5 (VAT included)                         │
  ├───────────────────┼───────────────────────────────────┼───────────────────────────────────────────┤
  │ Order total       │ £26                               │ £25                                       │
  ├───────────────────┼───────────────────────────────────┼───────────────────────────────────────────┤
  │ Invoice VAT shown │ £3.33 (product only)              │ £4.17 (product + shipping)                │
  ├───────────────────┼───────────────────────────────────┼───────────────────────────────────────────┤
  │ Invoice adds up?  │ £20 + £5 + £3.33 = £28.33 ≠ £26 ✗ │ £20 + £5 = £25, VAT £4.17 informational ✓ │
  └───────────────────┴───────────────────────────────────┴───────────────────────────────────────────┘
