### PR TITLE
fix(core): render plugin email tags in template preview and test send

### DIFF
--- a/administrator/components/com_j2commerce/src/Controller/EmailtemplateController.php
+++ b/administrator/components/com_j2commerce/src/Controller/EmailtemplateController.php
@@ -246,6 +246,8 @@ class EmailtemplateController extends FormController
         $body      = $this->input->post->getRaw('body', '');
         $subject   = $this->input->post->getString('subject', '');
         $customCss = $this->input->post->getRaw('custom_css', '');
+        $emailType = $this->input->post->getCmd('email_type', 'transactional');
+        $context   = $this->input->post->getCmd('context', 'preview');
 
         // Restore data-j2c-src placeholders back to src (editor injects these to prevent 404s)
         // GrapesJS may reorder attributes, so data-j2c-src may not be adjacent to src
@@ -261,8 +263,8 @@ class EmailtemplateController extends FormController
         $emailHelper = EmailHelper::getInstance();
         $order       = $emailHelper->getSampleOrderData();
 
-        $processedBody    = $emailHelper->processTags($body, $order);
-        $processedSubject = $emailHelper->processTags($subject, $order);
+        $processedBody    = EmailHelper::processTypeTags($emailType, $context, $order, $body);
+        $processedSubject = EmailHelper::processTypeTags($emailType, $context, $order, $subject);
 
         // Build full HTML with custom CSS
         $headStyles = '';
@@ -292,6 +294,8 @@ class EmailtemplateController extends FormController
         $subject   = $this->input->post->getString('subject', '');
         $customCss = $this->input->post->getRaw('custom_css', '');
         $recipient = $this->input->post->getString('recipient', '');
+        $emailType = $this->input->post->getCmd('email_type', 'transactional');
+        $context   = $this->input->post->getCmd('context', 'test');
 
         $json = ['success' => false, 'message' => ''];
 
@@ -307,8 +311,8 @@ class EmailtemplateController extends FormController
             $emailHelper = EmailHelper::getInstance();
             $order       = $emailHelper->getSampleOrderData();
 
-            $processedBody    = $emailHelper->processTags($body, $order);
-            $processedSubject = $emailHelper->processTags($subject, $order);
+            $processedBody    = EmailHelper::processTypeTags($emailType, $context, $order, $body);
+            $processedSubject = EmailHelper::processTypeTags($emailType, $context, $order, $subject);
 
             // Build full HTML
             $headStyles = '';

--- a/administrator/components/com_j2commerce/src/Helper/EmailHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/EmailHelper.php
@@ -2295,29 +2295,14 @@ class EmailHelper
         return $db->loadObject() ?: null;
     }
 
-    /**
-     * Process email tags for a given type and context.
-     *
-     * This method processes both core tags and plugin-specific tags.
-     *
-     * @param   string  $emailType  The email type
-     * @param   string  $context    The context
-     * @param   object  $data       Context data (order, voucher, etc.)
-     * @param   string  $body       The body to process
-     *
-     * @return  string  Processed body
-     *
-     * @since   6.1.0
-     */
     public static function processTypeTags(string $emailType, string $context, object $data, string $body): string
     {
-        // First, process core transactional tags if applicable
-        if ($emailType === 'transactional' && isset($data->order_id)) {
-            $instance = self::getInstance();
-            $body     = $instance->processTags($body, $data);
-        }
+        // Attach j2commerce subscribers — this path (admin preview/test) has no checkout flow
+        // to import the group, so without this the event reaches zero handlers and plugin tags
+        // get stripped to empty by processTags() below.
+        \Joomla\CMS\Plugin\PluginHelper::importPlugin('j2commerce');
 
-        // Dispatch event for plugin-specific tag processing
+        // Plugin event first — type-specific tags replaced before core strips unknown brackets
         try {
             $app   = Factory::getApplication();
             $event = new \Joomla\Event\Event('onJ2CommerceProcessEmailTags', [
@@ -2334,7 +2319,12 @@ class EmailHelper
                 $body = $result;
             }
         } catch (\Exception $e) {
-            // Event dispatching failed, continue with original body
+            // Continue with original body
+        }
+
+        // Core chrome tags (conditionals, site name, colour substitutions, unknown-tag strip)
+        if (isset($data->order_id) || isset($data->j2commerce_order_id)) {
+            $body = self::getInstance()->processTags($body, $data);
         }
 
         return $body;

--- a/administrator/components/com_j2commerce/tmpl/emailtemplate/edit.php
+++ b/administrator/components/com_j2commerce/tmpl/emailtemplate/edit.php
@@ -138,6 +138,7 @@ document.addEventListener("DOMContentLoaded", function() {
                 formData.append("body", body);
                 formData.append("subject", subject);
                 formData.append("custom_css", customCss);
+                formData.append("email_type", document.getElementById("jform_email_type")?.value || "transactional");
                 formData.append(token, "1");
 
                 const response = await fetch("index.php?option=com_j2commerce&task=emailtemplate.preview&format=raw", {
@@ -187,6 +188,7 @@ document.addEventListener("DOMContentLoaded", function() {
                 formData.append("subject", subject);
                 formData.append("custom_css", customCss);
                 formData.append("recipient", email);
+                formData.append("email_type", document.getElementById("jform_email_type")?.value || "transactional");
                 formData.append(token, "1");
 
                 const response = await fetch("index.php?option=com_j2commerce&task=emailtemplate.sendTest&format=json", {

--- a/media/com_j2commerce/js/administrator/grapesjs-j2commerce.js
+++ b/media/com_j2commerce/js/administrator/grapesjs-j2commerce.js
@@ -630,6 +630,7 @@ function setupPreviewIntegration(editor, options) {
             formData.append('body', body);
             formData.append('subject', subject);
             formData.append('custom_css', customCss);
+            formData.append('email_type', document.getElementById('jform_email_type')?.value || 'transactional');
             formData.append(token, '1');
 
             const response = await fetch(options.previewUrl, { method: 'POST', body: formData });


### PR DESCRIPTION
## Core Update

Admin email-template **Preview** and **Send Test** stripped plugin-provided tags to empty strings for non-transactional email types.

### Changes
- `EmailtemplateController`: `preview()` and `sendTest()` now pass the template's `email_type`/`context` to `EmailHelper::processTypeTags()` instead of the transactional-only `processTags()`
- `EmailHelper::processTypeTags()`: imports the `j2commerce` plugin group (the admin path never imports it, so `onJ2CommerceProcessEmailTags` reached zero listeners), dispatches the plugin event **before** core `processTags()` so unknown-tag stripping no longer deletes plugin tags, and triggers core processing on `j2commerce_order_id` as well
- `emailtemplate/edit.php` + `grapesjs-j2commerce.js`: preview and send-test requests now include the selected `email_type`

### Files Modified
| Type | Count |
|------|-------|
| PHP files | 3 |
| JS/CSS assets | 1 |

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Code style (php-cs-fixer) passed
- [x] Security gate passed (CSRF/ACL/injection sweep — no findings)
- [x] Core files only (non-core excluded)