### PR TITLE
fix(core): render plugin-provided HTML in Producttags view

### DIFF
--- a/components/com_j2commerce/src/View/Producttags/HtmlView.php
+++ b/components/com_j2commerce/src/View/Producttags/HtmlView.php
@@ -205,7 +205,7 @@ class HtmlView extends BaseHtmlView
         // If a plugin provided HTML output, still prepare document first
         // This ensures breadcrumbs, page title, and meta tags are set even when
         // a template plugin handles the actual HTML rendering
-        if (!empty($view_html)) {
+        if (!empty($viewHtml)) {
             $this->_prepareDocument();
             echo $viewHtml;
 


### PR DESCRIPTION
## Core Update

### Changes
Fixes a typo that left the plugin-provided-HTML branch in the tagged-products list view permanently dead. The empty-check referenced an undefined variable (`$view_html`) instead of the one actually populated by the event dispatch (`$viewHtml`), so `!empty()` was always false and the view always fell through to default template rendering, even when a template plugin (e.g. app_bootstrap5, app_uikit) provided its own output for `onJ2CommerceViewProductListTagHtml`.

### Files Modified
| Type | Count |
|------|-------|
| PHP files | 1 |

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only (non-core excluded)
- [x] Security gate: PASS (no CRITICAL/HIGH — trusted plugin-event branch, no request-derived input, no new escaping surface)