### PR TITLE
fix(core): reuse existing manufacturers, options, categories on sample data re-install

### DIFF
--- a/administrator/components/com_j2commerce/src/Helper/SampleDataHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/SampleDataHelper.php
@@ -798,10 +798,28 @@ final class SampleDataHelper
 
     private function createCategories(int $count, int $parentId, string $now): array
     {
+        $db     = $this->db;
         $catIds = [];
         $groups = \array_slice(self::CATEGORY_GROUPS, 0, $count);
 
         foreach ($groups as $group) {
+            // Re-install: reuse the existing sample category (title is stable, alias may be suffixed)
+            $title = $group['name'];
+            $query = $db->getQuery(true)
+                ->select($db->quoteName('id'))
+                ->from($db->quoteName('#__categories'))
+                ->where($db->quoteName('extension') . ' = ' . $db->quote('com_content'))
+                ->where($db->quoteName('metakey') . ' = ' . $db->quote(self::SAMPLE_TAG))
+                ->where($db->quoteName('title') . ' = :title')
+                ->bind(':title', $title);
+            $db->setQuery($query);
+            $existingCatId = (int) $db->loadResult();
+
+            if ($existingCatId > 0) {
+                $catIds[] = ['id' => $existingCatId, 'key' => $group['key'] ?? 'electronics', 'name' => $group['name']];
+                continue;
+            }
+
             $alias = $this->uniqueAlias($group['alias'], 'categories');
 
             $table                   = Table::getInstance('Category');
@@ -846,6 +864,27 @@ final class SampleDataHelper
         $names  = \array_slice(self::MANUFACTURER_NAMES, 0, $count);
 
         foreach ($names as $i => $mfgName) {
+            // Re-install: reuse the existing manufacturer (matched via its [SAMPLE] address)
+            $company = '[SAMPLE] ' . $mfgName;
+            $query   = $db->getQuery(true)
+                ->select($db->quoteName('m.j2commerce_manufacturer_id'))
+                ->from($db->quoteName('#__j2commerce_manufacturers', 'm'))
+                ->join(
+                    'INNER',
+                    $db->quoteName('#__j2commerce_addresses', 'a'),
+                    $db->quoteName('a.j2commerce_address_id') . ' = ' . $db->quoteName('m.address_id')
+                )
+                ->where($db->quoteName('a.type') . ' = ' . $db->quote('manufacturer'))
+                ->where($db->quoteName('a.company') . ' = :company')
+                ->bind(':company', $company);
+            $db->setQuery($query);
+            $existingMfgId = (int) $db->loadResult();
+
+            if ($existingMfgId > 0) {
+                $mfgIds[] = $existingMfgId;
+                continue;
+            }
+
             // Create an address record for the manufacturer (required FK)
             $addr              = new \stdClass();
             $addr->user_id     = 0;
@@ -976,9 +1015,25 @@ final class SampleDataHelper
         $options   = \array_slice(self::OPTIONS_DATA, 0, $count);
 
         foreach ($options as $i => $optData) {
+            $uniqueName = 'sample_' . strtolower(str_replace(' ', '_', $optData['name']));
+
+            // Re-install: reuse the existing sample option and its values
+            $query = $db->getQuery(true)
+                ->select($db->quoteName('j2commerce_option_id'))
+                ->from($db->quoteName('#__j2commerce_options'))
+                ->where($db->quoteName('option_unique_name') . ' = :uniqueName')
+                ->bind(':uniqueName', $uniqueName);
+            $db->setQuery($query);
+            $existingOptionId = (int) $db->loadResult();
+
+            if ($existingOptionId > 0) {
+                $optionIds[] = ['id' => $existingOptionId, 'values' => $optData['values']];
+                continue;
+            }
+
             $opt                     = new \stdClass();
             $opt->type               = $optData['type'];
-            $opt->option_unique_name = 'sample_' . strtolower(str_replace(' ', '_', $optData['name']));
+            $opt->option_unique_name = $uniqueName;
             $opt->option_name        = $optData['name'];
             $opt->ordering           = $i + 1;
             $opt->enabled            = 1;


### PR DESCRIPTION
## Summary
Fixes #1291

Follow-up to #1289 / PR #1290. Re-running the sample data wizard silently duplicated manufacturers (plus their address rows), options (plus option values), and sub-categories on every run — no crash, because those tables have no unique keys, just steadily accumulating duplicate rows.

## Changes
All in `SampleDataHelper.php`, using the same reuse-existing pattern PR #1290 introduced for vendors. Each guard matches the same marker `remove()` already uses to delete sample rows:

- `createCategories()` — looks up an existing sample category by `extension = 'com_content'`, `metakey = 'j2commerce-sample-data'`, and title (title is stable; alias may carry a `-1` suffix from `uniqueAlias()`). Found → reuse its id, skip creation.
- `createManufacturers()` — looks up an existing manufacturer via INNER JOIN on `#__j2commerce_addresses` where `type = 'manufacturer'` and `company = '[SAMPLE] {name}'`. Found → reuse its id, skip the duplicate address + manufacturer inserts.
- `createOptions()` — looks up an existing option by its deterministic `option_unique_name` (`sample_*`). Found → reuse its id (option values are loaded live from the DB by option id in `createVariableProducts()`, so linkage still works), skip the option + option value inserts.

All queries use `quoteName()` + bound parameters. First-install path unchanged. Products created on a re-run are assigned the reused category/manufacturer/option ids.

## Testing
1. Run the sample data wizard and install a profile (first install if sample data is absent).
2. Run the wizard again with the same profile.
3. Verify counts are unchanged after the second run:
   - `SELECT COUNT(*) FROM #__j2commerce_manufacturers`
   - `SELECT COUNT(*) FROM #__j2commerce_options WHERE option_unique_name LIKE 'sample_%'`
   - `SELECT COUNT(*) FROM #__categories WHERE metakey = 'j2commerce-sample-data'`
4. Verify no new `[SAMPLE]` manufacturer rows appeared in `#__j2commerce_addresses`.
5. Verify products created by the second run still display their category, manufacturer, and variant options correctly.

Note: duplicates left behind by re-installs made before this fix are not cleaned up (same scope decision as PR #1290) — removing sample data and re-installing clears them.

## Files Changed
- `administrator/components/com_j2commerce/src/Helper/SampleDataHelper.php` — idempotency guards in `createCategories()`, `createManufacturers()`, `createOptions()` (+56/−1 lines)

## Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Code style (php-cs-fixer) passed
- [x] Core files only
- [x] Security gate passed
