### PR TITLE
fix(core): force Bootstrap 5 framework for admin custom field rendering

### DIFF
--- a/administrator/components/com_j2commerce/src/Helper/CustomFieldHelper.php
+++ b/administrator/components/com_j2commerce/src/Helper/CustomFieldHelper.php
@@ -156,6 +156,11 @@ class CustomFieldHelper
         }
 
         try {
+            // Admin template is Bootstrap 5 (Atum) — the site subtemplate must not leak into backend markup
+            if (Factory::getApplication()->isClient('administrator')) {
+                return self::$resolvedFramework = 'bootstrap5';
+            }
+
             $subtemplate = (string) J2CommerceHelper::config()->get('subtemplate', 'bootstrap5');
         } catch (\Throwable) {
             $subtemplate = 'bootstrap5';


### PR DESCRIPTION
## Core Update

### Changes
`CustomFieldHelper::resolveFramework()` read the site `subtemplate` config with no client check. A store configured with the UIkit subtemplate therefore emitted `uk-*` markup in administrator renders, where the Atum template loads Bootstrap 5 and no UIkit CSS/JS exists.

Affected admin surfaces:
- **User edit form address fields** — `plg_user_j2commerce` injects the checkout address block into the com_users user edit form via `CustomFieldHelper::renderField()`, which auto-resolved to UIkit markup.
- **Customer edit phone widget** — the `PhoneField` form field (`forms/customer.xml` `phone_1`/`phone_2`) calls `renderPhoneWidget()` without a framework, producing a UIkit widget with a dead country dropdown (the `bootstrap.dropdown` init is skipped on the UIkit path), while `Customer/HtmlView::display()` registered assets for the Bootstrap path — a split-brain on one page.

### Fix
`resolveFramework()` now short-circuits to `bootstrap5` for the administrator client before consulting the `subtemplate` config. The result is cached per request as before. Explicit framework arguments (used by the site UIkit templates) still take precedence, so frontend rendering is unchanged. This also covers any future admin caller automatically.

### Files Modified
| Type | Count |
|------|-------|
| PHP files | 1 |

### Pre-Flight
- [x] PHP syntax check passed
- [x] No secrets detected
- [x] No FOF remnants
- [x] Code style (php-cs-fixer) passed
- [x] Security gate passed
- [x] Core files only (non-core excluded)
