### PR TITLE
fix(core): add missing voucher history empty state and view property visibility

### DIFF
--- a/administrator/components/com_j2commerce/src/View/Voucher/HtmlView.php
+++ b/administrator/components/com_j2commerce/src/View/Voucher/HtmlView.php
@@ -38,21 +38,32 @@ class HtmlView extends BaseHtmlView
      *
      * @var  \Joomla\CMS\Form\Form
      */
-    protected $form;
+    public $form;
 
     /**
      * The active item
      *
      * @var  object
      */
-    protected $item;
+    public $item;
 
     /**
      * The model state
      *
      * @var  object
      */
-    protected $state;
+    public $state;
+
+    /** History layout: ledger rows, list machinery and KPI totals. */
+    public array $ledger = [];
+    public $ledgerPagination;
+    public $ledgerState;
+    public $filterForm;
+    public array $activeFilters    = [];
+    public float $redeemedTotal    = 0.0;
+    public float $adjustmentsNet   = 0.0;
+    public float $remainingBalance = 0.0;
+    public bool $ledgerIsEmpty     = true;
 
     /**
      * Display the view

--- a/administrator/components/com_j2commerce/tmpl/voucher/history.php
+++ b/administrator/components/com_j2commerce/tmpl/voucher/history.php
@@ -14,6 +14,7 @@ defined('_JEXEC') or die;
 use J2Commerce\Component\J2commerce\Administrator\Helper\ConfigHelper;
 use J2Commerce\Component\J2commerce\Administrator\Helper\CurrencyHelper;
 use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
+use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
@@ -23,7 +24,7 @@ use Joomla\CMS\Router\Route;
 
 J2CommerceHelper::strapper()->addCSS();
 
-$wa = $this->getDocument()->getWebAssetManager();
+$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
 $wa->useScript('table.columns');
 
 $initialValue = (float) $this->item->voucher_value;
@@ -103,7 +104,7 @@ $listDirn   = $this->escape($this->ledgerState->get('list.direction'));
     </div>
 
     <?php if ($this->ledgerIsEmpty) : ?>
-        <?php echo $this->loadTemplate('historyempty'); ?>
+        <?php echo $this->loadTemplate('emptystate'); ?>
     <?php else : ?>
         <form action="<?php echo Route::_('index.php?option=com_j2commerce&view=voucher&layout=history&id=' . (int) $this->item->j2commerce_voucher_id); ?>" method="post" name="adminForm" id="adminForm">
             <div class="row">

--- a/administrator/components/com_j2commerce/tmpl/voucher/history_emptystate.php
+++ b/administrator/components/com_j2commerce/tmpl/voucher/history_emptystate.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @package     J2Commerce
+ * @subpackage  com_j2commerce
+ *
+ * @copyright   (C)2024-2026 J2Commerce, LLC <https://www.j2commerce.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Language\Text;
+
+/** @var \J2Commerce\Component\J2commerce\Administrator\View\Voucher\HtmlView $this */
+?>
+<div class="px-4 py-5 text-center">
+    <span class="fa-4x icon-list mb-3 d-block text-body-secondary" aria-hidden="true"></span>
+    <h3 class="fs-5"><?php echo Text::_('COM_J2COMMERCE_VOUCHER_HISTORY_EMPTYSTATE_TITLE'); ?></h3>
+    <p class="text-body-secondary col-lg-6 mx-auto mb-3">
+        <?php echo Text::_('COM_J2COMMERCE_VOUCHER_HISTORY_EMPTYSTATE_CONTENT'); ?>
+    </p>
+    <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#adjustBalanceModal">
+        <?php echo Text::_('COM_J2COMMERCE_VOUCHER_ADJUST_BALANCE'); ?>
+    </button>
+</div>


### PR DESCRIPTION
## Core Update

### Changes
Follow-up to #1311 (voucher balance adjustments & ledger):

- **Adds the missing empty-state sub-template** `tmpl/voucher/history_emptystate.php`. The history layout references an empty-state sub-template when a voucher's ledger has no entries, but the file was never committed in #1311 — opening the history of a voucher with an empty ledger currently throws a missing-template error.
- Loads it via `loadTemplate('emptystate')` so the filename follows the `*_emptystate` convention used by the other empty-state templates.
- Declares the history-layout view properties (`ledger`, `ledgerPagination`, `ledgerState`, `filterForm`, `activeFilters`, KPI totals) as typed public properties on `View\Voucher\HtmlView` and widens `form`/`item`/`state` to public — removes dynamic-property deprecations and protected-visibility diagnostics when templates read them.
- Uses `Factory::getApplication()->getDocument()` in `history.php` since `AbstractView::getDocument()` is protected.

### Files Modified
| Type | Count |
|------|-------|
| PHP files | 3 (1 view class, 2 admin templates — 1 new) |

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Code style (php-cs-fixer) passed
- [x] Core files only (non-core excluded)
- [x] Security gate passed (XSS/CSRF/ACL reviewed — all output escaped, forms tokenized, view ACL-gated)
