### PR TITLE
fix(core): return JSON on CSRF failure for AJAX confirmPayment posts

### DIFF
--- a/components/com_j2commerce/src/Controller/CheckoutController.php
+++ b/components/com_j2commerce/src/Controller/CheckoutController.php
@@ -1658,7 +1658,22 @@ class CheckoutController extends BaseController
             // raw PAN/CVV. Enforce CSRF on every browser POST here. Offsite
             // gateway returns arrive as GET redirects (no token) and are
             // finalized via order-state guards instead.
-            Session::checkToken('post') or $this->app->redirect($this->getCheckoutUrl());
+            if (!Session::checkToken('post')) {
+                // Payment-plugin JS posts here via fetch() expecting JSON. A redirect
+                // would be followed silently and hand the caller an HTML page, which
+                // fails downstream as an opaque parse error the shopper never sees.
+                $paction = $this->input->getString('paction', '');
+                $isAjax  = $paction === 'process'
+                    || strtolower($this->input->server->getString('HTTP_X_REQUESTED_WITH', '')) === 'xmlhttprequest';
+
+                if ($isAjax) {
+                    $this->jsonResponse(['success' => false, 'error' => Text::_('JINVALID_TOKEN')]);
+
+                    return;
+                }
+
+                $this->app->redirect($this->getCheckoutUrl());
+            }
         }
 
         $session        = $this->app->getSession();


### PR DESCRIPTION
## Core Update

### Changes
When `Session::checkToken('post')` fails on the `confirmPayment` branch that carries `orderpayment_type` (the branch every payment-plugin `fetch()` posts to with `paction=process`), the controller redirected to the checkout page. `fetch()` follows redirects silently, so the JS received an HTML document instead of JSON — the parse failure surfaced as an opaque client-side error and the shopper got a silently dead Pay button (root-caused while investigating extensions issue j2commerce6extensions#858; 20+ payment plugins share this AJAX contract).

The CSRF check itself is unchanged — only the failure **response format** is now negotiated, mirroring the `tos_check` branch directly above in the same method:
- AJAX callers (`paction === 'process'` or `X-Requested-With: XMLHttpRequest`) → `{"success": false, "error": JINVALID_TOKEN}`
- Non-AJAX posts → same redirect as before

Both exits terminate the request before any finalization code runs.

### Files Modified
| Type | Count |
|------|-------|
| PHP files | 1 |

### Pre-Flight
- [x] PHP syntax check passed
- [x] PHPStan clean
- [x] No secrets detected
- [x] No FOF remnants
- [x] Code style (php-cs-fixer v3.95.1) passed
- [x] Security gate: ✅ PASS (token enforcement unchanged; both failure exits halt before finalization; no data leak; no CSRF oracle)
- [x] Core files only