### PR TITLE
fix(core): render gateway payment form on zero-total context checkouts

### DIFF
--- a/components/com_j2commerce/src/Controller/CheckoutController.php
+++ b/components/com_j2commerce/src/Controller/CheckoutController.php
@@ -1454,7 +1454,13 @@ class CheckoutController extends BaseController
 
             $pluginHtml = '';
 
-            if (!empty($orderpaymentType) && !empty($existingOrder->order_id) && CurrencyHelper::baseChargeAmount($existingOrder) > 0.0) {
+            $showPayment = CurrencyHelper::baseChargeAmount($existingOrder) > 0.0;
+
+            if (!$showPayment) {
+                J2CommerceHelper::plugin()->event('ChangeShowPaymentOnTotalZero', [$existingOrder, &$showPayment]);
+            }
+
+            if (!empty($orderpaymentType) && !empty($existingOrder->order_id) && $showPayment) {
                 $paymentValues = [
                     'order_id'            => $existingOrder->order_id,
                     'orderpayment_id'     => $existingOrder->j2commerce_order_id ?? '',


### PR DESCRIPTION
## Core Update

### Changes
- `CheckoutController::confirm()` — checkout-context (pseudo-checkout) branch gated the gateway `PrePayment` form render solely on `CurrencyHelper::baseChargeAmount($existingOrder) > 0.0`. A legitimate zero-total context order (e.g. a subscription card-verification/update flow) reached the confirm step with no payment method form rendered for any gateway.
- Now computes `$showPayment` from the charge amount and, only when it is zero, dispatches `onJ2CommerceChangeShowPaymentOnTotalZero` (`[$existingOrder, &$showPayment]`) so a plugin owning the context can opt the order into the form render. Same dispatch pattern already used in the non-context cart branch of `confirm()` and in `confirmPayment()`.
- Nonzero orders are unaffected: the event fires only when the amount is zero and can only enable the render, never suppress it.

### Files Modified
| Type | Count |
|------|-------|
| PHP files | 1 |

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Code style (php-cs-fixer) passed
- [x] Security gate passed
- [x] Core files only (non-core excluded)
