### PR TITLE
feat(core): dispatch AfterDisplayLineItemTitle in confirmation and order views

### DIFF
--- a/components/com_j2commerce/tmpl/confirmation/bootstrap5/default.php
+++ b/components/com_j2commerce/tmpl/confirmation/bootstrap5/default.php
@@ -399,6 +399,7 @@ if ($info) {
                                         <?php if (!empty($item->orderitem_sku)) : ?>
                                             <br><span class="text-body-tertiary"><?php echo Text::_('COM_J2COMMERCE_CART_LINE_ITEM_SKU'); ?>: <?php echo $this->escape($item->orderitem_sku); ?></span>
                                         <?php endif; ?>
+                                        <?php echo J2CommerceHelper::plugin()->eventWithHtml('AfterDisplayLineItemTitle', [$item, $order, &$this->params]); ?>
                                     </div>
                                     <?php // Item price ?>
                                     <div class="text-end small fw-semibold text-nowrap">

--- a/components/com_j2commerce/tmpl/confirmation/uikit/default.php
+++ b/components/com_j2commerce/tmpl/confirmation/uikit/default.php
@@ -404,6 +404,7 @@ if ($info) {
                                         <?php if (!empty($item->orderitem_sku)) : ?>
                                             <br><span class="uk-text-muted"><?php echo Text::_('COM_J2COMMERCE_CART_LINE_ITEM_SKU'); ?>: <?php echo $this->escape($item->orderitem_sku); ?></span>
                                         <?php endif; ?>
+                                        <?php echo J2CommerceHelper::plugin()->eventWithHtml('AfterDisplayLineItemTitle', [$item, $order, &$this->params]); ?>
                                     </div>
                                     <?php // Item price ?>
                                     <div class="uk-text-right uk-text-small uk-text-bold uk-text-nowrap uk-flex-none">

--- a/components/com_j2commerce/tmpl/myprofile/bootstrap5/order.php
+++ b/components/com_j2commerce/tmpl/myprofile/bootstrap5/order.php
@@ -179,6 +179,7 @@ $statusName = !empty($order->orderstatus_name) ? Text::_($order->orderstatus_nam
                             'variant'    => 'compact',
                         ], JPATH_ROOT . '/components/com_j2commerce/layouts'); ?>
                         <?php endif; ?>
+                        <?php echo J2CommerceHelper::plugin()->eventWithHtml('AfterDisplayLineItemTitle', [$lineItem, $order, &$params]); ?>
                     </td>
                     <?php if ($params->get('show_sku', 0)): ?>
                     <td><?php echo $this->escape($lineItem->orderitem_sku); ?></td>

--- a/components/com_j2commerce/tmpl/myprofile/uikit/order.php
+++ b/components/com_j2commerce/tmpl/myprofile/uikit/order.php
@@ -180,6 +180,7 @@ $statusName = !empty($order->orderstatus_name) ? Text::_($order->orderstatus_nam
                             'framework'  => 'uikit',
                         ], JPATH_ROOT . '/components/com_j2commerce/layouts'); ?>
                         <?php endif; ?>
+                        <?php echo J2CommerceHelper::plugin()->eventWithHtml('AfterDisplayLineItemTitle', [$lineItem, $order, &$params]); ?>
                     </td>
                     <?php if ($params->get('show_sku', 0)): ?>
                     <td><?php echo $this->escape($lineItem->orderitem_sku); ?></td>


### PR DESCRIPTION
## Core Update

### Changes
Dispatch the existing `onJ2CommerceAfterDisplayLineItemTitle` plugin event inside the order-item loops of the confirmation order summary and the My Account order detail (bootstrap5 + uikit) — one inserted line per template, identical to the dispatch already shipping in the cart and checkout templates.

**Why:** plugins annotate cart line items through this event (payment-plan deposit/instalment details, booking dates, bundle contents, gift certificate info), but those annotations vanished after checkout because neither post-checkout view fired the event. A partial-payment item, for example, showed its deposit-scaled price under the full order total with no explanation to the shopper. With this change the same annotations render on the confirmation page and the order history detail automatically.

No new data flow or endpoint: both views are ownership/session-gated, the render is read-only, and the same subscriber plugins already receive the same order/item payload from the cart-side dispatches.

### Files Modified
| Type | Count |
|------|-------|
| PHP templates (bootstrap5 + uikit) | 4 |

- `components/com_j2commerce/tmpl/confirmation/bootstrap5/default.php`
- `components/com_j2commerce/tmpl/confirmation/uikit/default.php`
- `components/com_j2commerce/tmpl/myprofile/bootstrap5/order.php`
- `components/com_j2commerce/tmpl/myprofile/uikit/order.php`

### Pre-Flight
- [x] PHP syntax check passed (all 4 templates)
- [x] No secrets detected
- [x] No FOF remnants
- [x] Code style: template files (php-cs-fixer tmpl exclusion) — inserts mirror existing cart-template lines
- [x] Core files only (non-core excluded)
- [x] Security gate: PASS (read-only render in gated views; no new trust boundary — same event + payload already trusted in cart context)
