### PR TITLE
fix(core): repair dead inline help on product, vendor and manufacturer edit screens

### DIFF
--- a/administrator/components/com_j2commerce/forms/manufacturer.xml
+++ b/administrator/components/com_j2commerce/forms/manufacturer.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <form>
-    <inlinehelp button="show"/>
+    <config>
+        <inlinehelp button="show"/>
+    </config>
     <fieldset name="basic" label="COM_J2COMMERCE_FIELDSET_BASIC">
         <!-- Hidden primary key field - REQUIRED -->
         <field

--- a/administrator/components/com_j2commerce/forms/product.xml
+++ b/administrator/components/com_j2commerce/forms/product.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <form>
-    <inlinehelp button="show"/>
+    <config>
+        <inlinehelp button="show"/>
+    </config>
     <fieldset name="basic" label="COM_J2COMMERCE_FIELDSET_BASIC">
         <!-- Hidden primary key field - REQUIRED -->
         <field

--- a/administrator/components/com_j2commerce/forms/vendor.xml
+++ b/administrator/components/com_j2commerce/forms/vendor.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <form>
-    <inlinehelp button="show"/>
+    <config>
+        <inlinehelp button="show"/>
+    </config>
     <fieldset name="basic" label="COM_J2COMMERCE_FIELDSET_BASIC">
         <!-- Hidden primary key field - REQUIRED -->
         <field

--- a/administrator/components/com_j2commerce/src/View/Manufacturer/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Manufacturer/HtmlView.php
@@ -146,6 +146,7 @@ class HtmlView extends BaseHtmlView
 
         $toolbar->cancel('manufacturer.cancel', $isNew ? 'JTOOLBAR_CANCEL' : 'JTOOLBAR_CLOSE');
         $toolbar->divider();
+        $toolbar->inlinehelp();
         ToolbarHelper::help(Text::_('COM_J2COMMERCE_MANUFACTURER'), true, 'https://docs.j2commerce.com/v6/catalog/manufacturers');
     }
 }

--- a/administrator/components/com_j2commerce/src/View/Product/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Product/HtmlView.php
@@ -125,6 +125,7 @@ class HtmlView extends BaseHtmlView
 
         $toolbar->cancel('product.cancel', $isNew ? 'JTOOLBAR_CANCEL' : 'JTOOLBAR_CLOSE');
 
+        $toolbar->inlinehelp();
         $toolbar->help(Text::_('COM_J2COMMERCE_PRODUCT'), true, 'https://docs.j2commerce.com/v6/catalog/managing-products/');
     }
 }

--- a/administrator/components/com_j2commerce/src/View/Vendor/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Vendor/HtmlView.php
@@ -145,6 +145,7 @@ class HtmlView extends BaseHtmlView
 
         $toolbar->cancel('vendor.cancel', $isNew ? 'JTOOLBAR_CANCEL' : 'JTOOLBAR_CLOSE');
         $toolbar->divider();
+        $toolbar->inlinehelp();
         ToolbarHelper::help(Text::_('COM_J2COMMERCE_VENDORS'), true, 'https://docs.j2commerce.com/v6/catalog/vendors');
     }
 }


### PR DESCRIPTION
## Core Update

### Problem
The Product, Vendor and Manufacturer edit screens had a non-functional inline-help setup, in two halves:

1. **Wrong XML placement** — `forms/product.xml`, `forms/vendor.xml` and `forms/manufacturer.xml` declared `<inlinehelp button="show"/>` directly under the `<form>` root. Joomla's `FormField::renderField()` only reads this flag from `<form><config><inlinehelp>` (see `libraries/src/Form/FormField.php`), so field descriptions never rendered with the toggleable `hide-aware-inline-help` markup. (Component `config.xml` files are unaffected — their root element *is* `<config>`, matching core convention.)
2. **No toolbar toggle** — none of the three edit views ever added the inline-help button, so even with correct XML the feature was unreachable.

### Changes
- Wrapped `<inlinehelp button="show"/>` in `<config>...</config>` in the three form XMLs, matching core Joomla's own `com_content/forms/article.xml`.
- Added `$toolbar->inlinehelp();` to `addToolbar()` in the Product, Vendor and Manufacturer edit `HtmlView`s.

### Verified in the browser
- Vendor edit: Toggle Inline Help button appears; 4 field descriptions hidden by default and toggle on/off.
- Manufacturer edit: button appears; 2 descriptions toggle.
- Product (edited through the article editor): the injected J2Commerce form fields now render inline-help-aware descriptions consistent with the surrounding com_content fields.

### Files Modified
| Type | Count |
|------|-------|
| PHP view files | 3 (one line each) |
| Form XML | 3 |

### Pre-Flight
- [x] PHP syntax check passed
- [x] XML parse check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Code style (php-cs-fixer) passed
- [x] Security gate passed
- [x] Core files only