### PR TITLE
fix(core): confirm free orders and drop duplicate register address fields

### DIFF
--- a/components/com_j2commerce/src/Controller/CheckoutController.php
+++ b/components/com_j2commerce/src/Controller/CheckoutController.php
@@ -20,7 +20,6 @@ use J2Commerce\Component\J2commerce\Administrator\Helper\CartHelper;
 use J2Commerce\Component\J2commerce\Administrator\Helper\CurrencyHelper;
 use J2Commerce\Component\J2commerce\Administrator\Helper\CustomFieldHelper;
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
-use J2Commerce\Component\J2commerce\Administrator\Helper\OrderHistoryHelper;
 use J2Commerce\Component\J2commerce\Administrator\Helper\UtilitiesHelper;
 use J2Commerce\Component\J2commerce\Site\Helper\CheckoutContextHelper;
 use J2Commerce\Component\J2commerce\Site\Helper\CheckoutStepsHelper;
@@ -388,6 +387,11 @@ class CheckoutController extends BaseController
                 'onContentPrepareForm',
                 new PrepareFormEvent('onContentPrepareForm', ['subject' => $form, 'data' => new \stdClass()])
             );
+
+            // plg_user_j2commerce injects its address set for the standalone
+            // com_users registration page; the checkout register step renders
+            // its own address fields, so drop the duplicate group.
+            $form->removeGroup('j2commerce_address');
 
             return $form;
         } catch (\Throwable $e) {
@@ -1819,26 +1823,27 @@ class CheckoutController extends BaseController
         J2CommerceHelper::plugin()->event('ChangeShowPaymentOnTotalZero', [$orderTable, &$showPayment]);
 
         if (!empty($orderId) && (float) ($orderTable->order_total ?? 0) === 0.0 && !$showPayment) {
-            if (method_exists($orderTable, 'payment_complete')) {
-                $orderTable->payment_complete();
+            // Confirm the free order directly — OrderTable::store() fires
+            // onJ2CommerceOrderStatusChange, stock reduction, download grants
+            // and the status-change history entry. Side effects only run on a
+            // successful store of an actual (re-entrant-safe) transition.
+            $wasConfirmed = (int) ($orderTable->order_state_id ?? 0) === 1;
+
+            $orderTable->order_state_id     = 1;
+            $orderTable->transaction_status = 'Completed';
+
+            if ($orderTable->store() && !$wasConfirmed) {
+                J2CommerceHelper::plugin()->event('AfterConfirmFreeProduct', [$orderTable]);
+
+                // Payment succeeded — clear cart and checkout session (skip if already cleared)
+                if (!$cartCleared) {
+                    $this->clearCartAndSession($orderId, $session);
+                    $cartCleared = true;
+                }
+
+                // Send order confirmation emails for free orders
+                $this->sendOrderEmails($orderId);
             }
-
-            OrderHistoryHelper::add(
-                orderId: $orderId,
-                comment: Text::_('COM_J2COMMERCE_ORDER_HISTORY_PAYMENT_COMPLETE'),
-                orderStateId: (int) ($orderTable->order_state_id ?? 1),
-            );
-
-            J2CommerceHelper::plugin()->event('AfterConfirmFreeProduct', [$orderTable]);
-
-            // Payment succeeded — clear cart and checkout session (skip if already cleared)
-            if (!$cartCleared) {
-                $this->clearCartAndSession($orderId, $session);
-                $cartCleared = true;
-            }
-
-            // Send order confirmation emails for free orders
-            $this->sendOrderEmails($orderId);
         } else {
             $values = [
                 'order_id'       => $orderId,


### PR DESCRIPTION
## Core Update

### Changes

**1. Free ($0.00) orders never reached the Confirmed status.**
The free-order branch in `confirmPayment()` called `$orderTable->payment_complete()` behind a `method_exists()` guard, but that legacy J2Store method no longer exists anywhere in the codebase — the guard silently skipped and free orders stayed at New (5) on the confirmation page. The order is now confirmed directly (`order_state_id = 1`, `transaction_status = 'Completed'`) through `OrderTable::store()`, which fires `onJ2CommerceOrderStatusChange`, stock reduction, download grants and the status-change history entry — the same side-effect path payment plugins use. This also restores subscription activation for $0 subscription products, which hangs off the status-change event.

Hardening in the same branch:
- Side effects (`AfterConfirmFreeProduct`, cart clear, confirmation emails) only run when `store()` succeeds and the order actually transitioned — re-entrant confirm requests no longer re-send emails, and a persistence failure keeps the cart so the shopper can retry.
- The controller-level "Payment complete" history entry duplicated the `store()`-owned status-change row and was removed (along with the now-unused `OrderHistoryHelper` import).

**2. Duplicate address fields in the checkout register step.**
`plg_user_j2commerce` injects its address fieldset (group `j2commerce_address`, wrapped in `#billing-new`) into `com_users.registration` via `onContentPrepareForm` — intended for the standalone Joomla registration page. `buildRegistrationForm()` builds that same form for the checkout register step and rendered the injection below the checkout's own register-area custom fields, so guests creating an account saw two full sets of address fields. The injected group is now removed after the dispatch; the standalone registration page is unaffected, and the plugin's `j2reg[]` save path is untouched.

### Verified

Tested end-to-end on a $0 subscription product with a new-account registration checkout: single address set on the register step; confirmation page shows the Confirmed badge; DB order at `order_state_id=1` / `transaction_status=Completed`; single status-change history row and a single customer + admin notification pair; subscription row created with status `active` and the renewal order scheduled.

### Files Modified
| Type | Count |
|------|-------|
| PHP files | 1 |

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Code style (php-cs-fixer) passed
- [x] Security gate passed
- [x] Core files only
