### PR TITLE
fix(core): currency-aware ledger rounding and batched seeding

### DIFF
--- a/administrator/components/com_j2commerce/layouts/order/payment_balance.php
+++ b/administrator/components/com_j2commerce/layouts/order/payment_balance.php
@@ -34,8 +34,12 @@ $balanceDue = max(0.0, $orderTotalDisplay - max(0.0, $netPaid));
 // every value here is already in display currency.
 $fmt = static fn (float $value): string => CurrencyHelper::format($value, $currencyCode, 1.0);
 
-$balanceClass = $balanceDue > 0.01 ? 'text-danger fw-bold' : 'text-success fw-bold';
-$balanceLabel = $balanceDue > 0.01 ? $fmt($balanceDue) : Text::_('COM_J2COMMERCE_PAID_IN_FULL');
+// Half a minor unit of the order's currency — a hardcoded 0.01 misfires for
+// zero-decimal currencies (e.g. JPY) and is too coarse for 3-decimal ones.
+$threshold = 10 ** -CurrencyHelper::getDecimalPlace($currencyCode) / 2;
+
+$balanceClass = $balanceDue > $threshold ? 'text-danger fw-bold' : 'text-success fw-bold';
+$balanceLabel = $balanceDue > $threshold ? $fmt($balanceDue) : Text::_('COM_J2COMMERCE_PAID_IN_FULL');
 ?>
 <div class="alert alert-light border rounded-1 p-3 mb-3">
     <h6 class="mb-2">
