### PR TITLE
fix(core): reuse existing vendor rows on sample data re-install

### DIFF
--- a/administrator/components/com_j2commerce/src/Helper/SampleDataHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/SampleDataHelper.php
@@ -914,6 +914,20 @@ final class SampleDataHelper
                 continue;
             }
 
+            // Re-install: reuse the existing vendor row (unique key on j2commerce_user_id)
+            $query = $db->getQuery(true)
+                ->select($db->quoteName('j2commerce_vendor_id'))
+                ->from($db->quoteName('#__j2commerce_vendors'))
+                ->where($db->quoteName('j2commerce_user_id') . ' = :userId')
+                ->bind(':userId', $userId, ParameterType::INTEGER);
+            $db->setQuery($query);
+            $existingVendorId = (int) $db->loadResult();
+
+            if ($existingVendorId > 0) {
+                $vendorIds[] = $existingVendorId;
+                continue;
+            }
+
             $addr              = new \stdClass();
             $addr->user_id     = $userId;
             $addr->first_name  = $vendorName;


### PR DESCRIPTION
## Summary
Fixes #1289

Re-installing sample data crashed with `An internal error occurred. Please try again later`. On a second run, `createVendors()` in `SampleDataHelper.php` got an existing user id back from `createJoomlaUser()`, inserted a duplicate row into `#__j2commerce_addresses`, then died inserting into `#__j2commerce_vendors` because that table has a `UNIQUE KEY` on `j2commerce_user_id`.

## Changes
- `createVendors()` now checks `#__j2commerce_vendors` for an existing row with the resolved `j2commerce_user_id` before inserting. When found, the existing vendor id is reused (so products created in the new run still get vendors assigned) and both the duplicate address insert and the fatal vendor insert are skipped.
- Query uses `quoteName()` + bound `ParameterType::INTEGER` parameter.
- First-install path is unchanged.

## Related
The same re-install flow also silently duplicates manufacturers (+ their address rows), options (+ option values), and sub-categories — no crash because those tables have no unique keys. Tracked separately for a follow-up PR (see linked issue).

## Testing
1. Open the admin and run the J2Commerce sample data wizard; install any profile (first install).
2. Run the wizard again with the same profile.
3. Verify: no "An internal error occurred" message and the wizard completes with a summary.
4. Verify no duplicate vendor rows: `SELECT j2commerce_user_id, COUNT(*) FROM #__j2commerce_vendors GROUP BY j2commerce_user_id HAVING COUNT(*) > 1` returns empty.
5. Verify no new duplicate vendor addresses were added to `#__j2commerce_addresses` (rows left over from previously failed re-installs are not cleaned up by this fix).

## Files Changed
- `administrator/components/com_j2commerce/src/Helper/SampleDataHelper.php` — idempotency guard in `createVendors()` (14 lines added)

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Code style (php-cs-fixer) passed
- [x] Core files only
- [x] Security gate passed
