### PR TITLE
fix(core): dispatch dashboard plugin tabs inside the open uitab tabset

### DIFF
--- a/administrator/components/com_j2commerce/src/View/Dashboard/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Dashboard/HtmlView.php
@@ -60,10 +60,6 @@ class HtmlView extends BaseHtmlView
     public array $monthlySales = [];
     public array $yearlySales  = [];
 
-    // Plugin tab injection (uitab format) — main = col-md-8, side = col-md-4
-    public string $dashboardMainTabHtml = '';
-    public string $dashboardSideTabHtml = '';
-
     // Plugin quick icons
     public array $pluginQuickIcons = [];
 
@@ -169,10 +165,9 @@ class HtmlView extends BaseHtmlView
             'storeTimezone'    => $tz,
         ]);
 
-        // Plugin tab injection — plugins output uitab.addTab/endTab blocks
-        $eventData                  = [$this->monthlySales, $this->yearlySales, $this->revenueByDay];
-        $this->dashboardMainTabHtml = J2CommerceHelper::plugin()->eventWithHtml('DashboardMainTabContent', $eventData)->getArgument('html', '');
-        $this->dashboardSideTabHtml = J2CommerceHelper::plugin()->eventWithHtml('DashboardSideTabContent', $eventData)->getArgument('html', '');
+        // Plugin dashboard tabs (DashboardMainTabContent/DashboardSideTabContent) are
+        // dispatched by tmpl/dashboard/default.php inside the open uitab.startTabSet —
+        // uitab.addTab reads static state that startTabSet must have registered first.
 
         // Collect plugin quick icons
         $quickIconEvent = J2CommerceHelper::plugin()->event('GetQuickIcons', ['context' => 'j2commerce_dashboard']);

--- a/administrator/components/com_j2commerce/tmpl/dashboard/default.php
+++ b/administrator/components/com_j2commerce/tmpl/dashboard/default.php
@@ -9,6 +9,7 @@
 
 defined('_JEXEC') or die;
 
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\ModuleHelper;
 use Joomla\CMS\HTML\HTMLHelper;
@@ -22,6 +23,10 @@ use Joomla\CMS\Session\Session;
 $doc = Factory::getApplication()->getDocument();
 $renderer = $doc->loadRenderer('modules');
 $options = ['style' => 'none'];
+
+// Plugin dashboard tabs must be dispatched INSIDE the open uitab.startTabSet below —
+// uitab.addTab reads the tabset's static state that startTabSet registers.
+$dashboardTabEventData = [$this->monthlySales, $this->yearlySales, $this->revenueByDay];
 
 // Calculate % change for KPIs
 $prev = $this->previousPeriod;
@@ -213,7 +218,7 @@ $doc->getWebAssetManager()
                         endforeach;
                     endif; ?>
 
-                    <?php echo $this->dashboardMainTabHtml; ?>
+                    <?php echo J2CommerceHelper::plugin()->eventWithHtml('DashboardMainTabContent', $dashboardTabEventData)->getArgument('html', ''); ?>
 
                     <?php echo HTMLHelper::_('uitab.addTab', 'dashboardMainTabs', 'dashboard-add-main', '<span aria-hidden="true">+</span><span class="visually-hidden">' . Text::_('COM_J2COMMERCE_DASHBOARD_ADD_TAB_LABEL') . '</span>'); ?>
                         <p class="text-body-secondary"><?php echo Text::sprintf('COM_J2COMMERCE_DASHBOARD_ADD_TAB_HELP', '<code>j2commerce-dashboard-main-tab</code>'); ?></p>
@@ -241,7 +246,7 @@ $doc->getWebAssetManager()
                         echo HTMLHelper::_('uitab.endTab');
                     endforeach; ?>
 
-                    <?php echo $this->dashboardSideTabHtml; ?>
+                    <?php echo J2CommerceHelper::plugin()->eventWithHtml('DashboardSideTabContent', $dashboardTabEventData)->getArgument('html', ''); ?>
 
                     <?php echo HTMLHelper::_('uitab.addTab', 'dashboardSideTabs', 'dashboard-add-side', '<span aria-hidden="true">+</span><span class="visually-hidden">' . Text::_('COM_J2COMMERCE_DASHBOARD_ADD_TAB_LABEL') . '</span>'); ?>
                         <p class="text-body-secondary"><?php echo Text::sprintf('COM_J2COMMERCE_DASHBOARD_ADD_TAB_HELP', '<code>j2commerce-dashboard-side-tab</code>'); ?></p>


### PR DESCRIPTION
## Core Update

### Changes
Fixes the PHP warning shown on the J2Commerce dashboard whenever a plugin provides a dashboard tab:

```
Warning: Undefined array key "Joomla\CMS\HTML\Helpers\UiTab::startTabSet" in libraries/src/HTML/Helpers/UiTab.php on line 95
```

**Root cause:** `Dashboard\HtmlView::display()` dispatched the `DashboardMainTabContent` / `DashboardSideTabContent` plugin events and pre-rendered their HTML **before** the template executed `uitab.startTabSet`. Plugin handlers (e.g. app_aftershipreturns, app_trustpilot) build their tab with `HTMLHelper::_('uitab.addTab', 'dashboardMainTabs', ...)`, and `UiTab::addTab()` reads the tabset state that only `startTabSet` registers — so every plugin tab emitted the warning, and a plugin tab could never render as the active tab (`null == $id`).

**Fix:** dispatch the two events inline in `tmpl/dashboard/default.php` at the existing echo sites, inside the open `startTabSet` blocks. Rendered markup is otherwise identical; the two now-unused public view properties are removed.

### Files Modified
| Type | Count |
|------|-------|
| PHP files | 2 |

### Testing
1. Enable a plugin that provides a dashboard tab (e.g. AfterShip Returns or Trustpilot).
2. Open Components → J2Commerce (dashboard) with error reporting set to Maximum.
3. Before: one `UiTab::startTabSet` undefined-array-key warning per plugin tab. After: no warnings; plugin tabs (Returns/Trustpilot) render normally inside the main and side tabsets.

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Code style (php-cs-fixer) passed
- [x] Security gate passed
- [x] Core files only
