### PR TITLE
fix(core): clear cart for on-site gateways that finalize inline

### DIFF
--- a/components/com_j2commerce/src/Controller/CheckoutController.php
+++ b/components/com_j2commerce/src/Controller/CheckoutController.php
@@ -1819,6 +1819,7 @@ class CheckoutController extends BaseController
             // Payment succeeded — clear cart and checkout session (skip if already cleared)
             if (!$cartCleared) {
                 $this->clearCartAndSession($orderId, $session);
+                $cartCleared = true;
             }
 
             // Send order confirmation emails for free orders
@@ -1900,24 +1901,34 @@ class CheckoutController extends BaseController
             $this->sendOrderEmails($orderId);
         }
 
-        // Clear cart only after confirmed success. When paction=process and
-        // the plugin did NOT redirect, payment likely failed — preserve cart.
-        // Cart is cleared on the subsequent paction=display call instead.
-        // Skip if already cleared by order_placed timing.
-        //
-        // Only clear when the order reached one of the configured "placed"
+        // Clear cart only after the order reached one of the configured "placed"
         // states (clear_cart_states, defaulting to confirmed/processed/pending/
-        // shipped/delivered/scheduled). A failed or still-New order keeps the
-        // cart so the shopper can retry from the failed confirmation page. (#1190)
+        // shipped/delivered/scheduled). A failed or still-New order keeps the cart
+        // so the shopper can retry from the failed confirmation page. Skip if already
+        // cleared by order_placed timing. (#1190)
+        //
+        // paction handling: an OFF-SITE gateway only moves the order to Pending/New on
+        // the initial paction=process request and redirects the shopper away, so its
+        // cart must survive the round-trip and is cleared on the paction=display return
+        // instead. An ON-SITE gateway (Authorize.Net CIM, Stripe) finalizes inline on
+        // THIS paction=process request — reaching a confirmed/terminal state — and never
+        // makes a paction=display call, so it must clear here too; gating that on a
+        // confirmed (non-Pending) placed state tells the two apart. Gating the whole
+        // clear on paction!=='process' left on-site gateways with an uncleared cart.
         $clearStates = array_map('intval', (array) $params->get('clear_cart_states', []));
 
         if (empty($clearStates)) {
             $clearStates = [1, 2, 4, 7, 8, 9];
         }
 
-        $orderPlaced = \in_array((int) ($orderTable->order_state_id ?? 0), $clearStates, true);
+        $orderStateNow = (int) ($orderTable->order_state_id ?? 0);
+        $orderPlaced   = \in_array($orderStateNow, $clearStates, true);
 
-        if ($paction !== 'process' && !$cartCleared && $orderPlaced) {
+        // Confirmed/terminal states an on-site gateway reaches inline (excludes Pending(4),
+        // which at process-time means an off-site gateway is still awaiting its return trip).
+        $finalizedInline = \in_array($orderStateNow, [1, 2, 7, 8, 9], true);
+
+        if (!$cartCleared && $orderPlaced && ($paction !== 'process' || $finalizedInline)) {
             $this->clearCartAndSession($orderId, $session);
         }
 


### PR DESCRIPTION
## Core Update

Fixes the cart not being emptied after a completed checkout through an **on-site** payment gateway that finalizes inline.

### Problem
`CheckoutController::confirmPayment()` gated its cart-clear on `$paction !== 'process'`. On-site gateways (Authorize.Net CIM / saved-card, Stripe) whose `PostPayment` handler returns **rendered HTML and does not redirect** finalize the order on the same `paction=process` request and never make a second `paction=display` round-trip. The guard therefore skipped `clearCartAndSession()` for them permanently, so the shopper's cart stayed populated after a successful order.

### Fix
Gate the process-time clear on a confirmed/terminal order state instead of on `paction`:

- New `$finalizedInline = in_array($orderStateNow, [1, 2, 7, 8, 9], true)` — the states an on-site gateway reaches inline, **excluding Pending(4)**.
- Condition becomes `!$cartCleared && $orderPlaced && ($paction !== 'process' || $finalizedInline)`.

Off-site / redirect gateways are Pending/New at `paction=process` and redirect the shopper away, so `$finalizedInline` is false for them — their cart survives the round-trip and is still cleared on the `paction=display` return exactly as before (the predicate reduces to the original for every `$paction !== 'process'` case). On-site inline-finalizing gateways now clear correctly on the process request.

Also sets `$cartCleared = true;` in the free-order (`$0`) branch after `clearCartAndSession()`, to prevent a redundant (harmless, idempotent) second clear.

### Files Modified
| Type | Count |
|------|-------|
| PHP files | 1 |
| JS/CSS assets | 0 |
| Language files | 0 |
| XML/Config | 0 |

`components/com_j2commerce/src/Controller/CheckoutController.php`

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Code style (php-cs-fixer 3.95.1) passed
- [x] Core files only (non-core excluded)
- [x] Security review passed (no SQLi / XSS / CSRF / IDOR introduced; `order_state_id` is server-set, not request-controllable)
- [x] Verified live: on-site saved-card checkout now empties the cart; off-site behavior unchanged