@@ -52,7 +56,7 @@ $balanceLabel = $balanceDue > 0.01 ? $fmt($balanceDue) : Text::_('COM_J2COMMERCE
                 <td class="text-body-secondary"><?php echo Text::_('COM_J2COMMERCE_AMOUNT_PAID'); ?></td>
                 <td class="text-end"><?php echo $fmt($captured); ?></td>
             </tr>
-            <?php if ($refunded > 0.01) : ?>
+            <?php if ($refunded > $threshold) : ?>
                 <tr>
                     <td class="text-body-secondary"><?php echo Text::_('COM_J2COMMERCE_REFUNDED'); ?></td>
                     <td class="text-end text-danger">-<?php echo $fmt($refunded); ?></td>

--- a/administrator/components/com_j2commerce/src/CliCommands/SeedOrderLedgerCommand.php
+++ b/administrator/components/com_j2commerce/src/CliCommands/SeedOrderLedgerCommand.php
@@ -14,6 +14,7 @@ namespace J2Commerce\Component\J2commerce\Administrator\CliCommands;
 
 \defined('_JEXEC') or die;
 
+use J2Commerce\Component\J2commerce\Administrator\Helper\CurrencyHelper;
 use J2Commerce\Component\J2commerce\Administrator\Helper\OrderTransactionHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Log\Log;
@@ -36,6 +37,8 @@ class SeedOrderLedgerCommand extends AbstractCommand
     private const SEEDABLE_STATUSES = ['Completed', 'Refunded', 'Partially Refunded'];
 
     private const REVERSAL_EPSILON = 0.00001;
+
+    private const BATCH_SIZE = 500;
 
     protected function configure(): void
     {
@@ -63,53 +66,64 @@ class SeedOrderLedgerCommand extends AbstractCommand
     {
         $db = Factory::getContainer()->get(DatabaseInterface::class);
 
-        $query        = $db->getQuery(true)
-            ->select($db->quoteName([
-                'j2commerce_order_id', 'order_total', 'order_refund', 'transaction_id',
-                'transaction_status', 'transaction_details', 'currency_code',
-                'currency_value', 'orderpayment_type', 'created_by',
-            ]))
-            ->from($db->quoteName('#__j2commerce_orders'));
-        $placeholders = [];
-        $statuses     = self::SEEDABLE_STATUSES;
-
-        // bind() holds references — bind the array slots, not the loop variable.
-        foreach ($statuses as $i => $status) {
-            $placeholder    = ':status' . $i;
-            $placeholders[] = $placeholder;
-            $query->bind($placeholder, $statuses[$i]);
-        }
-
-        $query->where($db->quoteName('transaction_status') . ' IN (' . implode(',', $placeholders) . ')');
-
-        $db->setQuery($query);
-        $orders = $db->loadObjectList() ?: [];
-
         $seeded           = 0;
         $skipped          = 0;
         $failed           = 0;
         $reversalsSkipped = 0;
+        $offset           = 0;
 
-        foreach ($orders as $order) {
-            $orderId = (int) $order->j2commerce_order_id;
+        // Paged in fixed-size batches (ordered by PK) rather than loading every
+        // seedable order into memory at once — this table can grow large in
+        // production, and transaction_status doesn't change mid-run, so the
+        // paging window stays stable across iterations.
+        do {
+            $query        = $db->getQuery(true)
+                ->select($db->quoteName([
+                    'j2commerce_order_id', 'order_total', 'order_refund', 'transaction_id',
+                    'transaction_status', 'transaction_details', 'currency_code',
+                    'currency_value', 'orderpayment_type', 'created_by',
+                ]))
+                ->from($db->quoteName('#__j2commerce_orders'))
+                ->order($db->quoteName('j2commerce_order_id') . ' ASC');
+            $placeholders = [];
+            $statuses     = self::SEEDABLE_STATUSES;
 
-            try {
-                if (OrderTransactionHelper::hasLedger($orderId)) {
-                    $skipped++;
-                    continue;
-                }
-
-                $reversalsSkipped += self::seedOrder($order);
-                $seeded++;
-            } catch (\Throwable $e) {
-                $failed++;
-                Log::add(
-                    \sprintf('j2commerce:seed:order-ledger failed for order %d: %s', $orderId, $e->getMessage()),
-                    Log::WARNING,
-                    'j2commerce'
-                );
+            // bind() holds references — bind the array slots, not the loop variable.
+            foreach ($statuses as $i => $status) {
+                $placeholder    = ':status' . $i;
+                $placeholders[] = $placeholder;
+                $query->bind($placeholder, $statuses[$i]);
             }
-        }
+
+            $query->where($db->quoteName('transaction_status') . ' IN (' . implode(',', $placeholders) . ')');
+
+            $db->setQuery($query, $offset, self::BATCH_SIZE);
+            $orders = $db->loadObjectList() ?: [];
+
+            foreach ($orders as $order) {
+                $orderId = (int) $order->j2commerce_order_id;
+
+                try {
+                    if (OrderTransactionHelper::hasLedger($orderId)) {
+                        $skipped++;
+                        continue;
+                    }
+
+                    $reversalsSkipped += self::seedOrder($order);
+                    $seeded++;
+                } catch (\Throwable $e) {
+                    $failed++;
+                    Log::add(
+                        \sprintf('j2commerce:seed:order-ledger failed for order %d: %s', $orderId, $e->getMessage()),
+                        Log::WARNING,
+                        'j2commerce'
+                    );
+                }
+            }
+
+            $batchCount = \count($orders);
+            $offset += self::BATCH_SIZE;
+        } while ($batchCount === self::BATCH_SIZE);
 
         return ['seeded' => $seeded, 'skipped' => $skipped, 'failed' => $failed, 'reversalsSkipped' => $reversalsSkipped];
     }
@@ -152,21 +166,49 @@ class SeedOrderLedgerCommand extends AbstractCommand
                 }
 
                 $gatewayTxnId = (string) ($charge['id'] ?? $charge['gateway_txn_id'] ?? '');
-                OrderTransactionHelper::addCharge($orderId, $plugin, $gatewayTxnId, $amount, $currencyCode, $createdBy);
+                OrderTransactionHelper::addCharge(
+                    orderId: $orderId,
+                    pluginEl: $plugin,
+                    gatewayTxnId: $gatewayTxnId,
+                    amount: $amount,
+                    currencyCode: $currencyCode,
+                    createdBy: $createdBy
+                );
 
                 if ($gatewayTxnId !== '') {
                     $chargeLegs[] = ['gatewayTxnId' => $gatewayTxnId, 'amount' => $amount];
                 }
             }
         } elseif (is_numeric($details['captured'] ?? null) && (float) $details['captured'] > 0.0) {
-            OrderTransactionHelper::addCharge($orderId, $plugin, $transactionId, (float) $details['captured'], $currencyCode, $createdBy);
+            OrderTransactionHelper::addCharge(
+                orderId: $orderId,
+                pluginEl: $plugin,
+                gatewayTxnId: $transactionId,
+                amount: (float) $details['captured'],
+                currencyCode: $currencyCode,
+                createdBy: $createdBy
+            );
         } elseif (is_numeric($details['amount'] ?? null) && (float) $details['amount'] > 0.0) {
-            OrderTransactionHelper::addCharge($orderId, $plugin, $transactionId, (float) $details['amount'], $currencyCode, $createdBy);
+            OrderTransactionHelper::addCharge(
+                orderId: $orderId,
+                pluginEl: $plugin,
+                gatewayTxnId: $transactionId,
+                amount: (float) $details['amount'],
+                currencyCode: $currencyCode,
+                createdBy: $createdBy
+            );
         } else {
-            $orderTotalDisplay = (float) $order->order_total * $currencyValue;
+            $orderTotalDisplay = round((float) $order->order_total * $currencyValue, self::amountDecimals($currencyCode));
 
             if ($orderTotalDisplay > 0.0) {
-                OrderTransactionHelper::addCharge($orderId, $plugin, $transactionId, $orderTotalDisplay, $currencyCode, $createdBy);
+                OrderTransactionHelper::addCharge(
+                    orderId: $orderId,
+                    pluginEl: $plugin,
+                    gatewayTxnId: $transactionId,
+                    amount: $orderTotalDisplay,
+                    currencyCode: $currencyCode,
+                    createdBy: $createdBy
+                );
             }
         }
 
