### PR TITLE
fix(core): surface gateway error detail in payment methods manager

### DIFF
--- a/media/com_j2commerce/js/site/payment-methods.js
+++ b/media/com_j2commerce/js/site/payment-methods.js
@@ -109,7 +109,7 @@
                     'success': [Joomla.Text._('COM_J2COMMERCE_PAYMENT_METHODS_DELETED')]
                 });
             } else {
-                throw new Error(data.message || data.data?.message || Joomla.Text._('COM_J2COMMERCE_PAYMENT_METHODS_ERROR'));
+                throw new Error(data.message || data.data?.message || data.data?.error || data.error || Joomla.Text._('COM_J2COMMERCE_PAYMENT_METHODS_ERROR'));
             }
         } catch (error) {
             console.error('Delete card error:', error);
@@ -186,7 +186,7 @@
                     'success': [Joomla.Text._('COM_J2COMMERCE_PAYMENT_METHODS_DEFAULT_SET')]
                 });
             } else {
-                throw new Error(data.message || data.data?.message || Joomla.Text._('COM_J2COMMERCE_PAYMENT_METHODS_ERROR'));
+                throw new Error(data.message || data.data?.message || data.data?.error || data.error || Joomla.Text._('COM_J2COMMERCE_PAYMENT_METHODS_ERROR'));
             }
         } catch (error) {
             console.error('Set default card error:', error);


### PR DESCRIPTION
## Core Update

### Changes
- `payment-methods.js` (frontend saved-cards manager) — delete-card and set-default-card failure paths only read `data.message` / `data.data?.message`, but several payment plugins return the failure reason in `data.error` or `data.data.error`. Shoppers saw the generic `COM_J2COMMERCE_PAYMENT_METHODS_ERROR` string instead of the actual reason. The thrown-error fallback chain now also checks `data.data?.error || data.error` before falling back to the generic message.
- Display path is unchanged and safe: messages render via `Joomla.renderMessages()`, which sanitizes through `Joomla.sanitizeHtml`.

### Files Modified
| Type | Count |
|------|-------|
| JS/CSS assets | 1 |

### Pre-Flight
- [x] JS syntax check passed (node --check)
- [x] No secrets detected
- [x] Security gate passed
- [x] Core files only
