### PR TITLE
feat(core): dispatch AfterDisplayLineItemTitle in emails and admin edit views

### DIFF
--- a/administrator/components/com_j2commerce/layouts/templates/email/confirmed/admin.html
+++ b/administrator/components/com_j2commerce/layouts/templates/email/confirmed/admin.html
@@ -88,6 +88,7 @@
                   [IF:ITEM_SKU]<br /><span style="font-size: 12px; color: #9ca3af;">SKU: [ITEM_SKU]</span>[/IF:ITEM_SKU]
                   [IF:ITEM_OPTIONS]<br /><span style="font-size: 12px; color: #6b7280;">[ITEM_OPTIONS]</span>[/IF:ITEM_OPTIONS]
                   <br /><span style="font-size: 12px; color: #6b7280;">[ITEM_PRICE] each</span>
+                  [ITEM_ANNOTATIONS]
                 </td>
                 <td style="padding: 12px 10px; border-top: 1px solid #f3f4f6; text-align: center; vertical-align: top; font-size: 14px; color: [TEXT_COLOR];">[ITEM_QTY]</td>
                 <td style="padding: 12px 20px; border-top: 1px solid #f3f4f6; text-align: right; vertical-align: top; font-size: 14px; font-weight: 600; color: [TEXT_COLOR];">[ITEM_TOTAL]</td>

--- a/administrator/components/com_j2commerce/layouts/templates/email/confirmed/classic.html
+++ b/administrator/components/com_j2commerce/layouts/templates/email/confirmed/classic.html
@@ -91,6 +91,7 @@
                   <strong>[ITEM_NAME]</strong>
                   [IF:ITEM_SKU]<br /><span style="font-size: 11px; color: #888888;">SKU: [ITEM_SKU]</span>[/IF:ITEM_SKU]
                   [IF:ITEM_OPTIONS]<br /><span style="font-size: 12px; color: #666666;">[ITEM_OPTIONS]</span>[/IF:ITEM_OPTIONS]
+                  [ITEM_ANNOTATIONS]
                 </td>
                 <td style="padding: 10px 8px; border-bottom: 1px solid #dddddd; text-align: center; vertical-align: top;">[ITEM_QTY]</td>
                 <td style="padding: 10px 8px; border-bottom: 1px solid #dddddd; text-align: right; vertical-align: top;">[ITEM_PRICE]</td>

--- a/administrator/components/com_j2commerce/layouts/templates/email/confirmed/minimal.html
+++ b/administrator/components/com_j2commerce/layouts/templates/email/confirmed/minimal.html
@@ -68,6 +68,7 @@
                   <span style="font-weight: bold;">[ITEM_NAME]</span>
                   [IF:ITEM_SKU]<br /><span style="font-size: 12px; color: #9ca3af;">SKU: [ITEM_SKU]</span>[/IF:ITEM_SKU]
                   [IF:ITEM_OPTIONS]<br /><span style="font-size: 12px; color: #6b7280;">[ITEM_OPTIONS]</span>[/IF:ITEM_OPTIONS]
+                  [ITEM_ANNOTATIONS]
                 </td>
                 <td style="padding: 10px 0; border-bottom: 1px solid #e5e7eb; text-align: center; vertical-align: top;">[ITEM_QTY]</td>
                 <td style="padding: 10px 0; border-bottom: 1px solid #e5e7eb; text-align: right; vertical-align: top;">[ITEM_TOTAL]</td>

--- a/administrator/components/com_j2commerce/layouts/templates/email/confirmed/modern.html
+++ b/administrator/components/com_j2commerce/layouts/templates/email/confirmed/modern.html
@@ -168,6 +168,7 @@
                   [IF:ITEM_SKU]<br /><span style="font-size: 12px; color: #9ca3af;">SKU: [ITEM_SKU]</span>[/IF:ITEM_SKU]
                   [IF:ITEM_OPTIONS]<br /><span style="font-size: 12px; color: #6b7280;">[ITEM_OPTIONS]</span>[/IF:ITEM_OPTIONS]
                   <br /><span style="font-size: 12px; color: #6b7280;">[ITEM_PRICE] each</span>