@@ -176,7 +218,7 @@ class SeedOrderLedgerCommand extends AbstractCommand
             return 0;
         }
 
-        $refundDisplay = $orderRefundBase * $currencyValue;
+        $refundDisplay = round($orderRefundBase * $currencyValue, self::amountDecimals($currencyCode));
 
         if ($hasChargesArray) {
             return self::seedChargesReversal($orderId, $plugin, $transactionId, $chargeLegs, $refundDisplay, $createdBy);
@@ -185,9 +227,22 @@ class SeedOrderLedgerCommand extends AbstractCommand
         // Legacy single-transaction orders recorded exactly one charge, so
         // $transactionId doubles as both the reversal's own gateway id and its
         // parent capture id (both branches above wrote the capture with this id).
-        OrderTransactionHelper::addReversal($orderId, $plugin, $transactionId, $transactionId, $refundDisplay, $createdBy);
+        OrderTransactionHelper::addReversal(
+            orderId: $orderId,
+            pluginEl: $plugin,
+            refundTxnId: $transactionId,
+            parentTxnId: $transactionId,
+            amount: $refundDisplay,
+            createdBy: $createdBy
+        );
 
         return 0;
+    }
+
+    /** currencyCode may be '' when the order row lookup yields no currency — fall back to 2dp. */
+    private static function amountDecimals(string $currencyCode): int
+    {
+        return $currencyCode !== '' ? CurrencyHelper::getDecimalPlace($currencyCode) : 2;
     }
 
     /**
@@ -238,12 +293,12 @@ class SeedOrderLedgerCommand extends AbstractCommand
             $leg++;
 
             OrderTransactionHelper::addReversal(
-                $orderId,
-                $plugin,
-                $refundTxnId . '-seed-' . $leg,
-                $charge['gatewayTxnId'],
-                $take,
-                $createdBy
+                orderId: $orderId,
+                pluginEl: $plugin,
+                refundTxnId: $refundTxnId . '-seed-' . $leg,
+                parentTxnId: $charge['gatewayTxnId'],
+                amount: $take,
+                createdBy: $createdBy
             );
 
             $remaining -= $take;

--- a/administrator/components/com_j2commerce/src/Helper/OrderTransactionHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/OrderTransactionHelper.php
@@ -19,11 +19,7 @@ use Joomla\Database\ParameterType;
 \defined('_JEXEC') or die;
 
 /**
- * Shared order-transaction ledger accessor.
- *
- * One canonical table for captures, refunds, auths, and voids so every payment
- * plugin reads/writes the same source of truth instead of hand-rolling its own
- * accounting inside `transaction_details` JSON. See docs/plans/order_transactions_ledger_prd.md.
+ * Shared order-transaction ledger accessor. See docs/plans/order_transactions_ledger_prd.md.
  *
  * All amounts are in the ORDER (display) currency — matching `orders.currency_code`,
  * NOT the store base currency that `orders.order_total` is stored in (PRD design
@@ -40,9 +36,15 @@ final class OrderTransactionHelper
 {
     private const TABLE = '#__j2commerce_ordertransactions';
 
+    private const EPSILON = 0.00001;
+
     private static ?DatabaseInterface $db = null;
 
-    /** Per-request memo for hasLedger(); refreshed by writeRow() after an insert. */
+    /**
+     * Per-request memo for hasLedger(); refreshed by writeRow() after an insert.
+     *
+     * @var array<int, bool>
+     */
     private static array $ledgerMemo = [];
 
     private static function getDatabase(): DatabaseInterface
