### PR TITLE
fix(core): round order money fields to currency scale so balances reconcile

### DIFF
--- a/administrator/components/com_j2commerce/layouts/order/payment_balance.php
+++ b/administrator/components/com_j2commerce/layouts/order/payment_balance.php
@@ -21,8 +21,13 @@ $currencyValue = (float) ($displayData['currency_value'] ?? 1.0);
 $currencyValue = $currencyValue > 0 ? $currencyValue : 1.0;
 
 // order_total is stored in the store base currency; convert to the order's display
-// currency to match the ledger-derived figures below (which are already display currency).
-$orderTotalDisplay = (float) ($displayData['order_total'] ?? 0) * $currencyValue;
+// currency to match the ledger-derived figures below (which are already display currency),
+// and round to the display currency's scale so the balance subtraction lines up exactly
+// with the already-scaled netPaid (e.g. 39.925 → 39.93 for USD, not 9.995 balance).
+$orderTotalDisplay = round(
+    (float) ($displayData['order_total'] ?? 0) * $currencyValue,
+    CurrencyHelper::getDecimalPlace($currencyCode)
+);
 
 $summary    = OrderTransactionHelper::getBalanceSummary($orderId);
 $captured   = $summary['captured'];

--- a/administrator/components/com_j2commerce/src/Helper/CartOrder.php
+++ b/administrator/components/com_j2commerce/src/Helper/CartOrder.php
@@ -1510,18 +1510,27 @@ class CartOrder
         // Create the order record via OrderTable
         $orderTable = $mvcFactory->createTable('Order', 'Administrator');
 
+        // Round every stored money field to the base currency's decimal scale so the
+        // total is never over-precise (e.g. a 9.25% shipping tax yields 0.925 → a
+        // 3-decimal 39.925 total for a 2-decimal currency). Each field is rounded to
+        // the currency's own scale — 2 for USD/EUR, 0 for JPY, 3 for BHD/KWD — so the
+        // stored total matches what the gateway charges and every downstream sum
+        // (Balance Due, refunds, reports) reconciles exactly.
+        $moneyScale = CurrencyHelper::getDecimalPlace(ConfigHelper::getDefaultCurrency());
+        $money      = static fn (float $value): float => round($value, $moneyScale);
+
         $orderData = [
             'user_id'               => $userId,
             'user_email'            => $userEmail,
             'cart_id'               => $this->cart_id,
-            'order_total'           => $this->order_total,
-            'order_subtotal'        => $this->order_subtotal,
-            'order_subtotal_ex_tax' => $this->order_subtotal,
-            'order_tax'             => $this->order_tax,
-            'order_shipping'        => $this->order_shipping,
-            'order_shipping_tax'    => $this->order_shipping_tax,
-            'order_discount'        => $this->order_discount,
-            'order_surcharge'       => $this->order_surcharge,
+            'order_total'           => $money($this->order_total),
+            'order_subtotal'        => $money($this->order_subtotal),
+            'order_subtotal_ex_tax' => $money($this->order_subtotal),
+            'order_tax'             => $money($this->order_tax),
+            'order_shipping'        => $money($this->order_shipping),
+            'order_shipping_tax'    => $money($this->order_shipping_tax),
+            'order_discount'        => $money($this->order_discount),
+            'order_surcharge'       => $money($this->order_surcharge),
             'orderpayment_type'     => $this->orderpayment_type,
             'currency_id'           => $currencyId,
             'currency_code'         => $currencyCode,


### PR DESCRIPTION
## Core Update

Fixes order balances not reconciling when a currency's calculated total carried more precision than its minor unit.

### Problem
A 9.25% shipping tax on \$10 yields 0.925, so `order_total` was stored as **39.925** (3 decimals) for a 2-decimal currency, while the gateway charges 39.93. The order-view **Payment Balance** then subtracted the already-scaled ledger net-paid from the *unrounded* total: after a \$10 refund from a 39.93 charge it showed **Balance Due 9.99** instead of **10.00** (`39.925 - 29.93 = 9.995`).

### Changes
- **CartOrder** (`src/Helper/CartOrder.php`): round every stored money field (`order_total`, `order_subtotal`, `order_subtotal_ex_tax`, `order_tax`, `order_shipping`, `order_shipping_tax`, `order_discount`, `order_surcharge`) to the **base currency's** decimal scale at the order-persist boundary — currency-aware (2 for USD/EUR, 0 for JPY, 3 for BHD/KWD). New orders now store the total the gateway actually charges.
- **payment_balance layout** (`layouts/order/payment_balance.php`): round the displayed order total to the currency scale before the Balance Due subtraction, so existing orders reconcile on the order view too.

### Verification
- Existing order (39.925 stored): Payment Balance now shows Order Total \$39.93, Net Paid \$29.93, **Balance Due \$10.00** (was \$9.99).
- New order: `order_total` stored **39.93**; components 29 + 10 + 0.93 sum exactly to the total.

### Files Modified
| Type | Count |
|------|-------|
| PHP files | 2 |
| JS/CSS assets | 0 |
| Language files | 0 |
| XML/Config | 0 |

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Code style (php-cs-fixer) — changed lines clean
- [x] Security gate: PASS
- [x] Core files only (non-core excluded)