+                  [ITEM_ANNOTATIONS]
                 </td>
                 <td style="padding: 12px 10px; border-top: 1px solid #f3f4f6; text-align: center; vertical-align: top; font-size: 14px; color: [TEXT_COLOR];">[ITEM_QTY]</td>
                 <td style="padding: 12px 20px; border-top: 1px solid #f3f4f6; text-align: right; vertical-align: top; font-size: 14px; font-weight: 600; color: [TEXT_COLOR];">[ITEM_TOTAL]</td>

--- a/administrator/components/com_j2commerce/layouts/templates/invoice/modern.html
+++ b/administrator/components/com_j2commerce/layouts/templates/invoice/modern.html
@@ -126,6 +126,7 @@
                   <span style="font-size: 14px; font-weight: 600; color: #1f2937;">[ITEM_NAME]</span>
                   [IF:ITEM_SKU]<br /><span style="font-size: 12px; color: #9ca3af;">SKU: [ITEM_SKU]</span>[/IF:ITEM_SKU]
                   [IF:ITEM_OPTIONS]<br /><span style="font-size: 12px; color: #6b7280;">[ITEM_OPTIONS]</span>[/IF:ITEM_OPTIONS]
+                  [ITEM_ANNOTATIONS]
                 </td>
                 <td style="padding: 12px 10px; border-top: 1px solid #f3f4f6; text-align: center; vertical-align: top; font-size: 14px; color: #1f2937;">[ITEM_QTY]</td>
                 <td style="padding: 12px 10px; border-top: 1px solid #f3f4f6; text-align: right; vertical-align: top; font-size: 14px; color: #1f2937;">[ITEM_PRICE]</td>

--- a/administrator/components/com_j2commerce/layouts/templates/receipt/modern.html
+++ b/administrator/components/com_j2commerce/layouts/templates/receipt/modern.html
@@ -87,6 +87,7 @@
                   <span style="font-size: 14px; font-weight: 600; color: #1f2937;">[ITEM_NAME]</span>
                   [IF:ITEM_SKU]<br /><span style="font-size: 12px; color: #9ca3af;">SKU: [ITEM_SKU]</span>[/IF:ITEM_SKU]
                   [IF:ITEM_OPTIONS]<br /><span style="font-size: 12px; color: #6b7280;">[ITEM_OPTIONS]</span>[/IF:ITEM_OPTIONS]
+                  [ITEM_ANNOTATIONS]
                 </td>
                 <td style="padding: 12px 10px; border-top: 1px solid #f3f4f6; text-align: center; vertical-align: top; font-size: 14px; color: #1f2937;">[ITEM_QTY]</td>
                 <td style="padding: 12px 10px; border-top: 1px solid #f3f4f6; text-align: right; vertical-align: top; font-size: 14px; color: #1f2937;">[ITEM_PRICE]</td>

--- a/administrator/components/com_j2commerce/layouts/templates/receipt/thermal.html
+++ b/administrator/components/com_j2commerce/layouts/templates/receipt/thermal.html
@@ -104,6 +104,11 @@
       <td colspan="2" style="font-size: 11px; color: #555; padding-left: 8px;">[ITEM_OPTIONS]</td>
     </tr>
     [/IF:ITEM_OPTIONS]
+    [IF:ITEM_ANNOTATIONS]
+    <tr>
+      <td colspan="2" style="font-size: 11px; padding-left: 8px;">[ITEM_ANNOTATIONS]</td>
+    </tr>
+    [/IF:ITEM_ANNOTATIONS]
     <tr>
       <td style="padding-left: 8px;">[ITEM_QTY] x [ITEM_PRICE]</td>
       <td class="right bold">[ITEM_TOTAL]</td>

--- a/administrator/components/com_j2commerce/src/Helper/EmailHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/EmailHelper.php
@@ -746,6 +746,7 @@ class EmailHelper
 
                 $currencyCode  = $order->currency_code ?? '';
                 $currencyValue = (float) ($order->currency_value ?? 1);