@@ -83,7 +85,7 @@ final class OrderTransactionHelper
         $currencyCode = self::orderCurrencyCode($orderId);
         $id           = self::writeRow($orderId, $pluginEl, 'REVERSAL', $refundTxnId, $parentTxnId, $amount, $currencyCode, $createdBy);
 
-        self::syncOrderRefund($orderId);
+        self::syncOrderRefund($orderId, $createdBy);
 
         return $id;
     }
@@ -229,7 +231,11 @@ final class OrderTransactionHelper
         return ['captured' => $captured, 'refunded' => $refunded, 'net_paid' => $captured - $refunded];
     }
 
-    /** Newest-first ledger rows. Empty for legacy orders with no ledger rows. */
+    /**
+     * Newest-first ledger rows. Empty for legacy orders with no ledger rows.
+     *
+     * @return array<int, object>
+     */
     public static function getCharges(int $orderId): array
     {
         if (!self::hasLedger($orderId)) {
@@ -277,7 +283,7 @@ final class OrderTransactionHelper
                     continue;
                 }
 
-                if ($amount > $capture['remainder'] + 0.00001) {
+                if ($amount > $capture['remainder'] + self::EPSILON) {
                     throw new \RuntimeException(\sprintf(
                         'Refund amount %.5f exceeds the remaining refundable %.5f on transaction %s.',
                         $amount,
@@ -298,7 +304,7 @@ final class OrderTransactionHelper
 
         $totalRemainder = array_sum(array_column($captures, 'remainder'));
 
-        if ($amount > $totalRemainder + 0.00001) {
+        if ($amount > $totalRemainder + self::EPSILON) {
             throw new \RuntimeException(\sprintf(
                 'Refund amount %.5f exceeds the refundable total %.5f for order %d.',
                 $amount,
@@ -311,11 +317,11 @@ final class OrderTransactionHelper
         $remaining = $amount;
 
         foreach ($captures as $capture) {
-            if ($remaining <= 0.00001) {
+            if ($remaining <= self::EPSILON) {
                 break;
             }
 
-            if ($capture['remainder'] <= 0.00001) {
+            if ($capture['remainder'] <= self::EPSILON) {
                 continue;
             }
 
@@ -381,6 +387,13 @@ final class OrderTransactionHelper
             if ($existingId !== null) {
                 return $existingId;
             }
+        }
+
+        // VOID rows always carry amount 0.0 and may have no currencyCode to round
+        // against (order lookup failure) — skip rounding rather than round against
+        // the wrong currency's decimal places.
+        if ($currencyCode !== '') {
+            $amount = round($amount, CurrencyHelper::getDecimalPlace($currencyCode));
         }
 
         $db    = self::getDatabase();
@@ -560,6 +573,7 @@ final class OrderTransactionHelper
     // INTERNAL — reads
     // =========================================================================
 
+    /** @param array<int, string> $types */
     private static function sumByTypes(int $orderId, array $types): float
     {
         $db    = self::getDatabase();
@@ -715,8 +729,14 @@ final class OrderTransactionHelper
      * and rounding to the STORE BASE currency's decimal places — `order_refund` is
      * a base-currency column, so its precision must follow the base currency, not
      * the order's display currency (H2, PRD §6 / §10 D3-note).
+     *
+     * Writes the orders row directly rather than through OrderTable::store() —
+     * ConsoleApplication (CLI/seeder context) never calls loadIdentity(), so
+     * getIdentity() is null there and OrderTable::store() would fault reading
+     * $user->id. modified_on/modified_by are set here instead so that side effect
+     * of going through the Table class isn't lost.
      */
-    private static function syncOrderRefund(int $orderId): void
+    private static function syncOrderRefund(int $orderId, int $modifiedBy = 0): void
     {
         $order = self::fetchOrderRow($orderId);
 
@@ -729,13 +749,20 @@ final class OrderTransactionHelper
         $rate            = $rate > 0 ? $rate : 1.0;
         $decimals        = CurrencyHelper::getDecimalPlace(ConfigHelper::getDefaultCurrency());
         $baseRefunded    = round($displayRefunded / $rate, $decimals);
+        $now             = Factory::getDate()->toSql();
 
         $db    = self::getDatabase();
         $query = $db->getQuery(true)
             ->update($db->quoteName('#__j2commerce_orders'))
-            ->set($db->quoteName('order_refund') . ' = :orderRefund')
+            ->set([
+                $db->quoteName('order_refund') . ' = :orderRefund',
+                $db->quoteName('modified_on') . ' = :modifiedOn',
+                $db->quoteName('modified_by') . ' = :modifiedBy',
+            ])
             ->where($db->quoteName('j2commerce_order_id') . ' = :orderId')
             ->bind(':orderRefund', $baseRefunded, ParameterType::STRING)
+            ->bind(':modifiedOn', $now)
+            ->bind(':modifiedBy', $modifiedBy, ParameterType::INTEGER)
             ->bind(':orderId', $orderId, ParameterType::INTEGER);
 
         $db->setQuery($query);
@@ -746,6 +773,7 @@ final class OrderTransactionHelper
     // INTERNAL — legacy fallback (no ledger rows)
     // =========================================================================
 
+    /** @return float Display-currency amount — order_total is stored in the base currency. */
     private static function legacyCaptured(int $orderId): float
     {
         $order = self::fetchOrderRow($orderId);
@@ -754,16 +782,23 @@ final class OrderTransactionHelper
             return 0.0;
         }
 
-        return match ((string) $order->transaction_status) {
+        $base = match ((string) $order->transaction_status) {
             'Completed', 'Refunded', 'Partially Refunded' => (float) $order->order_total,
             default                                       => 0.0,
         };
+
+        return CurrencyHelper::convertForOrder($base, $order);
     }
 
+    /** @return float Display-currency amount — order_refund is stored in the base currency. */
     private static function legacyRefunded(int $orderId): float
     {
         $order = self::fetchOrderRow($orderId);
 
-        return $order !== null ? (float) ($order->order_refund ?? 0) : 0.0;
+        if ($order === null) {
+            return 0.0;
+        }
+
+        return CurrencyHelper::convertForOrder((float) ($order->order_refund ?? 0), $order);
     }
 }


### PR DESCRIPTION
## Core Update

Post-merge hardening of the #1270 shared order-transaction ledger.

### Changes
- **`OrderTransactionHelper`**
  - `writeRow()` rounds every ledger amount to the order currency's decimal places; VOID/empty-currency rows skip rounding rather than round against the wrong currency
  - `syncOrderRefund()` stamps `modified_on`/`modified_by` via a direct bound UPDATE — `OrderTable::store()` faults on the null identity in CLI (`ConsoleApplication`) context; `addReversal()` now passes `createdBy` through
  - `legacyCaptured()`/`legacyRefunded()` convert base → display currency via `CurrencyHelper::convertForOrder()` so the legacy (no-ledger) fallbacks honor the helper's display-currency contract
  - `0.00001` literal hoisted to an `EPSILON` class constant
- **`SeedOrderLedgerCommand`**
  - Pages seedable orders in 500-row PK-ordered batches instead of loading the whole orders table into memory; the status filter is immutable mid-run, so the paging window is stable and seeding stays idempotent via the existing `hasLedger()` guard
  - Backfilled charge/refund amounts rounded per currency (fallback 2dp when the order row has no currency code)
  - Named arguments at multi-parameter call sites
- **`layouts/order/payment_balance.php`**
  - Balance-due / refunded display threshold is now half a minor unit of the order currency (`10 ** -getDecimalPlace() / 2`) instead of a hardcoded `0.01`, which misfires for zero-decimal currencies (JPY) and is too coarse for 3-decimal ones

### Files Modified
| Type | Count |
|------|-------|
| PHP files | 3 |
| JS/CSS assets | 0 |
| Language files | 0 |
| XML/Config | 0 |

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Code style (php-cs-fixer) passed
- [x] Security gate passed (SQLi/XSS/refund-manipulation/IDOR/object-injection/log-exposure sweep — no findings; all new query fragments parameterized; `modified_on`/`modified_by` verified NOT NULL on the live schema and set explicitly)
- [x] Core files only (non-core excluded)