### PR TITLE
fix(core): keep batch-actions dialog template inside adminForm

### DIFF
--- a/administrator/components/com_j2commerce/tmpl/inventory/default.php
+++ b/administrator/components/com_j2commerce/tmpl/inventory/default.php
@@ -374,10 +374,13 @@ Text::script('COM_J2COMMERCE_INVENTORY_BATCH_NO_FIELDS');
             </div>
         </div>
     </div>
-</form>
 
-<?php if (!empty($this->items)) : ?>
-    <template id="joomla-dialog-batch"><?php echo $this->loadTemplate('batch_body'); ?></template>
-<?php endif; ?>
+    <?php // Must stay inside the form: for popupType=inline, joomla-dialog appends the dialog to
+          // this template's parentElement, so a template outside the form leaves the batch fields
+          // outside it too and they are never submitted. ?>
+    <?php if (!empty($this->items)) : ?>
+        <template id="joomla-dialog-batch"><?php echo $this->loadTemplate('batch_body'); ?></template>
+    <?php endif; ?>
+</form>
 
 <?php echo $this->footer ?? ''; ?>

--- a/administrator/components/com_j2commerce/tmpl/orders/default.php
+++ b/administrator/components/com_j2commerce/tmpl/orders/default.php
@@ -235,9 +235,12 @@ $dateFormat = ComponentHelper::getParams('com_j2commerce')->get('date_format', '
             </div>
         </div>
     </div>
-</form>
 
-<template id="joomla-dialog-batch"><?php echo $this->loadTemplate('batch_body'); ?></template>
+    <?php // Must stay inside the form: for popupType=inline, joomla-dialog appends the dialog to
+          // this template's parentElement, so a template outside the form leaves the batch fields
+          // outside it too and they are never submitted. ?>
+    <template id="joomla-dialog-batch"><?php echo $this->loadTemplate('batch_body'); ?></template>
+</form>
 
 <?php echo $this->loadTemplate('export_offcanvas'); ?>
 


### PR DESCRIPTION
## Core Fix

### Problem
`tmpl/orders/default.php` and `tmpl/inventory/default.php` declared `<template id="joomla-dialog-batch">` **after** the closing `</form>`. For a `popupButton()->popupType('inline')->url('#joomla-dialog-batch')`, `joomla-dialog.js`'s `findPreferredParent()` appends the rendered dialog to the *template's own parent element* — so with the template outside the form, the batch modal's fields (status select, notify-customer checkbox, comment, etc.) rendered outside `#adminForm` and were never included in the POST.

Effect: **Bulk Actions → Change Order Status never worked** — `OrdersController::updatestatus()` always received `order_state_id=0` regardless of what was picked in the modal, and threw `COM_J2COMMERCE_ERROR_NO_STATUS_SELECTED`. Same defect in the Inventory batch dialog.

Browser-verified before/after: dialog's DOM parent `MAIN` → `FORM`; POSTed `order_state_id` `null` → the actually-selected status id.

### Fix
Move each `<template id="joomla-dialog-batch">` to just inside its `</form>`, matching how core `com_content`'s own batch template is placed. No logic, controller, query, or ACL changes — verified via diff (move + one explanatory comment only).

### Files Modified
| Type | Count |
|------|-------|
| Admin templates (tmpl) | 2 |

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Core files only (non-core excluded)
- [x] Security gate: PASS — the three newly-reachable handlers (`OrdersController::updatestatus/delete`, `InventoryController::batch`) were independently audited since batch inputs now reach them for the first time; all already CSRF + `core.manage` boundary + explicit `authorise()` + parameterized SQL + escaped output. 0 CRITICAL/HIGH.