+                $params        = ComponentHelper::getParams('com_j2commerce');
                 $result        = '';
 
                 foreach ($items as $item) {
@@ -755,14 +756,15 @@ class EmailHelper
                     $imageUrl = $this->getProductImageForEmail((int) ($item->product_id ?? 0), $baseURL);
 
                     $itemTags = [
-                        '[ITEM_NAME]'    => htmlspecialchars($item->orderitem_name ?? ''),
-                        '[ITEM_SKU]'     => htmlspecialchars($item->orderitem_sku ?? ''),
-                        '[ITEM_QTY]'     => (string) (int) ($item->orderitem_quantity ?? 0),
-                        '[ITEM_PRICE]'   => CurrencyHelper::format((float) ($item->orderitem_price ?? 0), $currencyCode, $currencyValue),
-                        '[ITEM_TOTAL]'   => CurrencyHelper::format((float) ($item->orderitem_finalprice ?? 0), $currencyCode, $currencyValue),
-                        '[ITEM_IMAGE]'   => htmlspecialchars($imageUrl),
-                        '[ITEM_OPTIONS]' => $optionText,
-                        '[ITEM_WEIGHT]'  => (string) (float) ($item->orderitem_weight ?? 0),
+                        '[ITEM_NAME]'        => htmlspecialchars($item->orderitem_name ?? ''),
+                        '[ITEM_SKU]'         => htmlspecialchars($item->orderitem_sku ?? ''),
+                        '[ITEM_QTY]'         => (string) (int) ($item->orderitem_quantity ?? 0),
+                        '[ITEM_PRICE]'       => CurrencyHelper::format((float) ($item->orderitem_price ?? 0), $currencyCode, $currencyValue),
+                        '[ITEM_TOTAL]'       => CurrencyHelper::format((float) ($item->orderitem_finalprice ?? 0), $currencyCode, $currencyValue),
+                        '[ITEM_IMAGE]'       => htmlspecialchars($imageUrl),
+                        '[ITEM_OPTIONS]'     => $optionText,
+                        '[ITEM_WEIGHT]'      => (string) (float) ($item->orderitem_weight ?? 0),
+                        '[ITEM_ANNOTATIONS]' => (string) J2CommerceHelper::plugin()->eventWithHtml('AfterDisplayLineItemTitle', [$item, $order, &$params]),
                     ];
 
                     // Process per-item [IF:ITEM_*] and [IFNOT:ITEM_*] conditionals

--- a/administrator/components/com_j2commerce/tmpl/order/edit_items.php
+++ b/administrator/components/com_j2commerce/tmpl/order/edit_items.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 defined('_JEXEC') or die;
 
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
@@ -52,6 +53,7 @@ $currency = $item->currency_code ?? 'USD';
                         <div class="small text-muted">
                             <?php echo $this->escape($currency); ?> <?php echo number_format((float) $orderItem->orderitem_price, 2); ?> / unit
                         </div>
+                        <?php echo J2CommerceHelper::plugin()->eventWithHtml('AfterDisplayLineItemTitle', array($orderItem, $item, $this->params))->getArgument('html', ''); ?>
                     </td>
                     <td class="text-center">
                         <input type="number" class="form-control form-control-sm text-center" style="width: 80px; margin: 0 auto;"

--- a/administrator/components/com_j2commerce/tmpl/order/edit_summary.php
+++ b/administrator/components/com_j2commerce/tmpl/order/edit_summary.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 defined('_JEXEC') or die;
 
+use J2Commerce\Component\J2commerce\Administrator\Helper\J2CommerceHelper;
 use Joomla\CMS\Language\Text;
 
 $item = $this->item;
@@ -35,7 +36,10 @@ $currency = $item->currency_code ?? 'USD';
             <tbody>
                 <?php foreach ($orderItems as $orderItem) : ?>
                 <tr>
-                    <td><?php echo $this->escape($orderItem->orderitem_name); ?></td>
+                    <td>
+                        <?php echo $this->escape($orderItem->orderitem_name); ?>
+                        <?php echo J2CommerceHelper::plugin()->eventWithHtml('AfterDisplayLineItemTitle', array($orderItem, $item, $this->params))->getArgument('html', ''); ?>
+                    </td>
                     <td class="text-center"><?php echo (int) $orderItem->orderitem_quantity; ?></td>
                     <td class="text-end"><?php echo $this->escape($currency); ?> <?php echo number_format((float) $orderItem->orderitem_finalprice, 2); ?></td>
                 </tr>

--- a/modules/mod_j2commerce_cart/tmpl/default.php
+++ b/modules/mod_j2commerce_cart/tmpl/default.php
@@ -133,6 +133,8 @@ try {
                             <?php endif; ?>
                         </div>
 
+                        <?php echo J2CommerceHelper::plugin()->eventWithHtml('AfterDisplayLineItemTitle', [$item, $order, &$params]); ?>
+
                         <?php if (!empty($item->orderitemattributes)) : ?>
                             <div class="cart-item-options mt-1">
                                 <?php echo LayoutHelper::render('orderitem.attributes', [

--- a/modules/mod_j2commerce_cart/tmpl/default_uikit.php
+++ b/modules/mod_j2commerce_cart/tmpl/default_uikit.php
@@ -134,6 +134,8 @@ try {
                             <?php endif; ?>
                         </div>
 
+                        <?php echo J2CommerceHelper::plugin()->eventWithHtml('AfterDisplayLineItemTitle', [$item, $order, &$params]); ?>
+
                         <?php if (!empty($item->orderitemattributes)) : ?>
                             <div class="cart-item-options uk-margin-small-top">
                                 <?php echo LayoutHelper::render('orderitem.attributes', [

--- a/modules/mod_j2commerce_cart/tmpl/detailcartonhover.php
+++ b/modules/mod_j2commerce_cart/tmpl/detailcartonhover.php
@@ -152,6 +152,8 @@ $panelId = 'j2commerce-cart-detail-' . $moduleId;
                                 <?php endif; ?>
                             </div>
 
+                            <?php echo J2CommerceHelper::plugin()->eventWithHtml('AfterDisplayLineItemTitle', [$item, $order ?? null, &$params]); ?>
+
                             <div class="text-muted small">
                                 <?php if ($showQty) : ?>
                                     <span class="j2commerce-cart-item-qty"><?php echo (int) ($item->orderitem_quantity ?? 0); ?></span> &times;

--- a/modules/mod_j2commerce_cart/tmpl/detailcartonhover_uikit.php
+++ b/modules/mod_j2commerce_cart/tmpl/detailcartonhover_uikit.php
@@ -152,6 +152,8 @@ $panelId = 'j2commerce-cart-detail-' . $moduleId;
                                 <?php endif; ?>
                             </div>
 
+                            <?php echo J2CommerceHelper::plugin()->eventWithHtml('AfterDisplayLineItemTitle', [$item, $order ?? null, &$params]); ?>
+
                             <div class="uk-text-muted uk-text-small">
                                 <?php if ($showQty) : ?>
                                     <span class="j2commerce-cart-item-qty"><?php echo (int) ($item->orderitem_quantity ?? 0); ?></span> &times;


### PR DESCRIPTION
## Core Update

### Changes
PR #1306 added the `onJ2CommerceAfterDisplayLineItemTitle` dispatch to the
confirmation order summary and My Account order detail views, matching the
cart/checkout templates. Two more core surfaces still rendered bare item
rows without it:

- Transactional emails (order-confirmed x4 themes, invoice, receipt x2) via
  `EmailHelper::processItemsLoop()` — a new `[ITEM_ANNOTATIONS]` shortcode
  token now carries the event's HTML output into each item row.
- The admin order edit view (`edit_items.php`, `edit_summary.php`) — the
  read-only twin `view_items.php` already dispatched this event; the
  editable view did not.

Also extends the same dispatch to the frontend mini-cart module
(`mod_j2commerce_cart`, all 4 template variants), which renders line items
independently of the cart/checkout page templates.

Purely additive dispatch of an already-shipped event into rendering paths
that lacked it — no new endpoints, input handling, or SQL.

### Files Modified
| Type | Count |
|------|-------|
| PHP files | 3 |
| HTML email/invoice/receipt templates | 7 |
| Module templates (PHP) | 4 |

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Code style (php-cs-fixer) passed
- [x] Core files only (non-core excluded)
- [x] Security gate: PASS (no CRITICAL/HIGH; additive event dispatch only)